### PR TITLE
#1 fix: include runner image in native-build cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             .cache/native
             third_party/llama-go/*.a
             third_party/llama-go/llama.cpp/**/*.o
-          key: native-lint-${{ runner.os }}-${{ hashFiles('scripts/setup-native.sh') }}-${{ steps.subsha.outputs.sha }}
+          key: native-lint-${{ runner.os }}-${{ env.ImageOS }}-${{ hashFiles('scripts/setup-native.sh') }}-${{ steps.subsha.outputs.sha }}
       - name: Build native dependencies
         run: bash scripts/setup-native.sh
       - name: gofmt
@@ -77,7 +77,7 @@ jobs:
             .cache/native
             third_party/llama-go/*.a
             third_party/llama-go/llama.cpp/**/*.o
-          key: native-test-${{ matrix.os }}-${{ hashFiles('scripts/setup-native.sh') }}-${{ steps.subsha.outputs.sha }}
+          key: native-test-${{ matrix.os }}-${{ env.ImageOS }}-${{ hashFiles('scripts/setup-native.sh') }}-${{ steps.subsha.outputs.sha }}
       - name: Build native dependencies
         run: bash scripts/setup-native.sh
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
             .cache/native
             third_party/llama-go/*.a
             third_party/llama-go/llama.cpp/**/*.o
-          key: native-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/setup-native.sh') }}-${{ steps.subsha.outputs.sha }}
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ hashFiles('scripts/setup-native.sh') }}-${{ steps.subsha.outputs.sha }}
       - name: Build native dependencies
         run: bash scripts/setup-native.sh
       - name: gofmt
@@ -79,7 +79,7 @@ jobs:
             .cache/native
             third_party/llama-go/*.a
             third_party/llama-go/llama.cpp/**/*.o
-          key: native-${{ matrix.target }}-${{ hashFiles('scripts/setup-native.sh') }}-${{ steps.subsha.outputs.sha }}
+          key: native-${{ matrix.target }}-${{ env.ImageOS }}-${{ hashFiles('scripts/setup-native.sh') }}-${{ steps.subsha.outputs.sha }}
       - name: Build native dependencies
         run: bash scripts/setup-native.sh
       - name: Build hap binary

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -729,10 +729,13 @@ func TestRunawayGuardPausesAgent(t *testing.T) {
 	if len(h.herdr.sentInputs()) != 5 {
 		t.Fatalf("6th consecutive prompt must be blocked; sent %d", len(h.herdr.sentInputs()))
 	}
-	rate, _ := h.raw.GetAgentRate(context.Background(), "agent-8")
-	if !rate.Paused {
-		t.Error("agent should be paused pending human check-in")
-	}
+	// escalate() persists the pause AFTER the escalation audit row, so the
+	// pause may not be visible yet when PendingEscalations first reports 1 —
+	// poll instead of asserting immediately (flaked under -race).
+	waitFor(t, 3*time.Second, func() bool {
+		rate, _ := h.raw.GetAgentRate(context.Background(), "agent-8")
+		return rate.Paused
+	})
 
 	// Human interaction (agent starts working without our input) resumes.
 	h.push("agent-8", "working")


### PR DESCRIPTION
Follow-up to #9: the v0.2.0 rebuild on `ubuntu-22.04` failed at link time with

```
/usr/local/lib/../lib/libfaiss.so: undefined reference to `__isoc23_strtol@GLIBC_2.38'
```

because the native cache key (`native-<target>-<script hash>-<submodule sha>`) doesn't distinguish runner images — the 22.04 job restored the FAISS build cached by the earlier `ubuntu-latest` (24.04) run.

Fix: add `${{ env.ImageOS }}` (`ubuntu22` / `ubuntu24` / `macos14` — the same discriminator `actions/setup-go` uses in its cache keys) to all four native cache keys in `ci.yml` and `release.yml`. Any future runner-image change now misses the cache and rebuilds instead of silently restoring binaries with the wrong glibc floor.

The two poisoned caches were deleted manually and the v0.2.0 run re-ran, so this PR is about preventing recurrence, not unblocking the current release.

https://claude.ai/code/session_017eTY1KCvKoxYRDMxc6GECZ