### PR TITLE
#1 fix: auto-release tag push must use RELEASE_PAT (persist-credentials: false)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -54,6 +54,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # tags decide release-vs-recovery
+          # Do NOT persist GITHUB_TOKEN: checkout stores it as an
+          # http.extraheader that outranks gh's credential helper, so every
+          # git push would silently authenticate as GITHUB_TOKEN — and a
+          # GITHUB_TOKEN-pushed tag never triggers release.yml.
+          persist-credentials: false
       - name: Tag the manifest version, then pre-bump the next patch
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
The first two automated cycles (v0.3.3, v0.3.4) tagged correctly but never fired `release.yml`: `actions/checkout` persists `GITHUB_TOKEN` as an `http.extraheader` in git config, which takes precedence over the credential helper `gh auth setup-git` installs — so `git push origin v0.3.4` silently authenticated as `GITHUB_TOKEN`, and GITHUB_TOKEN-pushed refs never trigger workflows.

`persist-credentials: false` removes the embedded token so every git push in the job (tag + pre-bump branch) goes through the `RELEASE_PAT` credential helper, making the tag push fire the tag-driven `release.yml` as designed.

The two orphaned tags are being remediated separately by re-pushing them with owner credentials (which does trigger `release.yml`). This is a `.github/**` change, so merging it does not itself trigger auto-release.

https://claude.ai/code/session_01G5ANCGcVWmRUcTX4A1A2CK