### PR TITLE
#1 test+feat: real-claude approval integration test + send-from-detail-view in Escalations (v0.1.16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,13 @@ HAP_ITEST_CLAUDE=1 go test -tags integration ./test/integration/ -v
 - Current cases: `TestRealPaneInfo` (herdr `pane get` → cwd/ids),
   `TestRealConfirmDeliversMenuDigit` (confirming a label reply selects the
   numbered menu — the send-content regression), `TestRealClaudeConsult`
-  (headless claude smoke, gated by `HAP_ITEST_CLAUDE=1`).
+  (gated by `HAP_ITEST_CLAUDE=1`) drives a **real Claude Code session
+  (`--model haiku`)** to a real approval menu, confirms it through the
+  plugin, and asserts the menu digit reached claude (the command runs).
+- The claude case skips (never fails) if it can't elicit a prompt; it needs a
+  path OUTSIDE claude's auto-approved dirs (`/tmp`, `/workspaces`,
+  `~/.claude`) to force the permission menu — it touches a `$HOME` dotfile.
+  Override the model with `HAP_ITEST_CLAUDE_MODEL`.
 
 **Recommended: run the integration suite once after finishing any feature**,
 before opening the PR — the unit suite fakes herdr, so only this catches real

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.1.15"
+version = "0.1.16"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -87,6 +87,10 @@ type detailView struct {
 	lines  []string                 // wrapped to the pane width at open/resize
 	offset int                      // first visible line (↑/↓ scroll)
 	build  func(width int) []string // rebuilds lines from the snapshot on resize
+	// confirmID is the escalation's audit id captured at open time, so
+	// enter confirms the record ON SCREEN even if a background refresh
+	// clamped the list cursor. 0 = not a confirmable escalation detail.
+	confirmID int64
 }
 
 // ruleItem is one navigable row of the Config tab.
@@ -282,7 +286,16 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.tab = (m.tab + tabCount - 1) % tabCount
 			m.cursor = 0
 			m.message = ""
-		case "esc", "q", "v", "enter":
+		case "enter":
+			// On an escalation's detail view, Enter confirms+sends the
+			// record shown (by its snapshotted id, not the live cursor) and
+			// returns to the list — no need to close and re-press.
+			if id := m.detail.confirmID; id != 0 {
+				m.detail = nil
+				return m.confirmAuditID(id)
+			}
+			m.detail = nil
+		case "esc", "q", "v":
 			m.detail = nil
 		}
 		return m, nil
