### PR TITLE
#1 fix: bump-then-tag release model — manifest trails releases, never leads

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,31 +1,45 @@
 name: Auto Release
 
-# Pre-bump release automation. main's manifest version is kept one patch
-# AHEAD of the newest tag by an auto-merged "pre-bump" PR, so releasing is
-# just tagging:
+# Bump-then-tag release automation. `herdr plugin install` clones main and
+# scripts/install.sh downloads the release assets named by the manifest
+# version — so the version in herdr-plugin.toml must ALWAYS name a version
+# whose GitHub release exists (it trails releases, never leads them):
 #
-# 1. A feature PR merges → this workflow reads `version` from
-#    herdr-plugin.toml. It is untagged (pre-bumped by the previous cycle),
-#    so the workflow tags it with the owner's RELEASE_PAT — and that tag
-#    push fires the standard tag-driven release.yml, unchanged.
-# 2. After tagging, the workflow opens the NEXT pre-bump PR (patch+1; its
-#    commit carries [skip ci], so CI ignores it) and squash-merges it with
-#    RELEASE_PAT. main is now staged for the next cycle.
+# 1. A feature PR merges → the manifest still carries the latest RELEASED
+#    version (its tag exists). This workflow computes the next patch,
+#    opens the bump PR (release/bump-vNEXT: manifest → NEXT, commit marked
+#    [skip release]) and squash-merges it with the owner's RELEASE_PAT.
+# 2. It tags that bump commit vNEXT and pushes the tag with the PAT — the
+#    tag push fires the standard tag-driven release.yml, unchanged. Once
+#    the release publishes, main's manifest and the newest release agree
+#    again. During the build (~15 min) installs from main can still 404
+#    (install.sh's ~60s curl retry only bridges the post-publish upload
+#    gap) — the one, self-resolving window; pinned --ref installs are
+#    never affected.
 #
-# Manual minor/major (the reserved path): overwrite the pre-bumped version
-# in your feature PR (e.g. 0.4.0); on merge that exact version is tagged
-# and released, and the pre-bump re-arms at its patch+1.
+# Manual minor/major (the reserved path): overwrite `version` in your
+# feature PR (e.g. 0.4.0). On merge the manifest version has no tag, so
+# the workflow skips the bump and tags the merge commit directly.  The
+# same branch self-heals a crashed run that merged the bump but died
+# before pushing the tag.
 #
-# Recovery/bootstrap (manifest version already tagged — e.g. the very
-# first run, or a release cut by hand): the pre-bump PR is merged FIRST
-# (without [skip ci] — its commit gets tagged, and a skip keyword in a
-# tagged commit's message would suppress the tag-triggered release), the
-# bump commit is tagged, then a normal [skip ci] pre-bump re-arms.
+# Markers: the bump commit carries [skip release] — a custom marker that
+# only stops THIS workflow from re-running on that merge. It must NEVER
+# carry [skip ci]/[ci skip]/[no ci]: GitHub suppresses ALL workflows
+# triggered by a ref whose head commit message contains a skip-ci keyword,
+# including the vNEXT tag push onto that very commit — the release would
+# silently not build. The same applies ANYWHERE in a feature PR's
+# squash-merge message (title or body) if its merge is meant to release;
+# a pre-tag guard below refuses to mint such a dead tag.
 #
-# No loops: the [skip ci] pre-bump merge triggers nothing; the tag is
-# pushed with RELEASE_PAT deliberately so release.yml DOES fire. Doc and
-# workflow-only pushes don't trigger (paths-ignore); [skip release] in a
-# merge commit opts out; pushing a v*.*.* tag by hand still works.
+# No loops: the bump merge re-triggers this workflow once and the job-if
+# skips it; the tag is pushed with RELEASE_PAT deliberately so release.yml
+# DOES fire (checkout must not persist GITHUB_TOKEN — its http.extraheader
+# would outrank gh's credential helper and a GITHUB_TOKEN-pushed tag never
+# triggers workflows). Doc and workflow-only pushes don't trigger
+# (paths-ignore); pushing a v*.*.* tag by hand still works. If the release
+# BUILD fails after the tag exists, re-run that release.yml run — the
+# manifest already names the tagged version, nothing here needs re-running.
 on:
   push:
     branches: [main]
@@ -47,26 +61,26 @@ concurrency:
 
 jobs:
   release:
