### PR TITLE
#1 feat: per-entry Current situation in Escalations/Audit detail

### DIFF
--- a/internal/daemon/capture_test.go
+++ b/internal/daemon/capture_test.go
@@ -2,8 +2,11 @@ package daemon
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 )
 
 // The delayed-capture tests use real timers (the repo has no fake clock).
@@ -23,6 +26,18 @@ func TestCaptureDelaysClassificationRead(t *testing.T) {
 		t.Fatalf("pane read fired %d time(s) before the start delay elapsed", n)
 	}
 	waitFor(t, 5*time.Second, func() bool { return len(h.herdr.readLineCalls()) == 1 })
+
+	// The escalation records the pane content it was classified from —
+	// the per-entry "Current situation", distinct from the signature's
+	// first-seen provenance snapshot.
+	var esc []domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(context.Background())
+		return len(esc) == 1
+	})
+	if !strings.Contains(esc[0].PaneExcerpt, "Do you want to proceed") {
+		t.Errorf("escalation must carry the classified pane content, got %q", esc[0].PaneExcerpt)
+	}
 }
 
 func TestCaptureCoalescesEventBursts(t *testing.T) {
@@ -50,7 +65,7 @@ func TestCaptureCoalescesEventBursts(t *testing.T) {
 func TestCaptureStartVsEventDelay(t *testing.T) {
 	// The first capture waits start_ms; once it has fired, later events
 	// use the (much shorter) event_ms.
-	cfg := "[[capture_delay]]\nagent_type = \"*\"\nstart_ms = 3000\nevent_ms = 1\n"
+	cfg := "[[capture_delay]]\nagent_type = \"*\"\nstart_ms = 6000\nevent_ms = 1\n"
 	h := newHarness(t, cfg)
 	h.herdr.setPane(approvalPane)
 
@@ -59,12 +74,12 @@ func TestCaptureStartVsEventDelay(t *testing.T) {
 	if n := len(h.herdr.readLineCalls()); n != 0 {
 		t.Fatalf("first event must wait the start delay, read fired %d time(s)", n)
 	}
-	waitFor(t, 10*time.Second, func() bool { return len(h.herdr.readLineCalls()) == 1 })
+	waitFor(t, 15*time.Second, func() bool { return len(h.herdr.readLineCalls()) == 1 })
 
 	// Far beyond the event delay, far under another start delay: only the
-	// event delay can satisfy this deadline.
+	// event delay can satisfy this deadline, even on a stalled runner.
 	h.push("agent-cap3", "blocked")
-	waitFor(t, 1500*time.Millisecond, func() bool { return len(h.herdr.readLineCalls()) == 2 })
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.readLineCalls()) == 2 })
 }
 
 func TestCaptureTimersArePerPane(t *testing.T) {
@@ -85,14 +100,14 @@ func TestCaptureTimersArePerPane(t *testing.T) {
 func TestCaptureCanceledByWorkingTransition(t *testing.T) {
 	// The human answered before the capture fired: the pending capture is
 	// canceled — no stale read, no escalation for a pane that moved on.
-	cfg := "[[capture_delay]]\nagent_type = \"*\"\nstart_ms = 600\nevent_ms = 600\n"
+	cfg := "[[capture_delay]]\nagent_type = \"*\"\nstart_ms = 1500\nevent_ms = 1500\n"
 	h := newHarness(t, cfg)
 	h.herdr.setPane(approvalPane)
 
 	h.push("agent-cap4", "blocked")
 	time.Sleep(100 * time.Millisecond)
 	h.push("agent-cap4", "working")
-	time.Sleep(1200 * time.Millisecond)
+	time.Sleep(2500 * time.Millisecond)
 	if n := len(h.herdr.readLineCalls()); n != 0 {
 		t.Fatalf("working must cancel the pending capture, read fired %d time(s)", n)
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -803,7 +803,7 @@ func (d *Daemon) deliverAutonomous(ctx context.Context, s domain.Situation, sig 
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
 		SituationType: s.Type, Action: "auto:" + del.input, Input: del.input,
 		Confidence: dec.Confidence, Rationale: del.rationale, LLMOutput: del.llmOutput,
-		Status: "auto", CreatedAt: now,
+		Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
 	})
 	if err != nil {
 		slog.Error("audit write failed; blocking autonomous action (FR-024)", "error", err)
@@ -878,7 +878,7 @@ func (d *Daemon) deliverNoop(ctx context.Context, s domain.Situation, sig domain
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
 		SituationType: s.Type, Action: "noop", Input: "",
 		Confidence: dec.Confidence, Rationale: dec.Rationale,
-		Status: "auto", CreatedAt: now,
+		Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
 	})
 	if err != nil {
 		slog.Error("audit write failed; blocking autonomous noop (FR-024)", "error", err)
@@ -924,7 +924,11 @@ func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.Si
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
 		SituationType: s.Type, Action: "escalated", Confidence: dec.Confidence,
 		Rationale: rationale,
-		Status:    "escalated", Suggestion: dec.Suggestion, CreatedAt: now,
+		Status:    "escalated", Suggestion: dec.Suggestion,
+		// The content THIS escalation was classified from — per entry,
+		// unlike the signature's first-seen provenance snapshot.
+		PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes),
+		CreatedAt:   now,
 	}
 	if _, err := d.opt.Store.AppendAudit(ctx, rec); err != nil {
 		slog.Error("audit write failed for escalation", "error", err)
@@ -1450,7 +1454,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 			AgentID: s.AgentID, AgentType: s.AgentType, Signature: res.sig.Signature, Trigger: "llm-fallback",
 			SituationType: s.Type, Action: "noop", Input: "",
 			Rationale: "LLM: " + llmDec.Rationale, LLMOutput: llmDec.CapturedOutput,
-			Status: "auto", CreatedAt: now,
+			Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
 		}); err != nil {
 			slog.Error("audit write failed; blocking LLM noop (FR-024)", "error", err)
 			d.notify(ctx, "Herd Auto Prompter: persistence failure",
@@ -1523,7 +1527,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: res.sig.Signature, Trigger: "llm-fallback",
 		SituationType: s.Type, Action: "auto:" + llmDec.Action, Input: llmDec.Action,
 		Rationale: "LLM: " + llmDec.Rationale, LLMOutput: llmDec.CapturedOutput,
-		Status: "auto", CreatedAt: now,
+		Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
 	})
 	if err != nil {
 		slog.Error("audit write failed; blocking LLM action (FR-024)", "error", err)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -457,6 +457,9 @@ func TestPipelineAutoApprovesConfidentSignature(t *testing.T) {
 	if audits[0].Status != "auto" || audits[0].Input != "1" {
 		t.Errorf("audit record mismatch: %+v", audits[0])
 	}
+	if !contains(audits[0].PaneExcerpt, "Do you want to proceed") {
+		t.Errorf("auto audit must carry the classified pane content, got %q", audits[0].PaneExcerpt)
+	}
 }
 
 func TestLLMPromotionDeliversMenuDigitForLabel(t *testing.T) {

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -232,7 +232,7 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
 		SituationType: s.Type, Action: "auto:" + dec.Input, Input: dec.Input,
 		Confidence: dec.Confidence, Rationale: dec.Rationale,
-		Status: "auto", CreatedAt: now,
+		Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
 	})
 	if err != nil {
 		d.releasePane(s.AgentID)

--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -238,6 +238,11 @@ func TestLLMMultiTabConsultAndSeriesPromotion(t *testing.T) {
 	if len(audits) == 0 || audits[0].Action != "auto:1 2 1" || audits[0].Trigger != "llm-fallback" {
 		t.Fatalf("series promotion audit missing: %+v", audits)
 	}
+	// The per-entry excerpt must be the swept AGGREGATE (all tabs), not
+	// the single focused frame.
+	if !strings.Contains(audits[0].PaneExcerpt, "[question 3/3]") {
+		t.Errorf("series audit must carry the swept aggregate, got %q", audits[0].PaneExcerpt)
+	}
 	<-mu
 	for _, want := range []string{`"tab_count":3`, "select_options MUST be a list of exactly 3 integers", "[question 1/3]", "[question 3/3]"} {
 		if !strings.Contains(contextJSON, want) {

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -184,7 +184,11 @@ type AuditRecord struct {
 	CorrectsAuditID int64
 	Status          string // "auto" | "escalated" | "resolved" | "dismissed"
 	Suggestion      string
-	CreatedAt       time.Time
+	// PaneExcerpt is the pane content THIS record was classified from
+	// (per-entry, unlike the signature's first-seen provenance snapshot);
+	// "" on legacy rows and paths with no pane read (herdr unreachable).
+	PaneExcerpt string
+	CreatedAt   time.Time
 }
 
 // CorrectionRecord is a front-end-written correction amending an audit entry.

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -95,11 +95,11 @@ func (a *App) GetStatus(ctx context.Context) (Status, error) {
 	}
 	st.LatestKill = kill
 	st.Paused = domain.KillStateActive(kill)
-	esc, err := a.Store.PendingEscalations(ctx)
+	pending, err := a.Store.CountPendingEscalations(ctx)
 	if err != nil {
 		return st, err
 	}
-	st.PendingEscalations = len(esc)
+	st.PendingEscalations = int(pending)
 	if a.Herdr != nil {
 		if agents, err := a.Herdr.ListAgents(ctx); err == nil {
 			st.MonitoredAgents = agents

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -194,6 +194,9 @@ type ReadStore interface {
 	AuditLog(ctx context.Context, limit int) ([]domain.AuditRecord, error)
 	GetAudit(ctx context.Context, id int64) (*domain.AuditRecord, error)
 	PendingEscalations(ctx context.Context) ([]domain.AuditRecord, error)
+	// CountPendingEscalations counts pending escalations without fetching
+	// the (pane-excerpt-heavy) rows.
+	CountPendingEscalations(ctx context.Context) (int64, error)
 	UnprocessedCorrections(ctx context.Context) ([]domain.CorrectionRecord, error)
 	GetAgentRate(ctx context.Context, agentID string) (*domain.AgentRate, error)
 	GetErrorRetry(ctx context.Context, errorSignature string) (*domain.ErrorRetry, error)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -97,6 +97,7 @@ CREATE TABLE IF NOT EXISTS audit_log (
 	corrects_audit_id INTEGER NOT NULL DEFAULT 0,
 	status TEXT NOT NULL DEFAULT '',
 	suggestion TEXT NOT NULL DEFAULT '',
+	pane_excerpt TEXT NOT NULL DEFAULT '',
 	created_at INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_audit_status ON audit_log(status, id DESC);
@@ -191,6 +192,7 @@ func (s *Store) migrate() error {
 	// the column is already there.
 	for _, ddl := range []string{
 		`ALTER TABLE audit_log ADD COLUMN agent_type TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE audit_log ADD COLUMN pane_excerpt TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE llm_decisions ADD COLUMN confident_score INTEGER NOT NULL DEFAULT -1`,
 	} {
 		if _, err := s.db.Exec(ddl); err != nil &&
@@ -276,11 +278,11 @@ func (s *Store) AppendAudit(ctx context.Context, a domain.AuditRecord) (int64, e
 		res, err := tx.ExecContext(ctx, `
 			INSERT INTO audit_log (decision_id, agent_id, agent_type, signature, trigger, situation_type,
 				action_or_escalation, input, confidence, rationale, llm_output,
-				corrects_audit_id, status, suggestion, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				corrects_audit_id, status, suggestion, pane_excerpt, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			a.DecisionID, a.AgentID, a.AgentType, a.Signature, a.Trigger, string(a.SituationType),
 			a.Action, a.Input, a.Confidence, a.Rationale, a.LLMOutput,
-			a.CorrectsAuditID, a.Status, a.Suggestion, unix(a.CreatedAt))
+			a.CorrectsAuditID, a.Status, a.Suggestion, a.PaneExcerpt, unix(a.CreatedAt))
 		if err != nil {
 			return err
 		}
@@ -878,7 +880,7 @@ func (s *Store) scanAudits(rows *sql.Rows) ([]domain.AuditRecord, error) {
 		var created int64
 		if err := rows.Scan(&a.ID, &a.DecisionID, &a.AgentID, &a.AgentType, &a.Signature, &a.Trigger,
 			&situationType, &a.Action, &a.Input, &a.Confidence, &a.Rationale,
-			&a.LLMOutput, &a.CorrectsAuditID, &a.Status, &a.Suggestion, &created); err != nil {
+			&a.LLMOutput, &a.CorrectsAuditID, &a.Status, &a.Suggestion, &a.PaneExcerpt, &created); err != nil {
 			return nil, err
 		}
 		a.SituationType = domain.SituationType(situationType)
@@ -890,7 +892,7 @@ func (s *Store) scanAudits(rows *sql.Rows) ([]domain.AuditRecord, error) {
 
 const auditCols = `id, decision_id, agent_id, agent_type, signature, trigger, situation_type,
 	action_or_escalation, input, confidence, rationale, llm_output,
-	corrects_audit_id, status, suggestion, created_at`
+	corrects_audit_id, status, suggestion, pane_excerpt, created_at`
 
 // AuditLog returns recent audit records, newest first.
 func (s *Store) AuditLog(ctx context.Context, limit int) ([]domain.AuditRecord, error) {
@@ -920,6 +922,15 @@ func (s *Store) GetAudit(ctx context.Context, id int64) (*domain.AuditRecord, er
 }
 
 // PendingEscalations returns unresolved escalations, newest first.
+// CountPendingEscalations reports how many escalations are pending without
+// fetching the rows (each can carry a multi-KB pane excerpt).
+func (s *Store) CountPendingEscalations(ctx context.Context) (int64, error) {
+	var n int64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM audit_log WHERE status = 'escalated'`).Scan(&n)
+	return n, err
+}
+
 func (s *Store) PendingEscalations(ctx context.Context) ([]domain.AuditRecord, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT `+auditCols+` FROM audit_log WHERE status = 'escalated' ORDER BY id DESC LIMIT 200`)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -111,10 +111,16 @@ func TestDismissEscalationGuardsStatus(t *testing.T) {
 	// how a concurrent resolve/confirm wins over a late dismiss.
 	autoID, err := s.AppendAudit(ctx, domain.AuditRecord{
 		SituationType: domain.SituationChoice, Trigger: "t",
-		Action: "auto:2", Status: "auto", CreatedAt: time.Now(),
+		Action: "auto:2", Status: "auto",
+		PaneExcerpt: "pick one\n1. a\n2. b", CreatedAt: time.Now(),
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	// Fresh-DB round trip: pane_excerpt sits mid-table here (the ALTER
+	// puts it last on upgraded DBs) — both layouts must read back.
+	if rec, err := s.GetAudit(ctx, autoID); err != nil || rec == nil || rec.PaneExcerpt != "pick one\n1. a\n2. b" {
+		t.Fatalf("fresh-DB pane_excerpt round trip: %+v %v", rec, err)
 	}
 	if err := s.DismissEscalation(ctx, autoID); err == nil {
 		t.Error("dismissing a non-escalated row must fail")
@@ -874,22 +880,23 @@ func TestMigrateAddsAgentTypeToLegacyAuditLog(t *testing.T) {
 	t.Cleanup(func() { s.Close() })
 
 	ctx := context.Background()
-	// The pre-migration row reads back with an empty agent type.
+	// The pre-migration row reads back with an empty agent type and an
+	// empty per-entry pane excerpt (both columns are post-hoc ALTERs).
 	legacy, err := s.GetAudit(ctx, 1)
-	if err != nil || legacy == nil || legacy.AgentType != "" {
+	if err != nil || legacy == nil || legacy.AgentType != "" || legacy.PaneExcerpt != "" {
 		t.Fatalf("legacy row after migration: %+v %v", legacy, err)
 	}
 	// New rows round-trip the migrated column.
 	id, err := s.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: "a1", AgentType: "claude", Trigger: "agent-status: idle",
 		SituationType: domain.SituationIdle, Action: "escalated", Status: "escalated",
-		CreatedAt: time.Now(),
+		PaneExcerpt: "the pane as classified", CreatedAt: time.Now(),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	got, err := s.GetAudit(ctx, id)
-	if err != nil || got == nil || got.AgentType != "claude" {
+	if err != nil || got == nil || got.AgentType != "claude" || got.PaneExcerpt != "the pane as classified" {
 		t.Fatalf("migrated column round trip: %+v %v", got, err)
 	}
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -877,9 +877,15 @@ func (m Model) auditDetailLines(r domain.AuditRecord, snapshot string, w int) []
 	if r.CorrectsAuditID != 0 {
 		lines = detailField(lines, w, "Corrects audit", fmt.Sprintf("#%d", r.CorrectsAuditID))
 	}
-	// The captured pane content behind this record — the signature's
-	// FIRST-seen excerpt (rule provenance), not the pane at this exact
-	// moment; same semantics as the Rules detail.
+	// Current situation: the pane content THIS record was classified from
+	// (per entry). Below it, the matched rule's Original situation — the
+	// signature's FIRST-seen excerpt (rule provenance), which is shared by
+	// every record resolving to that rule; same semantics as the Rules
+	// detail. Legacy rows predate the per-entry column and show only the
+	// provenance block.
+	if r.PaneExcerpt != "" {
+		lines = detailField(lines, w, "Current situation", r.PaneExcerpt)
+	}
 	if r.Signature != "" {
 		if snapshot != "" {
 			lines = detailField(lines, w, "Original situation", snapshot)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -340,7 +340,8 @@ func appModel(t *testing.T) (Model, *frontend.App, *store.Store) {
 		ChosenAction: "1", Source: domain.SourceOperator, CreatedAt: now})
 	st.AppendAudit(ctx, domain.AuditRecord{Signature: "approval:deadbeef00112233",
 		Trigger: "apply?", SituationType: domain.SituationApproval, Action: "escalated",
-		Rationale: "shadow mode suggestion", Status: "escalated", CreatedAt: now})
+		Rationale: "shadow mode suggestion", Status: "escalated",
+		PaneExcerpt: "Bash(kubectl apply -f svc.yaml)\nDo you want to proceed?", CreatedAt: now})
 	st.SaveSignatureSnapshot(ctx, "approval:deadbeef00112233",
 		"Bash(kubectl apply -f deploy.yaml)\nDo you want to proceed?", now)
 
@@ -896,9 +897,11 @@ func TestEscalationWithoutRuleShowsNoneYet(t *testing.T) {
 	}
 }
 
-func TestEscalationDetailShowsOriginalSituation(t *testing.T) {
-	// The Escalations detail view surfaces the captured pane content
-	// (the signature's first-seen snapshot) so the operator has context.
+func TestEscalationDetailShowsCurrentAndOriginalSituation(t *testing.T) {
+	// The Escalations detail view shows the pane content THIS entry was
+	// classified from (Current situation) and, below it, the matched
+	// rule's first-seen snapshot (Original situation) — which is shared
+	// by every entry resolving to that rule.
 	m, _, _ := appModel(t)
 	m.tab = tabEscalations
 	m.cursor = 0
@@ -907,10 +910,39 @@ func TestEscalationDetailShowsOriginalSituation(t *testing.T) {
 		t.Fatal("v should open the escalation detail")
 	}
 	view := m.View()
-	for _, want := range []string{"Original situation", "kubectl apply"} {
+	for _, want := range []string{"Current situation", "svc.yaml", "Original situation", "deploy.yaml"} {
 		if !strings.Contains(view, want) {
 			t.Errorf("escalation detail missing %q:\n%s", want, view)
 		}
+	}
+	if strings.Index(view, "Current situation") > strings.Index(view, "Original situation") {
+		t.Error("Current situation must render above Original situation")
+	}
+}
+
+func TestEscalationDetailCurrentOnlyWithoutRule(t *testing.T) {
+	// An entry with a captured excerpt but no signature (no rule to show
+	// provenance for) renders only the Current situation block.
+	m, app, st := appModel(t)
+	ctx := context.Background()
+	if _, err := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w6:p1", SituationType: domain.SituationApproval, Trigger: "agent-status: blocked",
+		Action: "escalated", Status: "escalated",
+		PaneExcerpt: "overwrite scratch.txt? (y/n)", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	upd, _ := m.Update(refreshData(ctx, app))
+	m = upd.(Model)
+	m.tab = tabEscalations
+	m.cursor = 0 // newest first
+	m = press(t, m, "v")
+	view := m.View()
+	if !strings.Contains(view, "Current situation") || !strings.Contains(view, "scratch.txt") {
+		t.Errorf("detail must show the per-entry excerpt:\n%s", view)
+	}
+	if strings.Contains(view, "Original situation") {
+		t.Errorf("no signature: the rule-provenance block must be absent:\n%s", view)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #25, answering: *why does every escalation for the same agent show the same "Original situation" when a rule matched?*

## Investigation result — no capture caching

Every escalation performs a fresh (now delayed) pane read. But that content was never stored per entry: the detail block came from `signature_snapshots`, which is keyed by **signature** with deliberate first-sighting-wins semantics (rule provenance). Every entry resolving to the same matched rule — including paraphrases the semantic matcher remaps onto it — therefore showed the rule's first-ever excerpt.

## Fix (as requested)

- `audit_log` gains a per-entry `pane_excerpt` column (idempotent ALTER migration; legacy rows read back empty) — set by **every** live-situation audit writer: escalations, autonomous sends, noop decisions, LLM promotions, and multi-tab series delivery (which stores the swept aggregate, all tabs).
- The Escalations/Audit detail view now shows **Current situation** (this entry's captured pane content) first, and the matched rule's **Original situation** (first-seen provenance snapshot) below it — exactly the layout requested. Entries without a signature show only Current; legacy rows render as before.
- Perf (review finding): `GetStatus` now uses a new `CountPendingEscalations` instead of fetching up to 200 excerpt-heavy rows every 2s TUI tick just to display a count.

## Tests

Migration (legacy + fresh layouts), round-trips, excerpt presence on the escalate/auto/series paths (the series case asserts the swept aggregate, not a single frame), TUI ordering (Current above Original), signature-less and fallback renderings. Full suite green; lint clean.

https://claude.ai/code/session_01G5ANCGcVWmRUcTX4A1A2CK