### PR TITLE
#1 chore: move llama-go submodule to submodule/github.com/seed-hypermedia/llama-go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,20 +26,20 @@ jobs:
           cache: true
       - name: Native cache key (submodule commit)
         id: subsha
-        run: echo "sha=$(git submodule status third_party/llama-go | awk '{print substr($1,1,12)}' | tr -d '+-')" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git submodule status submodule/github.com/seed-hypermedia/llama-go | awk '{print substr($1,1,12)}' | tr -d '+-')" >> "$GITHUB_OUTPUT"
       - name: Cache native builds
         uses: actions/cache@v4
         with:
           path: |
             .cache/native
-            third_party/llama-go/*.a
-            third_party/llama-go/llama.cpp/**/*.o
+            submodule/github.com/seed-hypermedia/llama-go/*.a
+            submodule/github.com/seed-hypermedia/llama-go/llama.cpp/**/*.o
           key: native-lint-${{ runner.os }}-${{ env.ImageOS }}-${{ hashFiles('scripts/setup-native.sh') }}-${{ steps.subsha.outputs.sha }}
       - name: Build native dependencies
         run: bash scripts/setup-native.sh
       - name: gofmt
         run: |
-          out=$(gofmt -l . | grep -v '^third_party/' || true)
+          out=$(gofmt -l . | grep -v '^submodule/' || true)
           if [ -n "$out" ]; then
             echo "gofmt violations:" && echo "$out" && exit 1
           fi
@@ -69,14 +69,14 @@ jobs:
           cache: true
       - name: Native cache key (submodule commit)
         id: subsha
-        run: echo "sha=$(git submodule status third_party/llama-go | awk '{print substr($1,1,12)}' | tr -d '+-')" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git submodule status submodule/github.com/seed-hypermedia/llama-go | awk '{print substr($1,1,12)}' | tr -d '+-')" >> "$GITHUB_OUTPUT"
       - name: Cache native builds
         uses: actions/cache@v4
         with:
           path: |
             .cache/native
-            third_party/llama-go/*.a
-            third_party/llama-go/llama.cpp/**/*.o
+            submodule/github.com/seed-hypermedia/llama-go/*.a
+            submodule/github.com/seed-hypermedia/llama-go/llama.cpp/**/*.o
           key: native-test-${{ matrix.os }}-${{ env.ImageOS }}-${{ hashFiles('scripts/setup-native.sh') }}-${{ steps.subsha.outputs.sha }}
       - name: Build native dependencies
         run: bash scripts/setup-native.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,20 +27,20 @@ jobs:
           cache: true
       - name: Native cache key (submodule commit)
         id: subsha
-        run: echo "sha=$(git submodule status third_party/llama-go | awk '{print substr($1,1,12)}' | tr -d '+-')" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git submodule status submodule/github.com/seed-hypermedia/llama-go | awk '{print substr($1,1,12)}' | tr -d '+-')" >> "$GITHUB_OUTPUT"
       - name: Cache native builds
         uses: actions/cache@v4
         with:
           path: |
             .cache/native
-            third_party/llama-go/*.a
-            third_party/llama-go/llama.cpp/**/*.o
+            submodule/github.com/seed-hypermedia/llama-go/*.a
+            submodule/github.com/seed-hypermedia/llama-go/llama.cpp/**/*.o
           key: native-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ hashFiles('scripts/setup-native.sh') }}-${{ steps.subsha.outputs.sha }}
       - name: Build native dependencies
         run: bash scripts/setup-native.sh
       - name: gofmt
         run: |
-          out=$(gofmt -l . | grep -v '^third_party/' || true)
+          out=$(gofmt -l . | grep -v '^submodule/' || true)
           if [ -n "$out" ]; then echo "$out" && exit 1; fi
       - run: go vet -tags "${GO_BUILD_TAGS}" ./...
       - run: go test -tags "${GO_BUILD_TAGS}" ./... -count=1 -timeout 15m
@@ -71,14 +71,14 @@ jobs:
           cache: true
       - name: Native cache key (submodule commit)
         id: subsha
