### PR TITLE
#1 feat: delayed pane capture — read after the agent TUI has painted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,11 @@ Verify after any release: `gh release view vX.Y.Z` — expect 3 binaries,
   agents; anything that shells out repeatedly (LLM CLI, deep pane reads)
   belongs in a goroutine that funnels results back through a channel
   (see `consultLLM` / `llmResults`).
+- **Attention events are delay-captured** — the classification pane read
+  waits `[[capture_delay]]` (default 1s on an agent's first event, 200ms
+  after) via a per-pane `time.AfterFunc` → `delayedTr`, so the agent TUI
+  has painted and event bursts coalesce (latest wins, one capture per
+  burst). Daemon tests inherit a 1ms wildcard rule from the harness.
 - **Semantic matching degrades, never blocks** — situations resolve to
   learned signatures via embedding + vector search over the MASKED salient
   content (`daemon.resolveSignature`, `internal/match`, `internal/embedder`),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,6 +145,15 @@ type ClassifierRule struct {
 	Keywords  []string `toml:"keywords"`
 }
 
+// CaptureDelayRule delays the classification pane read after a herdr event,
+// so the agent TUI has painted before we snapshot it (a read fired straight
+// on the start event captures shell scrollback, not the agent's screen).
+type CaptureDelayRule struct {
+	AgentType string `toml:"agent_type"` // exact agent type, or "*"/"" for any
+	StartMs   int    `toml:"start_ms"`   // first event after agent start
+	EventMs   int    `toml:"event_ms"`   // all later events
+}
+
 // TUI configures the terminal UI's presentation (DR-003).
 type TUI struct {
 	// MaxContentWidth caps the character width of variable-length columns
@@ -164,6 +173,10 @@ type Config struct {
 	TUI         TUI              `toml:"tui"`
 	TaskSources []TaskSource     `toml:"task_sources"`
 	Classifier  []ClassifierRule `toml:"classifier"`
+	// CaptureDelays are optional per-agent-type overrides for the delayed
+	// pane capture; absent rules fall back to built-in defaults (not part
+	// of fillZeroes — optional tables, absent is not "zeroed").
+	CaptureDelays []CaptureDelayRule `toml:"capture_delay"`
 	// Paused persists nothing; pause state lives in the kill_events table.
 }
 
@@ -376,6 +389,38 @@ func (c Config) RewriteTimeout() time.Duration {
 		return c.LLMTimeout()
 	}
 	return time.Duration(c.LLM.RewriteTimeoutSeconds) * time.Second
+}
+
+// Built-in capture delays: the agent TUI needs ~a second to paint after
+// launch; later events only need a short settle.
+const (
+	defaultCaptureStartDelay = 1000 * time.Millisecond
+	defaultCaptureEventDelay = 200 * time.Millisecond
+)
+
+// CaptureDelay returns how long to wait before reading the pane after a
+// herdr event — start is the agent's first event since it appeared. The
+// first [[capture_delay]] rule matching the agent type (exact, "*", or
+// empty) wins; a matched field <= 0 and the no-rule case fall back to the
+// built-in defaults.
+func (c Config) CaptureDelay(agentType string, start bool) time.Duration {
+	for _, r := range c.CaptureDelays {
+		if r.AgentType != agentType && r.AgentType != "*" && r.AgentType != "" {
+			continue
+		}
+		ms := r.EventMs
+		if start {
+			ms = r.StartMs
+		}
+		if ms <= 0 {
+			break // matched but unset: built-in default
+		}
+		return time.Duration(ms) * time.Millisecond
+	}
+	if start {
+		return defaultCaptureStartDelay
+	}
+	return defaultCaptureEventDelay
 }
 
 // Save writes the config to path in TOML form (used by `config set`).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -510,3 +510,57 @@ func TestDeprecatedAllowlistPatternsEmptySliceMigrates(t *testing.T) {
 		t.Errorf("saved config must not re-emit the deprecated key:\n%s", data)
 	}
 }
