### PR TITLE
#1 fix: CI corpus gate ran zero tests — wrong -run pattern, add no-op guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,4 +112,9 @@ jobs:
       # internal/domain is pure Go (TestDomainPurity), so no native deps
       # or build tags are needed here.
       - name: Seed patterns must catch 100% of the irreversible-op corpus
-        run: go test ./internal/domain/ -run TestSeedAllowlistCatchesCorpus -v -count=1
+        # Guard against the -run pattern silently matching nothing (go test
+        # exits 0 with "no tests to run"): require the PASS line explicitly.
+        run: |
+          go test ./internal/domain/ -run 'TestSeedNeverAutoCatchesCorpus$' -v -count=1 | tee /tmp/corpus-gate.out
+          grep -q -- '--- PASS: TestSeedNeverAutoCatchesCorpus' /tmp/corpus-gate.out \
+            || { echo '::error::corpus gate did not execute TestSeedNeverAutoCatchesCorpus (test renamed?)'; exit 1; }


### PR DESCRIPTION
## Problem

The `corpus-gate` CI job (NFR-005a regression gate) ran

```
go test ./internal/domain/ -run TestSeedAllowlistCatchesCorpus -v -count=1
```

but the actual test is named `TestSeedNeverAutoCatchesCorpus` (`internal/domain/safety_test.go:23`). The `-run` regex matched zero tests, `go test` exited 0 with "no tests to run", and the gate has been passing **vacuously** — a corpus miss would never fail CI.

## Fix

- Point `-run` at the real test, anchored: `'TestSeedNeverAutoCatchesCorpus$'`.
- Add a guard against this whole bug class: the step now `tee`s the output and requires the literal `--- PASS: TestSeedNeverAutoCatchesCorpus` line, so a future test rename fails the job loudly (`::error::` annotation) instead of silently no-opping. With the runner's default `bash -eo pipefail`, a real test failure still propagates through the pipe.

## Verified

- Ran the exact step command locally with `pipefail`: test executes, `51/51` corpus entries matched, grep guard finds the PASS line, exit 0.
- Reviewed shell semantics for all four cases (pass / fail / no-match / rename) — each resolves correctly.

## Note on goimports

Flagged alongside this bug that the lint job runs only gofmt explicitly. No change needed: `.golangci.yml` already enables `goimports` under `formatters:`, and golangci-lint v2's `run` (what the CI action invokes) reports formatter violations as issues — goimports is already gating CI.