### PR TITLE
#1 feat: enrich LLM consult context — location ids, cwd, configurable pane excerpt (v0.1.14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,22 @@ command = [
 ]
 timeout_seconds = 120
 auto_act = false   # false: LLM suggestions are surfaced for your confirmation
+pane_excerpt_chars = 5000   # pane excerpt size in the consult context (default 5000)
+```
+
+`get_context` hands the model the classified situation (type, options,
+permission verb, error summary), a pane excerpt (the last
+`pane_excerpt_chars` characters, read deeper than the classification
+snapshot), the agent's herdr location (`workspace_id`, `tab_id`,
+`pane_id`, `agent_id`), and the pane's working directory (`cwd`,
+`foreground_cwd` — advisory: a deleted directory carries a
+`" (deleted)"` suffix and either may be empty). The location ids let the
+model run its own read-only `herdr` queries (`herdr pane read <pane_id>`,
+`herdr pane get <pane_id>`, ...) — to allow that with Claude Code, extend
+the allowlist, e.g.:
+
+```toml
+"--allowedTools", "mcp__hap__get_context,mcp__hap__submit_decision,Bash(herdr pane read:*),Bash(herdr pane get:*)",
 ```
 
 OpenAI Codex CLI (MCP server passed inline via `-c` overrides; `exec` is

--- a/e2e_harness/main.go
+++ b/e2e_harness/main.go
@@ -42,6 +42,12 @@ func run() error {
 	if err := cli.SetPaneContent("Bash command: ls docs/\nDo you want to proceed? (y/n)"); err != nil {
 		return err
 	}
+	if err := cli.SetPaneInfo(`{"id":"cli:pane:get","result":{"pane":{` +
+		`"agent":"claude","agent_status":"blocked","cwd":"/home/op/project",` +
+		`"foreground_cwd":"/home/op/project","pane_id":"pane-1","tab_id":"ws-1:t1",` +
+		`"workspace_id":"ws-1"},"type":"pane_info"}}`); err != nil {
+		return err
+	}
 
 	// Reproduce the reported environment: the daemon's cwd is deleted
 	// after launch (herdr started it from a since-removed workspace).

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.1.13"
+version = "0.1.14"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,10 @@ type LLM struct {
 	// the default — LLM suggestions are surfaced as escalation suggestions
 	// for the operator to confirm.
 	AutoAct bool `toml:"auto_act"`
+	// PaneExcerptChars caps the pane excerpt (last N characters) included
+	// in the consult context handed to the LLM. Zero or omitted restores
+	// the 5000-char default.
+	PaneExcerptChars int `toml:"pane_excerpt_chars"`
 }
 
 // TaskSource points an agent or workspace at a declared next-task list (FR-011).
@@ -123,7 +127,7 @@ func Default() Config {
 			MaxAutoPromptsPerMinute:   10,
 			MaxErrorRetries:           2,
 		},
-		LLM: LLM{TimeoutSeconds: 60},
+		LLM: LLM{TimeoutSeconds: 60, PaneExcerptChars: 5000},
 	}
 }
 
@@ -257,6 +261,9 @@ func (c *Config) fillZeroes() {
 	}
 	if c.LLM.TimeoutSeconds <= 0 {
 		c.LLM.TimeoutSeconds = d.LLM.TimeoutSeconds
+	}
+	if c.LLM.PaneExcerptChars <= 0 {
+		c.LLM.PaneExcerptChars = d.LLM.PaneExcerptChars
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -260,3 +260,32 @@ func TestResolvePathsHonorsXDGBases(t *testing.T) {
 		t.Errorf("state should pair under XDG_STATE_HOME, got %s", p.StateDir)
 	}
 }
+
+func TestPaneExcerptCharsDefaultsAndOverride(t *testing.T) {
+	// Omitted → 5000-char default; explicit value honored; zero restored.
+	path := filepath.Join(t.TempDir(), "config.toml")
+	os.WriteFile(path, []byte("[llm]\ncommand = [\"claude\"]\n"), 0o600)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.LLM.PaneExcerptChars != 5000 {
+		t.Errorf("default pane_excerpt_chars = %d, want 5000", cfg.LLM.PaneExcerptChars)
+	}
+
+	os.WriteFile(path, []byte("[llm]\npane_excerpt_chars = 800\n"), 0o600)
+	if cfg, err = Load(path); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.LLM.PaneExcerptChars != 800 {
+		t.Errorf("explicit pane_excerpt_chars lost: %d", cfg.LLM.PaneExcerptChars)
+	}
+
+	os.WriteFile(path, []byte("[llm]\npane_excerpt_chars = 0\n"), 0o600)
+	if cfg, err = Load(path); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.LLM.PaneExcerptChars != 5000 {
+		t.Errorf("zero should restore the default, got %d", cfg.LLM.PaneExcerptChars)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
 	"github.com/0xGosu/herdr-auto-pilot/internal/classify"
@@ -271,6 +272,7 @@ func (d *Daemon) handleTransition(ctx context.Context, tr domain.AgentTransition
 	situation := cls.Classify(tr.AgentType, tr.Status, pane)
 	situation.AgentID = tr.AgentID
 	situation.PaneID = tr.PaneID
+	situation.TabID = tr.TabID
 	situation.WorkspaceID = tr.WorkspaceID
 	if situation.AgentType == "" {
 		situation.AgentType = "unknown"
@@ -336,7 +338,7 @@ func (d *Daemon) handleTransition(ctx context.Context, tr domain.AgentTransition
 	case domain.ActionSend:
 		d.act(ctx, situation, sig, decision, tr, now)
 	case domain.ActionConsult:
-		d.consultLLM(ctx, situation, sig, now)
+		d.consultLLM(ctx, cfg, situation, sig, now)
 	default:
 		d.escalate(ctx, situation, sig, decision, tr, now)
 	}
@@ -504,36 +506,28 @@ func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.Si
 		"version", buildinfo.Version)
 }
 
-// consultLLM stages a request and launches the operator's LLM CLI in a
-// goroutine; the outcome funnels back into the main loop (NFR-006 timeout
-// handled by the adapter).
-func (d *Daemon) consultLLM(ctx context.Context, s domain.Situation, sig domain.SignatureResult,
-	now time.Time) {
+// consultLLM assembles the consult context, stages the request, and
+// launches the operator's LLM CLI — all inside a goroutine, because the
+// context assembly shells out to the herdr CLI (deep pane read + pane get)
+// and must not stall the main loop; every failure funnels back through
+// handleLLMOutcome (NFR-006 timeout handled by the adapter).
+func (d *Daemon) consultLLM(ctx context.Context, cfg config.Config, s domain.Situation,
+	sig domain.SignatureResult, now time.Time) {
 
-	contextJSON, _ := json.Marshal(map[string]any{
-		"situation_type":  s.Type,
-		"agent_type":      s.AgentType,
-		"options":         s.Options,
-		"permission_verb": s.PermissionVerb,
-		"error_summary":   s.ErrorSummary,
-		"pane_excerpt":    tail(s.Content, 2000),
-	})
+	llm := d.llmPort()
 	req := domain.LLMRequest{
 		RequestID: fmt.Sprintf("req-%s-%d", s.AgentID, now.UnixNano()),
 		Signature: sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
-		ContextJSON: string(contextJSON), Status: "pending", CreatedAt: now,
+		Status: "pending", CreatedAt: now,
 	}
-	if _, err := d.opt.Store.StageLLMRequest(ctx, req); err != nil {
-		slog.Error("staging LLM request failed; escalating", "error", err)
-		d.escalate(ctx, s, sig, domain.Decision{Action: domain.ActionEscalate,
-			Reason: domain.ReasonPersistenceFailed, Rationale: err.Error()}, domain.AgentTransition{AgentID: s.AgentID, Status: "blocked"}, now)
-		return
-	}
-
-	llm := d.llmPort()
 	go func() {
 		outcome := llmOutcome{situation: s, sig: sig, request: req}
 		err := logging.Guard("llm-consult", func() error {
+			req.ContextJSON = string(d.consultContext(ctx, cfg, s))
+			if _, err := d.opt.Store.StageLLMRequest(ctx, req); err != nil {
+				return fmt.Errorf("staging LLM request failed: %w", err)
+			}
+			outcome.request = req
 			decision, err := llm.Consult(ctx, req)
 			outcome.decision = decision
 			return err
@@ -544,6 +538,66 @@ func (d *Daemon) consultLLM(ctx context.Context, s domain.Situation, sig domain.
 		case <-ctx.Done():
 		}
 	}()
+}
+
+// consultContext builds the JSON context handed to the LLM CLI via the
+// get_context MCP tool: the classified situation, a pane excerpt, the
+// agent's herdr location, and the pane working directory.
+func (d *Daemon) consultContext(ctx context.Context, cfg config.Config, s domain.Situation) []byte {
+	chars := cfg.LLM.PaneExcerptChars
+	if chars <= 0 {
+		chars = config.Default().LLM.PaneExcerptChars
+	}
+
+	// The classification read is kept shallow so the first-match-wins
+	// classifier does not latch onto stale scrollback; the LLM excerpt
+	// gets its own deeper read (~10 chars/line is a conservative floor).
+	excerpt := s.Content
+	lines := chars / 10
+	if lines < d.opt.PaneReadLines {
+		lines = d.opt.PaneReadLines
+	}
+	if deep, err := d.opt.Herdr.ReadPane(ctx, s.PaneID, lines); err == nil {
+		excerpt = deep
+	} else {
+		slog.Warn("deep pane read for LLM context failed; using classification snapshot",
+			"pane", s.PaneID, "error", err)
+	}
+
+	// Pane location and cwd come from `pane get`; degrade to empty values
+	// when the adapter cannot report them (ports.InspectorPort is optional).
+	var info domain.PaneInfo
+	if insp, ok := d.opt.Herdr.(ports.InspectorPort); ok {
+		var err error
+		if info, err = insp.PaneInfo(ctx, s.PaneID); err != nil {
+			slog.Warn("pane info for LLM context failed", "pane", s.PaneID, "error", err)
+			info = domain.PaneInfo{}
+		}
+	}
+	tabID := s.TabID
+	if tabID == "" {
+		tabID = info.TabID
+	}
+	workspaceID := s.WorkspaceID
+	if workspaceID == "" {
+		workspaceID = info.WorkspaceID
+	}
+
+	contextJSON, _ := json.Marshal(map[string]any{
+		"situation_type":  s.Type,
+		"agent_type":      s.AgentType,
+		"options":         s.Options,
+		"permission_verb": s.PermissionVerb,
+		"error_summary":   s.ErrorSummary,
+		"pane_excerpt":    tail(excerpt, chars),
+		"workspace_id":    workspaceID,
+		"tab_id":          tabID,
+		"pane_id":         s.PaneID,
+		"agent_id":        s.AgentID,
+		"cwd":             info.Cwd,
+		"foreground_cwd":  info.ForegroundCwd,
+	})
+	return contextJSON
 }
 
 // handleLLMOutcome re-gates a staged LLM submission through the same safety
@@ -560,6 +614,9 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		reason := domain.ReasonLLMNoSubmit
 		if res.err != nil && strings.Contains(res.err.Error(), "timeout") {
 			reason = domain.ReasonLLMTimeout
+		}
+		if res.err != nil && strings.Contains(res.err.Error(), "staging LLM request") {
+			reason = domain.ReasonPersistenceFailed
 		}
 		d.escalate(ctx, s, res.sig, domain.Decision{
 			Action: domain.ActionEscalate, Reason: reason,
@@ -1015,5 +1072,13 @@ func tail(s string, n int) string {
 	if len(s) <= n {
 		return s
 	}
-	return s[len(s)-n:]
+	cut := s[len(s)-n:]
+	// Never start mid-rune: skip leading UTF-8 continuation bytes.
+	for i := 0; i < len(cut) && i < utf8.UTFMax; i++ {
+		if !utf8.RuneStart(cut[i]) {
+			continue
+		}
+		return cut[i:]
+	}
+	return cut
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/classify"
 	"github.com/0xGosu/herdr-auto-pilot/internal/control"
@@ -30,6 +32,13 @@ type fakeHerdr struct {
 	failSend      bool
 	panicOnRead   bool
 	failRead      bool
+	// failReadOver, when > 0, fails ReadPane calls asking for more than
+	// that many lines (isolates the deep LLM-context read from the
+	// shallow classification read).
+	failReadOver int
+	readLines    []int
+	paneInfo     domain.PaneInfo
+	failPaneInfo bool
 }
 
 func (f *fakeHerdr) Send(ctx context.Context, paneID, input string) error {
@@ -48,10 +57,29 @@ func (f *fakeHerdr) ReadPane(ctx context.Context, paneID string, lines int) (str
 	if f.panicOnRead {
 		panic("induced pane read panic")
 	}
+	f.readLines = append(f.readLines, lines)
 	if f.failRead {
 		return "", errors.New("induced read failure")
 	}
+	if f.failReadOver > 0 && lines > f.failReadOver {
+		return "", errors.New("induced deep read failure")
+	}
 	return f.pane, nil
+}
+
+func (f *fakeHerdr) PaneInfo(ctx context.Context, paneID string) (domain.PaneInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failPaneInfo {
+		return domain.PaneInfo{}, errors.New("induced pane info failure")
+	}
+	return f.paneInfo, nil
+}
+
+func (f *fakeHerdr) readLineCalls() []int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]int(nil), f.readLines...)
 }
 
 func (f *fakeHerdr) ListAgents(ctx context.Context) ([]domain.AgentTransition, error) {
@@ -166,6 +194,12 @@ type harness struct {
 }
 
 func newHarness(t *testing.T, cfgTOML string) *harness {
+	return newHarnessWrapped(t, cfgTOML, nil)
+}
+
+// newHarnessWrapped lets a test substitute the HerdrPort the daemon sees
+// (e.g. hiding optional interfaces) while keeping the fake for assertions.
+func newHarnessWrapped(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.HerdrPort) *harness {
 	t.Helper()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.toml")
@@ -184,6 +218,10 @@ func newHarness(t *testing.T, cfgTOML string) *harness {
 	fh := &fakeHerdr{}
 	fe := &fakeEvents{ch: make(chan domain.AgentTransition, 64)}
 	fl := &fakeLLM{}
+	var herdrPort ports.HerdrPort = fh
+	if wrap != nil {
+		herdrPort = wrap(fh)
+	}
 
 	// Socket paths must stay short for macOS (104-byte cap).
 	ctlPath := filepath.Join(testutil.SocketDir(t), "control.sock")
@@ -191,7 +229,7 @@ func newHarness(t *testing.T, cfgTOML string) *harness {
 		ConfigPath:        cfgPath,
 		ControlSocketPath: ctlPath,
 		Store:             fs,
-		Herdr:             fh,
+		Herdr:             herdrPort,
 		Events:            fe,
 		Notify:            fh,
 		LLM:               fl,
@@ -1064,5 +1102,198 @@ func TestAgentNamedOnDiscoveryAndWorking(t *testing.T) {
 	}
 	if inputs := h.herdr.sentInputs(); len(inputs) != 0 {
 		t.Errorf("discovery must not cause sends, got %v", inputs)
+	}
+}
+
+// captureConsultContext wires the fake LLM to record req.ContextJSON and
+// fail the consult (the escalation path is not under test here).
+func captureConsultContext(h *harness) *atomicString {
+	var captured atomicString
+	h.llm.configured = true
+	h.llm.consult = func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+		captured.set(req.ContextJSON)
+		return nil, errors.New("consult not under test")
+	}
+	return &captured
+}
+
+func decodeContext(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("context JSON unparseable: %v (%s)", err, raw)
+	}
+	return m
+}
+
+func TestConsultContextCarriesLocationCwdAndDeepExcerpt(t *testing.T) {
+	// The consult context must hand the LLM the agent's herdr location
+	// (workspace/tab/pane ids), the pane cwd, and a pane excerpt sourced
+	// from a deeper read than the classification snapshot.
+	h := newHarness(t, "")
+	captured := captureConsultContext(h)
+	filler := strings.Repeat("compiling module alpha beta gamma\n", 200) // ~6800 chars
+	h.herdr.setPane(filler + approvalPane)
+	h.herdr.mu.Lock()
+	h.herdr.paneInfo = domain.PaneInfo{
+		PaneID: "w2:p7", TabID: "w2:t3", WorkspaceID: "w2",
+		Cwd: "/home/op/project", ForegroundCwd: "/home/op/project/sub",
+	}
+	h.herdr.mu.Unlock()
+
+	// Fresh signature + configured LLM → consult (no seeding needed).
+	h.events.ch <- domain.AgentTransition{
+		AgentID: "w2:p7", PaneID: "w2:p7", TabID: "w2:t3", WorkspaceID: "w2",
+		AgentType: "claude", Status: "blocked",
+	}
+	waitFor(t, 5*time.Second, func() bool { return captured.get() != "" })
+
+	m := decodeContext(t, captured.get())
+	for key, want := range map[string]string{
+		"workspace_id":   "w2",
+		"tab_id":         "w2:t3",
+		"pane_id":        "w2:p7",
+		"agent_id":       "w2:p7",
+		"cwd":            "/home/op/project",
+		"foreground_cwd": "/home/op/project/sub",
+	} {
+		if got, _ := m[key].(string); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+	excerpt, _ := m["pane_excerpt"].(string)
+	if len(excerpt) != 5000 {
+		t.Errorf("pane_excerpt length = %d, want the 5000-char default", len(excerpt))
+	}
+	if !strings.Contains(excerpt, "Do you want to proceed?") {
+		t.Error("pane_excerpt must keep the tail of the pane")
+	}
+	// The deep read asks for pane_excerpt_chars/10 lines; the shallow
+	// classification read keeps the PaneReadLines default.
+	lines := h.herdr.readLineCalls()
+	if len(lines) < 2 || lines[len(lines)-1] != 500 {
+		t.Errorf("deep read should request 500 lines, got calls %v", lines)
+	}
+}
+
+func TestConsultContextExcerptSizeConfigurable(t *testing.T) {
+	h := newHarness(t, "[llm]\ncommand = [\"fake\"]\npane_excerpt_chars = 300\n")
+	captured := captureConsultContext(h)
+	h.herdr.setPane(strings.Repeat("noise line for the excerpt budget\n", 40) + approvalPane)
+
+	h.push("agent-ex", "blocked")
+	waitFor(t, 5*time.Second, func() bool { return captured.get() != "" })
+
+	m := decodeContext(t, captured.get())
+	excerpt, _ := m["pane_excerpt"].(string)
+	if len(excerpt) != 300 {
+		t.Errorf("pane_excerpt length = %d, want the configured 300", len(excerpt))
+	}
+}
+
+func TestConsultContextDegradesWithoutPaneInfo(t *testing.T) {
+	// A failing `pane get` must not block the consult: location falls back
+	// to the transition ids and cwd stays empty.
+	h := newHarness(t, "")
+	captured := captureConsultContext(h)
+	h.herdr.setPane(approvalPane)
+	h.herdr.mu.Lock()
+	h.herdr.failPaneInfo = true
+	h.herdr.mu.Unlock()
+
+	h.events.ch <- domain.AgentTransition{
+		AgentID: "w3:p1", PaneID: "w3:p1", TabID: "w3:t1", WorkspaceID: "w3",
+		AgentType: "claude", Status: "blocked",
+	}
+	waitFor(t, 5*time.Second, func() bool { return captured.get() != "" })
+
+	m := decodeContext(t, captured.get())
+	if got, _ := m["cwd"].(string); got != "" {
+		t.Errorf("cwd should degrade to empty, got %q", got)
+	}
+	if got, _ := m["tab_id"].(string); got != "w3:t1" {
+		t.Errorf("tab_id should come from the transition, got %q", got)
+	}
+}
+
+func TestConsultContextFallsBackToClassificationSnapshot(t *testing.T) {
+	// When the deep read fails, the excerpt falls back to the (shallow)
+	// classification snapshot instead of aborting the consult.
+	h := newHarness(t, "")
+	captured := captureConsultContext(h)
+	h.herdr.setPane(approvalPane)
+	h.herdr.mu.Lock()
+	h.herdr.failReadOver = 120 // classification read (120 lines) passes, deep read fails
+	h.herdr.mu.Unlock()
+
+	h.push("agent-fb", "blocked")
+	waitFor(t, 5*time.Second, func() bool { return captured.get() != "" })
+
+	m := decodeContext(t, captured.get())
+	if excerpt, _ := m["pane_excerpt"].(string); excerpt != approvalPane {
+		t.Errorf("excerpt should fall back to the classification snapshot, got %q", excerpt)
+	}
+}
+
+// inspectorlessHerdr exposes only the base HerdrPort surface, hiding the
+// fake's PaneInfo to exercise the optional-InspectorPort degradation.
+type inspectorlessHerdr struct{ f *fakeHerdr }
+
+func (h inspectorlessHerdr) Send(ctx context.Context, paneID, input string) error {
+	return h.f.Send(ctx, paneID, input)
+}
+
+func (h inspectorlessHerdr) ReadPane(ctx context.Context, paneID string, lines int) (string, error) {
+	return h.f.ReadPane(ctx, paneID, lines)
+}
+
+func (h inspectorlessHerdr) ListAgents(ctx context.Context) ([]domain.AgentTransition, error) {
+	return h.f.ListAgents(ctx)
+}
+
+func TestConsultContextWithoutInspectorPort(t *testing.T) {
+	// An adapter without the optional InspectorPort still consults: ids
+	// come from the transition and cwd stays empty.
+	h := newHarnessWrapped(t, "", func(f *fakeHerdr) ports.HerdrPort {
+		return inspectorlessHerdr{f}
+	})
+	captured := captureConsultContext(h)
+	h.herdr.setPane(approvalPane)
+
+	h.events.ch <- domain.AgentTransition{
+		AgentID: "w4:p1", PaneID: "w4:p1", TabID: "w4:t2", WorkspaceID: "w4",
+		AgentType: "claude", Status: "blocked",
+	}
+	waitFor(t, 5*time.Second, func() bool { return captured.get() != "" })
+
+	m := decodeContext(t, captured.get())
+	if got, _ := m["cwd"].(string); got != "" {
+		t.Errorf("cwd must stay empty without InspectorPort, got %q", got)
+	}
+	if got, _ := m["tab_id"].(string); got != "w4:t2" {
+		t.Errorf("tab_id should come from the transition, got %q", got)
+	}
+	if got, _ := m["workspace_id"].(string); got != "w4" {
+		t.Errorf("workspace_id should come from the transition, got %q", got)
+	}
+}
+
+func TestTailTrimsAtRuneBoundary(t *testing.T) {
+	if got := tail("hello", 10); got != "hello" {
+		t.Errorf("short input must pass through, got %q", got)
+	}
+	if got := tail("abcdef", 3); got != "def" {
+		t.Errorf("ascii cut = %q, want \"def\"", got)
+	}
+	// A 4-byte budget on "héllo" lands inside the 2-byte é: the leading
+	// continuation byte must be skipped, never emitted.
+	if got := tail("héllo", 4); got != "llo" {
+		t.Errorf("mid-rune cut = %q, want \"llo\"", got)
+	}
+	if got := tail("héllo", 5); got != "éllo" {
+		t.Errorf("boundary cut = %q, want \"éllo\"", got)
+	}
+	if got := tail(strings.Repeat("界", 10), 7); !utf8.ValidString(got) {
+		t.Errorf("tail must never emit invalid UTF-8, got %q", got)
 	}
 }

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -43,12 +43,22 @@ type TabInfo struct {
 	WorkspaceID string
 }
 
+// PaneInfo is per-pane metadata read via `herdr pane get` (herdr 0.7).
+type PaneInfo struct {
+	PaneID        string
+	TabID         string
+	WorkspaceID   string
+	Cwd           string // pane working directory; herdr renders a deleted dir with a " (deleted)" suffix
+	ForegroundCwd string // cwd of the foreground process; absent in some herdr responses
+}
+
 // Situation is a classified, attention-requiring state of one agent pane.
 type Situation struct {
 	Type           SituationType
 	AgentID        string
 	AgentType      string
 	PaneID         string
+	TabID          string
 	WorkspaceID    string
 	Content        string   // pane snapshot used for classification
 	Options        []string // normalized option set (choice situations)

--- a/internal/fakeherdr/fakeherdr.go
+++ b/internal/fakeherdr/fakeherdr.go
@@ -258,6 +258,9 @@ case "$1 $2" in
   "pane read")
     cat %q 2>/dev/null
     ;;
+  "pane get")
+    cat %q.paneinfo 2>/dev/null
+    ;;
   "agent list")
     cat %q.agents 2>/dev/null
     ;;
@@ -269,7 +272,7 @@ case "$1 $2" in
     ;;
 esac
 exit 0
-`, f.LogPath, f.FailFlag, f.PaneFile, f.PaneFile, f.PaneFile, f.PaneFile)
+`, f.LogPath, f.FailFlag, f.PaneFile, f.PaneFile, f.PaneFile, f.PaneFile, f.PaneFile)
 	if err := os.WriteFile(f.BinPath, []byte(script), 0o700); err != nil {
 		return nil, err
 	}
@@ -279,6 +282,11 @@ exit 0
 // SetPaneContent sets what `pane read` returns.
 func (f *FakeCLI) SetPaneContent(content string) error {
 	return os.WriteFile(f.PaneFile, []byte(content), 0o600)
+}
+
+// SetPaneInfo sets the raw JSON `pane get` returns.
+func (f *FakeCLI) SetPaneInfo(content string) error {
+	return os.WriteFile(f.PaneFile+".paneinfo", []byte(content), 0o600)
 }
 
 // SetAgentList sets the raw JSON `agent list` returns.

--- a/internal/herdr/cli.go
+++ b/internal/herdr/cli.go
@@ -12,7 +12,10 @@ import (
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
 )
+
+var _ ports.InspectorPort = (*CLI)(nil)
 
 // CLI issues one-shot Herdr control actions through the herdr binary
 // (HERDR_BIN_PATH), which stays portable across Unix sockets and Windows
@@ -112,6 +115,42 @@ func (c *CLI) ListAgents(ctx context.Context) ([]domain.AgentTransition, error) 
 		})
 	}
 	return agents, nil
+}
+
+// paneGetResponse is the JSON envelope `herdr pane get <pane_id>` prints
+// (verified against herdr 0.7). cwd may carry a literal " (deleted)"
+// suffix; foreground_cwd is absent on some panes.
+type paneGetResponse struct {
+	Result struct {
+		Pane struct {
+			PaneID        string `json:"pane_id"`
+			TabID         string `json:"tab_id"`
+			WorkspaceID   string `json:"workspace_id"`
+			Cwd           string `json:"cwd"`
+			ForegroundCwd string `json:"foreground_cwd"`
+		} `json:"pane"`
+	} `json:"result"`
+}
+
+// PaneInfo returns per-pane metadata (`pane get`), including the pane's
+// working directory (ports.InspectorPort).
+func (c *CLI) PaneInfo(ctx context.Context, paneID string) (domain.PaneInfo, error) {
+	out, err := c.run(ctx, "pane", "get", paneID)
+	if err != nil {
+		return domain.PaneInfo{}, err
+	}
+	var resp paneGetResponse
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &resp); err != nil {
+		return domain.PaneInfo{}, fmt.Errorf("parse pane get output: %w", err)
+	}
+	p := resp.Result.Pane
+	return domain.PaneInfo{
+		PaneID:        p.PaneID,
+		TabID:         p.TabID,
+		WorkspaceID:   p.WorkspaceID,
+		Cwd:           p.Cwd,
+		ForegroundCwd: p.ForegroundCwd,
+	}, nil
 }
 
 // workspaceListResponse is the `herdr workspace list` envelope

--- a/internal/herdr/herdr_test.go
+++ b/internal/herdr/herdr_test.go
@@ -301,3 +301,46 @@ func TestListWorkspacesTabsAndAgentTabIDs(t *testing.T) {
 		t.Errorf("tab list parsing: %+v", tabs)
 	}
 }
+
+func TestPaneInfo(t *testing.T) {
+	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second}
+	ctx := context.Background()
+
+	// Full envelope as printed by real herdr 0.7.
+	fake.SetPaneInfo(`{"id":"cli:pane:get","result":{"pane":{` +
+		`"agent":"claude","agent_status":"blocked","cwd":"/home/op/project",` +
+		`"foreground_cwd":"/home/op/project/sub","focused":false,"pane_id":"w1:p1",` +
+		`"revision":0,"tab_id":"w1:t1","workspace_id":"w1"},"type":"pane_info"}}`)
+	info, err := cli.PaneInfo(ctx, "w1:p1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.PaneID != "w1:p1" || info.TabID != "w1:t1" || info.WorkspaceID != "w1" {
+		t.Errorf("pane identity parsing: %+v", info)
+	}
+	if info.Cwd != "/home/op/project" || info.ForegroundCwd != "/home/op/project/sub" {
+		t.Errorf("cwd parsing: %+v", info)
+	}
+
+	// Deleted cwd renders with a literal suffix and no foreground_cwd;
+	// both pass through verbatim / zero-valued.
+	fake.SetPaneInfo(`{"id":"cli:pane:get","result":{"pane":{` +
+		`"cwd":"/gone/dir (deleted)","pane_id":"w1:p2","tab_id":"w1:t1",` +
+		`"workspace_id":"w1"},"type":"pane_info"}}`)
+	if info, err = cli.PaneInfo(ctx, "w1:p2"); err != nil {
+		t.Fatal(err)
+	}
+	if info.Cwd != "/gone/dir (deleted)" || info.ForegroundCwd != "" {
+		t.Errorf("deleted-cwd handling: %+v", info)
+	}
+
+	// CLI failure surfaces an error.
+	fake.SetFailing(true)
+	if _, err := cli.PaneInfo(ctx, "w1:p1"); err == nil {
+		t.Error("failing CLI must surface an error")
+	}
+}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -102,7 +102,7 @@ func toolDefinitions() []map[string]any {
 	return []map[string]any{
 		{
 			"name":        "get_context",
-			"description": "Get the situation context for the pending Herd Auto Prompter decision request: situation type, agent type, options, permission verb, and a pane excerpt.",
+			"description": "Get the situation context for the pending Herd Auto Prompter decision request: situation type, agent type, options, permission verb, error summary, a pane excerpt (last N chars of the pane), the agent's herdr location (workspace_id, tab_id, pane_id, agent_id — usable with read-only herdr CLI queries such as `herdr pane get <pane_id>` or `herdr pane read <pane_id>`), and the pane's working directory (cwd/foreground_cwd; advisory — a deleted dir carries a ' (deleted)' suffix and either may be empty).",
 			"inputSchema": map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -29,6 +29,14 @@ type LocatorPort interface {
 	ListTabs(ctx context.Context) ([]domain.TabInfo, error)
 }
 
+// InspectorPort is implemented by Herdr adapters that can report per-pane
+// metadata (tab/workspace ids, working directory) for enriching the LLM
+// consult context. Optional: callers type-assert and degrade to empty
+// values when absent.
+type InspectorPort interface {
+	PaneInfo(ctx context.Context, paneID string) (domain.PaneInfo, error)
+}
+
 // EventPort is the inbound Herdr event subscription (raw socket).
 type EventPort interface {
 	// Subscribe streams agent-status transitions until ctx is done.


### PR DESCRIPTION
## Summary

The `get_context` MCP tool previously handed the consulted LLM only six fields, with a pane excerpt capped at 2,000 bytes — often too thin to suggest the decision the operator would make. This PR enriches the consult context so the model can decide with real situational awareness:

- **Configurable pane excerpt** — new `[llm] pane_excerpt_chars` (default **5000**, `0`/omitted restores the default). The excerpt comes from a dedicated deeper pane read (`chars/10` lines, floored at the classification budget); the shallow 120-line classification read is deliberately untouched so the first-match-wins classifier cannot latch onto stale scrollback.
- **herdr location ids** — `workspace_id`, `tab_id`, `pane_id`, `agent_id` in the context, so the model can run its own read-only `herdr` queries (`herdr pane get/read <pane_id>`); README documents the `--allowedTools` addition needed to permit that.
- **Pane working directory** — `cwd` / `foreground_cwd` via a new optional `ports.InspectorPort` (`herdr pane get`, same type-assert-and-degrade pattern as `LocatorPort`). Deleted dirs pass through herdr's literal `" (deleted)"` suffix.

Every enrichment fails soft: adapters without `InspectorPort`, a failing `pane get`, or a failing deep read degrade to transition-sourced ids, empty cwd, and the classification snapshot — a consult is never blocked.

## Robustness that came out of review

- Context assembly, staging, and the CLI launch all moved **inside the consult goroutine**, so a wedged herdr CLI can no longer stall the daemon main loop; staging failures funnel back through `handleLLMOutcome` as `persistence_failed`.
- `tail()` no longer cuts mid-rune (UTF-8-safe excerpt boundary).

## Example payload (captured live)

```json
{
  "situation_type": "approval", "agent_type": "claude",
  "options": null, "permission_verb": "proceed", "error_summary": "",
  "pane_excerpt": "Bash command: ls docs/\nDo you want to proceed? (y/n)",
  "workspace_id": "ws-1", "tab_id": "ws-1:t1",
  "pane_id": "pane-1", "agent_id": "pane-1",
  "cwd": "/home/op/project", "foreground_cwd": "/home/op/project"
}
```

## Testing

- 8 new unit tests: context keys/deep-read/TabID propagation, configurable size, `pane get` failure and InspectorPort-absent degradation, deep-read fallback, herdr envelope parsing (incl. `" (deleted)"` cwd + missing `foreground_cwd`), config default/override/zero-restore, `tail` rune-boundary.
- Full suite green, plus `go test ./internal/daemon/ -race`.
- E2E: fake herdr → real daemon → **real `claude`** consulted via the hap MCP server and staged its suggestion; the enriched payload above was replayed from that run via `hap mcp`.

## Notes

- Privacy: up to 2.5× more raw terminal content is handed to the local LLM CLI (no masking on this path, pre-existing); the new knob lets operators shrink it.
- Version bumped to **0.1.14**.