### PR TITLE
#1 feat: submit_decision — select_options MCQ answers, confident_score, recommend_action

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,13 @@ When no confident learned rule applies, the plugin can consult a local
 LLM/agent CLI you already have installed. The model receives context and
 submits its suggestion through the plugin's own MCP server
 (`hap mcp` — tools `get_context` and `submit_decision`); its
-stdout is captured for audit only. Example for Claude Code:
+stdout is captured for audit only. `submit_decision` takes
+`recommend_action` (literal reply text, or `@noop` for "no reply
+needed"), `select_options` (the explicit multiple-choice answer: 1-based
+option numbers — `[2]` for a single menu, one integer per tab for a
+multi-tab form), and an optional `confident_score` (0-100, shown on the
+escalation entry so you can weigh the suggestion). Example for Claude
+Code:
 
 ```toml
 [llm]
@@ -275,7 +281,7 @@ stdout is captured for audit only. Example for Claude Code:
 # auto-repairs a prompt misplaced after other flags — see below).
 command = [
   "claude", "-p",
-  "Use the hap MCP tools: call get_context, decide what the operator would answer — or whether no reply is needed — then call submit_decision (action '@noop' to do nothing).",
+  "Use the hap MCP tools: call get_context, decide what the operator would answer — or whether no reply is needed — then call submit_decision (select_options for multiple-choice, recommend_action '@noop' to do nothing).",
   "--mcp-config", '{"mcpServers":{"hap":{"command":"{self}","args":["mcp"],"env":{"HAP_REQUEST_ID":"{request_id}"}}}}',
   "--allowedTools", "mcp__hap__get_context,mcp__hap__submit_decision",
 ]
@@ -315,7 +321,7 @@ command = [
   "-c", 'mcp_servers.hap.env.HAP_REQUEST_ID="{request_id}"',
   "-c", 'mcp_servers.hap.env.HAP_DB_PATH="{db}"',
   "-c", 'mcp_servers.hap.env.HAP_CONTROL_PATH="{control}"',
-  "Use the hap MCP tools: call get_context, decide what the operator would answer — or whether no reply is needed — then call submit_decision (action '@noop' to do nothing). Do not run any other commands.",
+  "Use the hap MCP tools: call get_context, decide what the operator would answer — or whether no reply is needed — then call submit_decision (select_options for multiple-choice, recommend_action '@noop' to do nothing). Do not run any other commands.",
 ]
 timeout_seconds = 180
 ```
@@ -340,7 +346,7 @@ needed):
 # (auto-repaired if misplaced).
 command = [
   "agy", "--print",
-  "Use the hap MCP tools: call get_context, decide what the operator would answer — or whether no reply is needed — then call submit_decision (action '@noop' to do nothing).",
+  "Use the hap MCP tools: call get_context, decide what the operator would answer — or whether no reply is needed — then call submit_decision (select_options for multiple-choice, recommend_action '@noop' to do nothing).",
   "--dangerously-skip-permissions",
 ]
 timeout_seconds = 180

--- a/docs/specs/herd-auto-prompter/solution.md
+++ b/docs/specs/herd-auto-prompter/solution.md
@@ -212,7 +212,7 @@ sequenceDiagram
 
 **Responsibilities.** For low-confidence situations with an LLM configured, launch the operator's LLM/agent CLI with an attached stdio MCP server (`mcp` subcommand) exposing `get_context` and `submit_decision`; capture stdout/stderr for audit only (FR-010, NFR-006).
 **Key Components.** `mcp` subcommand server, argv template expander, request/timeout controller, correlation id.
-**Key Interfaces.** MCP tools `get_context(request_id)` and `submit_decision(request_id, action, option_id?, rationale)` → the `mcp` process writes a **staged `llm_decisions` row** directly to the DB and nudges the daemon.
+**Key Interfaces.** MCP tools `get_context(request_id)` and `submit_decision(request_id, recommend_action, select_options?, confident_score?, rationale)` → the `mcp` process writes a **staged `llm_decisions` row** directly to the DB and nudges the daemon.
 **Data Models.** `llm_decisions` (staged submission; consumed and re-gated by the daemon, then promoted into `decisions` with `source=LLM` on acceptance), audit fields (captured output).
 **Dependencies.** Local LLM CLI, StorePort.
 **Error Handling.** No `submit_decision` or timeout → escalate (staged row marked `expired`); the submitted decision is re-gated by the confidence gate + never-auto patterns before acting; unparseable tool args → escalate.
@@ -309,6 +309,7 @@ erDiagram
         text action
         text option_id
         text rationale
