### PR TITLE
#1 fix: claude todo parser matches real TUI output

### DIFF
--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -126,48 +126,64 @@ func InferNextTask(agentType, transcript string) InferredTask {
 }
 
 // claudeTodoItemRE matches one line of Claude Code's todo-widget rendering:
-// optional indent, an optional ⎿/└ connector on the first item, a status
-// marker rune, then the task text. Markers are matched liberally across
-// Claude Code versions/fonts: completed ✔ ✓ ☒, in-progress ■ ▪ ◼,
-// pending □ ▫ ☐.
-var claudeTodoItemRE = regexp.MustCompile(`^\s*([⎿└]\s*)?([✔✓☒■▪◼□▫☐])\s+(\S.*)$`)
+// optional indent, an optional ⎿/└ connector, a status marker rune, then
+// the task text. Marker runes vary across Claude Code versions/fonts —
+// verified against real TUI copies in test/samples/claude_todo_sample*.txt:
+// completed ✔ ✓ ☒, in-progress ■ ▪ ◼ ◾, pending □ ▫ ☐ ◻ ◽.
+var claudeTodoItemRE = regexp.MustCompile(`^\s*(?:[⎿└]\s*)?([✔✓☒■▪◼◾□▫☐◻◽])\s+(\S.*)$`)
 
-// inferClaudeNextTask parses Claude Code's native todo widget:
+// claudeTodoHeaderRE matches the widget's header/status line — a spinner
+// glyph (frames vary: · * ✽ ✻ ✶ ✳ ✢, or the ● message bullet), a space,
+// and text containing the "…" ellipsis every header carries ("Wiring
+// daemon semantic resolver… (1h 42m · ↓ 133.0k tokens)"). A header ends
+// the current block so back-to-back renders with no blank line between
+// them never concatenate; requiring the ellipsis keeps an item's wrapped
+// continuation line from ever matching.
+var claudeTodoHeaderRE = regexp.MustCompile(`^\s*[·✻✽✶✳✢*●]\s.*…`)
+
+// inferClaudeNextTask parses Claude Code's native todo widget, e.g. (a
+// real TUI copy; the header spinner varies — · * ✽ ✻ — and a footer like
+// "… +2 pending, 3 completed" summarizes items hidden by truncation):
 //
-//	· Building integration test suite… (27m 52s · ↓ 73.9k tokens)
-//	  ⎿  ✔ Fix send: map option label to menu index
-//	     ✔ TUI full width rendering + config knob
-//	     ■ Real herdr+claude integration test suite
-//	     □ Docs + full verification + PR
+//	✻ Wiring daemon semantic resolver… (1h 42m 16s · ↓ 133.0k tokens)
+//	◼ Daemon: resolveSignature 5-step flow + initSemantic + Options wiring
+//	◻ Packaging: release.yml 4-runner matrix, install.sh, docs
+//	✔ Set up worktree, submodule, native deps
+//	 … +5 completed
 //
 // Claude re-renders the widget as it progresses, so only the freshest
