### PR TITLE
#1 feat: per-agent-type Tier-2 task inference (Claude todo-widget extractor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,12 @@ max_auto_prompts_per_minute = 10   # per agent
 max_error_retries = 2              # per error signature
 
 # Point agents/workspaces at a task list so idle agents get the next
-# unchecked item. Without a declared source, the plugin only infers a next
-# task from an explicit checklist the agent itself printed — never free-form
-# prose — and holds it to the higher inferred_task_bar.
+# unchecked item. Without a declared source, the plugin falls back to
+# inferring the next task from the agent's own native todo rendering —
+# never free-form prose — held to the higher inferred_task_bar. Inference
+# is agent-type-specific: currently only `claude` is supported (Claude
+# Code's ✔/■/□ todo widget; the in-progress item wins, else the first
+# pending one). Other agent types skip inference entirely and escalate.
 #
 # The prompt sent to the agent is rendered from a template. The default is:
 #   "Your next task is {next_task_content}. Read the full tasks list at {task_list_path}."

--- a/internal/domain/decide.go
+++ b/internal/domain/decide.go
@@ -201,7 +201,7 @@ func resolveSituation(in DecideInput, conf ConfidenceResult) (candidate, suggest
 		if in.DeclaredTask != nil {
 			return ActionNextDeclaredTask, "send next declared task: " + in.DeclaredTask.Prompt(), ReasonNone
 		}
-		inferred := InferNextTask(in.Situation.Content)
+		inferred := InferNextTask(in.Situation.AgentType, in.Situation.Content)
 		if inferred.Structured {
 			// Pane-history inference is held to the higher bar.
 			if conf.Score <= in.Thresholds.InferredTaskBar && in.State != nil && in.State.Mode == ModeAutonomous {
@@ -249,7 +249,7 @@ func materialize(in DecideInput, action string) (input, optionID string, ok bool
 		}
 		return in.DeclaredTask.Prompt(), "", true
 	case ActionNextInferredTask:
-		inferred := InferNextTask(in.Situation.Content)
+		inferred := InferNextTask(in.Situation.AgentType, in.Situation.Content)
 		if !inferred.Structured {
 			return "", "", false
 		}
@@ -278,7 +278,7 @@ func optionInSet(option string, options []string) bool {
 func rationaleFor(r EscalateReason) string {
 	switch r {
 	case ReasonNoTaskSource:
-		return "no declared task source and no qualifying structured next-task signal in pane history"
+		return "no declared task source and no native todo signal in pane history (inference runs only for supported agent types)"
 	case ReasonNoHistory:
 		return "no learned history for this signature"
 	case ReasonUnfamiliarOptions:

--- a/internal/domain/decide_test.go
+++ b/internal/domain/decide_test.go
@@ -219,8 +219,23 @@ func TestIdleInferredTaskRequiresStructuredSignal(t *testing.T) {
 	}
 }
 
+func TestIdleInferredTaskUnsupportedAgentTypeSkipsTier2(t *testing.T) {
+	// Inference is per-agent-type: an agent type without an extractor must
+	// escalate even when its pane shows a perfect todo widget.
+	in := autonomous(baseInput(SituationIdle),
+		ActionNextInferredTask, ActionNextInferredTask, ActionNextInferredTask,
+		ActionNextInferredTask, ActionNextInferredTask, ActionNextInferredTask,
+		ActionNextInferredTask, ActionNextInferredTask)
+	in.Situation.AgentType = "codex"
+	in.Situation.Content = "  ⎿  ✔ write parser\n     ■ add validation for config fields\n     □ wire logging"
+	d := Decide(in)
+	if d.Action != ActionEscalate || d.Reason != ReasonNoTaskSource {
+		t.Fatalf("unsupported agent type must skip tier-2 inference and escalate, got %+v", d)
+	}
+}
+
 func TestIdleInferredTaskHigherBar(t *testing.T) {
-	content := "TODO:\n- [x] write parser\n- [ ] add validation for config fields\n- [ ] wire logging"
+	content := "  ⎿  ✔ write parser\n     ■ add validation for config fields\n     □ wire logging"
 	// History consistent enough to clear the idle threshold (0.75) but the
 	// test uses a mixed history that stays below the inferred bar (0.9).
 	in := autonomous(baseInput(SituationIdle),

--- a/internal/domain/safety.go
+++ b/internal/domain/safety.go
@@ -239,7 +239,7 @@ func IrreversibleScanContent(s Situation, declaredTask string) string {
 		// Idle has no pending pane operation; what could be irreversible is
 		// the next-task prompt automation would send.
 		parts := []string{declaredTask}
-		if inferred := InferNextTask(s.Content); inferred.Structured {
+		if inferred := InferNextTask(s.AgentType, s.Content); inferred.Structured {
 			parts = append(parts, inferred.Task)
 		}
 		return strings.TrimSpace(strings.Join(parts, "\n"))

--- a/internal/domain/safety_test.go
+++ b/internal/domain/safety_test.go
@@ -251,8 +251,10 @@ func TestIrreversibleScanContent(t *testing.T) {
 		t.Errorf("idle scan must be the declared task only, got %q", got)
 	}
 
-	// Idle with a structured checklist: the inferred next item is scanned.
-	idleList := Situation{Type: SituationIdle, Content: "- [x] step one\n- [ ] drop the users table"}
+	// Idle with the agent's native todo widget: the inferred next item is
+	// scanned (inference is per-agent-type, so AgentType must be set).
+	idleList := Situation{Type: SituationIdle, AgentType: "claude",
+		Content: "  ⎿  ✔ step one\n     □ drop the users table"}
 	got = IrreversibleScanContent(idleList, "")
 	if !strings.Contains(got, "drop the users table") {
 		t.Errorf("idle scan must include the inferred next task, got %q", got)

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -96,69 +96,85 @@ func NextDeclaredTask(content string) string {
 	return ""
 }
 
-// numberedPlanRE matches an explicit numbered plan step like "2. Do thing".
-var numberedPlanRE = regexp.MustCompile(`^\s*\d+[.)]\s+(.\S.+)$`)
-
-// todoMarkerRE matches lines that signal an agent-emitted structured todo.
-var todoMarkerRE = regexp.MustCompile(`(?i)^\s*(#+\s*)?(todo|task list|tasks|next steps|plan)\b[:\s]*$`)
-
 // InferredTask is a next task inferred from the agent's own transcript.
 type InferredTask struct {
 	Task string
-	// Structured is true only when the transcript contained an explicit
-	// structured signal (checklist or numbered plan) with an unambiguous
-	// next item. Free-form prose never qualifies (FR-011).
+	// Structured is true only when the transcript contained the agent
+	// type's native structured todo rendering with an unambiguous next
+	// item. Free-form prose never qualifies (FR-011).
 	Structured bool
 }
 
-// InferNextTask scans a pane transcript for an explicit, structured signal —
-// a todo/checklist or numbered plan the agent itself emitted with an
-// unambiguous next item. It returns a zero value when nothing qualifies:
-// free-form prose that merely discusses possible work does NOT qualify.
-func InferNextTask(transcript string) InferredTask {
-	lines := strings.Split(transcript, "\n")
+// taskInferrers maps an agent type to its transcript task-list extractor.
+// Tier-2 inference is deliberately per-agent-type: each agent CLI renders
+// its todo list differently, and guessing from generic text is unsafe.
+var taskInferrers = map[string]func(transcript string) InferredTask{
+	"claude": inferClaudeNextTask,
+}
 
-	// Pass 1: checkbox checklist — unambiguous if there is exactly one
-	// contiguous checklist block; the next item is its first unchecked entry.
-	var unchecked []string
-	var sawChecklist bool
-	for _, line := range lines {
-		if m := uncheckedItemRE.FindStringSubmatch(line); m != nil {
-			sawChecklist = true
-			unchecked = append(unchecked, strings.TrimSpace(m[1]))
-		} else if checkedItemRE.MatchString(line) {
-			sawChecklist = true
-		}
+// InferNextTask scans a pane transcript for the agent type's native
+// structured todo signal with an unambiguous next item. Agent types
+// without a dedicated extractor return a zero value: Tier-2 inference is
+// skipped entirely rather than guessed (FR-011). The lookup is
+// case-insensitive, matching the classifier's agent-type handling.
+func InferNextTask(agentType, transcript string) InferredTask {
+	infer, ok := taskInferrers[strings.ToLower(agentType)]
+	if !ok {
+		return InferredTask{}
 	}
-	if sawChecklist && len(unchecked) > 0 {
-		return InferredTask{Task: unchecked[0], Structured: true}
-	}
-	if sawChecklist {
-		return InferredTask{} // checklist fully done — nothing next
-	}
+	return infer(transcript)
+}
 
-	// Pass 2: numbered plan under an explicit todo/plan marker. Only the
-	// block immediately following the most recent marker counts, and the
-	// first step is taken as next only when the plan is clearly a plan
-	// (>= 2 steps).
-	lastMarker := -1
-	for i, line := range lines {
-		if todoMarkerRE.MatchString(line) {
-			lastMarker = i
+// claudeTodoItemRE matches one line of Claude Code's todo-widget rendering:
+// optional indent, an optional ⎿/└ connector on the first item, a status
+// marker rune, then the task text. Markers are matched liberally across
+// Claude Code versions/fonts: completed ✔ ✓ ☒, in-progress ■ ▪ ◼,
+// pending □ ▫ ☐.
+var claudeTodoItemRE = regexp.MustCompile(`^\s*([⎿└]\s*)?([✔✓☒■▪◼□▫☐])\s+(\S.*)$`)
+
+// inferClaudeNextTask parses Claude Code's native todo widget:
+//
+//	· Building integration test suite… (27m 52s · ↓ 73.9k tokens)
+//	  ⎿  ✔ Fix send: map option label to menu index
+//	     ✔ TUI full width rendering + config knob
+//	     ■ Real herdr+claude integration test suite
+//	     □ Docs + full verification + PR
+//
+// Claude re-renders the widget as it progresses, so only the freshest
+// render counts: an item line carrying the ⎿/└ connector starts a new
+// block, later marker lines append to it, and every other line — blank
+// lines, narration, or an item's own hard-wrapped continuation (pane
+// content is screen rows, wrapped at pane width) — is ignored rather than
+// treated as a block break, so a wrapped item never splits the widget.
+// The next task is the in-progress (■) item when one exists — the agent
+// stopped mid-item — otherwise the first pending (□) item. A fully
+// completed list (or no widget at all) yields a zero value.
+func inferClaudeNextTask(transcript string) InferredTask {
+	type item struct{ marker, text string }
+	var block []item
+	for _, line := range strings.Split(transcript, "\n") {
+		m := claudeTodoItemRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
 		}
+		if m[1] != "" {
+			block = block[:0] // connector = a fresh render; supersede earlier ones
+		}
+		block = append(block, item{marker: m[2], text: strings.TrimSpace(m[3])})
 	}
-	if lastMarker >= 0 {
-		var steps []string
-		for _, line := range lines[lastMarker+1:] {
-			if m := numberedPlanRE.FindStringSubmatch(line); m != nil {
-				steps = append(steps, strings.TrimSpace(m[1]))
-			} else if len(steps) > 0 && strings.TrimSpace(line) != "" {
-				break
+	var firstPending string
+	for _, it := range block {
+		switch it.marker {
+		case "■", "▪", "◼":
+			return InferredTask{Task: it.text, Structured: true}
+		case "□", "▫", "☐":
+			if firstPending == "" {
+				firstPending = it.text
 			}
 		}
-		if len(steps) >= 2 {
-			return InferredTask{Task: steps[0], Structured: true}
-		}
+	}
+	if firstPending != "" {
+		return InferredTask{Task: firstPending, Structured: true}
 	}
 	return InferredTask{}
 }

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -97,48 +97,130 @@ func TestMatchWorkspace(t *testing.T) {
 }
 
 func TestInferNextTask(t *testing.T) {
+	claudeWidget := "· Building integration test suite… (27m 52s · ↓ 73.9k tokens)\n" +
+		"  ⎿  ✔ Fix send: map option label to menu index\n" +
+		"     ✔ TUI full width rendering + config knob\n" +
+		"     ■ Real herdr+claude integration test suite\n" +
+		"     □ Docs + full verification + PR\n"
+
 	cases := []struct {
 		name       string
+		agentType  string
 		transcript string
 		wantTask   string
 		structured bool
 	}{
 		{
-			name:       "agent-emitted checklist",
-			transcript: "Here is my plan:\n- [x] parse input\n- [ ] validate fields\n- [ ] emit output",
+			name:       "in-progress item preferred over pending",
+			agentType:  "claude",
+			transcript: claudeWidget,
+			wantTask:   "Real herdr+claude integration test suite",
+			structured: true,
+		},
+		{
+			name:      "first pending when nothing in progress",
+			agentType: "claude",
+			transcript: "  ⎿  ✔ parse input\n" +
+				"     □ validate fields\n" +
+				"     □ emit output\n",
 			wantTask:   "validate fields",
 			structured: true,
 		},
 		{
-			name:       "numbered plan under todo marker",
-			transcript: "TODO:\n1. refactor the store layer\n2. add integration tests",
-			wantTask:   "refactor the store layer",
+			name:      "all completed yields nothing",
+			agentType: "claude",
+			transcript: "  ⎿  ✔ everything\n" +
+				"     ✓ is done\n",
+			structured: false,
+		},
+		{
+			name:      "last block wins over stale earlier render",
+			agentType: "claude",
+			transcript: "  ⎿  □ old first item\n" +
+				"     □ old second item\n" +
+				"\nSome narration in between.\n\n" +
+				"  ⎿  ✔ old first item\n" +
+				"     ■ fresher current item\n" +
+				"     □ later item\n",
+			wantTask:   "fresher current item",
 			structured: true,
 		},
 		{
+			name:       "alternate marker runes handled",
+			agentType:  "claude",
+			transcript: "  ⎿  ☒ setup\n     ▪ wire the adapter\n     ☐ write docs\n",
+			wantTask:   "wire the adapter",
+			structured: true,
+		},
+		{
+			name:      "wrapped item line does not split the block",
+			agentType: "claude",
+			transcript: "  ⎿  ✔ setup\n" +
+				"     ■ a long in-progress item whose text\n" +
+				"       hard-wraps onto this continuation line\n" +
+				"     □ pending item\n",
+			wantTask:   "a long in-progress item whose text",
+			structured: true,
+		},
+		{
+			name:      "└ connector variant handled",
+			agentType: "claude",
+			transcript: "  └ ✔ setup\n" +
+				"    ■ current work\n",
+			wantTask:   "current work",
+			structured: true,
+		},
+		{
+			name:      "connector line without a marker neither parses nor resets",
+			agentType: "claude",
+			transcript: "  ⎿  ✔ setup\n" +
+				"     □ pending item\n" +
+				"\n· Reading 1 file…\n" +
+				"  ⎿ internal/herdr/cli.go\n",
+			wantTask:   "pending item",
+			structured: true,
+		},
+		{
+			name:       "agent type lookup is case-insensitive",
+			agentType:  "Claude",
+			transcript: "  ⎿  ■ current work\n",
+			wantTask:   "current work",
+			structured: true,
+		},
+		{
+			name:       "markdown checklist no longer qualifies",
+			agentType:  "claude",
+			transcript: "Here is my plan:\n- [x] parse input\n- [ ] validate fields\n- [ ] emit output",
+			structured: false,
+		},
+		{
+			name:       "numbered plan no longer qualifies",
+			agentType:  "claude",
+			transcript: "TODO:\n1. refactor the store layer\n2. add integration tests",
+			structured: false,
+		},
+		{
 			name:       "free-form prose does not qualify",
+			agentType:  "claude",
 			transcript: "We might want to think about improving error handling and maybe caching.",
 			structured: false,
 		},
 		{
-			name:       "completed checklist yields nothing",
-			transcript: "- [x] everything\n- [x] is done",
+			name:       "unsupported agent type skips inference entirely",
+			agentType:  "codex",
+			transcript: claudeWidget,
 			structured: false,
 		},
 		{
-			name:       "single numbered line is not a plan",
-			transcript: "Plan:\n1. just one ambiguous thing",
-			structured: false,
-		},
-		{
-			name:       "numbers without a todo marker do not qualify",
-			transcript: "The 3 issues were:\n1. flaky test\n2. race condition",
+			name:       "empty agent type skips inference",
+			agentType:  "",
+			transcript: claudeWidget,
 			structured: false,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := InferNextTask(c.transcript)
+			got := InferNextTask(c.agentType, c.transcript)
 			if got.Structured != c.structured {
 				t.Fatalf("Structured = %v, want %v (task %q)", got.Structured, c.structured, got.Task)
 			}


### PR DESCRIPTION
## What

Reworks Tier-2 idle next-task inference (FR-011) from a generic transcript parser into **per-agent-type extractors**:

- `InferNextTask(agentType, transcript)` now dispatches through a `taskInferrers` registry (case-insensitive agent-type lookup). Agent types **without** a dedicated extractor skip Tier-2 entirely — no more guessing from generic text.
- First registered extractor: **Claude Code's native todo-widget rendering** (status-marker runes, `⎿`/`└` connectors, optional indent), returning a structured next item only when unambiguous.
- The old generic checklist/numbered-plan passes are removed; free-form prose still never qualifies.
- `decide.go` threads the situation's agent type through; safety/tests/README updated accordingly.

## Why

Each agent CLI renders its todo list differently — a generic parser both misses real todo widgets and false-positives on prose that merely looks like a checklist. Scoping inference to known agent-native renderings keeps Tier-2 useful without unsafe guesses.

## Verification

- `go test ./... -count=1` — all 15 packages pass on this branch (after merging `origin/main` v0.1.17, i.e. together with the new LLM rewrite pipeline, which calls `InferNextTask` via `Decide`/`materialize`)
- `gofmt` / `go vet` clean; CI gates the rest

Note: this branch was lifted off the `main` checkout's staged work (repo rule: never commit to `main`) and merged with `origin/main` (v0.1.17) — the README merged cleanly.

https://claude.ai/code/session_01G5ANCGcVWmRUcTX4A1A2CK