### PR TITLE
#1 feat: LLM rewrite of literal outbound text (llm.rewrite_command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,56 @@ suggestion is re-gated through the same allowlist, kill switch, and rate
 guards; with `auto_act = true` it may act only when it doesn't contradict
 your learned history. On timeout or no submission the situation escalates.
 
+### LLM rewrite of literal replies (optional)
+
+When a learned rule resolves to **literal free text** — an idle next-task
+prompt, an error retry command, a free-text approval reply — the plugin can
+pass that text through a one-shot LLM CLI to adapt it to what's actually on
+the agent's screen before sending. Unlike the consult fallback there is no
+MCP round-trip: the CLI is run once and its **stdout is the rewritten
+text**.
+
+```toml
+[llm]
+rewrite_command = [
+  "claude", "-p",
+  "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
+  "--model", "haiku",
+]
+rewrite_timeout_seconds = 30   # omitted: inherits timeout_seconds
+# Wraps the original when the rewrite fails (never blocks the send):
+rewrite_fallback_template = "You must act based on the following: {original_text}"
+```
+
+Placeholders in `rewrite_command`: `{text}` (the literal reply a rule
+resolved to), `{situation_type}`, `{agent_type}`, `{pane_excerpt}` (last
+`pane_excerpt_chars` characters of the live pane). The same CLI auto-repair
+as `llm.command` applies (on the raw template, before substitution). No
+shell is involved — each element is one argv entry — but `{text}` and
+`{pane_excerpt}` carry untrusted pane content: embed them inside a prompt
+string (as in the example) rather than as standalone argv elements, so a
+value starting with `-` can never be parsed as a flag; the same values are
+also available as `HAP_REWRITE_TEXT` / `HAP_SITUATION_TYPE` /
+`HAP_AGENT_TYPE` env vars.
+
+Invariants:
+
+- **Numbered-menu answers are never rewritten** — a mapped digit reaches
+  the menu untouched. Only literal free text goes through the rewriter.
+- **A rewrite failure never blocks the send**: on error, timeout, or empty
+  output the original text is delivered wrapped in
+  `rewrite_fallback_template` (`{original_text}` placeholder; empty or
+  placeholder-less templates fall back to the built-in default).
+- **Safety controls still apply to the rewritten text**: output matching
+  the never-auto allowlist or the irreversible-operation heuristic is
+  discarded in favor of the wrapped original; if even that trips, the
+  situation escalates instead of sending. Kill switch, rate guard, and a
+  staleness re-check (the pane must still show the same situation) run
+  again at delivery time.
+- **Learning is unaffected**: decision history records the original
+  learned action, never the rewritten text, so rule confidence and the
+  variance guard keep working.
+
 #### Troubleshooting the fallback
 
 - **Escalations citing `not found in PATH`** — the daemon inherits herdr's

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -171,6 +171,8 @@ func runDaemon(ctx context.Context, paths config.Paths, args []string) error {
 			DBPath:          paths.DBPath(),
 			ControlPath:     paths.ControlSocketPath(),
 			Store:           st,
+			RewriteTemplate: cfg.LLM.RewriteCommand,
+			RewriteTimeout:  cfg.RewriteTimeout(),
 		}
 	}
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.1.16"
+version = "0.1.17"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,20 @@ type LLM struct {
 	// in the consult context handed to the LLM. Zero or omitted restores
 	// the 5000-char default.
 	PaneExcerptChars int `toml:"pane_excerpt_chars"`
+	// RewriteCommand is the argv template for the one-shot rewrite of
+	// literal outbound text (idle next-task prompts, error retry commands,
+	// free-text replies — never menu digits); placeholders {text},
+	// {situation_type}, {agent_type}, {pane_excerpt}. The rewritten text
+	// is read from the CLI's stdout. Empty means literal text is sent
+	// unchanged.
+	RewriteCommand []string `toml:"rewrite_command"`
+	// RewriteTimeoutSeconds bounds one rewrite run; zero or omitted
+	// inherits timeout_seconds.
+	RewriteTimeoutSeconds int `toml:"rewrite_timeout_seconds"`
+	// RewriteFallbackTemplate wraps the original text when the rewrite
+	// fails ({original_text} placeholder). Empty uses the built-in
+	// default; a rewrite failure never blocks the send.
+	RewriteFallbackTemplate string `toml:"rewrite_fallback_template"`
 }
 
 // TaskSource points an agent or workspace at a declared next-task list (FR-011).
@@ -136,6 +150,9 @@ func Default() Config {
 			MaxAutoPromptsPerMinute:   10,
 			MaxErrorRetries:           2,
 		},
+		// RewriteTimeoutSeconds stays zero here: Load seeds from Default
+		// before unmarshalling, and a non-zero seed would mask "omitted →
+		// inherit timeout_seconds" in fillZeroes.
 		LLM: LLM{TimeoutSeconds: 60, PaneExcerptChars: 5000},
 	}
 }
@@ -274,11 +291,23 @@ func (c *Config) fillZeroes() {
 	if c.LLM.PaneExcerptChars <= 0 {
 		c.LLM.PaneExcerptChars = d.LLM.PaneExcerptChars
 	}
+	// RewriteTimeoutSeconds is deliberately NOT filled: it inherits its
+	// sibling timeout_seconds dynamically (RewriteTimeout), and a Save
+	// after filling would freeze the inherited value into config.toml.
 }
 
 // LLMTimeout returns the configured LLM timeout as a duration.
 func (c Config) LLMTimeout() time.Duration {
 	return time.Duration(c.LLM.TimeoutSeconds) * time.Second
+}
+
+// RewriteTimeout returns the rewrite timeout: rewrite_timeout_seconds, or —
+// when zero/omitted — the consult timeout_seconds.
+func (c Config) RewriteTimeout() time.Duration {
+	if c.LLM.RewriteTimeoutSeconds <= 0 {
+		return c.LLMTimeout()
+	}
+	return time.Duration(c.LLM.RewriteTimeoutSeconds) * time.Second
 }
 
 // Save writes the config to path in TOML form (used by `config set`).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestLoadMissingFileYieldsDefaults(t *testing.T) {
@@ -304,5 +305,84 @@ func TestTUIMaxContentWidthParsed(t *testing.T) {
 	os.WriteFile(path, []byte("[learning]\ngraduation_n = 5\n"), 0o600)
 	if cfg, _ = Load(path); cfg.TUI.MaxContentWidth != 0 {
 		t.Errorf("omitted max_content_width should default to 0, got %d", cfg.TUI.MaxContentWidth)
+	}
+}
+
+func TestRewriteConfigKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+
+	// Omitted entirely: disabled command, timeout inherits the default
+	// consult timeout, template empty (domain resolves the default).
+	os.WriteFile(path, []byte("[llm]\ncommand = [\"claude\"]\n"), 0o600)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.LLM.RewriteCommand) != 0 {
+		t.Errorf("rewrite_command should default empty, got %v", cfg.LLM.RewriteCommand)
+	}
+	// Inheritance is resolved at use time, never materialized: a later Save
+	// must not freeze the inherited value into config.toml.
+	if cfg.LLM.RewriteTimeoutSeconds != 0 {
+		t.Errorf("omitted rewrite timeout should stay 0 (inherit at use time), got %d", cfg.LLM.RewriteTimeoutSeconds)
+	}
+	if cfg.RewriteTimeout() != 60*time.Second {
+		t.Errorf("RewriteTimeout() = %v, want inherited default 60s", cfg.RewriteTimeout())
+	}
+	if cfg.LLM.RewriteFallbackTemplate != "" {
+		t.Errorf("fallback template should stay empty (domain default applies), got %q", cfg.LLM.RewriteFallbackTemplate)
+	}
+
+	// Omitted rewrite timeout inherits a CUSTOM consult timeout — even
+	// after a Save/Load cycle (the zero survives the round trip).
+	os.WriteFile(path, []byte("[llm]\ntimeout_seconds = 120\n"), 0o600)
+	if cfg, err = Load(path); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.RewriteTimeout() != 120*time.Second {
+		t.Errorf("RewriteTimeout() = %v, want inherited 120s", cfg.RewriteTimeout())
+	}
+	if err := Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg, err = Load(path); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.LLM.RewriteTimeoutSeconds != 0 || cfg.RewriteTimeout() != 120*time.Second {
+		t.Errorf("Save must not freeze the inherited timeout: raw=%d effective=%v",
+			cfg.LLM.RewriteTimeoutSeconds, cfg.RewriteTimeout())
+	}
+
+	// Explicit values are honored verbatim.
+	os.WriteFile(path, []byte(`[llm]
+timeout_seconds = 120
+rewrite_command = ["claude", "-p", "rewrite: {text}"]
+rewrite_timeout_seconds = 30
+rewrite_fallback_template = "Do this: {original_text}"
+`), 0o600)
+	if cfg, err = Load(path); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.LLM.RewriteCommand) != 3 || cfg.LLM.RewriteCommand[2] != "rewrite: {text}" {
+		t.Errorf("rewrite_command lost: %v", cfg.LLM.RewriteCommand)
+	}
+	if cfg.LLM.RewriteTimeoutSeconds != 30 {
+		t.Errorf("explicit rewrite timeout lost: %d", cfg.LLM.RewriteTimeoutSeconds)
+	}
+	if cfg.LLM.RewriteFallbackTemplate != "Do this: {original_text}" {
+		t.Errorf("fallback template lost: %q", cfg.LLM.RewriteFallbackTemplate)
+	}
+
+	// Save/Load round trip keeps all three keys.
+	if err := Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	rt, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rt.LLM.RewriteCommand) != 3 || rt.LLM.RewriteTimeoutSeconds != 30 ||
+		rt.LLM.RewriteFallbackTemplate != "Do this: {original_text}" {
+		t.Errorf("round trip lost rewrite keys: %+v", rt.LLM)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -55,13 +55,20 @@ type Daemon struct {
 	classifier *classify.Classifier
 	llm        ports.LLMPort
 
-	transitions chan domain.AgentTransition
-	nudges      chan control.Kind
-	llmResults  chan llmOutcome
+	transitions    chan domain.AgentTransition
+	nudges         chan control.Kind
+	llmResults     chan llmOutcome
+	rewriteResults chan rewriteOutcome
 
 	// lastAutoSend tracks our own sends so a subsequent "working"
 	// transition is attributed to automation, not the human.
 	lastAutoSend map[string]time.Time
+
+	// rewriteInFlight tracks the one live outbound-text rewrite per agent;
+	// the token lets the outcome handler drop superseded results. Guarded
+	// by mu alongside rewriteSeq.
+	rewriteInFlight map[string]rewriteFlight
+	rewriteSeq      uint64
 
 	// wsNames caches the workspace id→name listing for task-source
 	// workspace matching; refreshed after workspaceCacheTTL.
@@ -77,6 +84,28 @@ type llmOutcome struct {
 	err       error
 }
 
+// rewriteFlight is the registry entry for one in-flight outbound rewrite.
+type rewriteFlight struct {
+	signature string
+	token     uint64
+	cancel    context.CancelFunc
+}
+
+// rewriteOutcome carries a finished rewrite back into the main loop. The
+// fallback template is snapshotted at handoff so a config reload mid-flight
+// cannot change the failure behavior of an already-launched rewrite.
+type rewriteOutcome struct {
+	situation domain.Situation
+	sig       domain.SignatureResult
+	tr        domain.AgentTransition
+	dec       domain.Decision
+	learned   string // original learned form for RecordDecision
+	fallback  string // snapshotted rewrite_fallback_template
+	rewritten string
+	err       error
+	token     uint64
+}
+
 // New creates a daemon.
 func New(opt Options) (*Daemon, error) {
 	if opt.Clock == nil {
@@ -89,11 +118,13 @@ func New(opt Options) (*Daemon, error) {
 		opt.PaneReadLines = 120
 	}
 	d := &Daemon{
-		opt:          opt,
-		transitions:  make(chan domain.AgentTransition, 256),
-		nudges:       make(chan control.Kind, 16),
-		llmResults:   make(chan llmOutcome, 16),
-		lastAutoSend: map[string]time.Time{},
+		opt:             opt,
+		transitions:     make(chan domain.AgentTransition, 256),
+		nudges:          make(chan control.Kind, 16),
+		llmResults:      make(chan llmOutcome, 16),
+		rewriteResults:  make(chan rewriteOutcome, 16),
+		lastAutoSend:    map[string]time.Time{},
+		rewriteInFlight: map[string]rewriteFlight{},
 	}
 	if err := d.reload(); err != nil {
 		return nil, err
@@ -225,6 +256,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 				d.handleLLMOutcome(ctx, res)
 				return nil
 			})
+		case res := <-d.rewriteResults:
+			logging.Guard("rewrite-result", func() error {
+				d.handleRewriteOutcome(ctx, res)
+				return nil
+			})
 		}
 	}
 }