-    name: Tag release & pre-bump
+    name: Bump patch & tag release
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, '[skip release]') }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # tags decide release-vs-recovery
+          fetch-depth: 0 # tags decide bump-vs-direct-tag
           # Do NOT persist GITHUB_TOKEN: checkout stores it as an
           # http.extraheader that outranks gh's credential helper, so every
           # git push would silently authenticate as GITHUB_TOKEN — and a
           # GITHUB_TOKEN-pushed tag never triggers release.yml.
           persist-credentials: false
-      - name: Tag the manifest version, then pre-bump the next patch
+      - name: Bump the patch version, then tag it for release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           set -euo pipefail
           [ -n "${GH_TOKEN}" ] || { echo "::error::RELEASE_PAT secret is not set"; exit 1; }
           # Work from the LATEST main, not the triggering SHA: a run queued
-          # behind another release must see that release's pre-bump.
+          # behind another release must see that release's bump commit.
           git fetch origin main
           git checkout -B main origin/main
           git config user.name "github-actions[bot]"
@@ -78,77 +92,87 @@ jobs:
           version() { sed -n 's/^version = "\(.*\)"/\1/p' herdr-plugin.toml; }
           next_patch() { IFS=. read -r MA MI PA <<<"$1"; echo "${MA}.${MI}.$((PA + 1))"; }
 
-          # Opens the pre-bump PR for $1 (commit suffixed with $2, e.g.
-          # " [skip ci]") and squash-merges it with the owner token.
+          # Opens the bump PR for $1 and squash-merges it with the owner
+          # token. [skip release] keeps this workflow from re-running on
+          # the merge; [skip ci] is forbidden here — the commit gets
+          # tagged, and a skip-ci keyword would suppress the release.
           # Self-healing: force-pushes the bot branch, reuses an open PR,
           # and treats an already-merged PR as success.
-          prebump() {
-            local NEXT="$1" MARKER="${2-}"
+          bump() {
+            local NEXT="$1"
             local BRANCH="release/bump-v${NEXT}"
+            local TITLE="#1 chore: bump plugin version to ${NEXT} [skip release]"
             local CUR; CUR=$(version)
             git checkout -B "${BRANCH}" origin/main
             sed -i "s/^version = \"${CUR}\"/version = \"${NEXT}\"/" herdr-plugin.toml
-            git commit -am "#1 chore: pre-bump plugin version to ${NEXT}${MARKER}"
+            git commit -am "${TITLE}"
             git push --force origin "HEAD:${BRANCH}"
             local PR
             PR=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number' || true)
             if [ -z "${PR}" ]; then
               gh pr create --base main --head "${BRANCH}" \
-                --title "#1 chore: pre-bump plugin version to ${NEXT}${MARKER}" \
-                --body "Automated pre-bump: stages v${NEXT} as the next release. Merged by the Auto Release workflow."
+                --title "${TITLE}" \
+                --body "Automated bump: v${NEXT} is being released from this commit by the Auto Release workflow."
             fi
             local i STATE
             for i in 1 2 3 4 5; do
               if gh pr merge "${BRANCH}" --squash --admin --delete-branch \
-                --subject "#1 chore: pre-bump plugin version to ${NEXT}${MARKER}" \
-                --body "Automated pre-bump for the next release."; then
+                --subject "${TITLE}" \
+                --body "Automated version bump for the v${NEXT} release."; then
                 break
               fi
               STATE=$(gh pr view "${BRANCH}" --json state --jq .state 2>/dev/null || echo "")
               [ "${STATE}" = "MERGED" ] && break
               if [ "$i" = 5 ]; then
-                echo "::error::could not merge the pre-bump PR (state: ${STATE:-unknown})"; exit 1
+                echo "::error::could not merge the bump PR (state: ${STATE:-unknown})"; exit 1
               fi
               sleep 5
             done
             git fetch origin main
             git checkout -B main origin/main
             grep -q "^version = \"${NEXT}\"" herdr-plugin.toml || {
-              echo "::error::main does not carry version ${NEXT} after the pre-bump merge"; exit 1; }
+              echo "::error::main does not carry version ${NEXT} after the bump merge"; exit 1; }
           }