+        int confident_score
         text captured_output
         text status
         int created_at
@@ -369,9 +370,9 @@ This section makes the coordination model explicit so the single-writer question
 ### MCP tool surface (internal, exposed to the LLM agent)
 
 - `get_context(request_id) -> { situation_type, agent_type, options?, permission_verb?, history_summary }`.
-- `submit_decision(request_id, action, option_id?, rationale)` — the `mcp` process writes an `LLM_DECISIONS` row (`status=pending`) and nudges the daemon; the daemon re-gates it (confidence + never-auto patterns) before promoting it into `DECISIONS` and acting.
+- `submit_decision(request_id, recommend_action, select_options?, confident_score?, rationale)` — the `mcp` process writes an `LLM_DECISIONS` row (`status=pending`) and nudges the daemon; the daemon re-gates it (confidence + never-auto patterns) before promoting it into `DECISIONS` and acting.
 - `action: "@noop"` (sentinel; `noop`/`no_op`/`no-op` normalize to it) — an explicit "no reply needed" decision: promoted like any other submission (audit `action=noop`, learned as `@noop`, runaway counter advanced) but nothing is ever sent to the pane. Breaks the LLM↔agent nudge loop on idle/done status reports. Free text such as "do nothing" is NOT normalized — it stays a literal reply.
-- Multi-tab MCQ forms (Claude AskUserQuestion / plan-mode): the daemon sweeps every tab (Right-arrow protocol, reset with a fixed Left-arrow burst) and the consult context carries the aggregated questions plus `tab_count` and `answer_format`. The answer is a space-separated digit series, one digit per tab INCLUDING the final Submit tab (e.g. `"1 2 3 2 1"`); a length mismatch is rejected — a partial answer is never delivered. Delivery is one digit keystroke per tab (the form advances itself), never literal text.
+- Multi-tab MCQ forms (Claude AskUserQuestion / plan-mode): the daemon sweeps every tab (Right-arrow protocol, reset with a fixed Left-arrow burst) and the consult context carries the aggregated questions plus `tab_count` and `answer_format`. The LLM answers with `select_options` — one integer per tab INCLUDING the final Submit tab (e.g. `[1, 2, 3, 2, 1]`), which the `mcp` process stages as the space-separated digit series (`"1 2 3 2 1"`) the daemon's length gate checks; a length mismatch is rejected — a partial answer is never delivered. Delivery is one digit keystroke per tab (the form advances itself), never literal text.
 
 ### Error Codes / semantics
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -908,6 +908,9 @@ func (d *Daemon) consultContext(ctx context.Context, cfg config.Config, s domain
 		workspaceID = info.WorkspaceID
 	}
 
