### PR TITLE
#1 fix: build linux release artifacts on ubuntu-22.04 (glibc 2.35 floor)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,11 @@ jobs:
           # CGO cannot cross-compile, so each target builds on its own
           # native runner. Intel macOS (darwin-amd64) is deliberately
           # unsupported: Apple Silicon only.
-          - { os: ubuntu-latest,    target: linux-amd64 }
-          - { os: ubuntu-24.04-arm, target: linux-arm64 }
+          # Linux artifacts build on 22.04 deliberately: CGO binaries (and
+          # the bundled FAISS libs) inherit the builder's glibc floor, and
+          # 24.04's glibc 2.39 breaks Debian 12 / Ubuntu 22.04 hosts.
+          - { os: ubuntu-22.04,     target: linux-amd64 }
+          - { os: ubuntu-22.04-arm, target: linux-arm64 }
           - { os: macos-14,         target: darwin-arm64 }
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Running `scripts/install.sh` end-to-end against the freshly published v0.2.0 release on a Debian 12 devcontainer revealed the installed binary cannot start:

```
./bin/hap: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
```

Root cause: since the semantic-matching branch, releases are CGO builds, and a CGO binary (plus the bundled `libfaiss*.so`) inherits the **glibc version floor of the build machine**. `ubuntu-latest` is 24.04 (glibc 2.39), so the artifacts require ≥2.38 and break on Debian 12 (2.36) and Ubuntu 22.04 (2.35). The previous pure-Go cross-compiled releases had no such floor, which is why this never mattered before.

Fix: pin the linux build-matrix runners to `ubuntu-22.04` / `ubuntu-22.04-arm` (glibc 2.35 floor — covers Debian 12 and Ubuntu 22.04+). The CI gate and publish jobs stay on `ubuntu-latest` since they ship no binaries.

After merge the `v0.2.0` tag needs to move once more so the release artifacts are rebuilt on the older runners.

https://claude.ai/code/session_017eTY1KCvKoxYRDMxc6GECZ