@@ -344,6 +380,15 @@ func (d *Daemon) handleTransition(ctx context.Context, tr domain.AgentTransition
 
 	decision := domain.Decide(in)
 
+	// Any newer decision for this agent owns the pane: an in-flight rewrite
+	// for a DIFFERENT situation must never deliver behind it. A same-
+	// signature send is kept — startRewrite drops it as a duplicate.
+	keepSig := ""
+	if decision.Action == domain.ActionSend {
+		keepSig = sig.Signature
+	}
+	d.cancelRewriteExcept(situation.AgentID, keepSig)
+
 	switch decision.Action {
 	case domain.ActionSend:
 		d.act(ctx, situation, sig, decision, tr, now)
@@ -352,6 +397,31 @@ func (d *Daemon) handleTransition(ctx context.Context, tr domain.AgentTransition
 	default:
 		d.escalate(ctx, situation, sig, decision, tr, now)
 	}
+}
+
+// truncateRunes shortens s to at most n runes, marking the cut with an
+// ellipsis (rune-safe: never splits a UTF-8 sequence).
+func truncateRunes(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n]) + "…"
+}
+
+// cancelRewriteExcept invalidates the agent's in-flight rewrite unless it is
+// for keepSig. The cancelled flight's outcome is dropped by the token check.
+func (d *Daemon) cancelRewriteExcept(agentID, keepSig string) {
+	d.mu.Lock()
+	fl, ok := d.rewriteInFlight[agentID]
+	if !ok || (keepSig != "" && fl.signature == keepSig) {
+		d.mu.Unlock()
+		return
+	}
+	delete(d.rewriteInFlight, agentID)
+	d.mu.Unlock()
+	fl.cancel()
+	slog.Info("in-flight rewrite superseded by a newer decision", "agent", agentID)
 }
 
 // readDecisionState gathers all store reads for one decision. The latest
@@ -408,10 +478,65 @@ func (d *Daemon) act(ctx context.Context, s domain.Situation, sig domain.Signatu
 		return
 	}
 
