### PR TITLE
#1 fix: dismiss escalations instantly — no confirmation needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,13 @@ The plugin never acts on a situation it hasn't learned from you.
    same. From the CLI: `confirm <id> --send` or
    `resolve <id> --action TEXT --send`. Escalations you don't want to
    answer can be **deleted**: `space` marks one or more rows, `x` deletes
-   the marked (or selected) ones, and `X` prunes everything older than an
-   age you pick (default 360 minutes). Deleting dismisses without
-   responding — the audit row is kept as `dismissed`, nothing is sent or
-   learned. CLI: `dismiss <id>...` and `escalations prune [minutes]`.
+   the marked (or selected) ones right away (no confirmation — dismissing
+   is safe, nothing is sent or learned), and `X` prunes everything older
+   than an age you pick (default 360 minutes). Deleting dismisses without
+   responding — the audit row is kept as `dismissed`. Deleting a learned
+   rule still asks for confirmation, and audit entries can't be deleted
+   individually (only the full clear-data reset removes them). CLI:
+   `dismiss <id>...` and `escalations prune [minutes]`.
 3. **Graduate.** After **5 consecutive consistent confirmations** (configurable)
    *and* confidence above the per-situation threshold, that signature becomes
    autonomous: next time, the plugin acts on its own and logs it.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -430,11 +430,13 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "x", "delete":
 		switch m.tab {
 		case tabEscalations:
-			return m.deleteEscalationsPrompt()
+			return m.deleteEscalations()
 		case tabSignatures:
 			return m.deleteSignaturePrompt()
 		case tabConfig:
 			return m.removeSelectedRule()
+		case tabAudit:
+			m.message = "audit log is append-only — entries can't be deleted individually"
 		}
 	case "X":
 		switch m.tab {
@@ -590,10 +592,10 @@ func describeEscalations(ids []int64) string {
 	return fmt.Sprintf("%d escalations (%s)", len(ids), strings.Join(parts, " "))
 }
 
-// deleteEscalationsPrompt confirms then dismisses the targeted escalations:
-// they leave the pending queue without a reply being sent or learned; the
+// deleteEscalations immediately dismisses the targeted escalations — no
+// confirmation: dismissing is safe (nothing is sent or learned) and the
 // audit rows are kept with status "dismissed".
-func (m Model) deleteEscalationsPrompt() (tea.Model, tea.Cmd) {
+func (m Model) deleteEscalations() (tea.Model, tea.Cmd) {
 	ids := m.deleteEscalationIDs()
 	if len(ids) == 0 {
 		return m, nil
@@ -601,38 +603,29 @@ func (m Model) deleteEscalationsPrompt() (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	desc := describeEscalations(ids)
 	m.message = ""
-	m.prompt = &prompt{
-		label: fmt.Sprintf("type 'yes' to delete %s — nothing is sent or learned", desc),
-		onSubmit: func(input string) tea.Cmd {
-			return func() tea.Msg {
-				if input != "yes" {
-					return actionResultMsg{message: "delete aborted"}
+	return m, func() tea.Msg {
+		// Skip-and-continue: a failed id usually means the row was
+		// resolved/confirmed concurrently; the rest still delete.
+		deleted := 0
+		var skipped []string
+		var firstErr error
+		for _, id := range ids {
+			if err := app.Dismiss(ctx, id); err != nil {
+				skipped = append(skipped, fmt.Sprintf("#%d", id))
+				if firstErr == nil {
+					firstErr = err
 				}
-				// Skip-and-continue: a failed id usually means the row was
-				// resolved/confirmed concurrently; the rest still delete.
-				deleted := 0
-				var skipped []string
-				var firstErr error
-				for _, id := range ids {
-					if err := app.Dismiss(ctx, id); err != nil {
-						skipped = append(skipped, fmt.Sprintf("#%d", id))
-						if firstErr == nil {
-							firstErr = err
-						}
-						continue
-					}
-					deleted++
-				}
-				if firstErr != nil {
-					return actionResultMsg{err: fmt.Errorf("deleted %d, skipped %s: %w",
-						deleted, strings.Join(skipped, " "), firstErr)}
-				}
-				return actionResultMsg{message: fmt.Sprintf(
-					"deleted %s; audit rows kept as dismissed", desc)}
+				continue
 			}
-		},
+			deleted++
+		}
+		if firstErr != nil {
+			return actionResultMsg{err: fmt.Errorf("deleted %d, skipped %s: %w",
+				deleted, strings.Join(skipped, " "), firstErr)}
+		}
+		return actionResultMsg{message: fmt.Sprintf(
+			"deleted %s; audit rows kept as dismissed", desc)}
 	}
-	return m, nil
 }
 
 // pruneEscalationsPrompt asks for an age in minutes (pre-filled with the

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -732,45 +732,77 @@ func TestEscalationMarkToggleAndRender(t *testing.T) {
 	}
 }
 
-func TestEscalationDeletePromptFlow(t *testing.T) {
+func TestEscalationDeleteImmediate(t *testing.T) {
 	m, _, st, oldID, freshID := escalationsModel(t)
 	ctx := context.Background()
 
-	// x with nothing marked targets the cursor row only.
-	m = press(t, m, "x")
-	if m.prompt == nil || !strings.Contains(m.prompt.label, fmt.Sprintf("escalation #%d", oldID)) {
-		t.Fatalf("x should prompt for the cursor row, got %+v", m.prompt)
-	}
-	// Any non-yes input aborts.
-	m = press(t, m, "n", "o")
-	upd, cmd := m.Update(pressKeyMsg("enter"))
+	// x with nothing marked deletes the cursor row right away — dismissing
+	// an escalation is safe, so no confirmation prompt opens.
+	upd, cmd := m.Update(pressKeyMsg("x"))
 	m = upd.(Model)
-	if msg, ok := cmd().(actionResultMsg); !ok || msg.message != "delete aborted" {
-		t.Fatalf("non-yes input must abort, got %+v", msg)
+	if m.prompt != nil {
+		t.Fatalf("x must not open a confirmation prompt, got %+v", m.prompt)
 	}
-	if esc, _ := st.PendingEscalations(ctx); len(esc) != 2 {
-		t.Fatalf("aborted delete must keep both escalations, got %d", len(esc))
+	if cmd == nil {
+		t.Fatal("x should return the dismiss command")
 	}
+	msg, ok := cmd().(actionResultMsg)
+	if !ok || msg.err != nil || !strings.Contains(msg.message, fmt.Sprintf("escalation #%d", oldID)) {
+		t.Fatalf("x should delete the cursor row immediately, got %+v", msg)
+	}
+	if rec, _ := st.GetAudit(ctx, oldID); rec == nil || rec.Status != "dismissed" {
+		t.Fatalf("audit #%d must be kept as dismissed, got %+v", oldID, rec)
+	}
+	if esc, _ := st.PendingEscalations(ctx); len(esc) != 1 || esc[0].ID != freshID {
+		t.Fatalf("only #%d should remain pending, got %+v", freshID, esc)
+	}
+}
 
-	// Mark both rows, x prompts for the batch, yes dismisses them.
-	m = press(t, m, " ", " ", "x")
-	if m.prompt == nil || !strings.Contains(m.prompt.label, "2 escalations") {
-		t.Fatalf("x should prompt for the marked batch, got %+v", m.prompt)
-	}
-	m = press(t, m, "y", "e", "s")
-	upd, cmd = m.Update(pressKeyMsg("enter"))
+func TestEscalationBatchDeleteImmediate(t *testing.T) {
+	m, _, st, oldID, freshID := escalationsModel(t)
+	ctx := context.Background()
+
+	// Mark both rows; x deletes the batch right away — no prompt.
+	m = press(t, m, " ", " ")
+	upd, cmd := m.Update(pressKeyMsg("x"))
 	m = upd.(Model)
+	if m.prompt != nil {
+		t.Fatalf("batch delete must not open a confirmation prompt, got %+v", m.prompt)
+	}
 	msg, ok := cmd().(actionResultMsg)
 	if !ok || msg.err != nil || !strings.Contains(msg.message, "deleted 2 escalations") {
-		t.Fatalf("yes should delete the marked escalations, got %+v", msg)
+		t.Fatalf("marked delete should run immediately, got %+v", msg)
 	}
 	if esc, _ := st.PendingEscalations(ctx); len(esc) != 0 {
 		t.Errorf("queue should be empty, got %+v", esc)
 	}
-	for _, id := range []int64{freshID, oldID} {
+	for _, id := range []int64{oldID, freshID} {
 		if rec, _ := st.GetAudit(ctx, id); rec == nil || rec.Status != "dismissed" {
 			t.Errorf("audit #%d must be kept as dismissed, got %+v", id, rec)
 		}
+	}
+}
+
+func TestAuditTabDeleteRefused(t *testing.T) {
+	m, _, st, oldID, _ := escalationsModel(t)
+	ctx := context.Background()
+
+	// Move to the Audit tab and press x: nothing may change — the audit
+	// log is append-only.
+	for m.tab != tabAudit {
+		m = press(t, m, "tab")
+	}
+	m.cursor = 0
+	upd, cmd := m.Update(pressKeyMsg("x"))
+	m = upd.(Model)
+	if cmd != nil {
+		t.Fatal("x on the audit tab must not run any mutation")
+	}
+	if !strings.Contains(m.message, "append-only") {
+		t.Errorf("x on the audit tab should explain the log is append-only, got %q", m.message)
+	}
+	if rec, _ := st.GetAudit(ctx, oldID); rec == nil || rec.Status != "escalated" {
+		t.Errorf("audit #%d must be untouched, got %+v", oldID, rec)
 	}
 }
 


### PR DESCRIPTION
Escalations are safe to dismiss (nothing is sent or learned; the audit row is kept as `dismissed`), so the TUI's `x` now deletes the cursor row or the marked batch immediately instead of asking to type `yes`.

The other two entry types keep their existing protection:
- **Rules** (learned signatures): deletion still requires confirmation (TUI `yes` prompt, CLI `--yes`/interactive) — deletion erases learned history.
- **Audit**: no delete/modify path exists; pressing `x` on the Audit tab now explains the log is append-only instead of silently ignoring the key. Only the gated full `clear-data` reset removes audit rows (unchanged).

CLI `dismiss <id>...` and `escalations prune` were already confirmation-free; the TUI now matches.

Tests: `TestEscalationDeleteImmediate`, `TestEscalationBatchDeleteImmediate`, `TestAuditTabDeleteRefused`. Full suite green.

https://claude.ai/code/session_01G5ANCGcVWmRUcTX4A1A2CK