-        run: echo "sha=$(git submodule status third_party/llama-go | awk '{print substr($1,1,12)}' | tr -d '+-')" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git submodule status submodule/github.com/seed-hypermedia/llama-go | awk '{print substr($1,1,12)}' | tr -d '+-')" >> "$GITHUB_OUTPUT"
       - name: Cache native builds
         uses: actions/cache@v4
         with:
           path: |
             .cache/native
-            third_party/llama-go/*.a
-            third_party/llama-go/llama.cpp/**/*.o
+            submodule/github.com/seed-hypermedia/llama-go/*.a
+            submodule/github.com/seed-hypermedia/llama-go/llama.cpp/**/*.o
           key: native-${{ matrix.target }}-${{ env.ImageOS }}-${{ hashFiles('scripts/setup-native.sh') }}-${{ steps.subsha.outputs.sha }}
       - name: Build native dependencies
         run: bash scripts/setup-native.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "third_party/llama-go"]
-	path = third_party/llama-go
+[submodule "submodule/github.com/seed-hypermedia/llama-go"]
+	path = submodule/github.com/seed-hypermedia/llama-go
 	url = https://github.com/seed-hypermedia/llama-go

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ native deps once** and the `vectors cpu` build tags always:
 bash scripts/setup-native.sh                   # one-time: submodules + llama-go libs + FAISS → /usr/local/lib
 go build -tags "vectors cpu" ./...             # CGO; needs a C/C++ toolchain
 go test -tags "vectors cpu" ./... -count=1     # full unit/golden/safety/semantic suite (what CI runs)
-gofmt -l . | grep -v third_party && go vet -tags "vectors cpu" ./...
+gofmt -l . | grep -v submodule && go vet -tags "vectors cpu" ./...
 golangci-lint run --build-tags "vectors,cpu"   # CI runs this too
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ cmake, a one-time native-deps build, and the `vectors cpu` build tags:
 bash scripts/setup-native.sh                 # one-time: submodules, llama-go libs, FAISS
 go build -tags "vectors cpu" ./...           # full build (CGO)
 go test -tags "vectors cpu" ./... -count=1   # full suite: unit, golden, safety, concurrency, semantic
-gofmt -l . | grep -v third_party ; go vet -tags "vectors cpu" ./...
+gofmt -l . | grep -v submodule ; go vet -tags "vectors cpu" ./...
 golangci-lint run --build-tags "vectors,cpu" # lint (CI runs this too)
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -66,4 +66,4 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 )
 
-replace github.com/tcpipuk/llama-go => ./third_party/llama-go
+replace github.com/tcpipuk/llama-go => ./submodule/github.com/seed-hypermedia/llama-go

--- a/scripts/setup-native.sh
+++ b/scripts/setup-native.sh
@@ -2,7 +2,7 @@
 # Build and install the native libraries hap needs since the semantic
 # signature matcher landed:
 #
-#   - libbinding.a + static llama.cpp archives from third_party/llama-go
+#   - libbinding.a + static llama.cpp archives from submodule/github.com/seed-hypermedia/llama-go
 #     (llama.cpp embeddings; BUILD_SHARED_LIBS=OFF so the hap binary links
 #     them statically — no llama/ggml runtime libraries to ship)
 #   - libfaiss_c + libfaiss shared libs from the blevesearch FAISS fork
@@ -60,8 +60,8 @@ elif [ "$OS" = "Darwin" ]; then
 fi
 
 echo "==> submodules (llama-go + shallow llama.cpp)"
-git submodule update --init third_party/llama-go
-git -C third_party/llama-go submodule update --init --depth 1 llama.cpp
+git submodule update --init submodule/github.com/seed-hypermedia/llama-go
+git -C submodule/github.com/seed-hypermedia/llama-go submodule update --init --depth 1 llama.cpp
 
 echo "==> llama-go static binding (CPU only, static archives)"
 # BUILD_SHARED_LIBS=OFF makes the Makefile copy .a archives — the shared
@@ -70,16 +70,16 @@ echo "==> llama-go static binding (CPU only, static archives)"
 LLAMA_CMAKE_ARGS="-DBUILD_SHARED_LIBS=OFF -DGGML_METAL=OFF -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF"
 # The llama-go Makefile only invalidates its cmake cache on GPU-flag
 # mismatches, not shared/static — wipe a build configured for shared libs.