+	// Numbered menus (Claude approvals/choices) accept the option's digit,
+	// not the label text; deliver the keystroke the menu expects. Free-text
+	// situations deliver the literal reply. s.Content is the classification
+	// snapshot, which carries the menu for the situation being acted on.
+	outbound, menuMapped := domain.DeliverOutbound(s.Type, s.Content, dec.Input)
+
+	// Literal free text can be adapted to the live pane by the optional
+	// rewrite CLI; menu digits must reach the menu untouched. The send
+	// completes asynchronously via handleRewriteOutcome, so the learned
+	// action is pinned NOW — situation state may drift before delivery.
+	if rw, ok := d.llmPort().(ports.RewriterPort); ok && rw.RewriteConfigured() &&
+		!menuMapped && dec.Input != "" {
+		d.startRewrite(ctx, rw, s, sig, dec, tr, d.learnedAction(ctx, s, dec))
+		return
+	}
+
+	// learned stays empty: deliverAutonomous computes it after the send,
+	// exactly as the pre-rewrite code did.
+	d.deliverAutonomous(ctx, s, sig, dec, tr, delivery{
+		sendText: outbound, input: dec.Input, rationale: dec.Rationale,
+	}, now)
+}
+
+// learnedAction is the action recorded in decision history for a rule-path
+// send (idle learns symbolically so signatures generalize across tasks).
+func (d *Daemon) learnedAction(ctx context.Context, s domain.Situation, dec domain.Decision) string {
+	switch {
+	case dec.OptionID != "":
+		return dec.OptionID
+	case s.Type == domain.SituationIdle:
+		if d.declaredTaskFor(ctx, s) != nil {
+			return domain.ActionNextDeclaredTask
+		}
+		return domain.ActionNextInferredTask
+	}
+	return dec.Input
+}
+
+// delivery describes one autonomous send: what to write to the pane, what
+// to audit, and what to learn.
+type delivery struct {
+	sendText  string // exactly what is written to the pane
+	input     string // audit Input and the "auto:" action label
+	rationale string
+	llmOutput string // rewrite CLI diagnostics, when applicable
+	learned   string // ChosenAction recorded for learning
+}
+
+// deliverAutonomous is the shared tail of every autonomous rule-path send:
+// pre-action audit guard (FR-024), delivery, and the daemon-owned learning
+// and counter writes.
+func (d *Daemon) deliverAutonomous(ctx context.Context, s domain.Situation, sig domain.SignatureResult,
+	dec domain.Decision, tr domain.AgentTransition, del delivery, now time.Time) {
+
 	auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: s.AgentID, Signature: sig.Signature, Trigger: trigger(tr),
-		SituationType: s.Type, Action: "auto:" + dec.Input, Input: dec.Input,
-		Confidence: dec.Confidence, Rationale: dec.Rationale, Status: "auto", CreatedAt: now,
+		SituationType: s.Type, Action: "auto:" + del.input, Input: del.input,
+		Confidence: dec.Confidence, Rationale: del.rationale, LLMOutput: del.llmOutput,
+		Status: "auto", CreatedAt: now,
 	})
 	if err != nil {
 		slog.Error("audit write failed; blocking autonomous action (FR-024)", "error", err)
@@ -420,12 +545,7 @@ func (d *Daemon) act(ctx context.Context, s domain.Situation, sig domain.Signatu
 		return
 	}
 
-	// Numbered menus (Claude approvals/choices) accept the option's digit,
-	// not the label text; deliver the keystroke the menu expects. Free-text
-	// situations deliver the literal reply. s.Content is the classification
-	// snapshot, which carries the menu for the situation being acted on.
-	outbound := domain.DeliverKeystroke(s.Type, s.Content, dec.Input)
-	if err := d.opt.Herdr.Send(ctx, s.PaneID, outbound); err != nil {
+	if err := d.opt.Herdr.Send(ctx, s.PaneID, del.sendText); err != nil {
 		slog.Error("agent send failed; escalating", "pane", s.PaneID, "error", err)
 		d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
 		d.notify(ctx, "Herd Auto Prompter: action delivery failed",
@@ -437,18 +557,12 @@ func (d *Daemon) act(ctx context.Context, s domain.Situation, sig domain.Signatu
 	d.lastAutoSend[s.AgentID] = now
 	d.mu.Unlock()
 
-	// Learning + counters (daemon-owned hot-path rows).
-	learned := dec.Input
-	switch {
-	case dec.OptionID != "":
-		learned = dec.OptionID
-	case s.Type == domain.SituationIdle:
-		// idle actions are learned symbolically
-		if d.declaredTaskFor(ctx, s) != nil {
-			learned = domain.ActionNextDeclaredTask
-		} else {
-			learned = domain.ActionNextInferredTask
-		}
+	// Learning + counters (daemon-owned hot-path rows). The rewrite path
+	// pins the learned action at decision time; the synchronous path
+	// resolves it here, after the send, as it always has.
+	learned := del.learned
+	if learned == "" {
+		learned = d.learnedAction(ctx, s, dec)
 	}
 	if _, err := d.opt.Store.RecordDecision(ctx, domain.DecisionRecord{
 		Signature: sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
@@ -480,7 +594,7 @@ func (d *Daemon) act(ctx context.Context, s domain.Situation, sig domain.Signatu
 
 	slog.Info("automated action delivered",
 		"agent", s.AgentID, "situation", s.Type, "confidence", dec.Confidence,
-		"rationale", dec.Rationale, "audit_id", auditID)
+		"rationale", del.rationale, "audit_id", auditID)
 }
 
 // escalate records and surfaces an escalation: no input is sent (FR-018).
@@ -559,25 +673,7 @@ func (d *Daemon) consultLLM(ctx context.Context, cfg config.Config, s domain.Sit
 // get_context MCP tool: the classified situation, a pane excerpt, the
 // agent's herdr location, and the pane working directory.
 func (d *Daemon) consultContext(ctx context.Context, cfg config.Config, s domain.Situation) []byte {
-	chars := cfg.LLM.PaneExcerptChars
-	if chars <= 0 {
-		chars = config.Default().LLM.PaneExcerptChars
-	}
-
-	// The classification read is kept shallow so the first-match-wins
-	// classifier does not latch onto stale scrollback; the LLM excerpt
-	// gets its own deeper read (~10 chars/line is a conservative floor).
-	excerpt := s.Content
-	lines := chars / 10
-	if lines < d.opt.PaneReadLines {
-		lines = d.opt.PaneReadLines
-	}
-	if deep, err := d.opt.Herdr.ReadPane(ctx, s.PaneID, lines); err == nil {
-		excerpt = deep
-	} else {
-		slog.Warn("deep pane read for LLM context failed; using classification snapshot",
-			"pane", s.PaneID, "error", err)
-	}
+	excerpt := d.paneExcerpt(ctx, cfg, s)
 
 	// Pane location and cwd come from `pane get`; degrade to empty values
 	// when the adapter cannot report them (ports.InspectorPort is optional).
@@ -604,7 +700,7 @@ func (d *Daemon) consultContext(ctx context.Context, cfg config.Config, s domain
 		"options":         s.Options,
 		"permission_verb": s.PermissionVerb,
 		"error_summary":   s.ErrorSummary,
-		"pane_excerpt":    tail(excerpt, chars),
+		"pane_excerpt":    excerpt,
 		"workspace_id":    workspaceID,
 		"tab_id":          tabID,
 		"pane_id":         s.PaneID,
@@ -613,6 +709,235 @@ func (d *Daemon) consultContext(ctx context.Context, cfg config.Config, s domain
 		"foreground_cwd":  info.ForegroundCwd,
 	})
 	return contextJSON
+}
+
+// paneExcerpt reads a deep pane excerpt (last llm.pane_excerpt_chars) for
+// LLM-facing context. It reads the VISIBLE screen: the consuming "recent"
+// delta was already drained by this transition's classification read, so a
+// ReadPane here would often return just the cursor line. A failed or empty
+// read keeps the classification snapshot (~10 chars/line is a conservative
+// floor for the line count).
+func (d *Daemon) paneExcerpt(ctx context.Context, cfg config.Config, s domain.Situation) string {
+	chars := cfg.LLM.PaneExcerptChars
+	if chars <= 0 {
+		chars = config.Default().LLM.PaneExcerptChars
+	}
+	excerpt := s.Content
+	lines := chars / 10
+	if lines < d.opt.PaneReadLines {
+		lines = d.opt.PaneReadLines
+	}
+	if deep, err := d.readVisible(ctx, s.PaneID, lines); err == nil && strings.TrimSpace(deep) != "" {
+		excerpt = deep
+	} else if err != nil {
+		slog.Warn("deep pane read for LLM context failed; using classification snapshot",
+			"pane", s.PaneID, "error", err)
+	}
+	return tail(excerpt, chars)
+}
+
+// startRewrite hands a literal outbound text to the rewrite CLI. The
+// subprocess runs in a goroutine — it must never stall the main loop — and
+// the send completes in handleRewriteOutcome. One flight per agent: a
+// duplicate transition for the same signature is dropped, a new situation
+// cancels and supersedes the old flight.
+func (d *Daemon) startRewrite(ctx context.Context, rw ports.RewriterPort, s domain.Situation,
+	sig domain.SignatureResult, dec domain.Decision, tr domain.AgentTransition, learned string) {
+
+	cfg, _, _ := d.snapshot()
+
+	d.mu.Lock()
+	if fl, ok := d.rewriteInFlight[s.AgentID]; ok {
+		if fl.signature == sig.Signature {
+			d.mu.Unlock()
+			slog.Info("rewrite already in flight for this situation; dropping duplicate",
+				"agent", s.AgentID)
+			return
+		}
+		fl.cancel() // a newer situation owns the pane now
+	}
+	d.rewriteSeq++
+	token := d.rewriteSeq
+	rctx, cancel := context.WithCancel(ctx)
+	d.rewriteInFlight[s.AgentID] = rewriteFlight{signature: sig.Signature, token: token, cancel: cancel}
+	d.mu.Unlock()
+
+	go func() {
+		outcome := rewriteOutcome{
+			situation: s, sig: sig, tr: tr, dec: dec, learned: learned,
+			fallback: cfg.LLM.RewriteFallbackTemplate, token: token,
+		}
+		outcome.err = logging.Guard("llm-rewrite", func() error {
+			req := domain.RewriteRequest{
+				Text: dec.Input, SituationType: s.Type, AgentType: s.AgentType,
+				PaneExcerpt: d.paneExcerpt(rctx, cfg, s),
+			}
+			text, err := rw.Rewrite(rctx, req)
+			outcome.rewritten = text
+			return err
+		})
+		select {
+		case d.rewriteResults <- outcome:
+		case <-ctx.Done():
+		}
+	}()
+}
+
+// rewriteSuggestion formats the original action as an escalation suggestion
+// the front-ends' Confirm flow can replay (same prefixes SuggestedAction
+// parses), for the rare case a rewrite outcome must escalate.
+func rewriteSuggestion(sitType domain.SituationType, learned, original string) string {
+	switch sitType {
+	case domain.SituationApproval:
+		return "respond: " + original
+	case domain.SituationChoice:
+		return "choose: " + original
+	case domain.SituationError:
+		return "on error: " + original
+	case domain.SituationIdle:
+		if learned == domain.ActionNextInferredTask {
+			return "send inferred next task: " + original
+		}
+		return "send next declared task: " + original
+	}
+	return original
+}
+
+// handleRewriteOutcome finalizes an async outbound rewrite: the rewritten
+// text is re-gated through every safety control (the rewriter is an LLM
+// authoring outbound text — FR-015 applies) and delivered. A rewrite
+// failure degrades to the fallback-wrapped original rather than blocking
+// the send; only safety trips on that wrapped form escalate.
+func (d *Daemon) handleRewriteOutcome(ctx context.Context, res rewriteOutcome) {
+	s := res.situation
+
+	// A superseded flight must never send: a newer situation owns the pane.
+	d.mu.Lock()
+	fl, ok := d.rewriteInFlight[s.AgentID]
+	if !ok || fl.token != res.token {
+		d.mu.Unlock()
+		slog.Info("rewrite outcome superseded; dropping", "agent", s.AgentID)
+		return
+	}
+	delete(d.rewriteInFlight, s.AgentID)
+	d.mu.Unlock()
+	fl.cancel()
+
+	cfg, allow, cls := d.snapshot()
+	now := d.opt.Clock.Now()
+
+	escalateWith := func(reason domain.EscalateReason, why string) {
+		d.escalate(ctx, s, res.sig, domain.Decision{
+			Action: domain.ActionEscalate, Reason: reason, Rationale: why,
+			Confidence: res.dec.Confidence,
+			Suggestion: rewriteSuggestion(s.Type, res.learned, res.dec.Input),
+		}, res.tr, now)
+	}
+
+	// Final text: the rewrite, or — on any failure, including safety trips
+	// on the rewritten form — the fallback-wrapped original.
+	final := strings.TrimSpace(res.rewritten)
+	note := "rewritten by llm.rewrite_command"
+	llmOutput := ""
+	degrade := func(why string) {
+		final = domain.ApplyRewriteFallback(res.fallback, res.dec.Input)
+		note = "rewrite " + why + "; fallback template applied"
+	}
+	switch {
+	case res.err != nil:
+		degrade(fmt.Sprintf("failed (%v)", res.err))
+		llmOutput = res.err.Error()
+	case final == "":
+		degrade("produced empty output")
+	default:
+		if pattern, matched := allow.Match(final); matched {
+			llmOutput = "discarded rewrite: " + truncateRunes(final, 500)
+			degrade("output matched never-auto pattern " + pattern)
+		} else if hit, sus := allow.SuspectedIrreversible(s.AgentType, final); sus {
+			llmOutput = "discarded rewrite: " + truncateRunes(final, 500)
+			degrade(fmt.Sprintf("output tripped irreversible indicator %s (%.60q)", hit.Pattern, hit.Excerpt))
+		}
+	}
+
+	// Safety controls are never bypassed (SC-5): the final text — even the
+	// fallback-wrapped original, whose framing could complete a pattern the
+	// raw original did not — is screened once more, and the world may have
+	// changed since Decide ran (kill switch, rate, the pane itself).
+	kill, err := d.opt.Store.LatestKillEvent(ctx)
+	if err != nil || domain.KillStateActive(kill) {
+		escalateWith(domain.ReasonKilled, "kill switch active at rewrite delivery time")
+		return
+	}
+	if pattern, matched := allow.Match(final); matched {
+		escalateWith(domain.ReasonAllowlistMatch, "rewritten outbound matches never-auto pattern: "+pattern)
+		return
+	}
+	if hit, sus := allow.SuspectedIrreversible(s.AgentType, final); sus {
+		escalateWith(domain.ReasonSuspectedIrrevers,
+			fmt.Sprintf("rewritten outbound tripped irreversible indicator %s (%.60q)", hit.Pattern, hit.Excerpt))
+		return
+	}
+	rate, err := d.opt.Store.GetAgentRate(ctx, s.AgentID)
+	if err != nil {
+		// Fail closed: an unreadable rate row must not skip the guard.
+		escalateWith(domain.ReasonPersistenceFailed, "agent rate read failed at rewrite delivery time: "+err.Error())
+		return
+	}
+	if ok, reason := domain.CheckRate(*rate, now, domain.RateLimits{
+		MaxConsecutive: cfg.Limits.MaxConsecutiveAutoPrompts,
+		MaxPerMinute:   cfg.Limits.MaxAutoPromptsPerMinute,
+	}); !ok {
+		escalateWith(reason, "runaway-loop guard at rewrite delivery time")
+		return
+	}
+
+	// Staleness: the rewrite took up to its timeout — never inject into a
+	// pane that moved on. Re-classify the visible screen with the original
+	// transition status. Signature equality is required only for
+	// approval/choice/error: idle signatures hash a masked content head
+	// that legitimately differs between the visible re-read and the
+	// original consuming "recent" read, so idle matches on type alone.
+	pane, err := d.readVisible(ctx, s.PaneID, d.opt.PaneReadLines)
+	if err != nil {
+		escalateWith(domain.ReasonHerdrUnreachable, "pane re-read failed before rewrite delivery: "+err.Error())
+		return
+	}
+	current := cls.Classify(s.AgentType, res.tr.Status, pane)
+	current.AgentID, current.PaneID, current.WorkspaceID = s.AgentID, s.PaneID, s.WorkspaceID
+	if current.Type != s.Type {
+		slog.Info("situation changed during rewrite; dropping send",
+			"agent", s.AgentID, "was", s.Type, "now", current.Type)
+		return
+	}
+	if s.Type != domain.SituationIdle {
+		if freshSig := domain.ComputeSignature(current); freshSig.Signature != res.sig.Signature {
+			slog.Info("signature changed during rewrite; dropping send", "agent", s.AgentID)
+			return
+		}
+	}
+	// The idle policy tolerates changed content, so the FRESH pane must be
+	// re-screened the way handleTransition screened the original: Decide's
+	// veto ran against content that may no longer be what's on screen.
+	if pattern, matched := allow.Match(current.Content); matched {
+		escalateWith(domain.ReasonAllowlistMatch,
+			"pane content matches never-auto pattern at rewrite delivery: "+pattern)
+		return
+	}
+	if hit, sus := allow.SuspectedIrreversible(s.AgentType,
+		domain.IrreversibleScanContent(current, "")); sus {
+		escalateWith(domain.ReasonSuspectedIrrevers,
+			fmt.Sprintf("pane tripped irreversible indicator at rewrite delivery: %s (%.60q)", hit.Pattern, hit.Excerpt))
+		return
+	}
+
+	original := truncateRunes(res.dec.Input, 200)
+	d.deliverAutonomous(ctx, s, res.sig, res.dec, res.tr, delivery{
+		sendText:  final,
+		input:     final,
+		rationale: fmt.Sprintf("%s; %s (original: %q)", res.dec.Rationale, note, original),
+		llmOutput: llmOutput,
+		learned:   res.learned,
+	}, now)
 }
 
 // handleLLMOutcome re-gates a staged LLM submission through the same safety
@@ -918,6 +1243,8 @@ func (d *Daemon) expireStaleLLMWork(ctx context.Context) {
 }
 
 func (d *Daemon) registerHumanInteraction(ctx context.Context, agentID string) {
+	// The human owns the pane now: a pending rewritten send is moot.
+	d.cancelRewriteExcept(agentID, "")
 	rate, err := d.opt.Store.GetAgentRate(ctx, agentID)
 	if err != nil {
 		return

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -155,6 +155,38 @@ func (f *fakeLLM) Consult(ctx context.Context, req domain.LLMRequest) (*domain.L
 	return f.consult(ctx, req)
 }
 
+// fakeRewriter layers ports.RewriterPort on the LLM fake so the daemon's
+// type assertion finds the optional rewrite capability.
+type fakeRewriter struct {
+	*fakeLLM
+	mu       sync.Mutex
+	rewrite  func(ctx context.Context, req domain.RewriteRequest) (string, error)
+	requests []domain.RewriteRequest
+}
+
+func (f *fakeRewriter) RewriteConfigured() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.rewrite != nil
+}
+
+func (f *fakeRewriter) Rewrite(ctx context.Context, req domain.RewriteRequest) (string, error) {
+	f.mu.Lock()
+	f.requests = append(f.requests, req)
+	fn := f.rewrite
+	f.mu.Unlock()
+	if fn == nil {
+		return "", errors.New("no rewrite configured")
+	}
+	return fn(ctx, req)
+}
+
+func (f *fakeRewriter) rewriteCalls() []domain.RewriteRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]domain.RewriteRequest(nil), f.requests...)
+}
+
 // failingStore injects persistence failures on audit writes (FR-024).
 type failingStore struct {
 	ports.StorePort
@@ -194,12 +226,23 @@ type harness struct {
 }
 
 func newHarness(t *testing.T, cfgTOML string) *harness {
-	return newHarnessWrapped(t, cfgTOML, nil)
+	return newHarnessFull(t, cfgTOML, nil, nil)
 }
 
 // newHarnessWrapped lets a test substitute the HerdrPort the daemon sees
 // (e.g. hiding optional interfaces) while keeping the fake for assertions.
 func newHarnessWrapped(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.HerdrPort) *harness {
+	return newHarnessFull(t, cfgTOML, wrap, nil)
+}
+
+// newHarnessRewriter installs a rewriter-capable LLM port.
+func newHarnessRewriter(t *testing.T, cfgTOML string,
+	rewrite func(ctx context.Context, req domain.RewriteRequest) (string, error)) (*harness, *fakeRewriter) {
+	fr := &fakeRewriter{fakeLLM: &fakeLLM{}, rewrite: rewrite}
+	return newHarnessFull(t, cfgTOML, nil, fr), fr
+}
+
+func newHarnessFull(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.HerdrPort, rw *fakeRewriter) *harness {
 	t.Helper()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.toml")
@@ -218,6 +261,11 @@ func newHarnessWrapped(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports
 	fh := &fakeHerdr{}
 	fe := &fakeEvents{ch: make(chan domain.AgentTransition, 64)}
 	fl := &fakeLLM{}
+	var llmPort ports.LLMPort = fl
+	if rw != nil {
+		fl = rw.fakeLLM
+		llmPort = rw
+	}
 	var herdrPort ports.HerdrPort = fh
 	if wrap != nil {
 		herdrPort = wrap(fh)
@@ -232,7 +280,7 @@ func newHarnessWrapped(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports
 		Herdr:             herdrPort,
 		Events:            fe,
 		Notify:            fh,
-		LLM:               fl,
+		LLM:               llmPort,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/daemon/rewrite_test.go
+++ b/internal/daemon/rewrite_test.go
@@ -1,0 +1,426 @@
+package daemon
+
+// Tests for the optional outbound-text rewrite (llm.rewrite_command): the
+// async pipeline in startRewrite/handleRewriteOutcome, its safety re-gates,
+// and the never-block-the-send fallback semantics.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// idleRewriteHarness seeds a declared-task idle signature for the given
+// agent and returns the harness, the rewriter fake, and the original prompt
+// the pipeline would send without a rewriter.
+func idleRewriteHarness(t *testing.T, agent, extraCfg string,
+	rewrite func(ctx context.Context, req domain.RewriteRequest) (string, error)) (*harness, *fakeRewriter, string) {
+	t.Helper()
+	dir := t.TempDir()
+	taskFile := filepath.Join(dir, "tasks.md")
+	os.WriteFile(taskFile, []byte("- [ ] step two\n"), 0o600)
+
+	idlePane := "All tests pass. Task is complete.\n"
+	cfg := fmt.Sprintf("[[task_sources]]\nagent = %q\npath = %q\n%s", agent, taskFile, extraCfg)
+	h, fr := newHarnessRewriter(t, cfg, rewrite)
+	h.herdr.setPane(idlePane)
+	h.seedAutonomous(idlePane, domain.SituationIdle, domain.ActionNextDeclaredTask)
+	original := fmt.Sprintf("Your next task is step two. Read the full tasks list at %s.", taskFile)
+	return h, fr, original
+}
+
+func TestRewriteAppliedToIdleDeclaredTask(t *testing.T) {
+	// A literal idle prompt goes through the rewrite CLI; the rewritten
+	// text is what reaches the pane and the audit, while learning still
+	// records the symbolic action.
+	h, fr, original := idleRewriteHarness(t, "agent-rw1", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			return "REWRITTEN: please do step two", nil
+		})
+
+	h.push("agent-rw1", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	if got := h.herdr.sentInputs()[0]; got != "REWRITTEN: please do step two" {
+		t.Errorf("sent %q, want the rewritten text", got)
+	}
+
+	calls := fr.rewriteCalls()
+	if len(calls) != 1 || calls[0].Text != original {
+		t.Fatalf("rewriter saw %+v, want one call with the original prompt %q", calls, original)
+	}
+	if calls[0].SituationType != domain.SituationIdle || calls[0].PaneExcerpt == "" {
+		t.Errorf("rewrite request missing context: %+v", calls[0])
+	}
+
+	audits, err := h.raw.AuditLog(context.Background(), 10)
+	if err != nil || len(audits) == 0 {
+		t.Fatalf("audit log: %v %v", audits, err)
+	}
+	if audits[0].Input != "REWRITTEN: please do step two" || audits[0].Status != "auto" {
+		t.Errorf("audit should carry the delivered text: %+v", audits[0])
+	}
+	if !strings.Contains(audits[0].Rationale, "rewritten by llm.rewrite_command") ||
+		!strings.Contains(audits[0].Rationale, "step two") {
+		t.Errorf("audit rationale should note the rewrite and the original: %q", audits[0].Rationale)
+	}
+
+	// Learning stays symbolic — rewritten text must not enter history.
+	decs, err := h.raw.DecisionsForSignature(context.Background(), audits[0].Signature, 50)
+	if err != nil || len(decs) == 0 {
+		t.Fatalf("decisions: %v %v", decs, err)
+	}
+	if decs[0].ChosenAction != domain.ActionNextDeclaredTask {
+		t.Errorf("learned %q, want %q", decs[0].ChosenAction, domain.ActionNextDeclaredTask)
+	}
+}
+
+func TestRewriteSkippedForMenuMappedApproval(t *testing.T) {
+	// A numbered-menu answer must reach the menu as the digit, untouched by
+	// the rewriter.
+	h, fr := newHarnessRewriter(t, "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			return "SHOULD NEVER BE SENT", nil
+		})
+	h.herdr.setPane(approvalPane)
+	h.seedAutonomous(approvalPane, domain.SituationApproval, "Yes")
+
+	h.push("agent-rw2", "blocked")
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	if got := h.herdr.sentInputs()[0]; got != "1" {
+		t.Errorf("sent %q, want the menu digit \"1\"", got)
+	}
+	if calls := fr.rewriteCalls(); len(calls) != 0 {
+		t.Errorf("rewriter must not be consulted for menu answers, saw %d calls", len(calls))
+	}
+}
+
+func TestRewriteFailureSendsFallbackWrappedOriginal(t *testing.T) {
+	// A rewrite failure never blocks the send — the original is delivered
+	// inside the default quoting template.
+	h, _, original := idleRewriteHarness(t, "agent-rw3", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			return "", errors.New("induced rewrite failure")
+		})
+
+	h.push("agent-rw3", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	want := "You must act based on the following: " + original
+	if got := h.herdr.sentInputs()[0]; got != want {
+		t.Errorf("sent %q, want fallback-wrapped original %q", got, want)
+	}
+
+	audits, _ := h.raw.AuditLog(context.Background(), 10)
+	if len(audits) == 0 || !strings.Contains(audits[0].Rationale, "rewrite failed") ||
+		!strings.Contains(audits[0].Rationale, "fallback template applied") {
+		t.Errorf("audit rationale should note the failed rewrite: %+v", audits)
+	}
+	if len(audits) > 0 && !strings.Contains(audits[0].LLMOutput, "induced rewrite failure") {
+		t.Errorf("audit LLMOutput should carry rewrite diagnostics: %q", audits[0].LLMOutput)
+	}
+}
+
+func TestRewriteCustomFallbackTemplate(t *testing.T) {
+	extra := "[llm]\nrewrite_fallback_template = \"Operator rule says: {original_text}\"\n"
+	h, _, original := idleRewriteHarness(t, "agent-rw4", extra,
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			return "", errors.New("nope")
+		})
+
+	h.push("agent-rw4", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	want := "Operator rule says: " + original
+	if got := h.herdr.sentInputs()[0]; got != want {
+		t.Errorf("sent %q, want custom-template fallback %q", got, want)
+	}
+}
+
+func TestRewrittenTextTrippingAllowlistFallsBack(t *testing.T) {
+	// SC-5/FR-015: the rewriter is an LLM authoring outbound text — output
+	// naming an irreversible operation is discarded and the safe original
+	// (wrapped) is delivered instead.
+	h, _, original := idleRewriteHarness(t, "agent-rw5", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			return "sounds good, just force-push the branch afterwards", nil
+		})
+
+	h.push("agent-rw5", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	want := "You must act based on the following: " + original
+	if got := h.herdr.sentInputs()[0]; got != want {
+		t.Errorf("sent %q, want the dangerous rewrite discarded for %q", got, want)
+	}
+	audits, _ := h.raw.AuditLog(context.Background(), 10)
+	if len(audits) == 0 || !strings.Contains(audits[0].Rationale, "never-auto") {
+		t.Errorf("audit should note the discarded rewrite: %+v", audits)
+	}
+}
+
+func TestRewriteFallbackAlsoTrippingEscalates(t *testing.T) {
+	// If even the fallback-wrapped original trips the safety screen (here
+	// via a booby-trapped operator template), nothing is sent and the
+	// situation escalates with the original as the confirmable suggestion.
+	extra := "[llm]\nrewrite_fallback_template = \"force-push first, then: {original_text}\"\n"
+	h, _, _ := idleRewriteHarness(t, "agent-rw6", extra,
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			return "", errors.New("induced failure")
+		})
+
+	h.push("agent-rw6", "idle")
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := h.raw.AuditLog(context.Background(), 10)
+		for _, a := range audits {
+			if a.Status == "escalated" {
+				return true
+			}
+		}
+		return false
+	})
+	if got := h.herdr.sentInputs(); len(got) != 0 {
+		t.Errorf("nothing must be sent when the fallback trips the allowlist, sent %v", got)
+	}
+	audits, _ := h.raw.AuditLog(context.Background(), 10)
+	if !strings.Contains(audits[0].Suggestion, "send next declared task: ") {
+		t.Errorf("escalation should carry a confirmable original suggestion: %+v", audits[0])
+	}
+}
+
+func TestRewriteStaleSituationDropsSend(t *testing.T) {
+	// The pane moved on while the rewrite ran: nothing is sent, nothing
+	// escalates — the new situation drives its own pipeline event.
+	freeApproval := "Do you want to continue? (y/n)\n"
+	release := make(chan struct{})
+	h, fr := newHarnessRewriter(t, "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			<-release
+			return "y please", nil
+		})
+	h.herdr.setPane(freeApproval)
+	h.seedAutonomous(freeApproval, domain.SituationApproval, "y")
+
+	h.push("agent-rw7", "blocked")
+	waitFor(t, 3*time.Second, func() bool { return len(fr.rewriteCalls()) == 1 })
+	h.herdr.setPane("compiling project, please wait...\n") // situation gone
+	close(release)
+
+	time.Sleep(300 * time.Millisecond)
+	if got := h.herdr.sentInputs(); len(got) != 0 {
+		t.Errorf("stale rewrite must not send, sent %v", got)
+	}
+	audits, _ := h.raw.AuditLog(context.Background(), 10)
+	for _, a := range audits {
+		if a.Status == "auto" || a.Status == "escalated" {
+			t.Errorf("stale rewrite must neither act nor escalate: %+v", a)
+		}
+	}
+}
+
+func TestRewriteDuplicateTransitionSendsOnce(t *testing.T) {
+	release := make(chan struct{})
+	h, fr, _ := idleRewriteHarness(t, "agent-rw8", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			<-release
+			return "rewritten once", nil
+		})
+
+	h.push("agent-rw8", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(fr.rewriteCalls()) == 1 })
+	// The same situation fires again while the first rewrite is in flight.
+	h.push("agent-rw8", "idle")
+	time.Sleep(200 * time.Millisecond)
+	close(release)
+
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	time.Sleep(300 * time.Millisecond)
+	if got := h.herdr.sentInputs(); len(got) != 1 {
+		t.Errorf("duplicate in-flight rewrite must send exactly once, sent %v", got)
+	}
+	if calls := fr.rewriteCalls(); len(calls) != 1 {
+		t.Errorf("duplicate transition must not spawn a second rewrite, saw %d", len(calls))
+	}
+}
+
+func TestRewriteKillSwitchMidFlightEscalates(t *testing.T) {
+	release := make(chan struct{})
+	h, fr, _ := idleRewriteHarness(t, "agent-rw9", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			<-release
+			return "too late", nil
+		})
+
+	h.push("agent-rw9", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(fr.rewriteCalls()) == 1 })
+	h.raw.InsertKillEvent(context.Background(), domain.KillEvent{
+		State: "active", Scope: "global", Author: "test", CreatedAt: time.Now(),
+	})
+	close(release)
+
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := h.raw.AuditLog(context.Background(), 10)
+		for _, a := range audits {
+			if a.Status == "escalated" && strings.Contains(a.Rationale, "kill switch") {
+				return true
+			}
+		}
+		return false
+	})
+	if got := h.herdr.sentInputs(); len(got) != 0 {
+		t.Errorf("kill switch must block the rewritten send, sent %v", got)
+	}
+}
+
+func TestRewriteSupersededByNewSituationDropsOldFlight(t *testing.T) {
+	// A new decision for the agent (here: a menu approval) cancels the
+	// in-flight idle rewrite; the old outcome must be dropped by the token
+	// check and its context cancelled so the CLI stops burning tokens.
+	release := make(chan struct{})
+	cancelled := make(chan struct{}, 1)
+	h, fr, _ := idleRewriteHarness(t, "agent-rw11", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			select {
+			case <-ctx.Done():
+				cancelled <- struct{}{}
+				return "", ctx.Err()
+			case <-release:
+				return "stale rewrite", nil
+			}
+		})
+
+	h.push("agent-rw11", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(fr.rewriteCalls()) == 1 })
+
+	// The pane now shows a numbered approval: a different situation whose
+	// decision (digit send) must invalidate the idle flight.
+	h.herdr.setPane(approvalPane)
+	h.seedAutonomous(approvalPane, domain.SituationApproval, "Yes")
+	h.push("agent-rw11", "blocked")
+
+	waitFor(t, 3*time.Second, func() bool { // the flight's context is cancelled
+		select {
+		case <-cancelled:
+			return true
+		default:
+			return false
+		}
+	})
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	close(release)
+	time.Sleep(300 * time.Millisecond)
+	sent := h.herdr.sentInputs()
+	if len(sent) != 1 || sent[0] != "1" {
+		t.Errorf("only the new decision's digit may send, got %v", sent)
+	}
+}
+
+func TestRewriteRateGuardAtDeliveryEscalates(t *testing.T) {
+	// The send lands up to the rewrite timeout after Decide: a runaway
+	// counter that filled up in between must still block it.
+	release := make(chan struct{})
+	h, fr, _ := idleRewriteHarness(t, "agent-rw12", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			<-release
+			return "rewritten", nil
+		})
+
+	h.push("agent-rw12", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(fr.rewriteCalls()) == 1 })
+	h.raw.UpdateAgentRate(context.Background(), domain.AgentRate{
+		AgentID: "agent-rw12", ConsecutiveAuto: 1000, WindowStart: time.Now(), CountInWindow: 1000,
+	})
+	close(release)
+
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := h.raw.AuditLog(context.Background(), 10)
+		for _, a := range audits {
+			if a.Status == "escalated" && strings.Contains(a.Rationale, "runaway-loop guard") {
+				return true
+			}
+		}
+		return false
+	})
+	if got := h.herdr.sentInputs(); len(got) != 0 {
+		t.Errorf("rate guard must block the rewritten send, sent %v", got)
+	}
+}
+
+func TestRewriteSignatureChangeSameTypeDropsSend(t *testing.T) {
+	// Approval → different approval while the rewrite ran: same type, new
+	// signature — the learned answer belongs to the OLD dialog, so nothing
+	// may send.
+	freeApproval := "Do you want to continue? (y/n)\n"
+	release := make(chan struct{})
+	h, fr := newHarnessRewriter(t, "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			<-release
+			return "y please", nil
+		})
+	h.herdr.setPane(freeApproval)
+	h.seedAutonomous(freeApproval, domain.SituationApproval, "y")
+
+	h.push("agent-rw13", "blocked")
+	waitFor(t, 3*time.Second, func() bool { return len(fr.rewriteCalls()) == 1 })
+	// Still an approval, but a different permission dialog.
+	h.herdr.setPane("Bash(rm campsite.txt)\nDo you want to proceed? (y/n)\n")
+	close(release)
+
+	time.Sleep(300 * time.Millisecond)
+	if got := h.herdr.sentInputs(); len(got) != 0 {
+		t.Errorf("signature drift must drop the send, sent %v", got)
+	}
+}
+
+func TestRewriteIdleContentDriftStillDelivers(t *testing.T) {
+	// Policy pin: idle staleness matches on TYPE only. Idle content
+	// legitimately differs between the recent-delta classification read and
+	// the visible re-read, so a still-idle pane with different text keeps
+	// the send.
+	release := make(chan struct{})
+	h, fr, _ := idleRewriteHarness(t, "agent-rw14", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			<-release
+			return "rewritten idle prompt", nil
+		})
+
+	h.push("agent-rw14", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(fr.rewriteCalls()) == 1 })
+	h.herdr.setPane("Finished formatting. Everything is done here.\n") // still idle, new words
+	close(release)
+
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	if got := h.herdr.sentInputs()[0]; got != "rewritten idle prompt" {
+		t.Errorf("sent %q, want the rewritten prompt despite idle content drift", got)
+	}
+}
+
+func TestRewriteAuditFailureBlocksSend(t *testing.T) {
+	// FR-024 holds on the rewrite path too: no audit record, no send.
+	release := make(chan struct{})
+	h, fr, _ := idleRewriteHarness(t, "agent-rw10", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			<-release
+			return "rewritten", nil
+		})
+
+	h.push("agent-rw10", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(fr.rewriteCalls()) == 1 })
+	h.store.(*failingStore).setFailAudit(true)
+	close(release)
+
+	waitFor(t, 3*time.Second, func() bool {
+		for _, n := range h.herdr.notified() {
+			if strings.Contains(n, "persistence failure") {
+				return true
+			}
+		}
+		return false
+	})
+	if got := h.herdr.sentInputs(); len(got) != 0 {
+		t.Errorf("audit failure must block the send (FR-024), sent %v", got)
+	}
+}

