### PR TITLE
#1 chore: bump plugin version to 0.3.7 [skip release]

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.3.6"
+version = "0.3.7"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.3.7 is being released from this commit by the Auto Release workflow.