-
-          # A queued run whose merge was absorbed by the previous release
-          # finds a pre-bump commit on top: nothing new to release.
-          if git log -1 --format=%s | grep -q "chore: pre-bump plugin version"; then
-            echo "HEAD is the pre-bump staging commit; nothing to release"
-            exit 0
-          fi
 
           CURRENT=$(version)
           [ -n "$CURRENT" ] || { echo "::error::no version in herdr-plugin.toml"; exit 1; }
 
           if git rev-parse -q --verify "refs/tags/v${CURRENT}" >/dev/null; then
-            # Recovery/bootstrap: the manifest was never pre-bumped. Merge
-            # a pre-bump WITHOUT [skip ci] (its commit gets tagged below;
-            # a skip keyword there would suppress the tag-triggered
-            # release), then tag it. [skip release] only stops THIS
-            # workflow from re-running on that merge.
+            # Already-released guard: the manifest version's tag pointing
+            # at HEAD means this exact state was released by a previous
+            # run — a queued run whose merge was absorbed (HEAD is the
+            # bump commit, or a feature merge the tag landed on when it
+            # interleaved with the bump). Nothing new to release.
+            if [ "$(git rev-parse HEAD)" = "$(git rev-parse "refs/tags/v${CURRENT}^{commit}")" ]; then
+              echo "HEAD is already released as v${CURRENT}; nothing to release"
+              exit 0
+            fi
+            # Steady state: the manifest carries the latest released
+            # version — stage the next patch, then tag the bump commit.
             RELEASE=$(next_patch "$CURRENT")
             if git rev-parse -q --verify "refs/tags/v${RELEASE}" >/dev/null; then
               echo "::error::tag v${RELEASE} already exists but the manifest says ${CURRENT}; fix the manifest manually"
               exit 1
             fi
-            prebump "${RELEASE}" " [skip release]"
+            bump "${RELEASE}"
           else
-            # Steady state: the pre-bumped (or manually bumped) manifest
-            # version releases as-is, tagged at the feature merge.
+            # The manifest version has no tag: a manual minor/major bump
+            # merged inside the feature PR, or a crashed run that merged
+            # the bump but never tagged. Tag it where it stands — HEAD's
+            # manifest carries exactly this version, so this branch is
+            # also the crash self-heal.
             RELEASE="$CURRENT"
           fi
 
+          grep -q "^version = \"${RELEASE}\"" herdr-plugin.toml || {
+            echo "::error::manifest does not carry ${RELEASE} at tag time"; exit 1; }
+          # Never tag a commit whose message carries a GitHub skip-ci
+          # keyword: the tag push onto it would be suppressed and the
+          # release would silently not build (no failed run to re-run).
+          if git log -1 --format=%B | grep -qiE '\[(skip ci|ci skip|no ci|skip actions|actions skip)\]'; then
+            echo "::error::HEAD's commit message contains a skip-ci keyword; tagging it would not fire release.yml. Land a clean commit (or hand-tag one) and re-run."
+            exit 1
+          fi
           git tag "v${RELEASE}"
           git push origin "v${RELEASE}"
           echo "tagged v${RELEASE}; the tag-driven release.yml takes it from here"
-
-          # Re-arm: stage the next patch so the following merge releases
-          # by tagging alone. [skip ci]: nothing runs on this merge.
-          prebump "$(next_patch "${RELEASE}")" " [skip ci]"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,27 +101,39 @@ with a ticket/issue id**. Examples from history:
 
 ## Version bump & release
 
-Releases are **automated on merge to main** with a pre-bump model
+Releases are **automated on merge to main** with a bump-then-tag model
 (`.github/workflows/auto-release.yml`); `version` in `herdr-plugin.toml`
-is the single source of truth and is kept one patch AHEAD of the newest
-tag:
+is the single source of truth and always names a version whose GitHub
+release exists — it TRAILS releases, never leads them. This is
+load-bearing: `herdr plugin install` clones main and `scripts/install.sh`
+downloads the release assets named by the manifest version, so a manifest
+pointing at an unreleased version 404s every install.
 
 - **Patch (the default)** — just merge your feature PR. The workflow finds