--- a/internal/domain/menu.go
+++ b/internal/domain/menu.go
@@ -76,20 +76,25 @@ func MenuKeystroke(content, chosen string) (string, bool) {
 	return chosen, false
 }
 
-// DeliverKeystroke maps a chosen reply to the numbered-menu digit, but ONLY
+// DeliverOutbound maps a chosen reply to the numbered-menu digit, but ONLY
 // for approval/choice situations. Free-text prompts — idle next-task prompts,
 // error-retry commands — are always delivered literally, so a pane that
 // happens to contain an ordinary numbered list (e.g. a summary "1. ran tests")
 // can never hijack the reply into a bare digit. paneContent is the live
-// screen; returns the digit when it maps, else chosen unchanged.
-func DeliverKeystroke(sitType SituationType, paneContent, chosen string) string {
+// screen. The bool reports whether a menu digit was mapped: false means the
+// returned text is free text (callers deciding whether to rewrite literal
+// outbound text key off this).
+func DeliverOutbound(sitType SituationType, paneContent, chosen string) (string, bool) {
 	if sitType != SituationApproval && sitType != SituationChoice {
-		return chosen
+		return chosen, false
 	}
-	if key, ok := MenuKeystroke(paneContent, chosen); ok {
-		return key
-	}
-	return chosen
+	return MenuKeystroke(paneContent, chosen)
+}
+
+// DeliverKeystroke is DeliverOutbound for callers that only need the text.
+func DeliverKeystroke(sitType SituationType, paneContent, chosen string) string {
+	out, _ := DeliverOutbound(sitType, paneContent, chosen)
+	return out
 }
 
 // uniquePrefixMatch returns an option's number when exactly one option label

--- a/internal/domain/menu_test.go
+++ b/internal/domain/menu_test.go
@@ -58,3 +58,34 @@ func TestMenuKeystrokeAmbiguousPrefixStaysLiteral(t *testing.T) {
 		t.Errorf("exact label = (%q, %v), want (2, true)", got, mapped)
 	}
 }