@@ -460,7 +473,12 @@ func (m Model) confirmSelected() (tea.Model, tea.Cmd) {
 	if rec == nil {
 		return m, nil
 	}
-	id := rec.ID
+	return m.confirmAuditID(rec.ID)
+}
+
+// confirmAuditID confirms+sends a specific escalation by id (used by the
+// list and by the detail overlay, which confirms the record it snapshotted).
+func (m Model) confirmAuditID(id int64) (tea.Model, tea.Cmd) {
 	return m, m.do(fmt.Sprintf("confirmed #%d and sent", id), func(ctx context.Context) error {
 		return m.app.Confirm(ctx, id, true)
 	})
@@ -539,11 +557,16 @@ func (m Model) viewSelected() (tea.Model, tea.Cmd) {
 			r := *rec
 			build := func(width int) []string { return m.auditDetailLines(r, width) }
 			m.message = ""
-			m.detail = &detailView{
+			d := &detailView{
 				title: fmt.Sprintf("%s #%d", kind, r.ID),
 				lines: build(m.wrapWidth()),
 				build: build,
 			}
+			// Only the Escalations detail is confirmable via enter.
+			if m.tab == tabEscalations {
+				d.confirmID = r.ID
+			}
+			m.detail = d
 		}
 	}
 	return m, nil
@@ -1012,6 +1035,9 @@ func (m Model) View() string {
 
 func (m Model) helpLine() string {
 	if m.detail != nil {
+		if m.detail.confirmID != 0 {
+			return "enter: confirm+send  ↑/↓: scroll  tab: switch tab  esc/q/v: close"
+		}
 		return "↑/↓: scroll  tab: switch tab  esc/q/v: close"
 	}
 	common := "tab: switch  ↑/↓: select  p: pause  r: resume  q: quit"

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -513,4 +514,146 @@ func TestMaxContentWidthCapsRows(t *testing.T) {
 			t.Errorf("row exceeds the configured cap: %d cells: %q", n, ln)
 		}
 	}
+}
+
+// captureHerdr records inputs delivered to the agent pane.
+type captureHerdr struct{ sent []string }
+
+func (c *captureHerdr) Send(_ context.Context, _, input string) error {
+	c.sent = append(c.sent, input)
+	return nil
+}
+func (c *captureHerdr) ReadPane(context.Context, string, int) (string, error)        { return "", nil }
+func (c *captureHerdr) ListAgents(context.Context) ([]domain.AgentTransition, error) { return nil, nil }
+
+func TestEscalationDetailEnterConfirmsAndCloses(t *testing.T) {
+	// v opens the escalation detail; enter there must confirm+send and return
+	// to the list (detail closed), not merely close the overlay.
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	h := &captureHerdr{}
+	app := &frontend.App{Store: st, Herdr: h, ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	ctx := context.Background()
+	st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:p1", SituationType: domain.SituationApproval, Trigger: "apply?",
+		Action: "escalated", Status: "escalated", Suggestion: "respond: Yes",
+		CreatedAt: time.Now(),
+	})
+
+	m := New(ctx, app)
+	m.width, m.height = 100, 30
+	upd, _ := m.Update(refreshData(ctx, app))
+	m = upd.(Model)
+	m.tab = tabEscalations
+	m = press(t, m, "v")
+	if m.detail == nil {
+		t.Fatal("v on Escalations should open the detail view")
+	}
+
+	upd, cmd := m.Update(pressKeyMsg("enter"))
+	m = upd.(Model)
+	if m.detail != nil {
+		t.Error("enter in the escalation detail should close it and return to the list")
+	}
+	if cmd == nil {
+		t.Fatal("enter should issue the confirm+send command")
+	}
+	res, ok := cmd().(actionResultMsg)
+	if !ok || res.err != nil {
+		t.Fatalf("confirm+send should succeed, got %+v (ok=%v)", res, ok)
+	}
+	if len(h.sent) != 1 || h.sent[0] != "Yes" {
+		t.Errorf("expected the suggestion delivered to the agent, got %v", h.sent)
+	}
+}
+
+func TestAuditDetailEnterOnlyCloses(t *testing.T) {
+	// The send-on-enter shortcut is Escalations-only; the Audit detail's
+	// enter must still just close the overlay (no send).
+	m := testModel(t)
+	m.tab = tabAudit
+	m = press(t, m, "v")
+	if m.detail == nil {
+		t.Fatal("v on Audit should open the detail view")
+	}
+	upd, cmd := m.Update(pressKeyMsg("enter"))
+	m = upd.(Model)
+	if m.detail != nil {
+		t.Error("enter should close the audit detail")
+	}
+	if cmd != nil {
+		t.Error("audit detail enter must not trigger a send command")
+	}
+}
+
+func TestEscalationDetailEnterConfirmsSnapshotNotClampedCursor(t *testing.T) {
+	// Safety: if a background refresh shrinks the escalations list and clamps
+	// the cursor while the detail overlay is open, enter must confirm the
+	// record ON SCREEN (snapshotted at open), never whatever the cursor now
+	// points at.
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	h := &captureHerdr{}
+	app := &frontend.App{Store: st, Herdr: h, ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	ctx := context.Background()
+	idA, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:pA", SituationType: domain.SituationApproval, Trigger: "a",
+		Action: "escalated", Status: "escalated", Suggestion: "respond: Apple", CreatedAt: time.Now(),
+	})
+	idB, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:pB", SituationType: domain.SituationApproval, Trigger: "b",
+		Action: "escalated", Status: "escalated", Suggestion: "respond: Banana", CreatedAt: time.Now().Add(time.Second),
+	})
+
+	m := New(ctx, app)
+	m.width, m.height = 100, 30
+	upd, _ := m.Update(refreshData(ctx, app))
+	m = upd.(Model)
+	m.tab = tabEscalations
+
+	// Point the cursor at escalation B and open its detail.
+	for i := range m.data.escalations {
+		if m.data.escalations[i].ID == idB {
+			m.cursor = i
+		}
+	}
+	m = press(t, m, "v")
+	if m.detail == nil || m.detail.confirmID != idB {
+		t.Fatalf("detail should snapshot escalation B (id %d), got confirmID=%d", idB, m.detail.confirmID)
+	}
+
+	// Background: B gets resolved elsewhere; a refresh shrinks the list and
+	// clamps the cursor onto A.
+	st.UpdateAuditStatus(ctx, idB, "resolved")
+	upd, _ = m.Update(refreshData(ctx, app))
+	m = upd.(Model)
+	if len(m.data.escalations) != 1 || m.data.escalations[0].ID != idA {
+		t.Fatalf("expected only escalation A pending after resolve, got %+v", m.data.escalations)
+	}
+
+	// Enter must confirm B (the displayed snapshot), not A (the clamped cursor).
+	upd, cmd := m.Update(pressKeyMsg("enter"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("enter should issue a confirm command")
+	}
+	res, ok := cmd().(actionResultMsg)
+	if !ok || res.err != nil {
+		t.Fatalf("confirm should succeed, got %+v", res)
+	}
+	if !strings.Contains(res.message, fmt.Sprintf("#%d", idB)) {
+		t.Errorf("should confirm the displayed escalation #%d, message was %q", idB, res.message)
+	}
+	if len(h.sent) != 1 || h.sent[0] != "Banana" {
+		t.Errorf("should deliver B's suggestion, got %v", h.sent)
+	}
+	_ = idA
 }

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -15,6 +15,7 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xGosu/herdr-auto-pilot/internal/classify"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
 	"github.com/0xGosu/herdr-auto-pilot/internal/herdr"