-  the manifest version untagged (staged by the previous cycle's auto-merged
-  "pre-bump" PR), tags it with the owner's `RELEASE_PAT`, and that tag
-  fires the standard tag-driven `release.yml`. Afterwards the workflow
-  auto-merges the next pre-bump PR (`release/bump-vX.Y.Z+1`, commit marked
-  `[skip ci]` so CI ignores it). Never bump the manifest for patch work.
-- **Minor/major (the reserved manual path)** — overwrite the pre-bumped
-  `version` in `herdr-plugin.toml` INSIDE your feature PR (e.g. `0.4.0`);
-  on merge that exact version is tagged and released, then the pre-bump
-  re-arms at its patch+1.
+  the manifest version already tagged (the last release), auto-merges a
+  bump PR (`release/bump-vX.Y.Z+1`, commit marked `[skip release]`), tags
+  that bump commit with the owner's `RELEASE_PAT`, and the tag fires the
+  standard tag-driven `release.yml`. Never bump the manifest for patch
+  work.
+- **Minor/major (the reserved manual path)** — overwrite `version` in
+  `herdr-plugin.toml` INSIDE your feature PR (e.g. `0.4.0`); on merge the
+  workflow finds that version untagged, skips the bump, and tags the
+  merge commit directly. (The same branch self-heals a crashed run that
+  bumped but never tagged.)
 - Doc/workflow-only pushes (`**.md`, `docs/**`, `.github/**`) and merge
   commits containing `[skip release]` do not release. Hand-pushing a
   `v*.*.*` tag still works (release.yml is unchanged and tag-driven).
-- If a merge ever finds the manifest already tagged (bootstrap/recovery),
-  the workflow merges the pre-bump first, tags the bump commit, and
-  re-arms — self-healing, no manual step.
+- Never put `[skip ci]`-family keywords ANYWHERE in the squash-merge
+  message (title or body) of a PR that should release: GitHub suppresses
+  ALL workflows for refs whose head commit carries one — including the
+  tag push onto that commit, so the release silently never builds. The
+  workflow refuses to tag such a commit. `[skip release]` (our custom
+  marker) is safe on tagged commits but suppresses auto-release itself,
+  so keep the literal string out of ordinary merge messages too.
+- Between the bump merge and the release publishing (~15 min), installs
+  from main can fail with 404 — install.sh's ~60 s curl retry only
+  bridges the post-publish upload gap, not the build. Retry once the
+  release publishes; pinned `--ref vX.Y.Z` installs are never affected.
 - If the release BUILD fails after the tag exists, re-run the failed
   release.yml run; do not re-run auto-release (it would advance versions).
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.3.6"
+version = "0.3.5"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Fixes the install-breaking flaw in the pre-bump release model: `herdr plugin install` clones main and `scripts/install.sh` downloads release assets for the **manifest version** — which the pre-bump model kept one patch AHEAD of the newest release, so installs from main permanently 404'd (today main says 0.3.6, newest release is v0.3.5).

## New model (bump AFTER merge, tag the bump commit)

**New invariant: the manifest version on main always names a version whose release exists** (except the ~15 min build window right after a cycle starts).

- **Patch (default)**: feature PR merges → workflow finds the manifest version already tagged → auto-merges a bump PR (manifest → next patch, commit carries the custom skip-release marker) → tags that bump commit with `RELEASE_PAT` → tag fires the unchanged tag-driven `release.yml`.
- **Minor/major (manual)**: overwrite `version` inside your feature PR; on merge the untagged manifest version is tagged directly at the merge commit. The same branch self-heals a crashed run that bumped but never tagged.
- **Guards**: a tag-points-at-HEAD check absorbs queued duplicate runs (including the interleaved-merge race); a pre-tag check refuses to tag any commit whose message contains a GitHub skip-ci keyword (such a tag would silently never build); the existing PAT/persist-credentials, concurrency, retry-merge, and version-assert machinery is kept.

## Healing the current state

This PR also reverts `herdr-plugin.toml` to **0.3.5** (the latest published release — installs work again the moment this merges). Because the manifest is not paths-ignored, merging this PR triggers the NEW workflow end-to-end: bump PR to 0.3.6 → tag v0.3.6 → release build → manifest and releases aligned, pipeline validated.

**Merge note: use the default squash message (title + this body is fine) — it deliberately avoids the literal bracketed skip-keyword strings, which anywhere in the squash message would suppress the trigger or the release.**

Docs: CLAUDE.md release section rewritten (model, skip-keyword hazard scoped to the whole squash message, honest description of the ~15 min window — install.sh's ~60 s retry only bridges the post-publish upload gap; pinned `--ref` installs unaffected).

https://claude.ai/code/session_01G5ANCGcVWmRUcTX4A1A2CK