+
+func TestDeliverOutbound(t *testing.T) {
+	menu := "Allow this tool?\n❯ 1. Yes\n  2. No\n"
+	tests := []struct {
+		name    string
+		sitType SituationType
+		content string
+		chosen  string
+		want    string
+		mapped  bool
+	}{
+		{"approval label maps to digit", SituationApproval, menu, "Yes", "1", true},
+		{"choice numeric selection maps", SituationChoice, menu, "2", "2", true},
+		{"approval free text without menu stays literal", SituationApproval, "Enter a message:", "looks good", "looks good", false},
+		{"idle never maps even over a numbered list", SituationIdle, "done:\n1. ran tests\n2. built", "continue with the plan", "continue with the plan", false},
+		{"error retry command stays literal", SituationError, menu, "go test ./...", "go test ./...", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, mapped := DeliverOutbound(tc.sitType, tc.content, tc.chosen)
+			if got != tc.want || mapped != tc.mapped {
+				t.Errorf("DeliverOutbound(%v, %q) = (%q, %v), want (%q, %v)",
+					tc.sitType, tc.chosen, got, mapped, tc.want, tc.mapped)
+			}
+			// DeliverKeystroke must stay in lockstep with DeliverOutbound.
+			if ks := DeliverKeystroke(tc.sitType, tc.content, tc.chosen); ks != got {
+				t.Errorf("DeliverKeystroke = %q, DeliverOutbound text = %q", ks, got)
+			}
+		})
+	}
+}