+	// "options" and "tab_count" are a wire contract with the mcp server's
+	// select_options resolver (mcpserver.consultContextFields) — keep the
+	// key names in sync.
 	fields := map[string]any{
 		"situation_type":  s.Type,
 		"agent_type":      s.AgentType,
@@ -921,13 +924,15 @@ func (d *Daemon) consultContext(ctx context.Context, cfg config.Config, s domain
 		"agent_id":        s.AgentID,
 		"cwd":             info.Cwd,
 		"foreground_cwd":  info.ForegroundCwd,
-		"no_reply_option": "if the agent needs no reply (it finished or is only reporting status), submit_decision with action \"@noop\" to explicitly do nothing",
+		"no_reply_option": "if the agent needs no reply (it finished or is only reporting status), submit_decision with recommend_action \"@noop\" to explicitly do nothing",
 	}
 	if s.TabCount > 1 {
 		fields["tab_count"] = s.TabCount
 		fields["answer_format"] = fmt.Sprintf(
-			"this is a multi-tab question form with %d tabs (the final tab is Submit); the pane excerpt lists every question in order. submit_decision action MUST be a space-separated series of exactly %d digits, one chosen option digit per tab including Submit, e.g. \"1 2 3 2 1\"",
+			"this is a multi-tab question form with %d tabs (the final tab is Submit); the pane excerpt lists every question in order. submit_decision select_options MUST be a list of exactly %d integers, one chosen option number per tab including Submit, e.g. [1, 2, 3, 2, 1]",
 			s.TabCount, s.TabCount)
+	} else if len(s.Options) > 0 {
+		fields["answer_format"] = "answer with submit_decision select_options: a one-element list with the 1-based number of the chosen option, e.g. [2]"
 	}
 	contextJSON, _ := json.Marshal(fields)
 	return contextJSON
@@ -1217,6 +1222,16 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		if isNoop {
 			// Raw "@noop" is never surfaced to humans.
 			suggested = domain.ActionNoopSuggestion
+		}
+		// Surface the agent's self-reported confidence on the escalation so
+		// the operator can weigh the suggestion (-1 = not reported).
+		if llmDec.ConfidentScore >= 0 {
+			conf := fmt.Sprintf("llm confidence %d/100", llmDec.ConfidentScore)
+			if why == "" {
+				why = conf
+			} else {
+				why += "; " + conf
+			}
 		}
 		d.escalate(ctx, s, res.sig, domain.Decision{
 			Action: domain.ActionEscalate, Reason: reason, Rationale: why,

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1166,6 +1166,44 @@ func TestLLMFallbackStagingRegateAndPromotion(t *testing.T) {
 	}
 }
 
+func TestLLMConfidentScoreShownOnEscalation(t *testing.T) {
+	// The agent's self-reported confident_score (0-100) must reach the
+	// escalation entry the operator sees; without one (-1) nothing is added.
+	cfg := "[llm]\ncommand = [\"fake\"]\ntimeout_seconds = 5\n" // auto_act off → shadow reject
+	h := newHarness(t, cfg)
+	h.herdr.setPane(approvalPane)
+	h.llm.configured = true
+	h.llm.consult = func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+		id, err := h.raw.InsertLLMDecision(ctx, domain.LLMDecision{
+			RequestID: req.RequestID, Signature: req.Signature,
+			SituationType: req.SituationType, AgentType: req.AgentType,
+			Action: "1", Rationale: "operator always approves",
+			ConfidentScore: 62, Status: "pending", CreatedAt: time.Now(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &domain.LLMDecision{
+			ID: id, RequestID: req.RequestID, Action: "1",
+			Rationale: "operator always approves", ConfidentScore: 62, Status: "pending",
+		}, nil
+	}
+
+	ctx := context.Background()
+	h.push("agent-cs", "blocked")
+	var esc []domain.AuditRecord
+	waitFor(t, 5*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	if !strings.Contains(esc[0].Rationale, "llm confidence 62/100") {
+		t.Errorf("escalation rationale should carry the confident score, got %q", esc[0].Rationale)
+	}
+	if !strings.Contains(esc[0].Rationale, "[shadow_mode]") {
+		t.Errorf("shadow-mode reject expected, got %q", esc[0].Rationale)
+	}
+}
+
 type atomicString struct {
 	mu sync.Mutex
 	v  string

--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -239,7 +239,7 @@ func TestLLMMultiTabConsultAndSeriesPromotion(t *testing.T) {
 		t.Fatalf("series promotion audit missing: %+v", audits)
 	}
 	<-mu
-	for _, want := range []string{`"tab_count":3`, "space-separated series of exactly 3 digits", "[question 1/3]", "[question 3/3]"} {
+	for _, want := range []string{`"tab_count":3`, "select_options MUST be a list of exactly 3 integers", "[question 1/3]", "[question 3/3]"} {
 		if !strings.Contains(contextJSON, want) {
 			t.Errorf("consult context missing %q: %s", want, contextJSON)
 		}

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -213,14 +213,17 @@ func KillStateActive(latest *KillEvent) bool {
 
 // LLMDecision is a staged submission written by the mcp process.
 type LLMDecision struct {
-	ID             int64
-	RequestID      string
-	Signature      string
-	SituationType  SituationType
-	AgentType      string
-	Action         string
-	OptionID       string
-	Rationale      string
+	ID            int64
+	RequestID     string
+	Signature     string
+	SituationType SituationType
+	AgentType     string
+	Action        string
+	OptionID      string
+	Rationale     string
+	// ConfidentScore is the agent's self-reported confidence in this
+	// decision, 0-100; -1 means the agent did not report one.
+	ConfidentScore int
 	CapturedOutput string
 	Status         string // pending | accepted | rejected | expired
 	CreatedAt      time.Time

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/control"
@@ -112,16 +114,19 @@ func toolDefinitions() []map[string]any {
 		},
 		{
 			"name":        "submit_decision",
-			"description": "Submit your decision for the pending request. action is the literal reply text to send to the agent (for choices, the exact option text). If the agent needs NO reply at all — it finished, it is only reporting status, or any prompt would just nudge it pointlessly — submit action \"@noop\" to explicitly do nothing. The daemon re-gates this through the confidence gate and never-auto patterns before acting.",
+			"description": "Submit your decision for the pending request. For multiple-choice situations (the context lists options or a multi-tab question form), answer with select_options — the 1-based option number(s). Otherwise recommend_action is the literal reply text to send to the agent. If the agent needs NO reply at all — it finished, it is only reporting status, or any prompt would just nudge it pointlessly — submit recommend_action \"@noop\" to explicitly do nothing. The daemon re-gates this through the confidence gate and never-auto patterns before acting.",
 			"inputSchema": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"request_id": map[string]any{"type": "string", "description": "Decision request id (optional; defaults to the current request)"},
-					"action":     map[string]any{"type": "string", "description": "Literal reply text to send to the agent, or \"@noop\" to explicitly send nothing (use when no reply is needed)"},
-					"option_id":  map[string]any{"type": "string", "description": "Selected option text for multiple-choice situations"},
-					"rationale":  map[string]any{"type": "string", "description": "Why this action matches the operator's likely intent"},
+					"recommend_action": map[string]any{"type": "string",
+						"description": "Literal reply text to send to the agent, or \"@noop\" to explicitly send nothing (use when no reply is needed). For multiple-choice situations use select_options instead."},
+					"select_options": map[string]any{"type": "array", "items": map[string]any{"type": "integer", "minimum": 1, "maximum": 9},
+						"description": "Answer for multiple-choice situations: the chosen option number(s), 1-based. A single menu takes exactly one integer, e.g. [2]. A multi-tab question form takes exactly one integer per tab in tab order, Submit included, e.g. [1, 2, 3, 2, 1]."},
+					"confident_score": map[string]any{"type": "integer", "minimum": 0, "maximum": 100,
+						"description": "How confident you are in this decision, 0 (a guess) to 100 (certain); shown to the operator with the decision"},
+					"rationale": map[string]any{"type": "string", "description": "Why this action matches the operator's likely intent"},
 				},
-				"required": []string{"action"},
 			},
 		},
 	}
@@ -130,11 +135,65 @@ func toolDefinitions() []map[string]any {
 type toolCallParams struct {
 	Name      string `json:"name"`
 	Arguments struct {
-		RequestID string `json:"request_id"`
-		Action    string `json:"action"`
-		OptionID  string `json:"option_id"`
-		Rationale string `json:"rationale"`
+		RequestID       string `json:"request_id"`
+		RecommendAction string `json:"recommend_action"`
+		SelectOptions   []int  `json:"select_options"`
+		ConfidentScore  *int   `json:"confident_score"`
+		Rationale       string `json:"rationale"`
+		// Legacy aliases from the pre-rename tool surface; accepted so a
+		// consult started under an older prompt still lands.
+		Action   string `json:"action"`
+		OptionID string `json:"option_id"`
 	} `json:"arguments"`
+}
+
+// consultContextFields is the slice of the daemon's context_json blob the
+// select_options resolver needs; everything else stays opaque. The key
+// names are a wire contract with daemon.consultContext — renaming either
+// side silently degrades single-menu answers to bare digits (the daemon's
+// gates still re-check them).
+type consultContextFields struct {
+	Options  []string `json:"options"`
+	TabCount int      `json:"tab_count"`
+}
+
+// resolveSelectOptions turns 1-based option numbers into the outbound reply
+// the daemon's gates expect: the option's text for a single menu (falling
+// back to the bare digit when the context lists no options — numbered menus
+// accept an already-numeric selection), or the space-joined digit series for
+// a multi-tab form (one digit per tab, Submit included).
+func resolveSelectOptions(contextJSON string, selects []int) (action, optionID string, err error) {
+	var cc consultContextFields
+	// The blob is daemon-authored JSON; if it doesn't parse, degrade to no
+	// options/tabs rather than refusing the submission.
+	_ = json.Unmarshal([]byte(contextJSON), &cc)
+	if cc.TabCount > 1 && len(selects) != cc.TabCount {
+		return "", "", fmt.Errorf("this multi-tab form has %d tabs (Submit included): select_options needs exactly %d integers in tab order, got %d",
+			cc.TabCount, cc.TabCount, len(selects))
+	}
+	if cc.TabCount <= 1 && len(selects) != 1 {
+		return "", "", fmt.Errorf("this situation takes a single choice: select_options needs exactly one integer, got %d", len(selects))
+	}
+	for i, n := range selects {
+		if n < 1 || n > 9 {
+			return "", "", fmt.Errorf("select_options[%d] = %d: option numbers are 1-based menu digits (1-9)", i, n)
+		}
+	}
+	if cc.TabCount > 1 {
+		digits := make([]string, len(selects))
+		for i, n := range selects {
+			digits[i] = strconv.Itoa(n)
+		}
+		return strings.Join(digits, " "), "", nil
+	}
+	n := selects[0]
+	if len(cc.Options) > 0 {
+		if n > len(cc.Options) {
+			return "", "", fmt.Errorf("select_options[0] = %d but only %d options are offered", n, len(cc.Options))
+		}
+		return cc.Options[n-1], cc.Options[n-1], nil
+	}
+	return strconv.Itoa(n), "", nil
 }
 
 func (s *Server) callTool(ctx context.Context, raw json.RawMessage) (any, error) {
@@ -156,23 +215,49 @@ func (s *Server) callTool(ctx context.Context, raw json.RawMessage) (any, error)
 		return textResult(req.ContextJSON), nil
 
 	case "submit_decision":
-		if p.Arguments.Action == "" {
-			return nil, fmt.Errorf("action is required")
+		action := p.Arguments.RecommendAction
+		if action == "" {
+			action = p.Arguments.Action // legacy alias
+		}
+		selects := p.Arguments.SelectOptions
+		if action == "" && len(selects) == 0 {
+			return nil, fmt.Errorf("recommend_action or select_options is required")
+		}
+		score := -1
+		if p.Arguments.ConfidentScore != nil {
+			score = *p.Arguments.ConfidentScore
+			if score < 0 || score > 100 {
+				return nil, fmt.Errorf("confident_score must be between 0 and 100, got %d", score)
+			}
 		}
 		// Accept the common noop spellings; a noop never carries an option.
-		p.Arguments.Action = domain.NormalizeNoopAction(p.Arguments.Action)
-		if p.Arguments.Action == domain.ActionNoop {
-			p.Arguments.OptionID = ""
+		action = domain.NormalizeNoopAction(action)
+		optionID := p.Arguments.OptionID
+		if action == domain.ActionNoop {
+			optionID, selects = "", nil
 		}
 		req, err := s.resolveRequest(ctx, requestID)
 		if err != nil {
 			return nil, err
 		}
+		if len(selects) > 0 {
+			// The explicit MCQ answer wins over any free-text action: it is
+			// resolved against the staged context so the daemon's gates see
+			// the option text (single menu) or the digit series (multi-tab).
+			resolved, resolvedOption, rerr := resolveSelectOptions(req.ContextJSON, selects)
+			if rerr != nil {
+				return nil, rerr
+			}
+			// Unconditional: on the bare-digit path resolvedOption is empty,
+			// and a stale caller-supplied option_id must not survive it.
+			action, optionID = resolved, resolvedOption
+		}
 		_, err = s.Store.InsertLLMDecision(ctx, domain.LLMDecision{
 			RequestID: req.RequestID, Signature: req.Signature,
 			SituationType: req.SituationType, AgentType: req.AgentType,
-			Action: p.Arguments.Action, OptionID: p.Arguments.OptionID,
-			Rationale: p.Arguments.Rationale, Status: "pending",
+			Action: action, OptionID: optionID,
+			Rationale: p.Arguments.Rationale, ConfidentScore: score,
+			Status:    "pending",
 			CreatedAt: time.Now(),
 		})
 		if err != nil {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -96,11 +96,12 @@ func TestMCPLifecycleAndTools(t *testing.T) {
 	}
 
 	// submit_decision stages a pending llm_decisions row (Task 28
-	// acceptance).
+	// acceptance). select_options resolves the 1-based number against the
+	// staged context's options; confident_score rides along.
 	resp = c.call(t, "tools/call", map[string]any{
 		"name": "submit_decision",
 		"arguments": map[string]any{
-			"action": "green", "option_id": "green", "rationale": "operator prefers green",
+			"select_options": []int{2}, "confident_score": 85, "rationale": "operator prefers green",
 		},
 	})
 	text, _ = json.Marshal(resp)
@@ -113,8 +114,149 @@ func TestMCPLifecycleAndTools(t *testing.T) {
 		t.Fatalf("pending decisions: %+v %v", pending, err)
 	}
 	d := pending[0]
-	if d.RequestID != "req-42" || d.Action != "green" || d.Status != "pending" {
+	if d.RequestID != "req-42" || d.Action != "green" || d.OptionID != "green" ||
+		d.ConfidentScore != 85 || d.Status != "pending" {
 		t.Errorf("staged row mismatch: %+v", d)
+	}
+}
+
+func TestMCPSelectOptionsValidation(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+
+	stage := func(reqID, contextJSON string) {
+		t.Helper()
+		if _, err := st.StageLLMRequest(ctx, domain.LLMRequest{
+			RequestID: reqID, Signature: "choice:abc", SituationType: domain.SituationChoice,
+			AgentType: "claude", ContextJSON: contextJSON, CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A multi-tab form takes exactly one integer per tab, joined to the
+	// digit series the daemon's series gate expects.
+	stage("req-mt", `{"options":[],"tab_count":3}`)
+	c := startServer(t, st, "req-mt")
+	resp := c.call(t, "tools/call", map[string]any{
+		"name": "submit_decision", "arguments": map[string]any{"select_options": []int{1, 2}},
+	})
+	if text, _ := json.Marshal(resp); !strings.Contains(string(text), "exactly 3 integers") {
+		t.Fatalf("wrong series length must error with the expected count: %s", text)
+	}
+	resp = c.call(t, "tools/call", map[string]any{
+		"name": "submit_decision", "arguments": map[string]any{"select_options": []int{1, 2, 1}},
+	})
+	if text, _ := json.Marshal(resp); !strings.Contains(string(text), "staged") {
+		t.Fatalf("valid series should stage: %s", text)
+	}
+	pending, _ := st.PendingLLMDecisions(ctx)
+	if len(pending) != 1 || pending[0].Action != "1 2 1" {
+		t.Fatalf("multi-tab selects should join to a digit series, got %+v", pending)
+	}
+	if err := st.UpdateLLMDecisionStatus(ctx, pending[0].ID, "expired"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A single menu takes exactly one integer, bounded by the offered set.
+	stage("req-sg", `{"options":["red","green"]}`)
+	c = startServer(t, st, "req-sg")
+	for _, bad := range [][]int{{1, 2}, {3}, {0}} {
+		resp = c.call(t, "tools/call", map[string]any{
+			"name": "submit_decision", "arguments": map[string]any{"select_options": bad},
+		})
+		if text, _ := json.Marshal(resp); !strings.Contains(string(text), "isError") {
+			t.Fatalf("select_options %v must be a tool error: %s", bad, text)
+		}
+	}
+
+	// Without parsed options in the context, the bare digit is delivered
+	// (numbered menus accept a numeric selection).
+	stage("req-nd", `{}`)
+	c = startServer(t, st, "req-nd")
+	resp = c.call(t, "tools/call", map[string]any{
+		"name": "submit_decision", "arguments": map[string]any{"select_options": []int{2}},
+	})
+	if text, _ := json.Marshal(resp); !strings.Contains(string(text), "staged") {
+		t.Fatalf("optionless context should still stage the digit: %s", text)
+	}
+	pending, _ = st.PendingLLMDecisions(ctx)
+	if len(pending) != 1 || pending[0].Action != "2" {
+		t.Fatalf("optionless select should stage the bare digit, got %+v", pending)
+	}
+}
+
+func TestMCPConfidentScoreValidation(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	if _, err := st.StageLLMRequest(ctx, domain.LLMRequest{
+		RequestID: "req-cs", SituationType: domain.SituationIdle,
+		ContextJSON: "{}", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	c := startServer(t, st, "req-cs")
+
+	for _, bad := range []int{-1, 101} {
+		resp := c.call(t, "tools/call", map[string]any{
+			"name":      "submit_decision",
+			"arguments": map[string]any{"recommend_action": "continue", "confident_score": bad},
+		})
+		if text, _ := json.Marshal(resp); !strings.Contains(string(text), "isError") {
+			t.Fatalf("confident_score %d must be a tool error: %s", bad, text)
+		}
+	}
+	if pending, _ := st.PendingLLMDecisions(ctx); len(pending) != 0 {
+		t.Fatal("out-of-range confident_score must not stage a decision")
+	}
+
+	// Omitted score stages the -1 "not reported" sentinel.
+	resp := c.call(t, "tools/call", map[string]any{
+		"name": "submit_decision", "arguments": map[string]any{"recommend_action": "continue"},
+	})
+	if text, _ := json.Marshal(resp); !strings.Contains(string(text), "staged") {
+		t.Fatalf("submission without a score should stage: %s", text)
+	}
+	pending, _ := st.PendingLLMDecisions(ctx)
+	if len(pending) != 1 || pending[0].ConfidentScore != -1 {
+		t.Fatalf("omitted confident_score should store -1, got %+v", pending)
+	}
+}
+
+func TestMCPLegacyActionAliasAccepted(t *testing.T) {
+	// A consult started under the pre-rename prompt may still submit with
+	// the old field names; they must keep working.
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	if _, err := st.StageLLMRequest(ctx, domain.LLMRequest{
+		RequestID: "req-old", SituationType: domain.SituationChoice,
+		ContextJSON: `{"options":["red","green"]}`, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	c := startServer(t, st, "req-old")
+	resp := c.call(t, "tools/call", map[string]any{
+		"name":      "submit_decision",
+		"arguments": map[string]any{"action": "green", "option_id": "green"},
+	})
+	if text, _ := json.Marshal(resp); !strings.Contains(string(text), "staged") {
+		t.Fatalf("legacy action/option_id should stage: %s", text)
+	}
+	pending, _ := st.PendingLLMDecisions(ctx)
+	if len(pending) != 1 || pending[0].Action != "green" || pending[0].OptionID != "green" {
+		t.Fatalf("legacy alias mismatch: %+v", pending)
 	}
 }
 
@@ -198,7 +340,8 @@ func TestMCPSubmitNoopNormalized(t *testing.T) {
 		resp := c.call(t, "tools/call", map[string]any{
 			"name": "submit_decision",
 			"arguments": map[string]any{
-				"action": spelling, "option_id": "should-be-blanked", "rationale": "agent is done",
+				"recommend_action": spelling, "option_id": "should-be-blanked",
+				"select_options": []int{1}, "rationale": "agent is done",
 			},
 		})
 		if text, _ := json.Marshal(resp); !strings.Contains(string(text), "staged") {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -147,6 +147,7 @@ CREATE TABLE IF NOT EXISTS llm_decisions (
 	action TEXT NOT NULL,
 	option_id TEXT NOT NULL DEFAULT '',
 	rationale TEXT NOT NULL DEFAULT '',
+	confident_score INTEGER NOT NULL DEFAULT -1,
 	captured_output TEXT NOT NULL DEFAULT '',
 	status TEXT NOT NULL DEFAULT 'pending',
 	created_at INTEGER NOT NULL
@@ -190,6 +191,7 @@ func (s *Store) migrate() error {
 	// the column is already there.
 	for _, ddl := range []string{
 		`ALTER TABLE audit_log ADD COLUMN agent_type TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE llm_decisions ADD COLUMN confident_score INTEGER NOT NULL DEFAULT -1`,
 	} {
 		if _, err := s.db.Exec(ddl); err != nil &&
 			!strings.Contains(err.Error(), "duplicate column name") {
@@ -529,10 +531,10 @@ func (s *Store) InsertLLMDecision(ctx context.Context, d domain.LLMDecision) (in
 	err := s.tx(ctx, func(tx *sql.Tx) error {
 		res, err := tx.ExecContext(ctx, `
 			INSERT INTO llm_decisions (request_id, signature, situation_type, agent_type,
-				action, option_id, rationale, captured_output, status, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				action, option_id, rationale, confident_score, captured_output, status, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			d.RequestID, d.Signature, string(d.SituationType), d.AgentType,
-			d.Action, d.OptionID, d.Rationale, d.CapturedOutput,
+			d.Action, d.OptionID, d.Rationale, d.ConfidentScore, d.CapturedOutput,
 			orDefault(d.Status, "pending"), unix(d.CreatedAt))
 		if err != nil {
 			return err
@@ -1181,7 +1183,7 @@ func (s *Store) scanLLMDecisions(rows *sql.Rows) ([]domain.LLMDecision, error) {
 		var situationType string
 		var created int64
 		if err := rows.Scan(&d.ID, &d.RequestID, &d.Signature, &situationType, &d.AgentType,
-			&d.Action, &d.OptionID, &d.Rationale, &d.CapturedOutput, &d.Status, &created); err != nil {
+			&d.Action, &d.OptionID, &d.Rationale, &d.ConfidentScore, &d.CapturedOutput, &d.Status, &created); err != nil {
 			return nil, err
 		}
 		d.SituationType = domain.SituationType(situationType)
@@ -1192,7 +1194,7 @@ func (s *Store) scanLLMDecisions(rows *sql.Rows) ([]domain.LLMDecision, error) {
 }
 
 const llmDecisionCols = `id, request_id, signature, situation_type, agent_type,
-	action, option_id, rationale, captured_output, status, created_at`
+	action, option_id, rationale, confident_score, captured_output, status, created_at`
 
 // PendingLLMDecisions returns staged decisions awaiting daemon consumption.
 func (s *Store) PendingLLMDecisions(ctx context.Context) ([]domain.LLMDecision, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -429,7 +429,8 @@ func TestLLMRequestDecisionFlow(t *testing.T) {
 	}
 
 	_, err = s.InsertLLMDecision(ctx, domain.LLMDecision{
-		RequestID: "req-1", Action: "a", Rationale: "because", CreatedAt: time.Now(),
+		RequestID: "req-1", Action: "a", Rationale: "because",
+		ConfidentScore: 62, CreatedAt: time.Now(),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -437,6 +438,9 @@ func TestLLMRequestDecisionFlow(t *testing.T) {
 	pending, err := s.PendingLLMDecisions(ctx)
 	if err != nil || len(pending) != 1 {
 		t.Fatalf("pending llm decisions: %+v %v", pending, err)
+	}
+	if pending[0].ConfidentScore != 62 {
+		t.Errorf("confident score round trip: got %d, want 62", pending[0].ConfidentScore)
 	}
 	if err := s.UpdateLLMDecisionStatus(ctx, pending[0].ID, "accepted"); err != nil {
 		t.Fatal(err)
@@ -765,6 +769,64 @@ func TestDecodeVectorRejectsCorruptBlob(t *testing.T) {
 	}
 	if v, err := decodeVector(nil, 0); err != nil || v != nil {
 		t.Errorf("empty blob should be nil vector, got %v/%v", v, err)
+	}
+}
+
+func TestMigrateAddsConfidentScoreToLegacyLLMDecisions(t *testing.T) {
+	// A database created before confident_score existed has an
+	// llm_decisions table WITHOUT the column; CREATE IF NOT EXISTS skips
+	// the existing table, so only the ALTER in migrate() can add it. The
+	// column lands at the end (fresh DBs carry it mid-table) — harmless,
+	// because every query names its columns explicitly.
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`
+		CREATE TABLE llm_decisions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			request_id TEXT NOT NULL,
+			signature TEXT NOT NULL DEFAULT '',
+			situation_type TEXT NOT NULL DEFAULT '',
+			agent_type TEXT NOT NULL DEFAULT '',
+			action TEXT NOT NULL,
+			option_id TEXT NOT NULL DEFAULT '',
+			rationale TEXT NOT NULL DEFAULT '',
+			captured_output TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'pending',
+			created_at INTEGER NOT NULL
+		);
+		INSERT INTO llm_decisions (request_id, action, status, created_at)
+		VALUES ('req-legacy', 'Yes', 'pending', 1);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("opening a legacy DB must migrate, got: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	ctx := context.Background()
+	// The pre-migration row reads back the -1 "not reported" sentinel.
+	legacy, err := s.LLMDecisionByRequest(ctx, "req-legacy")
+	if err != nil || legacy == nil || legacy.ConfidentScore != -1 {
+		t.Fatalf("legacy row after migration: %+v %v", legacy, err)
+	}
+	// New rows round-trip the migrated column.
+	if _, err := s.InsertLLMDecision(ctx, domain.LLMDecision{
+		RequestID: "req-new", Action: "No", ConfidentScore: 40, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fresh, err := s.LLMDecisionByRequest(ctx, "req-new")
+	if err != nil || fresh == nil || fresh.ConfidentScore != 40 {
+		t.Fatalf("migrated column round trip: %+v %v", fresh, err)
 	}
 }
 


### PR DESCRIPTION
Reshapes the `submit_decision` MCP tool so LLM agents answer MCQs explicitly instead of via fragile free-text parsing, and report how confident they are.

## Changes

- **`action` → `recommend_action`** for clarity. The old `action`/`option_id` JSON keys are still parsed as silent legacy aliases, so a consult started under an older prompt still lands.
- **New `select_options` (list of integers, 1-based)** — the explicit MCQ answer for Claude/Codex menus. Resolved at the tool boundary against the staged consult context:
  - single menu: `[2]` → the option's text (bare digit when the context lists no options);
  - multi-tab form: `[1, 2, 1]` → the `"1 2 1"` digit series, validated against `tab_count` up front so the LLM gets an immediate, retryable tool error instead of a daemon-side escalation.
  - All daemon safety gates (option-in-set, series length, never-auto screens) still re-check everything downstream — nothing bypasses them.
- **New `confident_score` (integer 0–100, optional)** — persisted on `llm_decisions` (new column, `-1` = not reported, idempotent ALTER migration) and shown on the Escalation entry as `llm confidence N/100` in the rationale so the operator can weigh the suggestion.
- The consult context now instructs the model accordingly (`select_options` formats for single menus and multi-tab forms, `recommend_action "@noop"`); README recipes and the solution spec updated.

## Tests

New: select_options validation matrix (lengths, bounds, optionless context), confident_score range + `-1` sentinel, legacy alias acceptance, legacy-DB migration, escalation rationale surfacing. Full suite green.

https://claude.ai/code/session_01G5ANCGcVWmRUcTX4A1A2CK