@@ -61,6 +63,15 @@ func runHerdr(t *testing.T, args ...string) string {
 	return strings.TrimSpace(string(out))
 }
 
+// tryHerdr runs a best-effort herdr command with a bounded timeout, ignoring
+// the result — used for fire-and-forget keystrokes and teardown so a stuck
+// herdr can never wedge the test loop or cleanup.
+func tryHerdr(args ...string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = exec.CommandContext(ctx, herdrBin(), args...).Run()
+}
+
 // startMenuAgent spawns a scratch agent that presents a numbered menu
 // (bash `select`, exactly the shape Claude's approvals use) and returns its
 // pane id. The agent writes its picked option to markerPath.
@@ -90,7 +101,7 @@ func startMenuAgent(t *testing.T, markerPath string) string {
 	if pane == "" {
 		t.Fatalf("no pane id in agent start output: %s", out)
 	}
-	t.Cleanup(func() { _ = exec.Command(herdrBin(), "pane", "close", pane).Run() })
+	t.Cleanup(func() { tryHerdr("pane", "close", pane) })
 	return pane
 }
 
@@ -182,26 +193,176 @@ func TestRealConfirmDeliversMenuDigit(t *testing.T) {
 	t.Fatal("confirm did not drive the menu selection (send did not land)")
 }
 