--- a/internal/domain/rewrite.go
+++ b/internal/domain/rewrite.go
@@ -1,0 +1,36 @@
+package domain
+
+import "strings"
+
+// Rewrite support for literal outbound text (llm.rewrite_command): when a
+// learned rule resolves to free text (an idle next-task prompt, an error
+// retry command, a free-text approval reply), the daemon can hand it to a
+// one-shot LLM CLI to adapt it to the live pane before delivery. These are
+// the pure pieces; the subprocess lives in internal/llm.
+
+// RewriteRequest is everything the rewrite CLI template can reference.
+type RewriteRequest struct {
+	// Text is the literal outbound text a learned rule resolved to.
+	Text          string
+	SituationType SituationType
+	AgentType     string
+	// PaneExcerpt is the tail of the live pane, for {pane_excerpt}.
+	PaneExcerpt string
+}
+
+// DefaultRewriteFallbackTemplate wraps the original text when the rewrite
+// CLI fails: the send must never be blocked by a rewrite failure, so the
+// already-safety-screened original is delivered inside a quoting frame.
+const DefaultRewriteFallbackTemplate = "You must act based on the following: {original_text}"
+
+// ApplyRewriteFallback renders the failure-path outbound text. An empty
+// template — or one missing the {original_text} placeholder, which would
+// silently drop the learned action — falls back to the default. A single
+// substitution pass means placeholder-like text inside the original is
+// never re-expanded.
+func ApplyRewriteFallback(template, original string) string {
+	if !strings.Contains(template, "{original_text}") {
+		template = DefaultRewriteFallbackTemplate
+	}
+	return strings.NewReplacer("{original_text}", original).Replace(template)
+}