-if [ -f third_party/llama-go/build/CMakeCache.txt ] &&
-  ! grep -q "BUILD_SHARED_LIBS:BOOL=OFF" third_party/llama-go/build/CMakeCache.txt; then
+if [ -f submodule/github.com/seed-hypermedia/llama-go/build/CMakeCache.txt ] &&
+  ! grep -q "BUILD_SHARED_LIBS:BOOL=OFF" submodule/github.com/seed-hypermedia/llama-go/build/CMakeCache.txt; then
   echo "    (wiping shared-lib cmake cache)"
-  rm -rf third_party/llama-go/build third_party/llama-go/llama.cpp/*.o \
-    third_party/llama-go/*.o third_party/llama-go/*.a \
-    third_party/llama-go/*.so third_party/llama-go/*.dylib
+  rm -rf submodule/github.com/seed-hypermedia/llama-go/build submodule/github.com/seed-hypermedia/llama-go/llama.cpp/*.o \
+    submodule/github.com/seed-hypermedia/llama-go/*.o submodule/github.com/seed-hypermedia/llama-go/*.a \
+    submodule/github.com/seed-hypermedia/llama-go/*.so submodule/github.com/seed-hypermedia/llama-go/*.dylib
 fi
-if [ ! -f third_party/llama-go/libbinding.a ] || [ ! -f third_party/llama-go/libllama.a ]; then
-  rm -f third_party/llama-go/*.a third_party/llama-go/*.so third_party/llama-go/*.dylib
-  CMAKE_ARGS="${LLAMA_CMAKE_ARGS}" make -C third_party/llama-go libbinding.a -j"${JOBS}"
+if [ ! -f submodule/github.com/seed-hypermedia/llama-go/libbinding.a ] || [ ! -f submodule/github.com/seed-hypermedia/llama-go/libllama.a ]; then
+  rm -f submodule/github.com/seed-hypermedia/llama-go/*.a submodule/github.com/seed-hypermedia/llama-go/*.so submodule/github.com/seed-hypermedia/llama-go/*.dylib
+  CMAKE_ARGS="${LLAMA_CMAKE_ARGS}" make -C submodule/github.com/seed-hypermedia/llama-go libbinding.a -j"${JOBS}"
 fi
 
 echo "==> FAISS (blevesearch fork @ ${FAISS_COMMIT:0:7})"


### PR DESCRIPTION
## What

Moves the `llama-go` git submodule from `third_party/llama-go` to `submodule/github.com/seed-hypermedia/llama-go` — the canonical layout for all submodules going forward (`submodule/github.com/<org>/<repo>`, keyed by the clone URL's org).

## Changes

- `git mv` of the submodule, with the submodule **name** in `.gitmodules` renamed to match the new path
- `go.mod`: `replace github.com/tcpipuk/llama-go` now points at the new path (the Go module name itself is upstream's identity and unchanged)
- `scripts/setup-native.sh`: submodule init + static-archive paths
- `.github/workflows/{ci,release}.yml`: native cache paths, cache-key `git submodule status` path, and the gofmt exclusion (`^third_party/` → `^submodule/`)
- `CLAUDE.md` / `CONTRIBUTING.md` docs

`test/samples/claude_todo_sample3.txt` still mentions `third_party` — that's captured pane text used as a classifier fixture, deliberately untouched.

## Verified

- `go build -tags "vectors cpu" ./...` and `go vet` pass
- Full unit suite (`go test -tags "vectors cpu" ./... -count=1`): **all 17 packages pass**
- `git submodule status --recursive` resolves both llama-go and the nested llama.cpp at the new path; both working trees clean
- Fresh clones / CI are unaffected: `actions/checkout` with `submodules: recursive` reads only `.gitmodules`, and the native cache keys include `hashFiles('scripts/setup-native.sh')`, so stale caches with the old layout can't be restored

## Migration note for existing clones

Because the submodule *name* changed, `git submodule sync` can't migrate an existing clone. After pulling this change, run:

```sh
rm -rf third_party .git/modules/third_party
bash scripts/setup-native.sh   # re-inits the submodule and rebuilds the static libs
```