### PR TITLE
#1 chore: drop Intel-macOS (darwin-amd64) release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,10 @@ jobs:
       matrix:
         include:
           # CGO cannot cross-compile, so each target builds on its own
-          # native runner.
+          # native runner. Intel macOS (darwin-amd64) is deliberately
+          # unsupported: Apple Silicon only.
           - { os: ubuntu-latest,    target: linux-amd64 }
           - { os: ubuntu-24.04-arm, target: linux-arm64 }
-          - { os: macos-13,         target: darwin-amd64 }
           - { os: macos-14,         target: darwin-arm64 }
     runs-on: ${{ matrix.os }}
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,8 +94,10 @@ with a ticket/issue id**. Examples from history:
 
 Releases are **tag-driven**: merging a PR does NOT create a release.
 `.github/workflows/release.yml` fires on a `v*.*.*` tag push, runs the full
-CI gate, then builds on FOUR native runners (CGO cannot cross-compile):
-`hap-{linux,darwin}-{amd64,arm64}` (llama.cpp statically linked in), a
+CI gate, then builds on THREE native runners (CGO cannot cross-compile; Intel
+macOS is deliberately unsupported):
+`hap-{linux-amd64,linux-arm64,darwin-arm64}` (llama.cpp statically
+linked in), a
 `hap-native-<os>-<arch>.tar.gz` per platform (FAISS shared libs, plus
 libomp on macOS, rpath'd to `<plugin>/lib`), the
 `all-minilm-l6-v2-q8_0.gguf` embedding model fetched from Hugging Face

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,6 +33,10 @@ case "$(uname -m)" in
   x86_64 | amd64) ARCH="amd64" ;;
   *) fail "unsupported architecture: $(uname -m)" ;;
 esac
+# No Intel-macOS release assets are published: Apple Silicon only.
+if [ "$OS" = "darwin" ] && [ "$ARCH" = "amd64" ]; then
+  fail "Intel macOS (darwin-amd64) is not supported; hap ships Apple Silicon (arm64) builds only"
+fi
 ASSET="hap-${OS}-${ARCH}"
 NATIVE_ASSET="hap-native-${OS}-${ARCH}.tar.gz"
 MODEL_FILE="all-minilm-l6-v2-q8_0.gguf"


### PR DESCRIPTION
Apple Silicon only, per operator decision:

- `release.yml`: remove the `macos-13` / `darwin-amd64` matrix entry — one fewer ~15-minute uncached native build per tagged release; the matrix is now linux-amd64, linux-arm64, darwin-arm64.
- `install.sh`: Intel Macs now fail fast with "Intel macOS (darwin-amd64) is not supported" instead of retrying a nonexistent release asset for a minute and dying on a 404.
- `CLAUDE.md`: release-flow docs updated (three runners, explicit note that Intel macOS is deliberately unsupported).

CI is unaffected — it already tests on `macos-14` (arm64) only.

https://claude.ai/code/session_017eTY1KCvKoxYRDMxc6GECZ