+
+func TestCaptureDelayRuleMatching(t *testing.T) {
+	rules := func(rs ...CaptureDelayRule) Config {
+		c := Default()
+		c.CaptureDelays = rs
+		return c
+	}
+	cases := []struct {
+		name  string
+		cfg   Config
+		agent string
+		start bool
+		want  time.Duration
+	}{
+		{"no rules start default", rules(), "claude", true, 1000 * time.Millisecond},
+		{"no rules event default", rules(), "claude", false, 200 * time.Millisecond},
+		{"exact match start", rules(CaptureDelayRule{AgentType: "claude", StartMs: 1500, EventMs: 50}), "claude", true, 1500 * time.Millisecond},
+		{"exact match event", rules(CaptureDelayRule{AgentType: "claude", StartMs: 1500, EventMs: 50}), "claude", false, 50 * time.Millisecond},
+		{"first match wins", rules(
+			CaptureDelayRule{AgentType: "claude", StartMs: 100},
+			CaptureDelayRule{AgentType: "*", StartMs: 900},
+		), "claude", true, 100 * time.Millisecond},
+		{"wildcard matches any", rules(CaptureDelayRule{AgentType: "*", StartMs: 300}), "codex", true, 300 * time.Millisecond},
+		{"empty agent_type matches any", rules(CaptureDelayRule{AgentType: "", EventMs: 70}), "codex", false, 70 * time.Millisecond},
+		{"matched but unset field falls back", rules(CaptureDelayRule{AgentType: "claude", EventMs: 80}), "claude", true, 1000 * time.Millisecond},
+		{"non-matching rule skipped", rules(CaptureDelayRule{AgentType: "codex", StartMs: 5}), "claude", true, 1000 * time.Millisecond},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.CaptureDelay(tc.agent, tc.start); got != tc.want {
+				t.Errorf("CaptureDelay(%q, start=%v) = %v, want %v", tc.agent, tc.start, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCaptureDelayLoadedFromTOML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	os.WriteFile(path, []byte("[[capture_delay]]\nagent_type = \"claude\"\nstart_ms = 1500\nevent_ms = 250\n"), 0o600)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.CaptureDelay("claude", true); got != 1500*time.Millisecond {
+		t.Errorf("start delay = %v, want 1.5s", got)
+	}
+	if got := cfg.CaptureDelay("claude", false); got != 250*time.Millisecond {
+		t.Errorf("event delay = %v, want 250ms", got)
+	}
+	// A type without a rule uses the built-in defaults.
+	if got := cfg.CaptureDelay("codex", true); got != 1000*time.Millisecond {
+		t.Errorf("unmatched start delay = %v, want 1s", got)
+	}
+}

--- a/internal/daemon/capture_test.go
+++ b/internal/daemon/capture_test.go
@@ -1,0 +1,126 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// The delayed-capture tests use real timers (the repo has no fake clock).
+// Margins are deliberately wide for shared CI runners (macos-14 stalls):
+// "nothing fired yet" sleeps sit far under the configured delay, and every
+// "must be the short delay" deadline sits far under the long delay it is
+// contrasted with.
+
+func TestCaptureDelaysClassificationRead(t *testing.T) {
+	cfg := "[[capture_delay]]\nagent_type = \"*\"\nstart_ms = 1200\nevent_ms = 1\n"
+	h := newHarness(t, cfg)
+	h.herdr.setPane(approvalPane)
+
+	h.push("agent-cap1", "blocked")
+	time.Sleep(300 * time.Millisecond)
+	if n := len(h.herdr.readLineCalls()); n != 0 {
+		t.Fatalf("pane read fired %d time(s) before the start delay elapsed", n)
+	}
+	waitFor(t, 5*time.Second, func() bool { return len(h.herdr.readLineCalls()) == 1 })
+}
+
+func TestCaptureCoalescesEventBursts(t *testing.T) {
+	// Rapid events for one pane reschedule the pending capture (latest
+	// wins): exactly one read and one escalation fire for the burst.
+	cfg := "[[capture_delay]]\nagent_type = \"*\"\nstart_ms = 500\nevent_ms = 500\n"
+	h := newHarness(t, cfg)
+	h.herdr.setPane(approvalPane)
+
+	for range 3 {
+		h.push("agent-cap2", "blocked")
+	}
+	waitFor(t, 5*time.Second, func() bool { return len(h.herdr.readLineCalls()) >= 1 })
+	// A superseded timer must never fire late: give strays time to show.
+	time.Sleep(800 * time.Millisecond)
+	if n := len(h.herdr.readLineCalls()); n != 1 {
+		t.Fatalf("burst must coalesce to exactly 1 pane read, got %d", n)
+	}
+	esc, err := h.raw.PendingEscalations(context.Background())
+	if err != nil || len(esc) != 1 {
+		t.Fatalf("burst must produce exactly 1 escalation, got %d (%v)", len(esc), err)
+	}
+}
+
+func TestCaptureStartVsEventDelay(t *testing.T) {
+	// The first capture waits start_ms; once it has fired, later events
+	// use the (much shorter) event_ms.
+	cfg := "[[capture_delay]]\nagent_type = \"*\"\nstart_ms = 3000\nevent_ms = 1\n"
+	h := newHarness(t, cfg)
+	h.herdr.setPane(approvalPane)
+
+	h.push("agent-cap3", "blocked")
+	time.Sleep(500 * time.Millisecond)
+	if n := len(h.herdr.readLineCalls()); n != 0 {
+		t.Fatalf("first event must wait the start delay, read fired %d time(s)", n)
+	}
+	waitFor(t, 10*time.Second, func() bool { return len(h.herdr.readLineCalls()) == 1 })
+
+	// Far beyond the event delay, far under another start delay: only the
+	// event delay can satisfy this deadline.
+	h.push("agent-cap3", "blocked")
+	waitFor(t, 1500*time.Millisecond, func() bool { return len(h.herdr.readLineCalls()) == 2 })
+}
+
+func TestCaptureTimersArePerPane(t *testing.T) {
+	// Two panes must not cancel each other's pending captures.
+	cfg := "[[capture_delay]]\nagent_type = \"*\"\nstart_ms = 200\nevent_ms = 200\n"
+	h := newHarness(t, cfg)
+	h.herdr.setPane(approvalPane)
+
+	h.push("agent-capA", "blocked")
+	h.push("agent-capB", "blocked")
+	waitFor(t, 5*time.Second, func() bool { return len(h.herdr.readLineCalls()) == 2 })
+	esc, err := h.raw.PendingEscalations(context.Background())
+	if err != nil || len(esc) != 2 {
+		t.Fatalf("both panes must escalate, got %d (%v)", len(esc), err)
+	}
+}
+
+func TestCaptureCanceledByWorkingTransition(t *testing.T) {
+	// The human answered before the capture fired: the pending capture is
+	// canceled — no stale read, no escalation for a pane that moved on.
+	cfg := "[[capture_delay]]\nagent_type = \"*\"\nstart_ms = 600\nevent_ms = 600\n"
+	h := newHarness(t, cfg)
+	h.herdr.setPane(approvalPane)
+
+	h.push("agent-cap4", "blocked")
+	time.Sleep(100 * time.Millisecond)
+	h.push("agent-cap4", "working")
+	time.Sleep(1200 * time.Millisecond)
+	if n := len(h.herdr.readLineCalls()); n != 0 {
+		t.Fatalf("working must cancel the pending capture, read fired %d time(s)", n)
+	}
+	esc, err := h.raw.PendingEscalations(context.Background())
+	if err != nil || len(esc) != 0 {
+		t.Fatalf("no escalation expected after cancel, got %d (%v)", len(esc), err)
+	}
+}
+
+func TestCaptureDetectedResetsStartDelay(t *testing.T) {
+	// A new agent discovered in a previously-used pane gets the full start
+	// settle again — captureStarted is per agent tenancy, not forever.
+	cfg := "[[capture_delay]]\nagent_type = \"*\"\nstart_ms = 2000\nevent_ms = 1\n"
+	h := newHarness(t, cfg)
+	h.herdr.setPane(approvalPane)
+
+	h.push("agent-cap5", "blocked")
+	waitFor(t, 10*time.Second, func() bool { return len(h.herdr.readLineCalls()) == 1 })
+	// Sanity: the event delay is in effect now.
+	h.push("agent-cap5", "blocked")
+	waitFor(t, 1500*time.Millisecond, func() bool { return len(h.herdr.readLineCalls()) == 2 })
+
+	// Rediscovery (pane re-created / new tenant): back to the start delay.
+	h.push("agent-cap5", "detected")
+	h.push("agent-cap5", "blocked")
+	time.Sleep(500 * time.Millisecond)
+	if n := len(h.herdr.readLineCalls()); n != 2 {
+		t.Fatalf("detected must restore the start delay, read fired %d time(s)", n)
+	}
+	waitFor(t, 10*time.Second, func() bool { return len(h.herdr.readLineCalls()) == 3 })
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -82,6 +82,17 @@ type Daemon struct {
 	llmResults     chan llmOutcome
 	rewriteResults chan rewriteOutcome
 	sweepResults   chan sweepOutcome
+	// delayedTr re-enters attention transitions whose capture delay has
+	// elapsed; the pane read happens back on the main loop, like every
+	// other pipeline entry point.
+	delayedTr chan domain.AgentTransition
+
+	// pendingCapture coalesces attention-event bursts per pane: one timer
+	// per pane, latest event wins, exactly one capture fires per burst.
+	// captureStarted marks panes whose first capture has fired, so later
+	// events use the shorter event delay. Both guarded by mu.
+	pendingCapture map[string]*captureEntry
+	captureStarted map[string]bool
 
 	// configured flips after the first successful reload so reloadEmbedder
 	// can tell first load from a config change.
@@ -177,6 +188,9 @@ func New(opt Options) (*Daemon, error) {
 		llmResults:      make(chan llmOutcome, 16),
 		rewriteResults:  make(chan rewriteOutcome, 16),
 		sweepResults:    make(chan sweepOutcome, 16),
+		delayedTr:       make(chan domain.AgentTransition, 256),
+		pendingCapture:  map[string]*captureEntry{},
+		captureStarted:  map[string]bool{},
 		lastAutoSend:    map[string]time.Time{},
 		lastAutoNoop:    map[string]time.Time{},
 		rewriteInFlight: map[string]rewriteFlight{},
@@ -324,6 +338,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 				d.handleTransition(ctx, tr)
 				return nil
 			})
+		case tr := <-d.delayedTr:
+			logging.Guard("pipeline", func() error {
+				d.handleAttention(ctx, tr)
+				return nil
+			})
 		case kind := <-d.nudges:
 			logging.Guard("nudge", func() error {
 				if kind == control.KindReload {
@@ -354,7 +373,6 @@ func (d *Daemon) Run(ctx context.Context) error {
 
 // handleTransition evaluates one agent-status transition end to end.
 func (d *Daemon) handleTransition(ctx context.Context, tr domain.AgentTransition) {
-	_, _, cls := d.snapshot()
 	now := d.opt.Clock.Now()
 
 	// Auto-generate a short friendly name on first sight — for EVERY
@@ -362,8 +380,7 @@ func (d *Daemon) handleTransition(ctx context.Context, tr domain.AgentTransition
 	// "working", so a brand-new agent is named the moment it appears, not
 	// only when it first needs attention (insert-if-absent, so operator
 	// renames are never clobbered).
-	agentName, err := d.opt.Store.EnsureAgentName(ctx, tr.AgentID)
-	if err != nil {
+	if _, err := d.opt.Store.EnsureAgentName(ctx, tr.AgentID); err != nil {
 		slog.Warn("agent name generation failed", "agent", tr.AgentID, "error", err)
 	}
 
@@ -388,12 +405,100 @@ func (d *Daemon) handleTransition(ctx context.Context, tr domain.AgentTransition
 		if paused || !ours || now.Sub(last) > 10*time.Second {
 			d.registerHumanInteraction(ctx, tr.AgentID)
 		}
+		// The agent resumed: a pending delayed capture would read a pane
+		// that moved on (the consuming recent-delta still holds the old
+		// menu AND the answer) — activity supersedes it.
+		d.cancelCapture(tr.PaneID)
 		return
 	case "idle", "done", "blocked":
-		// attention-requiring; continue below
+		// Attention-requiring: the pane read is DELAYED so the agent TUI
+		// has painted (an immediate read on the start event captures shell
+		// scrollback, not the agent's screen). Bursts coalesce per pane —
+		// the latest event wins and exactly one capture fires.
+		d.scheduleCapture(ctx, tr)
+		return
 	default:
 		// "detected" and unknown statuses: named above, nothing to act on.
+		// "detected" is discovery (pane created / subscriber replay): a
+		// fresh agent in this pane must get the full start settle again,
+		// and any pending capture belongs to a previous tenant. A replay
+		// on subscriber reconnect only costs one extra long settle.
+		if tr.Status == "detected" {
+			d.cancelCapture(tr.PaneID)
+			d.mu.Lock()
+			delete(d.captureStarted, tr.PaneID)
+			d.mu.Unlock()
+		}
 		return
+	}
+}
+
+// cancelCapture stops and forgets the pane's pending delayed capture —
+// activity or discovery supersedes it. A closure that already started
+// firing sees its map entry gone and bails (generation check).
+func (d *Daemon) cancelCapture(paneID string) {
+	d.mu.Lock()
+	if p := d.pendingCapture[paneID]; p != nil {
+		p.timer.Stop()
+		delete(d.pendingCapture, paneID)
+	}
+	d.mu.Unlock()
+}
+
+// captureEntry is one pane's pending delayed capture; the pointer identity
+// doubles as the generation token that closes the Timer.Stop race.
+type captureEntry struct {
+	timer *time.Timer
+}
+
+// scheduleCapture (re)arms the pane's capture timer: a newer event cancels
+// a pending one (latest wins). When the timer fires, the transition
+// re-enters the main loop through delayedTr — nothing sleeps in Run.
+func (d *Daemon) scheduleCapture(ctx context.Context, tr domain.AgentTransition) {
+	cfg, _, _ := d.snapshot()
+	d.mu.Lock()
+	if p := d.pendingCapture[tr.PaneID]; p != nil {
+		p.timer.Stop()
+	}
+	// The start delay applies until the pane's FIRST capture actually
+	// fires — a burst of events during startup keeps the longer settle.
+	delay := cfg.CaptureDelay(tr.AgentType, !d.captureStarted[tr.PaneID])
+	entry := &captureEntry{}
+	entry.timer = time.AfterFunc(delay, func() {
+		d.mu.Lock()
+		current := d.pendingCapture[tr.PaneID] == entry
+		if current {
+			delete(d.pendingCapture, tr.PaneID)
+			d.captureStarted[tr.PaneID] = true
+		}
+		d.mu.Unlock()
+		if !current {
+			// Superseded: Stop() lost the race with this func starting,
+			// but the map entry identity says a newer capture owns the
+			// pane now. Only the newest delivers.
+			return
+		}
+		select {
+		case d.delayedTr <- tr:
+		case <-ctx.Done():
+		}
+	})
+	d.pendingCapture[tr.PaneID] = entry
+	d.mu.Unlock()
+}
+
+// handleAttention is the post-delay half of the pipeline: the classification
+// pane read and everything after it. It runs on the main loop (via
+// delayedTr) and re-derives its inputs at fire time, so every gate — kill
+// switch, rate guard, retry ceiling — applies AFTER the delay.
+func (d *Daemon) handleAttention(ctx context.Context, tr domain.AgentTransition) {
+	_, _, cls := d.snapshot()
+	now := d.opt.Clock.Now()
+	// Insert-if-absent; the transition handler already named the agent,
+	// this just re-reads (and covers rows racing a clear-data).
+	agentName, err := d.opt.Store.EnsureAgentName(ctx, tr.AgentID)
+	if err != nil {
+		slog.Warn("agent name generation failed", "agent", tr.AgentID, "error", err)
 	}
 
 	pane, err := d.opt.Herdr.ReadPane(ctx, tr.PaneID, d.opt.PaneReadLines)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -292,10 +292,13 @@ func newHarnessFull(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.He
 	t.Helper()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.toml")
-	if cfgTOML != "" {
-		if err := os.WriteFile(cfgPath, []byte(cfgTOML), 0o600); err != nil {
-			t.Fatal(err)
-		}
+	// Existing tests assume near-synchronous attention handling: append a
+	// tiny wildcard capture delay LAST, so a test-supplied
+	// [[capture_delay]] rule earlier in the config still wins (first
+	// match wins) while everything else skips the real-world settle.
+	cfgTOML += tinyCaptureDelay
+	if err := os.WriteFile(cfgPath, []byte(cfgTOML), 0o600); err != nil {
+		t.Fatal(err)
 	}
 	raw, err := store.Open(filepath.Join(dir, "test.db"))
 	if err != nil {
@@ -357,6 +360,21 @@ func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("condition not met within timeout")
+}
+
+// tinyCaptureDelay keeps tests near-synchronous; appended LAST to every
+// harness config so a test-supplied [[capture_delay]] rule still wins
+// (first match wins).
+const tinyCaptureDelay = "\n[[capture_delay]]\nagent_type = \"*\"\nstart_ms = 1\nevent_ms = 1\n"
+
+// writeConfig rewrites the harness config mid-test (callers nudge reload),
+// re-appending the tiny capture delay so the daemon keeps test-speed
+// capture timing after the reload.
+func (h *harness) writeConfig(t *testing.T, cfgTOML string) {
+	t.Helper()
+	if err := os.WriteFile(h.cfgPath, []byte(cfgTOML+tinyCaptureDelay), 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func (h *harness) push(agentID, status string) {
@@ -992,7 +1010,7 @@ func TestIdleTaskSourceMatchesAgentShortName(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfgTOML := fmt.Sprintf("[[task_sources]]\nagent = \"docs-writer\"\npath = %q\n", taskFile)
-	os.WriteFile(h.cfgPath, []byte(cfgTOML), 0o600)
+	h.writeConfig(t, cfgTOML)
 	if err := control.Nudge(ctx, h.ctlPath, control.KindReload); err != nil {
 		t.Fatal(err)
 	}
@@ -1096,7 +1114,7 @@ func TestCorrectionDemotesAutonomousSignature(t *testing.T) {
 func TestConfigReloadPropagatesWithinBudget(t *testing.T) {
 	// NFR-009 / SC-2: a config edit + nudge is reflected ≤ 1s.
 	h := newHarness(t, "[thresholds]\napproval = 0.8\n")
-	os.WriteFile(h.cfgPath, []byte("[thresholds]\napproval = 0.99\n"), 0o600)
+	h.writeConfig(t, "[thresholds]\napproval = 0.99\n")
 
 	start := time.Now()
 	if err := control.Nudge(context.Background(), h.ctlPath, control.KindReload); err != nil {

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -866,6 +866,20 @@ func (a *App) SignatureDetail(ctx context.Context, prefix string) (SignatureRow,
 	return row, history, nil
 }
 
+// SignatureSnapshot returns the pane excerpt a signature was first seen
+// with, or "" on a nil app, empty signature, miss, or error — detail views
+// degrade to their "not captured yet" fallback rather than failing.
+func (a *App) SignatureSnapshot(ctx context.Context, signature string) string {
+	if a == nil || signature == "" {
+		return ""
+	}
+	excerpt, err := a.Store.GetSignatureSnapshot(ctx, signature)
+	if err != nil {
+		return ""
+	}
+	return excerpt
+}
+
 // DeleteSignature resolves the prefix, deletes the signature with its
 // decision history and error-retry row, and nudges the daemon to drop any
 // in-memory state. Returns the resolved key and removed decision count.

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -960,3 +960,22 @@ func TestResolveDigitSeriesStaleFormFails(t *testing.T) {
 		t.Errorf("the correction itself must still be recorded: %+v", corr)
 	}
 }
+
+func TestSignatureSnapshotAccessor(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+
+	if err := st.SaveSignatureSnapshot(ctx, "approval:feed0000beef1111",
+		"Do you want to proceed?\n1. Yes\n2. No", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if got := app.SignatureSnapshot(ctx, "approval:feed0000beef1111"); !strings.Contains(got, "proceed") {
+		t.Errorf("snapshot hit = %q, want the stored excerpt", got)
+	}
+	if got := app.SignatureSnapshot(ctx, "approval:unknown0000000000"); got != "" {
+		t.Errorf("snapshot miss should be empty, got %q", got)
+	}
+	if got := app.SignatureSnapshot(ctx, ""); got != "" {
+		t.Errorf("empty signature should be empty, got %q", got)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -704,7 +704,9 @@ func (m Model) viewSelected() (tea.Model, tea.Cmd) {
 				kind = "Escalation"
 			}
 			r := *rec
-			build := func(width int) []string { return m.auditDetailLines(r, width) }
+			// Fetched once at open time (not on every resize rebuild).
+			snapshot := m.app.SignatureSnapshot(m.ctx, r.Signature)
+			build := func(width int) []string { return m.auditDetailLines(r, snapshot, width) }
 			m.message = ""
 			d := &detailView{
 				title: fmt.Sprintf("%s #%d", kind, r.ID),
@@ -841,7 +843,7 @@ func locationLabel(id string, lookup func() (label string, number int, ok bool))
 	return id
 }
 
-func (m Model) auditDetailLines(r domain.AuditRecord, w int) []string {
+func (m Model) auditDetailLines(r domain.AuditRecord, snapshot string, w int) []string {
 	var lines []string
 	agent := r.AgentID
 	if n := m.data.status.AgentName(r.AgentID); n != "" {
@@ -874,6 +876,16 @@ func (m Model) auditDetailLines(r domain.AuditRecord, w int) []string {
 	}
 	if r.CorrectsAuditID != 0 {
 		lines = detailField(lines, w, "Corrects audit", fmt.Sprintf("#%d", r.CorrectsAuditID))
+	}
+	// The captured pane content behind this record — the signature's
+	// FIRST-seen excerpt (rule provenance), not the pane at this exact
+	// moment; same semantics as the Rules detail.
+	if r.Signature != "" {
+		if snapshot != "" {
+			lines = detailField(lines, w, "Original situation", snapshot)
+		} else {
+			lines = detailField(lines, w, "Original situation", "(not captured yet — recorded on the rule's next sighting)")
+		}
 	}
 	return lines
 }

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -895,3 +895,33 @@ func TestEscalationWithoutRuleShowsNoneYet(t *testing.T) {
 		t.Errorf("audit list should dash-mark rows without a rule:\n%s", list)
 	}
 }
+
+func TestEscalationDetailShowsOriginalSituation(t *testing.T) {
+	// The Escalations detail view surfaces the captured pane content
+	// (the signature's first-seen snapshot) so the operator has context.
+	m, _, _ := appModel(t)
+	m.tab = tabEscalations
+	m.cursor = 0
+	m = press(t, m, "v")
+	if m.detail == nil {
+		t.Fatal("v should open the escalation detail")
+	}
+	view := m.View()
+	for _, want := range []string{"Original situation", "kubectl apply"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("escalation detail missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestEscalationDetailSnapshotFallback(t *testing.T) {
+	// No snapshot stored yet: the detail shows the not-captured fallback
+	// instead of an empty block.
+	m := testModel(t)
+	m.height = 44
+	m.tab = tabEscalations
+	m = press(t, m, "v")
+	if !strings.Contains(m.View(), "not captured yet") {
+		t.Errorf("missing snapshot should render the fallback line:\n%s", m.View())
+	}
+}

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -97,3 +97,13 @@ max_content_width = 0      # cap on variable-length list columns; 0 = full termi
 # situation = "approval"                # approval | choice | error | idle
 # regex = ['(?i)shall I go ahead\?']
 # keywords = ["waiting for approval"]
+
+# ── Capture delay (repeatable; first matching rule wins) ────────────
+# Delay before reading the pane after a herdr agent event, so the agent
+# TUI has painted (avoids capturing shell scrollback at startup).
+# A matched rule's unset (or 0) field uses the built-in default — later
+# rules are not consulted; a true 0ms delay is not expressible (use 1).
+# [[capture_delay]]
+# agent_type = "claude"      # exact agent type, or "*" for any
+# start_ms = 1500            # first event after the agent starts (default 1000)
+# event_ms = 200             # subsequent events (default 200)


### PR DESCRIPTION
Fixes stale-capture poisoning: the daemon read the pane immediately on a herdr status event, so an agent's first event captured shell scrollback (the `claude` launch command, old session output) instead of the agent's screen — feeding classification, the situation signature, the provenance snapshot, and the `pane_excerpt` fallback with garbage.

## What changed

- **Per-pane delayed capture**: attention events (`idle`/`done`/`blocked`) now schedule the classification read — default **1000ms** for a pane's first event, **200ms** for later ones, configurable per `agent_type` via repeatable `[[capture_delay]]` rules (first match wins; unset fields use the built-in defaults). Documented in `sample/config.toml`.
- **Burst coalescing**: more events for the same pane cancel and rearm the pending capture (latest wins) — exactly one capture/decision fires per burst. A pointer-identity generation check closes the `Timer.Stop` race.
- **Lifecycle correctness** (from code review): a `working` transition cancels the pending capture (the pane moved on — prevents replaying a menu answer into a resumed agent), and a `detected` event resets the pane's capture state so a new agent in a reused pane gets the full start settle.
- **Main loop stays non-blocking**: the timer runs off-loop and re-enters via a buffered channel into the split-out `handleAttention`, so kill switch / rate guard / retry ceiling all apply *after* the delay (same pattern as `consultLLM`/`llmResults`).
- **TUI**: Escalations and Audit detail views now show an **Original situation** block — the captured pane content behind the record (signature's first-seen snapshot; `(not captured yet …)` fallback).

## Verification

- New tests: delay honored, bursts coalesce to exactly one read+escalation, start-vs-event delay, per-pane timer independence, working-cancels, detected-resets; config rule matching/TOML matrix; frontend accessor; TUI detail blocks. Harness injects a 1ms wildcard rule so the existing suite keeps its timing (wide CI margins on the new tests).
- Full suite green (17/17 packages); `gofmt`/`vet`/`golangci-lint` clean.
- E2E smoke (fake herdr → real daemon, default delays): approval classified after the 1s settle, consult outcome audited.
- Integration suite against a real herdr: the two real-herdr cases pass (claude/model cases skip as designed).

https://claude.ai/code/session_01G5ANCGcVWmRUcTX4A1A2CK