-// TestRealClaudeConsult drives a real Claude Code consult end to end. It is
-// gated behind HAP_ITEST_CLAUDE=1 because it needs a working, authenticated
-// claude CLI and spends tokens.
+// claudeModel is the model alias the real-claude cases run with; haiku keeps
+// responses fast. Override with HAP_ITEST_CLAUDE_MODEL.
+func claudeModel() string {
+	if m := os.Getenv("HAP_ITEST_CLAUDE_MODEL"); m != "" {
+		return m
+	}
+	return "haiku"
+}
+
+// startClaudeAgent launches an interactive Claude Code session in a herdr
+// pane, with permission prompting on so a Bash tool call raises an approval
+// menu, and returns its pane id. It also clears the first-run "trust this
+// folder" prompt so the REPL is ready for input.
+func startClaudeAgent(t *testing.T, cli *herdr.CLI, cwd string) string {
+	t.Helper()
+	out := runHerdr(t, "agent", "start", "hapclaude", "--cwd", cwd, "--no-focus",
+		"--", "claude", "--model", claudeModel(), "--permission-mode", "default")
+	var resp struct {
+		Result struct {
+			Agent struct {
+				PaneID string `json:"pane_id"`
+			} `json:"agent"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("parse claude agent start: %v (%s)", err, out)
+	}
+	pane := resp.Result.Agent.PaneID
+	if pane == "" {
+		t.Fatalf("no pane id from claude agent start: %s", out)
+	}
+	t.Cleanup(func() { tryHerdr("pane", "close", pane) })
+
+	// Claude asks to trust a new folder on first start; option 1 ("Yes, I
+	// trust") is pre-selected, so Enter clears it. Wait for the REPL prompt.
+	deadline := time.Now().Add(40 * time.Second)
+	for time.Now().Before(deadline) {
+		content, _ := cli.ReadPaneVisible(context.Background(), pane, 30)
+		if strings.Contains(content, "trust this folder") || strings.Contains(content, "I trust") {
+			tryHerdr("pane", "send-keys", pane, "enter")
+			time.Sleep(3 * time.Second)
+			continue
+		}
+		// Ready REPL = the input caret plus the status bar's context-window
+		// percentage (e.g. "(0%)") — model-independent, unlike the model
+		// name, so a full-id HAP_ITEST_CLAUDE_MODEL still matches. Both can
+		// flash mid-boot before input is accepted, so settle first.
+		// (Screen shapes verified against Claude Code 2.1.206.)
+		if strings.Contains(content, "❯") && strings.Contains(content, "%)") {
+			time.Sleep(4 * time.Second)
+			return pane
+		}
+		time.Sleep(1 * time.Second)
+	}
+	t.Skip("claude REPL did not become ready within 40s (slow start or unauthenticated claude)")
+	return pane
+}
+
+// driveToApproval sends prompt to claude and waits for an approval menu,
+// re-sending once if the first attempt does not surface a prompt (a keystroke
+// lost to a still-initializing REPL is the common flake).
+func driveToApproval(t *testing.T, cli *herdr.CLI, pane, prompt string) (domain.Situation, bool) {
+	t.Helper()
+	for attempt := 0; attempt < 2; attempt++ {
+		if err := cli.Send(context.Background(), pane, prompt); err != nil {
+			t.Fatalf("send prompt to claude: %v", err)
+		}
+		if sit, ok := waitForApproval(t, cli, pane, 45*time.Second); ok {
+			return sit, true
+		}
+	}
+	return domain.Situation{}, false
+}
+
+// waitForApproval polls the pane's visible screen until the classifier sees
+// an approval/choice with a numbered option set, and returns that situation.
+// It returns ok=false if no approval menu appears within the deadline (e.g.
+// claude auto-approved or never called the tool) so the caller can skip.
+func waitForApproval(t *testing.T, cli *herdr.CLI, pane string, within time.Duration) (domain.Situation, bool) {
+	t.Helper()
+	cls := classify.New(nil)
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		content, err := cli.ReadPaneVisible(context.Background(), pane, 60)
+		if err == nil {
+			s := cls.Classify("claude", "blocked", content)
+			if (s.Type == domain.SituationApproval || s.Type == domain.SituationChoice) &&
+				len(domain.ParseNumberedOptions(content)) > 0 {
+				return s, true
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return domain.Situation{}, false
+}
+
+// TestRealClaudeConsult drives a REAL Claude Code session end to end: it
+// makes claude raise an approval menu, then confirms it through the plugin's
+// send path and verifies the menu digit actually reached claude (the command
+// runs). Gated behind HAP_ITEST_CLAUDE=1 — it needs an authenticated claude
+// and spends tokens. Skips (never fails) if it cannot elicit a prompt.
 func TestRealClaudeConsult(t *testing.T) {
 	if os.Getenv("HAP_ITEST_CLAUDE") != "1" {
 		t.Skip("set HAP_ITEST_CLAUDE=1 to run the real Claude consult test")
 	}
+	requireHerdr(t)
 	if _, err := exec.LookPath("claude"); err != nil {
 		t.Skipf("claude CLI not found: %v", err)
 	}
-	// A trivial prompt that must call the two hap MCP tools would require a
-	// staged request + running MCP server; that full path is covered by the
-	// e2e_harness. Here we only assert the claude CLI is invokable headless.
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-	out, err := exec.CommandContext(ctx, "claude", "-p", "reply with the single word OK").CombinedOutput()
+
+	cli := herdr.NewCLI()
+	work := t.TempDir()
+
+	// The marker must live OUTSIDE claude's auto-approved directories
+	// (/tmp, /workspaces, ~/.claude and the trusted cwd) so touching it
+	// actually raises a permission prompt. A dotfile in $HOME's root
+	// qualifies and is cross-platform.
+	home, err := os.UserHomeDir()
 	if err != nil {
-		t.Fatalf("claude -p failed: %v (%s)", err, string(out))
+		t.Skipf("cannot resolve home dir: %v", err)
 	}
-	if !strings.Contains(strings.ToUpper(string(out)), "OK") {
-		t.Errorf("claude did not reply as expected: %s", string(out))
+	// Per-PID name so concurrent runs don't collide, and a SIGKILL leaves at
+	// most one identifiable stray file.
+	marker := filepath.Join(home, fmt.Sprintf(".hap-claude-itest-marker-%d", os.Getpid()))
+	_ = os.Remove(marker)
+	t.Cleanup(func() { _ = os.Remove(marker) })
+
+	pane := startClaudeAgent(t, cli, work)
+
+	// Ask claude to run a Bash command it must request permission for; it
+	// renders a numbered "Do you want to proceed?" menu — exactly the shape
+	// the send fix targets.
+	prompt := "Use the Bash tool to run exactly this one command and nothing else: touch " + marker
+	sit, ok := driveToApproval(t, cli, pane, prompt)
+	if !ok {
+		t.Skip("claude did not raise an approval menu (auto-approved or slow); nothing to assert")
 	}
+	t.Logf("claude approval detected; options=%v", sit.Options)
+
+	// Confirm through the plugin, exactly as an operator pressing Enter in
+	// the Escalations tab would: the learned reply is the LABEL "Yes"; the
+	// send fix must deliver the menu digit so claude proceeds.
+	st, err := store.Open(filepath.Join(work, "hap.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	app := &frontend.App{Store: st, Herdr: cli, Author: "itest"}
+	ctx := context.Background()
+	id, err := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: pane, SituationType: domain.SituationApproval, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: "LLM suggested: Yes", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// If the digit reached claude, the approval clears and the Bash command
+	// runs, creating the marker file.
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(marker); err == nil {
+			return // claude proceeded — the digit landed
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	pane1, _ := cli.ReadPaneVisible(ctx, pane, 40)
+	t.Fatalf("claude did not proceed after confirm; the menu digit did not land.\npane:\n%s", pane1)
 }

--- a/test/integration/testdata/config.toml
+++ b/test/integration/testdata/config.toml
@@ -22,9 +22,12 @@
   max_error_retries = 2
 
 [llm]
+# The prompt must come immediately after -p (claude quirk; the plugin also
+# auto-repairs it). --model haiku keeps the consult fast in the local suite.
 command = [
   "claude", "-p",
   "Use the hap MCP tools: call get_context, decide what the operator would answer, then call submit_decision.",
+  "--model", "haiku",
   "--mcp-config", '{"mcpServers":{"hap":{"command":"{self}","args":["mcp"],"env":{"HAP_REQUEST_ID":"{request_id}"}}}}',
   "--allowedTools", "mcp__hap__get_context,mcp__hap__submit_decision",
 ]


### PR DESCRIPTION
Two changes on top of the numbered-menu send fix (PR #2):

## 1. Real-claude end-to-end integration test

Extends `TestRealClaudeConsult` (local suite, build tag `integration`, excluded from CI) from a headless smoke into a **full real-world validation of the send fix**:
1. Starts a real **Claude Code** session (`--model haiku`) in a herdr pane, clears the first-run "trust folder" prompt.
2. Asks claude to run a Bash command touching a file **outside** its auto-approved dirs → a real numbered approval menu appears.
3. Confirms through the real `frontend.App` send path (learned reply is the label `"Yes"`).
4. Asserts the **menu digit reached claude**: the approval clears and the command runs (marker file created).

Skips (never fails) if it can't elicit a prompt; gated by `HAP_ITEST_CLAUDE=1`. `testdata/config.toml` consult recipe uses `--model haiku`. Verified live (~13s, full suite green).

## 2. TUI: send an escalation from its detail view

In the **Escalations** tab, pressing **`enter` inside a row's detail view** (opened with `v`) now confirms+sends that escalation and returns to the list — no need to close the overlay first. The detail snapshots the escalation's audit id at open time and enter confirms **that** record, so a background refresh that clamps the list cursor can never send the wrong agent's reply (covered by a dedicated safety test). Audit/Agents/Rules detail views are unaffected. Help line shows `enter: confirm+send` for escalation details.

## Testing

- New TUI unit tests: enter confirms+sends+closes on an escalation detail; audit-detail enter sends nothing; refresh-induced cursor clamp still confirms the on-screen record.
- Full `go test ./...` green; integration suite passes live.
- Code review applied (the cursor-clamp safety fix came from it).

Version bumped to **0.1.16** (the TUI change is a product feature). Tag `v0.1.16` after merge to release.