--- a/internal/domain/rewrite_test.go
+++ b/internal/domain/rewrite_test.go
@@ -1,0 +1,51 @@
+package domain
+
+import "testing"
+
+func TestApplyRewriteFallback(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		original string
+		want     string
+	}{
+		{
+			name:     "empty template uses default",
+			template: "",
+			original: "go test ./...",
+			want:     "You must act based on the following: go test ./...",
+		},
+		{
+			name:     "custom template",
+			template: "Please do this now: {original_text}",
+			original: "retry the build",
+			want:     "Please do this now: retry the build",
+		},
+		{
+			name:     "template without placeholder falls back to default",
+			template: "just some words",
+			original: "go vet ./...",
+			want:     "You must act based on the following: go vet ./...",
+		},
+		{
+			name:     "placeholder in original not re-expanded",
+			template: "Do: {original_text}",
+			original: "echo {original_text}",
+			want:     "Do: echo {original_text}",
+		},
+		{
+			name:     "empty original still renders",
+			template: "",
+			original: "",
+			want:     "You must act based on the following: ",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ApplyRewriteFallback(tt.template, tt.original); got != tt.want {
+				t.Errorf("ApplyRewriteFallback(%q, %q) = %q, want %q",
+					tt.template, tt.original, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -332,6 +332,9 @@ var ConfigFieldKeys = []string{
 	"llm.command",
 	"llm.timeout_seconds",
 	"llm.auto_act",
+	"llm.rewrite_command",
+	"llm.rewrite_timeout_seconds",
+	"llm.rewrite_fallback_template",
 }
 
 // FieldValue renders the current value of a SetField key for display.
@@ -361,6 +364,12 @@ func FieldValue(cfg config.Config, key string) string {
 		return strconv.Itoa(cfg.LLM.TimeoutSeconds)
 	case "llm.auto_act":
 		return strconv.FormatBool(cfg.LLM.AutoAct)
+	case "llm.rewrite_command":
+		return JoinCommand(cfg.LLM.RewriteCommand)
+	case "llm.rewrite_timeout_seconds":
+		return strconv.Itoa(cfg.LLM.RewriteTimeoutSeconds)
+	case "llm.rewrite_fallback_template":
+		return cfg.LLM.RewriteFallbackTemplate
 	}
 	return ""
 }
@@ -423,6 +432,20 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 				return fmt.Errorf("llm.command: %w", err)
 			}
 			cfg.LLM.Command = argv // empty disables the LLM fallback
+			return nil
+		case "llm.rewrite_command":
+			argv, err := SplitCommand(value)
+			if err != nil {
+				return fmt.Errorf("llm.rewrite_command: %w", err)
+			}
+			cfg.LLM.RewriteCommand = argv // empty disables the rewrite
+			return nil
+		case "llm.rewrite_timeout_seconds":
+			return setInt(&cfg.LLM.RewriteTimeoutSeconds)
+		case "llm.rewrite_fallback_template":
+			// Any text is accepted; empty restores the built-in default at
+			// use time (domain.ApplyRewriteFallback).
+			cfg.LLM.RewriteFallbackTemplate = value
 			return nil
 		}
 		return fmt.Errorf("unknown config field %q", key)

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -269,6 +269,11 @@ func TestSetFieldValidatesAndPersists(t *testing.T) {
 		{"llm.auto_act", "true", false},
 		{"llm.auto_act", "maybe", true},
 		{"llm.command", `claude -p "decide for me"`, false},
+		{"llm.rewrite_command", `claude -p "rewrite: {text}" --model haiku`, false},
+		{"llm.rewrite_command", `claude -p "unbalanced`, true},
+		{"llm.rewrite_timeout_seconds", "45", false},
+		{"llm.rewrite_timeout_seconds", "zero", true},
+		{"llm.rewrite_fallback_template", "Act on: {original_text}", false},
 		{"nonexistent.field", "1", true},
 	}
 	for _, c := range cases {
@@ -288,6 +293,13 @@ func TestSetFieldValidatesAndPersists(t *testing.T) {
 	}
 	if len(cfg.LLM.Command) != 3 || cfg.LLM.Command[2] != "decide for me" {
 		t.Errorf("llm.command quote handling: %v", cfg.LLM.Command)
+	}
+	if len(cfg.LLM.RewriteCommand) != 5 || cfg.LLM.RewriteCommand[2] != "rewrite: {text}" {
+		t.Errorf("llm.rewrite_command quote handling: %v", cfg.LLM.RewriteCommand)
+	}
+	if cfg.LLM.RewriteTimeoutSeconds != 45 ||
+		cfg.LLM.RewriteFallbackTemplate != "Act on: {original_text}" {
+		t.Errorf("rewrite keys not persisted: %+v", cfg.LLM)
 	}
 	// Every editable key renders a value.
 	for _, key := range frontend.ConfigFieldKeys {

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -30,6 +30,12 @@ type Adapter struct {
 	Store           ports.ReadStore
 	// SelfPath overrides the {self} placeholder (defaults to os.Executable).
 	SelfPath string
+	// RewriteTemplate is the argv template for the one-shot outbound-text
+	// rewrite (llm.rewrite_command); placeholders {text}, {situation_type},
+	// {agent_type}, {pane_excerpt}. Empty disables rewriting.
+	RewriteTemplate []string
+	// RewriteTimeout bounds one rewrite run (<=0 falls back to Timeout).
+	RewriteTimeout time.Duration
 }
 
 // Configured reports whether an LLM CLI is configured (IR-005).
@@ -62,15 +68,8 @@ func (a *Adapter) Consult(ctx context.Context, req domain.LLMRequest) (*domain.L
 	// after other flags) so a slightly-off operator config still works.
 	argv = NormalizeLLMCommand(argv)
 
-	// The daemon's PATH can be narrower than the operator's shell (GUI- or
-	// hook-launched); surface that as itself instead of a bare exit error.
-	// A command containing a separator never consults PATH, so it gets a
-	// message that doesn't misdiagnose a missing file as a PATH problem.
-	if _, err := exec.LookPath(argv[0]); err != nil {
-		if strings.ContainsRune(argv[0], os.PathSeparator) {
-			return nil, fmt.Errorf("llm command %q not runnable: %w", argv[0], err)
-		}
-		return nil, fmt.Errorf("llm command %q not found in PATH (the daemon's PATH may differ from your shell): %w", argv[0], err)
+	if err := preflight(argv[0]); err != nil {
+		return nil, err
 	}
 
 	timeout := a.Timeout
@@ -144,6 +143,21 @@ func (a *Adapter) WorkDir() string {
 func dirLives(dir string) bool {
 	fi, err := os.Stat(dir)
 	return err == nil && fi.IsDir()
+}
+
+// preflight verifies the CLI is runnable before spawning. The daemon's PATH
+// can be narrower than the operator's shell (GUI- or hook-launched); surface
+// that as itself instead of a bare exit error. A command containing a
+// separator never consults PATH, so it gets a message that doesn't
+// misdiagnose a missing file as a PATH problem.
+func preflight(argv0 string) error {
+	if _, err := exec.LookPath(argv0); err != nil {
+		if strings.ContainsRune(argv0, os.PathSeparator) {
+			return fmt.Errorf("llm command %q not runnable: %w", argv0, err)
+		}
+		return fmt.Errorf("llm command %q not found in PATH (the daemon's PATH may differ from your shell): %w", argv0, err)
+	}
+	return nil
 }
 
 func truncate(s string, n int) string {

--- a/internal/llm/rewrite.go
+++ b/internal/llm/rewrite.go
@@ -1,0 +1,102 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// Rewrite implements ports.RewriterPort: a one-shot subprocess that adapts
+// literal outbound text to the live pane. Unlike Consult's MCP-staged flow,
+// the rewritten text IS the CLI's stdout (trimmed); stderr is kept separate
+// for diagnostics. Every failure mode returns an error — the daemon falls
+// back to the quoting template and still delivers, so a broken rewrite CLI
+// can never block a learned action.
+
+// maxRewriteOutput caps the accepted rewritten text (matches Consult's
+// 16KB capture cap).
+const maxRewriteOutput = 16 * 1024
+
+// RewriteConfigured reports whether a rewrite CLI is configured.
+func (a *Adapter) RewriteConfigured() bool {
+	return a != nil && len(a.RewriteTemplate) > 0
+}
+
+// Rewrite launches the rewrite CLI and returns its trimmed stdout.
+func (a *Adapter) Rewrite(ctx context.Context, req domain.RewriteRequest) (string, error) {
+	if !a.RewriteConfigured() {
+		return "", fmt.Errorf("no rewrite CLI configured")
+	}
+	// Auto-repair BEFORE substitution: the normalizer pattern-matches argv
+	// shapes, and substituted pane text is untrusted — it must not be able
+	// to perturb the repair (same fixes as Consult: claude/agy want the
+	// prompt right after -p/--print, codex needs the exec subcommand).
+	template := NormalizeLLMCommand(a.RewriteTemplate)
+	argv := make([]string, len(template))
+	for i, arg := range template {
+		arg = strings.ReplaceAll(arg, "{text}", req.Text)
+		arg = strings.ReplaceAll(arg, "{situation_type}", string(req.SituationType))
+		arg = strings.ReplaceAll(arg, "{agent_type}", req.AgentType)
+		arg = strings.ReplaceAll(arg, "{pane_excerpt}", req.PaneExcerpt)
+		argv[i] = arg
+	}
+
+	if err := preflight(argv[0]); err != nil {
+		return "", err
+	}
+
+	timeout := a.RewriteTimeout
+	if timeout <= 0 {
+		timeout = a.Timeout
+	}
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, argv[0], argv[1:]...)
+	cmd.Dir = a.WorkDir()
+	// After the timeout kills the CLI, don't wait on lingering grandchildren
+	// holding the output pipes open — fail safe promptly.
+	cmd.WaitDelay = 2 * time.Second
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = append(os.Environ(),
+		"HAP_REWRITE_TEXT="+req.Text,
+		"HAP_SITUATION_TYPE="+string(req.SituationType),
+		"HAP_AGENT_TYPE="+req.AgentType,
+	)
+	runErr := cmd.Run()
+
+	if runErr != nil {
+		// Classify as timeout only when the run actually failed: a CLI
+		// finishing right at the deadline must keep its valid output.
+		if runCtx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("rewrite timeout after %s (stderr: %s)",
+				timeout, tailOf(stderr.String(), 500))
+		}
+		return "", fmt.Errorf("rewrite CLI failed: %w (stderr: %s)",
+			runErr, tailOf(stderr.String(), 500))
+	}
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", fmt.Errorf("rewrite CLI produced empty output (stderr: %s)",
+			tailOf(stderr.String(), 500))
+	}
+	if len(result) > maxRewriteOutput {
+		// The result is SENT to a pane — a mid-rune byte cut or a truncated
+		// half-instruction is worse than the safe fallback, so oversized
+		// output is a failure, not a trim.
+		return "", fmt.Errorf("rewrite CLI produced oversized output (%d bytes > %d cap)",
+			len(result), maxRewriteOutput)
+	}
+	return result, nil
+}

--- a/internal/llm/rewrite_test.go
+++ b/internal/llm/rewrite_test.go
@@ -1,0 +1,141 @@
+package llm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+func TestRewriteConfigured(t *testing.T) {
+	var nilAdapter *Adapter
+	if nilAdapter.RewriteConfigured() {
+		t.Error("nil adapter must report not configured")
+	}
+	if (&Adapter{}).RewriteConfigured() {
+		t.Error("empty template must report not configured")
+	}
+	if !(&Adapter{RewriteTemplate: []string{"cat"}}).RewriteConfigured() {
+		t.Error("non-empty template must report configured")
+	}
+}
+
+func TestRewriteSubstitutesPlaceholders(t *testing.T) {
+	// The script dumps its argv to a file so the substitution is observable.
+	dir := t.TempDir()
+	argvFile := filepath.Join(dir, "argv")
+	script := writeScript(t,
+		`printf '%s\n' "$@" > `+argvFile+"\necho rewritten reply\n")
+	a := &Adapter{
+		RewriteTemplate: []string{script,
+			"text={text}", "sit={situation_type}", "agent={agent_type}", "pane={pane_excerpt}"},
+		RewriteTimeout: 5 * time.Second,
+	}
+	got, err := a.Rewrite(context.Background(), domain.RewriteRequest{
+		Text:          "go test ./...",
+		SituationType: domain.SituationError,
+		AgentType:     "claude",
+		PaneExcerpt:   "FAIL: TestX",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "rewritten reply" {
+		t.Errorf("result = %q, want trimmed stdout", got)
+	}
+	argv, err := os.ReadFile(argvFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "text=go test ./...\nsit=error\nagent=claude\npane=FAIL: TestX\n"
+	if string(argv) != want {
+		t.Errorf("argv = %q, want %q", argv, want)
+	}
+}
+
+func TestRewriteStderrExcludedFromResult(t *testing.T) {
+	script := writeScript(t, "echo 'diagnostic noise' >&2\necho '  the reply  '\n")
+	a := &Adapter{RewriteTemplate: []string{script}, RewriteTimeout: 5 * time.Second}
+	got, err := a.Rewrite(context.Background(), domain.RewriteRequest{Text: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "the reply" {
+		t.Errorf("result = %q, want stderr excluded and whitespace trimmed", got)
+	}
+}
+
+func TestRewriteEmptyOutputErrors(t *testing.T) {
+	script := writeScript(t, "echo 'why it failed' >&2\nexit 0\n")
+	a := &Adapter{RewriteTemplate: []string{script}, RewriteTimeout: 5 * time.Second}
+	_, err := a.Rewrite(context.Background(), domain.RewriteRequest{Text: "x"})
+	if err == nil || !strings.Contains(err.Error(), "empty output") {
+		t.Fatalf("empty stdout must error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "why it failed") {
+		t.Errorf("error should carry the stderr tail: %v", err)
+	}
+}
+
+func TestRewriteNonZeroExitErrors(t *testing.T) {
+	script := writeScript(t, "echo 'boom' >&2\nexit 3\n")
+	a := &Adapter{RewriteTemplate: []string{script}, RewriteTimeout: 5 * time.Second}
+	_, err := a.Rewrite(context.Background(), domain.RewriteRequest{Text: "x"})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("non-zero exit must error with stderr tail, got %v", err)
+	}
+}
+
+func TestRewriteTimeout(t *testing.T) {
+	script := writeScript(t, "sleep 30\n")
+	a := &Adapter{RewriteTemplate: []string{script}, RewriteTimeout: 300 * time.Millisecond}
+	start := time.Now()
+	_, err := a.Rewrite(context.Background(), domain.RewriteRequest{Text: "x"})
+	if err == nil || !strings.Contains(err.Error(), "timeout") {
+		t.Fatalf("timeout must error, got %v", err)
+	}
+	if time.Since(start) > 5*time.Second {
+		t.Error("rewrite did not honor the timeout bound")
+	}
+}
+
+func TestRewriteTimeoutFallsBackToConsultTimeout(t *testing.T) {
+	script := writeScript(t, "sleep 30\n")
+	a := &Adapter{
+		RewriteTemplate: []string{script},
+		Timeout:         300 * time.Millisecond, // RewriteTimeout unset
+	}
+	start := time.Now()
+	if _, err := a.Rewrite(context.Background(), domain.RewriteRequest{Text: "x"}); err == nil {
+		t.Fatal("timeout must error")
+	}
+	if time.Since(start) > 5*time.Second {
+		t.Error("rewrite did not inherit the consult timeout")
+	}
+}
+
+func TestRewritePreflightsMissingCommand(t *testing.T) {
+	a := &Adapter{
+		RewriteTemplate: []string{"hap-rewrite-command-that-does-not-exist"},
+		RewriteTimeout:  time.Second,
+	}
+	_, err := a.Rewrite(context.Background(), domain.RewriteRequest{Text: "x"})
+	if err == nil || !strings.Contains(err.Error(), "not found in PATH") {
+		t.Fatalf("missing command must produce a PATH-aware error, got %v", err)
+	}
+}
+
+func TestRewriteOversizedOutputErrors(t *testing.T) {
+	// The result is sent to a pane: 64KB of output is a failure (the daemon
+	// falls back to the wrapped original), never a mid-rune trim.
+	script := writeScript(t, `head -c 65536 /dev/zero | tr '\0' 'a'`+"\n")
+	a := &Adapter{RewriteTemplate: []string{script}, RewriteTimeout: 5 * time.Second}
+	_, err := a.Rewrite(context.Background(), domain.RewriteRequest{Text: "x"})
+	if err == nil || !strings.Contains(err.Error(), "oversized") {
+		t.Fatalf("oversized output must error, got %v", err)
+	}
+}

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -67,6 +67,18 @@ type LLMPort interface {
 	Configured() bool
 }
 
+// RewriterPort is an optional capability of the LLM adapter: a one-shot
+// rewrite of literal outbound text before delivery (llm.rewrite_command).
+// Unlike Consult's MCP-staged flow, the rewritten text is the subprocess's
+// stdout. Callers type-assert and degrade gracefully when absent.
+type RewriterPort interface {
+	// Rewrite runs the configured rewrite CLI and returns the rewritten
+	// text, or an error on timeout / failure / empty output.
+	Rewrite(ctx context.Context, req domain.RewriteRequest) (string, error)
+	// RewriteConfigured reports whether a rewrite CLI is configured.
+	RewriteConfigured() bool
+}
+
 // StorePort is the persistence boundary. Write-ownership is partitioned:
 // daemon-exclusive writers for signatures/agent_rate/error_retries/decisions
 // and daemon-emitted audit rows; front-ends write corrections/kill_events;


### PR DESCRIPTION
## What

Adds an optional **LLM rewrite step** for literal outbound text on the autonomous rule path, configured in `config.toml`:

```toml
[llm]
rewrite_command = ["claude", "-p", "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}", "--model", "haiku"]
rewrite_timeout_seconds = 30            # omitted: inherits timeout_seconds
rewrite_fallback_template = "You must act based on the following: {original_text}"
```

When a learned rule resolves to literal free text (idle next-task prompt, error retry command, free-text approval reply), the daemon runs the one-shot rewrite CLI — stdout is the rewritten text — and delivers the result. **Menu-digit answers are never rewritten.**

## Invariants

- A rewrite failure (error / timeout / empty / oversized output) **never blocks the send**: the original is delivered wrapped in `rewrite_fallback_template`.
- The rewritten text is **re-gated through every safety control** at delivery time: kill switch, never-auto allowlist, irreversible heuristic (degrade to the wrapped original first; escalate only if that also trips), rate guard, and a staleness re-check of the visible pane.
- **Learning is unaffected**: decision history records the original learned action (`@next_task:*`, option label, retry command), never the nondeterministic rewritten text.
- The subprocess runs in a goroutine funneled back through the main select loop (never stalls it); one flight per agent with a token registry — newer decisions and human interaction cancel in-flight rewrites.
- Audit-before-send (FR-024) holds: the audit row (with the final text, the rewrite note, and the original) commits before delivery.

## Implementation

- `internal/domain`: `RewriteRequest`, `ApplyRewriteFallback` (pure), `DeliverOutbound` (menu-mapped bool; `DeliverKeystroke` unchanged wrapper)
- `internal/ports`: optional `RewriterPort` (LLMPort untouched — no fake breakage)
- `internal/llm/rewrite.go`: one-shot subprocess; auto-repair runs on the raw template **before** untrusted pane text is substituted; separate stdout/stderr
- `internal/daemon`: `startRewrite` / `handleRewriteOutcome` pipeline; `act()` tail extracted into shared `deliverAutonomous`; pane excerpts switched to the visible read (the consuming `recent` delta is already drained by classification — also fixes the consult-context excerpt)
- Frontend/TUI/CLI: three new `llm.rewrite_*` config keys
- 30+ new unit tests incl. safety invariants (allowlist-tripping rewrite discarded, booby-trapped fallback escalates, kill switch mid-flight, FR-024, supersede/dedupe, staleness policies)

## Verification

- `go test ./... -count=1` — all 15 packages pass (run twice via test-runner agent)
- `gofmt` / `go vet` / `golangci-lint` clean
- `go test -tags integration ./test/integration/` against a real herdr 0.7.1 — pass
- Code-reviewed (two review passes); all Major/Minor findings fixed: visible-read excerpt, in-flight invalidation on newer decisions, fail-closed rate guard, no materialized timeout inheritance, oversized-output fail-safe, normalize-before-substitute
- Live CLI smoke: `hap config set llm.rewrite_*` round-trips with quote handling

Bumps plugin version to **0.1.17** (tag after merge per release flow).

https://claude.ai/code/session_01G5ANCGcVWmRUcTX4A1A2CK