-// render counts: an item line carrying the ⎿/└ connector starts a new
-// block, later marker lines append to it, and every other line — blank
-// lines, narration, or an item's own hard-wrapped continuation (pane
-// content is screen rows, wrapped at pane width) — is ignored rather than
-// treated as a block break, so a wrapped item never splits the widget.
-// The next task is the in-progress (■) item when one exists — the agent
-// stopped mid-item — otherwise the first pending (□) item. A fully
-// completed list (or no widget at all) yields a zero value.
+// render counts: a blank line or a widget header line ends the current
+// block, and the next item line after that starts a new block superseding
+// earlier ones. Other non-item lines — an item's own hard-wrapped
+// continuation (pane content is screen rows, wrapped at pane width), the
+// "… +N" footer, or adjacent narration — never split a block, so a
+// wrapped item cannot hide an in-progress entry. The next task is the
+// first in-progress item when one exists (the widget sorts in-progress
+// before pending), otherwise the first pending item. A fully completed
+// list (or no widget at all) yields a zero value.
 func inferClaudeNextTask(transcript string) InferredTask {
 	type item struct{ marker, text string }
 	var block []item
+	inBlock := false
 	for _, line := range strings.Split(transcript, "\n") {
-		m := claudeTodoItemRE.FindStringSubmatch(line)
-		if m == nil {
+		if m := claudeTodoItemRE.FindStringSubmatch(line); m != nil {
+			if !inBlock {
+				block = block[:0] // a newer render supersedes earlier ones
+				inBlock = true
+			}
+			block = append(block, item{marker: m[1], text: strings.TrimSpace(m[2])})
 			continue
 		}
-		if m[1] != "" {
-			block = block[:0] // connector = a fresh render; supersede earlier ones
+		if strings.TrimSpace(line) == "" || claudeTodoHeaderRE.MatchString(line) {
+			inBlock = false // a blank line or fresh header ends the widget
 		}
-		block = append(block, item{marker: m[2], text: strings.TrimSpace(m[3])})
 	}
 	var firstPending string
 	for _, it := range block {
 		switch it.marker {
-		case "■", "▪", "◼":
+		case "■", "▪", "◼", "◾":
 			return InferredTask{Task: it.text, Structured: true}
-		case "□", "▫", "☐":
+		case "□", "▫", "☐", "◻", "◽":
 			if firstPending == "" {
 				firstPending = it.text
 			}

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -1,6 +1,10 @@
 package domain
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestNextDeclaredTask(t *testing.T) {
 	cases := []struct {
@@ -96,6 +100,34 @@ func TestMatchWorkspace(t *testing.T) {
 	}
 }
 
+// TestInferClaudeNextTaskRealSamples pins the parser against verbatim
+// copies of Claude Code's TUI (test/samples/claude_todo_sample*.txt):
+// mixed narration, shell-echo ⎿ widgets, varying header spinners (* ✽ ✻),
+// the "… +N pending, M completed" truncation footer, and the real marker
+// runes ◼ (in progress) / ◻ (pending) / ✔ (completed) without connectors.
+func TestInferClaudeNextTaskRealSamples(t *testing.T) {
+	cases := []struct {
+		file string
+		want string
+	}{
+		{"claude_todo_sample1.txt", "Set up worktree, submodule, native deps (llama-go libbinding.a, FAISS libfaiss_c, cmake)"},
+		{"claude_todo_sample2.txt", "Set up worktree, submodule, native deps (llama-go libbinding.a, FAISS libfaiss_c, cmake)"},
+		{"claude_todo_sample3.txt", "Daemon: resolveSignature 5-step flow + initSemantic + Options wiring + hap status"},
+	}
+	for _, c := range cases {
+		t.Run(c.file, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join("..", "..", "test", "samples", c.file))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := InferNextTask("claude", string(data))
+			if !got.Structured || got.Task != c.want {
+				t.Errorf("InferNextTask = %+v, want structured task %q", got, c.want)
+			}
+		})
+	}
+}
+
 func TestInferNextTask(t *testing.T) {
 	claudeWidget := "· Building integration test suite… (27m 52s · ↓ 73.9k tokens)\n" +
 		"  ⎿  ✔ Fix send: map option label to menu index\n" +
@@ -150,6 +182,49 @@ func TestInferNextTask(t *testing.T) {
 			agentType:  "claude",
 			transcript: "  ⎿  ☒ setup\n     ▪ wire the adapter\n     ☐ write docs\n",
 			wantTask:   "wire the adapter",
+			structured: true,
+		},
+		{
+			name:      "real TUI markers ◼/◻ without connectors",
+			agentType: "claude",
+			transcript: "* Setting up native build environment… (27m 29s · ↓ 66.0k tokens)\n" +
+				"◼ Set up worktree and native deps\n" +
+				"◻ Embedder adapter\n",
+			wantTask:   "Set up worktree and native deps",
+			structured: true,
+		},
+		{
+			name:      "connectorless renders separated by a blank line supersede",
+			agentType: "claude",
+			transcript: "✽ Working… (1m · ↓ 1k tokens)\n" +
+				"◼ task A\n" +
+				"◻ task B\n" +
+				"\n" +
+				"✻ Working… (2m · ↓ 2k tokens)\n" +
+				"✔ task A\n" +
+				"◼ task B\n",
+			wantTask:   "task B",
+			structured: true,
+		},
+		{
+			name:      "back-to-back renders without a blank line supersede via the header",
+			agentType: "claude",
+			transcript: "✽ Working… (1m · ↓ 1k tokens)\n" +
+				"◼ task A\n" +
+				"◻ task B\n" +
+				"✻ Working… (2m · ↓ 2k tokens)\n" +
+				"✔ task A\n" +
+				"◼ task B\n",
+			wantTask:   "task B",
+			structured: true,
+		},
+		{
+			name:      "pending-only ◻ list falls back to first pending",
+			agentType: "claude",
+			transcript: "✻ Planning… (2m 3s · ↓ 1.2k tokens)\n" +
+				"◻ first pending thing\n" +
+				"◻ second pending thing\n",
+			wantTask:   "first pending thing",
 			structured: true,
 		},
 		{

--- a/test/samples/claude_todo_sample1.txt
+++ b/test/samples/claude_todo_sample1.txt
@@ -1,0 +1,8 @@
+bleve's cosine metric maps to FAISS inner-product over normalized vectors, so hit.Score is the true cosine — thresholds compare directly. Writing the matcher package now.
+
+* Setting up native build environment… (27m 29s · ↓ 66.0k tokens)
+◼ Set up worktree, submodule, native deps (llama-go libbinding.a, FAISS libfaiss_c, cmake)
+◼ Add go.mod deps (llama-go replace, bleve/v2) and verify -tags vectors builds
+◼ Matcher internal/match (bleve KNN + BM25)
+◻ Embedder adapter internal/embedder (llama-go wrapper)
+◻ Daemon: resolveSignature 5-step flow + initSemantic + Options wiring + hap status

--- a/test/samples/claude_todo_sample2.txt
+++ b/test/samples/claude_todo_sample2.txt
@@ -1,0 +1,16 @@
+Found 1 new diagnostic issue in 1 file (ctrl+o to expand)
+
+The link drags in -lggml-vulkan -lvulkan. Checking why the vulkan variant got compiled in.
+
+  Searching for 2 patterns, listing 1 directory, running 9 shell commands…
+  ⎿  $ sed -n '40,52p' /workspaces/native-build/faiss/c_api/CMakeLists.txt
+
+● Background command "Build faiss core then relink faiss_c" failed with exit code 1
+
+✽ Setting up native build environment… (1h 24m 14s · ↓ 85.3k tokens · thought for 2s)
+◼ Set up worktree, submodule, native deps (llama-go libbinding.a, FAISS libfaiss_c, cmake)
+◼ Add go.mod deps (llama-go replace, bleve/v2) and verify -tags vectors builds
+◼ Embedder adapter internal/embedder (llama-go wrapper)
+◼ Matcher internal/match (bleve KNN + BM25)
+◻ Daemon: resolveSignature 5-step flow + initSemantic + Options wiring + hap status
+ … +2 pending, 3 completed

--- a/test/samples/claude_todo_sample3.txt
+++ b/test/samples/claude_todo_sample3.txt
@@ -1,0 +1,12 @@
+
+● Running 1 shell command…
+  ⎿  $ go test -tags "vectors cpu" ./... -count=1 2>&1 | grep -vE "^ok|no test files" | head -8; echo ===; gofmt -l . 2>/dev/null | grep -v third_party | head
+Found 10 new diagnostic issues in 1 file (ctrl+o to expand)
+
+✻ Wiring daemon semantic resolver… (1h 42m 16s · ↓ 133.0k tokens)
+◼ Daemon: resolveSignature 5-step flow + initSemantic + Options wiring + hap status
+◻ Packaging: release.yml 4-runner matrix, install.sh (libfaiss_c + HF model), setup-native.sh, docs
+◻ Run full test suite via subagent, code review via subagent, fix findings, open PR
+✔ Set up worktree, submodule, native deps (llama-go libbinding.a, FAISS libfaiss_c, cmake)
+✔ Add go.mod deps (llama-go replace, bleve/v2) and verify -tags vectors builds
+ … +5 completed


### PR DESCRIPTION
## Summary

Cross-checked the Tier-2 `claude` todo-widget extractor (merged in #5) against three verbatim copies of Claude Code's TUI and fixed two defects the real output exposed:

- **Missing marker runes.** The TUI renders pending items as `◻` (U+25FB) and in-progress as `◼` (U+25FC). The pending set was missing `◻` entirely, so a widget with only pending items extracted nothing. Marker sets now cover both glyph families: completed `✔ ✓ ☒`, in-progress `■ ▪ ◼ ◾`, pending `□ ▫ ☐ ◻ ◽`.
- **Wrong `⎿`-connector assumption.** Real todo items carry no connector (`⎿` belongs to other widgets, e.g. shell-command echoes), so the connector-based fresh-render detection never fired and stale re-renders could merge. Blocks now end on a blank line **or a widget header line** (spinner glyph + `…` ellipsis); the next item starts a fresh block that supersedes earlier renders, while hard-wrapped item lines and the `… +N pending, M completed` footer never split a block.

## Test plan

- `TestInferClaudeNextTaskRealSamples` pins the parser against the three verbatim TUI copies in `test/samples/claude_todo_sample*.txt`.
- New table cases: `◼/◻` connectorless format, pending-only fallback, and both supersede shapes (blank-line separated and back-to-back renders).
- Full `go test ./... -count=1` green after rebasing onto latest `main`; `gofmt`/`go vet` clean.