### PR TITLE
#1 feat: TUI list scrolling, in-list search, themes, durable status, Config-tab completeness

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,16 @@ The plugin never acts on a situation it hasn't learned from you.
    responding — the audit row is kept as `dismissed`. Deleting a learned
    rule still asks for confirmation, and audit entries can't be deleted
    individually (only the full clear-data reset removes them). CLI:
-   `dismiss <id>...` and `escalations prune [minutes]`.
+   `dismiss <id>...` and `escalations prune [minutes]`. Long lists scroll
+   with the cursor and show a `… N more` line when rows are clipped, and
+   `/` opens an incremental search on the *Agents*, *Escalations*,
+   *Audit*, and *Rules* tabs — case-insensitive substring over the visible
+   columns. `esc`/`enter` closes the search input keeping the filter,
+   backspacing the query to empty clears it, and while typing, every
+   printable key goes into the query — action keys like `q`, `y`, and `x`
+   can't fire mid-search. Action outcomes (confirm, resolve, delete, …)
+   stay pinned in a status area (`✓`/`✗` plus timestamp) until the next
+   action, so the result of a multi-step operation isn't missed.
 3. **Graduate.** After **5 consecutive consistent confirmations** (configurable)
    *and* confidence above the per-situation threshold, that signature becomes
    autonomous: next time, the plugin acts on its own and logs it.
@@ -135,8 +144,10 @@ the full record — including the **original situation**, the pane snapshot
 first captured for the rule, so you can see exactly what a rule answers,
 not just the action it sends (rules learned before this feature pick it
 up on their next sighting) — plus recent decisions and last audit
-context. `f`
-filters by mode, and `x` deletes a signature you no longer trust — deletion erases
+context. The list shows each rule's full signature id untruncated, ready
+to copy into the CLI. `f`
+filters by mode (composing with `/` search), and `x` deletes a signature
+you no longer trust — deletion erases
 its decision history too (audit rows are kept), so it re-learns from
 scratch. Signatures are addressed by unique prefix, git-style:
 
@@ -183,6 +194,22 @@ model_path = ""            # "" = bundled <plugin>/models/all-minilm-l6-v2-q8_0.
 similarity_threshold = 0.90 # min cosine similarity to reuse a learned signature
 bm25_min_score = 0.35       # min normalized BM25 similarity for the text fallback, (0,1]
 gpu_layers = 0              # inert in official builds (GPU backends compiled out)
+
+# TUI appearance. `theme` picks a named palette: default, dark, light,
+# high-contrast. Empty or unknown names resolve to default — the exact
+# original look — so existing setups see no change.
+[tui]
+max_content_width = 0       # cap variable-width list columns; 0 = full width
+theme = "high-contrast"
+
+# Optional per-role color overrides, layered on top of the theme; unset
+# roles inherit the theme's value. Values are terminal color strings
+# lipgloss accepts: 256-color codes ("205") or hex ("#ff5faf"). Roles:
+# title, section, error, ok, paused, running, help. Edited in config.toml
+# only (the TUI shows them read-only).
+[tui.palette]
+title = "205"
+error = "#ff5f5f"
 
 # Point agents/workspaces at a task list so idle agents get the next
 # unchecked item. Without a declared source, the plugin falls back to
@@ -244,9 +271,20 @@ patterns are merged with a warning, and the next config save rewrites the
 file under the new key.)
 
 or `hap rules add '<regex>'` / `rules remove <index>`, or press `a`/`x` on
-the TUI's *Config* tab — which also edits every config field inline
-(`enter`), adds/removes task sources (`t`/`x`), and clears learned data
-(`X`). Prompts that *look* destructive
+the TUI's *Config* tab — which also lists every scalar config field,
+adds/removes task sources (`t`/`x`), and clears learned data (`X`).
+Simple fields — numbers, booleans, and the `tui.theme` enum, including
+`llm.pane_excerpt_chars`, `safety.disable_seed`, and
+`tui.max_content_width` — edit inline (`enter`) or via
+`hap config set <key> <value>`. Free-text fields (`llm.command`,
+`llm.rewrite_command`, `llm.rewrite_fallback_template`,
+`embedding.model_path`) show read-only in the TUI, because a one-line
+prompt mangles quoted argv values — edit them in `config.toml` or with
+`config set`, which accepts every key. The safety indicator patterns and
+`[[capture_delay]]` rules also display read-only on the tab (capture
+delays show the built-in defaults, 1000 ms first event / 200 ms after,
+when none are configured), and long values are truncated to one line —
+the full value lives in `config.toml`. Prompts that *look* destructive
 but match no pattern are escalated by a suspected-irreversible heuristic
 rather than automated. The heuristic needs corroboration to fire — a
 destructive verb aimed at a data/infrastructure target, explicit no-undo

--- a/docs/plans/enhance-tui-ux/proposal.md
+++ b/docs/plans/enhance-tui-ux/proposal.md
@@ -1,0 +1,91 @@
+# Proposal: Enhance the Herd Auto Prompter TUI UI/UX
+
+> Code references (`tui.go:<line>` etc.) verified against commit `6a22f8a` (main, 2026-07-11).
+
+## Why
+
+The TUI (`internal/tui`) is the primary control surface for Herd Auto Prompter, mirroring every CLI capability across six tabs (Agents, Escalations, Audit, Rules, Config, Pause/Kill). It is functional but has accumulated UX debt that degrades operability as real deployments grow:
+
+- **List views do not scroll or paginate.** Scrolling exists only inside the detail overlay (`detailView` uses `m.detail.offset` / `detailPageSize()`). The list bodies for Agents, Escalations, Audit, and Rules render from the top with no viewport offset, so once the number of rows exceeds the available pane height the tail of the list is silently clipped. On a busy herd (many monitored agents, a backlog of escalations, a long audit trail), the operator cannot reach rows below the fold — a correctness-affecting gap, not just cosmetics.
+- **Filtering is inconsistent and absent from most tabs.** Only the Rules tab has a display-side filter (the `f` key cycling `sigMode` via `visibleSignatures()`). Agents, Escalations, and Audit offer no way to narrow a long list, so finding a specific agent or record means visual scanning.
+- **Theming is hardcoded and not operator-controllable.** Colors are literal 256-color codes scattered through package-level `lipgloss.NewStyle()` vars (e.g. `titleStyle` `Color("205")`, `errStyle` `Color("196")`, `okStyle` `Color("46")`). There is no palette abstraction and the `[tui]` config exposes only `MaxContentWidth`. Operators on light terminals, low-color terminals, or with accessibility needs cannot adjust contrast.
+- **The Config tab lags the config surface.** The tab's editable field list is the fixed `frontend.ConfigFieldKeys` registry (frontend.go 450–471), which omits recently added scalar fields — `llm.pane_excerpt_chars` (config.go 83), `safety.disable_seed` (config.go 44), and `tui.max_content_width` (config.go 162) — and the tab has no display at all for the structured safety-indicator configuration (`safety.irreversible_indicators` / `[[safety.indicator_rules]]`, config.go 48–59) or `[[capture_delay]]` rules (config.go 151–155). The operator cannot see or edit these without opening `config.toml`, and nothing keeps the registry in sync as config grows. Meanwhile the argv-template fields that ARE editable (`llm.command`, `llm.rewrite_command`) round-trip through a one-line quoting parse (`JoinCommand` display → hand-retyped prompt → `SplitCommand`, frontend.go 627–) that mangles real-world values with nested quotes or JSON arguments — editing them inline is effectively broken — and their full values overflow the config row (`buildRuleItems` renders `FieldValue` untruncated, tui.go 189).
+- **Action feedback is transient and unstructured.** Outcomes surface through a single status string (`m.message`). Color differentiation already exists — success is rendered with `okStyle` and errors with `errStyle` (tui.go lines 251–253) — so the gap is *not* first-time color coding. The gap is persistence, structure, and placement: the message is a single transient line that is easily missed after a multi-step operation (resolve, rename, delete). The delta is a durable, structured status area, not colorizing what is already colorized.
+
+This is a **focused polish** effort: cohesive, incremental UX improvements to the existing six-tab layout — not a redesign.
+
+## What Changes
+
+Scoped to the TUI presentation layer only. In scope:
+
+1. **List scrolling & pagination** — introduce a per-list viewport offset (mirroring the detail overlay's proven `offset` + page-size model) for the Agents, Escalations, Audit, and Rules list bodies, with keyboard scrolling, selection that keeps the cursor in view, and a "N more" affordance when rows are clipped.
+2. **In-list search / filter across tabs** — generalize the Rules-only filter into a consistent search/filter interaction available on Agents, Escalations, Audit, and Rules (incremental text match over the visible columns), preserving the existing Rules mode-cycle behavior.
+3. **Configurable visual theming** — centralize the hardcoded color literals into a single named palette, add theme fields to the existing `[tui]` TOML section (with safe defaults preserving today's look), and improve empty / loading / error state rendering.
+4. **Improved action feedback** — evolve the single transient status line into a durable, structured status area. The existing `okStyle`/`errStyle` success-vs-error color differentiation is retained; the new work adds persistence and clear placement so outcomes of multi-step operations are not missed.
+5. **Config tab completeness** — extend the scalar field registry (`ConfigFieldKeys` / `FieldValue` / `SetField`) with the missing fields (`llm.pane_excerpt_chars`, `safety.disable_seed`, `tui.max_content_width`, plus the new `tui.theme` from item 3) so they are displayed and editable on the Config tab and via `config set` alike (CLI parity, FR-022), and add read-only Config-tab sections for the safety-indicator patterns and capture-delay rules (with effective built-in defaults shown when unconfigured). Field rows gain an editability classification: only simple single-value fields (numbers, booleans, the `tui.theme` enum) stay editable through the TUI prompt; free-text fields — argv templates, template strings, paths, and any other long string, today `llm.command`, `llm.rewrite_command`, `llm.rewrite_fallback_template`, `embedding.model_path` — become TUI-read-only as a standing rule (new free-text fields default to read-only) — `enter`/`e` shows a message directing the operator to `config.toml`, while `config set` continues to accept every key — and long values render truncated to one line. Classifier manifests (`[[classifier]]`) remain file-only.
+
+Explicitly **out of scope** (per interview constraints):
+
+- No new TUI framework — stays within Bubble Tea + lipgloss.
+- No changes to the `frontend.App` API surface or the CLI-parity contract (FR-022). These are presentation-only changes; the TUI keeps calling the same `App` methods.
+- No reassignment of existing keybindings — new keys are additive only.
+- No navigation/layout restructure (no side panel, no dashboard) — the six-tab model is preserved.
+
+## Technical Solution
+
+### Library / framework changes
+
+None. All work uses the incumbent stack: `charmbracelet/bubbletea` (Model/Update/View loop) and `charmbracelet/lipgloss` (styling). No dependency is added, removed, or upgraded.
+
+### Core-flow changes — list rendering & input
+
+Today only the detail overlay maintains a scroll offset. The list tabs share a single `m.cursor` (up/down handling at tui.go lines 366–372, clamped on refresh (`refreshMsg`) at 232–233 — the `WindowSizeMsg` handler clamps only `detail.offset`, at 226 — and reset to 0 on tab switch at 297/302/359/363). The design **keeps that single shared `m.cursor`** — cursor state does not become per-tab — and adds a viewport `offset` that *follows* the cursor to keep it visible. The `offset` resets to 0 alongside the existing cursor reset on tab switch, and is clamped on `WindowSizeMsg` exactly as `detail.offset` already is. The updated per-tab render/input flow:
+
+```
+tea.KeyMsg
+  │
+  ├─ search-input active? ── yes ─▶ append/backspace into query ──▶ recompute filtered rows
+  │                                                                └─▶ clamp shared cursor + viewport offset
+  │
+  ├─ ↑ / k ─▶ move shared m.cursor up ──▶ if cursor < offset: offset-- (keep cursor visible)
+  ├─ ↓ / j ─▶ move shared m.cursor down ▶ if cursor ≥ offset+pageSize: offset++
+  ├─ /      ─▶ enter search-input mode for the active tab
+  ├─ f      ─▶ (Rules only) cycle sigMode — unchanged
+  └─ other  ─▶ existing handlers (enter/v details, x delete, resolve, …)
+
+View(activeTab):
+  rows      = filter(allRows, query, mode)      # search + existing Rules mode
+  pageSize  = listPageSize(m.height)            # same chrome accounting as detailPageSize
+  window    = rows[offset : offset+pageSize]
+  render header + window + "… N more" footer when len(rows) > offset+pageSize
+```
+
+The viewport `offset` and per-tab search query are new UI state on `Model` (analogous to the existing `detail.offset` and `sigMode`). The shared `m.cursor` is unchanged in kind; only its clamping is extended to account for the active filter's row count.
+
+### Data-model / DB-schema changes
+
+No database schema changes. The only persisted-config change is additive fields on the existing `[tui]` TOML table (`config.TUI` struct), which continues to be optional with defaults via `config.Default()`:
+
+```
+config.TUI (before)              config.TUI (after)
+┌────────────────────┐           ┌──────────────────────────────────────┐
+│ MaxContentWidth int│           │ MaxContentWidth int                  │  (unchanged)
+└────────────────────┘           │ Theme          string (named enum)   │  (new, default "" = current look)
+                                 │ Palette        (optional overrides)  │  (new, secondary)
+                                 └──────────────────────────────────────┘
+```
+
+Recommended shape (to be pinned in requirements): a **named-theme enum** as the primary knob — `""`/default, `dark`, `light`, `high-contrast` — with optional per-role color overrides (`Palette`) as a secondary mechanism. This keeps validation and default-resolution simple: an empty/absent `Theme` must resolve to today's exact 256-color values, and per-role overrides layer on top of the selected named theme. Existing operators see no visual change unless they opt in.
+
+### API breaking changes
+
+None. No change to `frontend.App` method signatures, no change to the CLI-parity surface, and no reassignment of existing TUI keybindings. New keybindings (search entry, any new scroll aliases) are additive; existing bindings retain their current meaning.
+
+## Impact
+
+- **`internal/tui` (primary):** new per-list viewport `offset` + per-tab search state on `Model` (the shared `m.cursor` stays shared); `Update` gains search-input handling and list scroll routing; per-tab `View` functions windowed and filtered; color literals replaced by palette lookups; status-area rendering reworked for persistence/structure while keeping `okStyle`/`errStyle`. This is where the bulk of the change lands.
+- **`internal/config`:** additive fields on the `TUI` struct (`Theme` named enum + optional `Palette` overrides) plus their defaults; documentation of the new `[tui]` keys. No breaking change to existing config files.
+- **`internal/frontend`:** additive only — new entries in `ConfigFieldKeys` (frontend.go 450–471), `FieldValue` (474–521), and `SetField` (525–) for the missing scalar fields and the new `[tui]` keys, with type-appropriate validation. No `App` method signature or returned-shape change; `config set` gains the same keys automatically (shared registry).
+- **Tests (`internal/tui/tui_test.go`):** extended to cover list scrolling/clamping (paralleling the existing `TestDetailViewScrolls`), search filtering on each tab (paralleling the existing Rules `f`-filter test), theme resolution with defaults, and the "renders within pane height" invariant.
+- **Docs:** README / config reference updated for the new `[tui]` theme keys and search keybinding.
+- **Operators:** better navigability of long lists and clearer feedback; zero behavior change unless they opt into a theme. No migration required — new config keys are optional.

--- a/docs/plans/enhance-tui-ux/requirements.md
+++ b/docs/plans/enhance-tui-ux/requirements.md
@@ -1,0 +1,313 @@
+# Requirements Delta: Herd Auto Prompter TUI UI/UX
+
+> Code references (`tui.go:<line>` etc.) verified against commit `6a22f8a` (main, 2026-07-11), which includes the per-entry Current situation change (#29) that shifted references below tui.go ~880 by +6 versus earlier revisions of this spec.
+
+## Overview
+
+This is a delta specification for a focused-polish enhancement to the Herd Auto Prompter TUI (`internal/tui`). Each requirement is coded:
+
+- **AR-** = Add (new behavior) — carries Description, User Role, Acceptance Criteria.
+- **CR-** = Change (modify existing behavior) — carries Description, User Role, and Acceptance Criteria in which each `~~struck-through~~` original criterion is immediately followed by its replacement(s).
+- **BR-** = Remove (retire existing behavior) — carries Description and a `Reference: file:line`.
+
+Requirements use EARS+ syntax and are grouped by impacted module. Scope is TUI presentation only: no `frontend.App` method signature changes, no CLI-parity behavior changes (FR-022), no existing keybinding is reassigned, and the incumbent Bubble Tea + lipgloss stack is retained.
+
+Terminology: a **list tab** is one of Agents, Escalations, Audit, or Rules — the four tabs that render a scrollable row list (Config and Pause/Kill are not list tabs and are out of scope for list scrolling/search). `pageSize` is the number of list rows that fit under the current pane chrome, computed the same way `detailPageSize()` already computes the detail-overlay page size.
+
+## Impacted User Roles
+
+- **Operator** — the single human who runs the TUI as a Herdr pane and drives every control (navigation, search, resolving escalations, editing config, pause/kill). This is the only user role for the TUI. This change introduces no new user role; every AR/CR below applies to the Operator.
+
+---
+
+## Module: `internal/tui` — List viewport & scrolling
+
+### AR-001 — Per-list viewport offset
+**Description:** Each list tab tracks the index of its first visible row so the list body can be windowed.
+**User Role:** Operator
+**Acceptance Criteria:**
+- The system SHALL maintain a viewport `offset` (index of the first visible row) for each list tab, initialized to 0.
+
+### AR-002 — Windowed list rendering
+**Description:** A list tab renders only the slice of rows that fits the pane.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHEN rendering a list tab, the system SHALL display only rows `[offset, offset + pageSize)` of that tab's currently visible (filtered) rows.
+
+### AR-003 — Offset follows the shared cursor when scrolling down
+**Description:** Moving the selection below the window scrolls the window down to keep it visible.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHEN the shared `m.cursor` moves to a row at or beyond `offset + pageSize`, the system SHALL increase `offset` so the cursor row remains visible within the window.
+
+### AR-004 — Offset follows the shared cursor when scrolling up
+**Description:** Moving the selection above the window scrolls the window up to keep it visible.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHEN the shared `m.cursor` moves to a row before `offset`, the system SHALL decrease `offset` so the cursor row remains visible within the window.
+
+### CR-005 — Shared cursor retained, not made per-tab
+**Description:** The existing single shared list cursor is preserved; only the new per-tab offset is added alongside it.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~The system uses a single shared `m.cursor` for list selection (tui.go 366–372) with no viewport offset.~~
+- The system SHALL continue to use the single shared `m.cursor` for list selection and SHALL NOT introduce per-tab cursor state; the new per-tab `offset` is the only added selection-related state.
+
+### CR-006 — Offset reset on tab switch
+**Description:** Switching tabs resets the viewport alongside the existing cursor reset.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~On tab switch the system resets `m.cursor` to 0 (tui.go 297/302/359/363).~~
+- WHEN the operator switches tabs, the system SHALL reset both `m.cursor` and that tab's viewport `offset` to 0.
+
+### CR-007 — Offset clamped on resize
+**Description:** Resizing the pane keeps the viewport within valid bounds.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~On `tea.WindowSizeMsg` the system clamps only `detail.offset` (tui.go 226).~~
+- WHEN a `tea.WindowSizeMsg` is received, the system SHALL clamp each list tab's `offset` to `[0, max(0, rowCount − pageSize)]`, consistent with the existing `detail.offset` clamp.
+
+### CR-008 — Cursor clamp accounts for filtered row count
+**Description:** The cursor never points past the currently visible (filtered) list.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~The system clamps `m.cursor` to the unfiltered row count (tui.go 232–233), where `rowCount()` (tui.go 463–479) returns raw slice lengths for the Agents, Escalations, and Audit tabs (only `tabSignatures` reflects `sigMode` via `visibleSignatures()`).~~
+- WHEN clamping `m.cursor`, the system SHALL clamp against the count of currently visible (filtered) rows so the cursor never points past the filtered list.
+- The system SHALL make `rowCount()` (tui.go 463–479) search-filter-aware for every list tab (Agents, Escalations, Audit, Rules) so the cursor-clamp path on refresh (tui.go 232–233) and the resize clamp (CR-007) both operate on the filtered count; the Rules tab SHALL continue to compose its `sigMode` filter (per CR-017) with the search query.
+
+### AR-009 — Clipped-rows affordance
+**Description:** A "N more" indicator shows when rows exist below the window.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHEN the visible (filtered) row count exceeds `offset + pageSize`, the system SHALL render a "… N more" indicator showing how many rows remain below the window, consistent with the existing detail-overlay "… N more line(s)" affordance (tui.go 1291).
+
+### AR-010 — Render within pane height
+**Description:** A list tab never overflows the pane, preserving the height invariant already enforced for the detail view.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHILE rendering any list tab, the system SHALL keep the header, windowed rows, and footer/help within the current pane height so no row or the help line is clipped.
+
+### CR-032 — Rules tab shows the full signature ID
+**Description:** The Rules tab list renders each rule's complete signature ID (e.g. `idle:83b2285833fd4c6ebf40a2bc`) instead of the abbreviated form, so the operator can read the full identifier without opening the detail overlay.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~The Rules tab renders each row's signature ID via `shortSig()`, which truncates it to 16 characters plus an ellipsis in a fixed 18-cell column (`shortSig` tui.go 1038–1043; `renderSignatures` tui.go 1266–1269).~~
+- WHEN rendering the Rules tab list, the system SHALL display each row's full signature ID untruncated (e.g. `idle:83b2285833fd4c6ebf40a2bc`, not `idle:83b2285833f…`), and SHALL NOT abbreviate it via `shortSig()`.
+- The system SHALL size the signature-ID column to the widest full ID among the currently visible (filtered) rows so the remaining columns shift right without overlapping, consistent with the existing fixed-column row layout in `renderSignatures`.
+- The change SHALL apply to the Rules list body only and SHALL NOT alter the abbreviated `shortSig()` rendering used in the signature detail-overlay title (tui.go 268) or the delete-confirmation prompt (tui.go 975, 986).
+
+---
+
+## Module: `internal/tui` — In-list search / filter
+
+### AR-011 — Search entry key
+**Description:** Pressing the currently-unbound `/` opens search for the active list tab.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHEN the operator presses `/` on the Agents, Escalations, Audit, or Rules tab, the system SHALL enter search-input mode for that tab.
+
+### AR-012 — Incremental query editing
+**Description:** Typing edits the query and re-filters immediately.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHILE in search-input mode, the system SHALL append typed characters to the tab's query, remove the last character on backspace, and recompute the filtered rows after each edit.
+
+### AR-013 — Filter predicate
+**Description:** A non-empty query narrows the list by case-insensitive substring match.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHILE a tab's search query is non-empty, the system SHALL display only rows whose visible column text contains the query as a case-insensitive substring.
+
+### AR-014 — Exit search mode retaining the active filter
+**Description:** Leaving search-input mode keeps the current query as an active filter.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHEN the operator presses `esc` while in search-input mode with a non-empty query, the system SHALL exit search-input mode and retain the current query as an active filter over the list.
+- WHEN the operator presses `enter` while in search-input mode, the system SHALL behave identically to `esc`: exit search-input mode retaining a non-empty query as the active filter (an empty query leaves no filter), and SHALL NOT trigger the tab's `enter` action (confirm/detail/edit).
+
+### AR-015 — Clear the active filter
+**Description:** The operator can restore the full list without a new keybinding, using the query-editing path already defined.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHEN the operator deletes the query back to empty via backspace (per AR-012), the system SHALL clear the filter and restore the full list.
+- WHEN the operator presses `esc` while in search-input mode with an already-empty query, the system SHALL exit search-input mode with no active filter.
+- WHILE on a list tab that is NOT in search-input mode and has no active filter, the system SHALL treat `esc` as a no-op, preserving today's behavior where the top-level list-mode key router has no `esc` handler; `esc` SHALL retain its existing meaning of closing the detail overlay (tui.go 314) and cancelling an inline prompt. This adds a list-mode meaning to `esc` only while search is engaged and reassigns no existing binding.
+
+### CR-016 — Search recomputes cursor and offset
+**Description:** Changing the filter keeps selection and viewport within bounds.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~Cursor and offset are recomputed only on tab switch and resize.~~
+- WHEN the filtered row set changes due to a query edit, the system SHALL clamp the shared `m.cursor` and the tab's `offset` to the new filtered row count so both stay within bounds.
+
+### CR-017 — Rules mode filter preserved and composed with search
+**Description:** The existing Rules `f`-key mode cycle keeps working and combines with the new search.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~The Rules tab filters solely by `sigMode` via the `f` key (`visibleSignatures()`, tui.go 124–136, 405).~~
+- The system SHALL retain the existing Rules `f`-key mode cycle and SHALL compose it with the new search query so both filters apply together on the Rules tab.
+
+### AR-018 — Empty-result feedback
+**Description:** A filter that matches nothing shows an explicit empty-state message.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHEN a tab's active filter matches zero rows, the system SHALL render an explicit empty-state message indicating no rows match the current filter, consistent with the existing Rules "no signatures match the filter" message (tui.go 1256).
+
+### CR-019 — Search keys do not trigger action bindings
+**Description:** Typing a query never fires a destructive or navigational action binding.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~Printable keys (`q`, `y`, `p`, `r`, `e`, `c`, `n`, `v`, `f`, `a`, `t`, `x`, `X`, `j`, `k`, `h`, `l`, space) always invoke their action or navigation bindings — including `q` (quit, tui.go 355), `y` (confirm+send on Escalations, tui.go 379), `j`/`k` (cursor), and `h`/`l` (tab switch).~~
+- WHILE in search-input mode, the system SHALL route ALL printable keys to the query and SHALL NOT invoke any action or navigation binding — in particular `q` (quit), `y` (confirm+send), `p`, `r`, `e`, `c`, `n`, `v`, `f`, `a`, `t`, `x`, `X`, `j`/`k` (cursor), `h`/`l` (tab switch), and space.
+
+---
+
+## Module: `internal/tui` — Theming & palette
+
+### CR-020 — Centralized palette
+**Description:** All styles resolve through one named palette instead of scattered color literals.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~Styles use hardcoded `lipgloss.Color` literals (titleStyle 205, errStyle 196, okStyle 46, sectionStyle 117, pausedStyle 196, runningStyle 46 at tui.go 41–50).~~
+- The system SHALL resolve every list/detail/status style through a single named palette rather than scattered hardcoded `lipgloss.Color` literals.
+
+### AR-021 — Named theme selection
+**Description:** The active palette is chosen by name from config.
+**User Role:** Operator
+**Acceptance Criteria:**
+- The system SHALL select the active palette from the `[tui] theme` configuration value, supporting at least the named themes `default`, `dark`, `light`, and `high-contrast`.
+
+### AR-022 — `default` and empty resolve to the current appearance
+**Description:** There is exactly one "current look" palette, reachable either by omitting `theme` or by naming it `default`.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHEN `[tui] theme` is empty/absent OR set to `default`, the system SHALL resolve to the identical current-appearance palette using the exact 256-color values in use today, so `default` is the explicit spelling of the empty-string fallback and existing operators observe no visual change.
+
+### AR-023 — Optional per-role overrides
+**Description:** Individual color roles can be overridden on top of the selected theme.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHERE per-role color overrides are provided in `[tui]`, the system SHALL apply them on top of the selected named theme, and an unset role SHALL inherit the named theme's value.
+
+### CR-024 — Empty / loading / error state styling
+**Description:** Empty, loading, and error states render through the resolved palette.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~Error state renders via the hardcoded `errStyle` (`errStyle.Render("error: …")`, tui.go 1192).~~
+- The system SHALL style empty-list, pre-first-data (loading), and error states through the resolved palette, retaining the existing error rendering path via the palette's error role.
+
+---
+
+## Module: `internal/tui` — Action feedback / status area
+
+### CR-025 — Durable structured status area
+**Description:** Action outcomes persist in a clearly-placed status area rather than a single easily-missed line.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~Action outcomes surface only as a single transient `m.message` line.~~
+- WHEN an action produces an outcome, the system SHALL present it in a durable, clearly-placed status area so the outcome of a multi-step operation remains readable after it completes.
+
+### CR-026 — Success/error differentiation retained
+**Description:** Success and error outcomes stay visually distinct, now sourced from the palette.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~Success renders via `okStyle` and errors via `errStyle` from hardcoded literals (tui.go 251–253).~~
+- The system SHALL render success outcomes via the palette's ok role and errors via the palette's error role, preserving today's success-versus-error differentiation.
+
+---
+
+## Module: `internal/config` — TUI configuration
+
+### AR-027 — `theme` field
+**Description:** A new optional `theme` key selects the palette.
+**User Role:** Operator
+**Acceptance Criteria:**
+- The system SHALL add an optional `theme` string field to the `[tui]` TOML table (`config.TUI`), defaulting to empty (which AR-022 resolves to the current appearance).
+
+### AR-028 — `palette` override field
+**Description:** A new optional per-role override mechanism layers on the selected theme.
+**User Role:** Operator
+**Acceptance Criteria:**
+- The system SHALL add an optional per-role color override mechanism to the `[tui]` TOML table (`config.TUI`), WHERE absent roles inherit the selected named theme (per AR-023).
+
+### CR-029 — Backward-compatible config
+**Description:** Existing `[tui]` config files stay valid with the new optional fields.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~`[tui]` exposes only `MaxContentWidth`.~~
+- The system SHALL keep existing `[tui]` configuration files valid, leave `MaxContentWidth` behavior unchanged, and treat all new theme fields as optional with safe defaults via `config.Default()`.
+
+### AR-030 — Invalid theme handling
+**Description:** An unknown theme name degrades gracefully to the default.
+**User Role:** Operator
+**Acceptance Criteria:**
+- IF `[tui] theme` names an unknown theme, THEN the system SHALL fall back to the default palette rather than failing to start.
+
+---
+
+## Module: `internal/tui` + `internal/frontend` — Config tab completeness
+
+### CR-033 — Config tab exposes every scalar config field
+**Description:** The Config tab's editable field list (shared with `config set`) covers the scalar fields added to the config since the registry was last extended, plus the new `[tui]` keys this spec introduces.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~`ConfigFieldKeys` (frontend.go 450–471) lists 20 scalar keys and omits `llm.pane_excerpt_chars` (config.go 83), `safety.disable_seed` (config.go 44), and `tui.max_content_width` (config.go 162), so the Config tab (`buildRuleItems`, tui.go 184–217) and `config set` neither display nor edit them.~~
+- The system SHALL add `llm.pane_excerpt_chars`, `safety.disable_seed`, and `tui.max_content_width` to `ConfigFieldKeys`, `FieldValue` (frontend.go 474–521), and `SetField` (frontend.go 525–), with type-appropriate validation, so each is displayed and editable on the Config tab and via `config set` alike (CLI parity, FR-022); all four new keys are simple scalars and therefore TUI-editable per CR-036's classification.
+- WHEN the `tui.theme` field lands (AR-027), the system SHALL expose it through the same registry, with `SetField` validation consistent with AR-030 (unknown names fall back to the default palette, never an error that blocks saving other fields — or reject with a clear message listing the valid names; pick ONE behavior and test it).
+- The system SHALL keep `ConfigFieldKeys`, `FieldValue`, and `SetField` in three-way parity, and a unit test SHALL fail when a key is present in one and missing in another (extending the existing iteration test at frontend_test.go 379).
+
+### AR-034 — Read-only display of safety-indicator configuration
+**Description:** The Config tab shows the operator the suspected-irreversible indicator patterns that are in effect, which today are invisible outside `config.toml`.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHEN rendering the Config tab, the system SHALL display `safety.irreversible_indicators` and each `[[safety.indicator_rules]]` entry (pattern + agent scope; config.go 48–59) as read-only rows in a "Safety indicators" section, following the existing sectioned layout of `buildRuleItems` (tui.go 184–217).
+- WHEN the operator invokes edit/remove (`enter`/`e`/`x`) on one of these rows, the system SHALL show an informational message that they are edited in `config.toml` (mirroring the existing "config fields are edited (enter), not removed" message, tui.go 1140) and SHALL NOT mutate config.
+
+### AR-035 — Read-only display of capture-delay rules
+**Description:** The Config tab shows the effective delayed-capture timing, including the built-in defaults when no rule is configured.
+**User Role:** Operator
+**Acceptance Criteria:**
+- WHEN rendering the Config tab, the system SHALL display each `[[capture_delay]]` rule (agent type, start_ms, event_ms; config.go 151–155) as a read-only row.
+- WHEN no `[[capture_delay]]` rules are configured, the system SHALL show the effective built-in defaults (start 1000 ms / event 200 ms, config.go 396–399) so the operator can see what timing applies.
+- Classifier manifests (`[[classifier]]`, config.go 141–146) SHALL remain file-only and out of scope for this change.
+
+### CR-036 — TUI field editability classification
+**Description:** Only simple single-value fields stay editable through the TUI's inline prompt; free-text and argv-template fields become TUI-read-only, because their one-line prompt round-trip mangles real values. `config set` is unaffected.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~Every `ConfigFieldKeys` row is editable through the inline prompt (`editSelectedRule`, tui.go 1054–1074) — including the argv-template fields `llm.command` and `llm.rewrite_command`, whose edit path round-trips a one-line quoting parse (`JoinCommand` display → hand-retyped prompt → `SplitCommand`, frontend.go 627–) that mangles values containing nested quotes or JSON arguments, so editing them in the TUI is effectively broken.~~
+- The system SHALL classify each registry field as TUI-editable or TUI-read-only. Numeric, boolean, and short-enum fields SHALL remain TUI-editable: `thresholds.*`, `learning.graduation_n`, `limits.*`, `llm.timeout_seconds`, `llm.auto_act`, `llm.rewrite_timeout_seconds`, `llm.pane_excerpt_chars`, `safety.disable_seed`, `embedding.disabled`, `embedding.similarity_threshold`, `embedding.bm25_min_score`, `embedding.gpu_layers`, `tui.max_content_width`, `tui.theme`.
+- The system SHALL mark the free-text/argv fields TUI-read-only: `llm.command`, `llm.rewrite_command`, `llm.rewrite_fallback_template`, `embedding.model_path`.
+- The system SHALL apply this as a general rule, not a fixed list: any registry field whose value is free-form text — argv templates, template strings with placeholders, file paths, or any other long string — SHALL default to TUI-read-only when added, now or in the future; only single-value numeric, boolean, and short-enum fields qualify as TUI-editable. The classification SHALL live in one place in the registry (e.g. a per-key editable flag or type tag) so a new field cannot become TUI-editable by omission.
+- WHERE per-role palette overrides exist in `[tui]` (AR-028), they SHALL follow the same rule: visible on the Config tab at most as read-only rows, edited only via `config.toml`; `tui.theme` (a short enum) remains the only TUI-editable theming key.
+- WHEN the operator presses `enter` or `e` on a TUI-read-only field, the system SHALL show an informational message directing them to edit the value in `config.toml` (noting that `config set <key> <value>` also remains available) and SHALL NOT open the edit prompt or mutate config.
+- The system SHALL keep `SetField` accepting ALL registry keys unchanged — the read-only classification applies to the TUI inline prompt only, preserving CLI parity (FR-022).
+
+### CR-037 — Truncated display of long config values
+**Description:** Long field values render truncated to one line instead of overflowing the row.
+**User Role:** Operator
+**Acceptance Criteria:**
+- ~~Config rows render the full `FieldValue` string (`buildRuleItems` label `"%-38s %s"`, tui.go 189), so a long `llm.command` or `llm.rewrite_command` overflows or wraps the row.~~
+- WHEN a config row's rendered value exceeds the row's width budget, the system SHALL truncate it with a trailing ellipsis (consistent with the existing `oneLine` helper, tui.go 1452) so every config row stays on one line; the full value remains available in `config.toml`.
+
+---
+
+## Module: `internal/frontend` — Non-impact assertion
+
+### AR-031 — No frontend API change
+**Description:** All changes are presentation-only; the frontend API is untouched apart from the additive field-registry entries CR-033 requires.
+**User Role:** Operator
+**Acceptance Criteria:**
+- The system SHALL implement all of the above without changing any `frontend.App` method signature or returned data shape, and the TUI SHALL continue to obtain its data through the existing `App` methods (`GetStatus`, `Escalations`, `Audit`, `Signatures`, etc.).
+- WHERE CR-033 extends the field registry, the frontend change SHALL be limited to additive entries in `ConfigFieldKeys`, `FieldValue`, and `SetField` — no signature or returned-shape change, and every existing key keeps its current behavior.
+
+---
+
+## Module: `internal/tui` — Non-list tab non-impact assertion
+
+### AR-032 — Config and Pause/Kill navigation unchanged
+**Description:** The scrolling, search, and filtered-`rowCount()` changes leave the non-list tabs' cursor navigation intact.
+**User Role:** Operator
+**Acceptance Criteria:**
+- The system SHALL NOT apply list scrolling, search-input mode, or the search filter to the Config or Pause/Kill tabs, which share the single `m.cursor` and are driven by `rowCount()` (Config via `len(m.items)`/`buildRuleItems`, Pause/Kill via `len(m.data.kills)`, tui.go 463–479).
+- WHILE making `rowCount()` search-filter-aware for the four list tabs (per CR-008), the system SHALL leave the `tabConfig` and `tabKill` branches of `rowCount()` returning their current counts so Config field/pattern/source navigation and the Pause/Kill view behave exactly as they do today.

--- a/docs/plans/enhance-tui-ux/tasks.md
+++ b/docs/plans/enhance-tui-ux/tasks.md
@@ -1,0 +1,329 @@
+# Tasks: Enhance the Herd Auto Prompter TUI UI/UX
+
+Implementation checklist grounded in the approved `proposal.md` and `requirements.md` delta. Scope is TUI presentation only — no `frontend.App` signature changes, no keybinding reassignment, no new framework. `_Requirements:_` codes reference `requirements.md`.
+
+> Code references (`tui.go:<line>` etc.) verified against commit `6a22f8a` (main, 2026-07-11).
+
+> Note: task 30 realizes a new requirement, **CR-032 (Rules list shows the full signature id)**, added to the delta during tasks review at the operator's request. It changes the Rules list column from the truncated `shortSig()` form (`sig[:16] + "…"`, tui.go 1038–1043, used at 1267) to the full `r.Signature` (e.g. `idle:83b2285833fd4c6ebf40a2bc`), which is already carried on the row and shown in the detail overlay (tui.go 996).
+
+> Note: workstream G (tasks 31–34) realizes **CR-033/AR-034/AR-035/CR-036/CR-037 (Config tab completeness & editability)**, added after the operator found recently added config fields missing from the Config tab and inline editing of the argv-template fields (`llm.command`, `llm.rewrite_command`) broken. The finalization tasks were renumbered 31–32 → 35–36 accordingly.
+
+## Dependency Graph
+
+Critical path: **D → C** (config fields before theme resolution) and **A → B** (viewport before search-driven clamping). Workstreams A, C/D, and E are largely independent and can proceed in parallel; B depends on A; C depends on D.
+
+- Foundation: 1, 25 (state + config fields)
+- Then: A (2–8), D→C (25–26→18–24), E (27–29), the standalone Rules-id change (30), and G (31–34; 31 waits for 25)
+- B (9–17) starts once A tasks 1–6 land
+- Finalization: 35–36 last
+
+## Workstream A — List viewport & scrolling
+
+- [ ] 1\. Add per-tab viewport offset state and page-size helper
+  - Add a per-tab `offset` field to `Model` and a `listPageSize(m.height)` helper mirroring `detailPageSize()` chrome accounting.
+  - Acceptance Criteria:
+    - `Model` holds an `offset` per list tab, initialized to 0.
+    - `listPageSize` returns the row count that fits under the current pane chrome.
+  - _Dependencies: none_
+  - _Requirements: AR-001, AR-002_
+  - _Complexity: Small_
+
+- [ ] 2\. Window each list tab's View to the offset slice
+  - Render only rows `[offset, offset+pageSize)` of the visible rows; keep the shared `m.cursor` unchanged in kind.
+  - Acceptance Criteria:
+    - Each list tab renders at most `pageSize` rows starting at `offset`.
+    - No per-tab cursor state is introduced.
+  - _Dependencies: 1_
+  - _Requirements: AR-002, CR-005_
+  - _Complexity: Medium_
+
+- [ ] 3\. Make the offset follow the shared cursor
+  - Route ↑/↓ and `j`/`k` so `offset` increases when cursor ≥ `offset+pageSize` and decreases when cursor < `offset`.
+  - Acceptance Criteria:
+    - Selecting a row below the window scrolls down; above the window scrolls up; cursor always stays visible.
+  - _Dependencies: 1, 2_
+  - _Requirements: AR-003, AR-004_
+  - _Complexity: Medium_
+
+- [ ] 4\. Reset offset on tab switch
+  - At the existing cursor-reset points (tui.go 297/302/359/363), also reset that tab's `offset` to 0.
+  - Acceptance Criteria:
+    - Switching tabs resets both `m.cursor` and `offset` to 0.
+  - _Dependencies: 1_
+  - _Requirements: CR-006_
+  - _Complexity: Small_
+
+- [ ] 5\. Clamp offset on resize
+  - Extend `WindowSizeMsg` handling to clamp each list `offset` to `[0, max(0, rowCount−pageSize)]`, alongside the existing `detail.offset` clamp.
+  - Acceptance Criteria:
+    - After a resize no list offset points past the last full window.
+  - _Dependencies: 1_
+  - _Requirements: CR-007_
+  - _Complexity: Small_
+
+- [ ] 6\. Clamp the shared cursor to the filtered row count
+  - Change the `m.cursor` clamp (tui.go 232–233) to clamp against the visible (filtered) row count.
+  - Acceptance Criteria:
+    - `m.cursor` never exceeds the number of currently visible rows.
+  - _Dependencies: 1_
+  - _Requirements: CR-008_
+  - _Complexity: Small_
+
+- [ ] 7\. Render the clipped-rows affordance
+  - Show a "… N more" indicator when visible rows exceed `offset+pageSize`, matching the detail-overlay style (tui.go 1291).
+  - Acceptance Criteria:
+    - The indicator shows the exact count of rows below the window and disappears when none remain.
+  - _Dependencies: 2_
+  - _Requirements: AR-009_
+  - _Complexity: Small_
+
+- [ ] 8\. Tests — list scrolling and pane-height invariant
+  - Add scroll/clamp tests paralleling `TestDetailViewScrolls`, plus a "renders within pane height" assertion per list tab paralleling tui_test.go 267–268.
+  - Acceptance Criteria:
+    - Tests cover scroll down/up, resize clamp, and that no list tab renders more rows than the pane height.
+  - _Dependencies: 2, 3, 5, 7_
+  - _Requirements: AR-010_
+  - _Complexity: Medium_
+
+## Workstream B — In-list search / filter
+
+- [ ] 9\. Add search state and bind `/`
+  - Add per-tab query + search-input-mode flag to `Model`; bind the currently-unbound `/` to enter search on Agents/Escalations/Audit/Rules.
+  - Acceptance Criteria:
+    - Pressing `/` on a list tab enters search-input mode; no existing binding changes.
+  - _Dependencies: 1_
+  - _Requirements: AR-011_
+  - _Complexity: Medium_
+
+- [ ] 10\. Incremental query editing
+  - Append typed characters, backspace removes the last, recompute filtered rows after each edit.
+  - Acceptance Criteria:
+    - The filtered list updates on every keystroke while in search mode.
+  - _Dependencies: 9_
+  - _Requirements: AR-012_
+  - _Complexity: Small_
+
+- [ ] 11\. Case-insensitive substring filter
+  - Filter each tab's rows by case-insensitive substring over the visible column text.
+  - Acceptance Criteria:
+    - Only rows containing the query (any case) in a visible column are shown.
+  - _Dependencies: 10_
+  - _Requirements: AR-013_
+  - _Complexity: Medium_
+
+- [ ] 12\. Exit and clear behavior
+  - `esc` or `enter` with a non-empty query exits search-input mode retaining the filter; with an empty query exits with no filter; `enter` must not trigger the tab's enter action (confirm/detail/edit); backspace-to-empty restores the full list.
+  - Acceptance Criteria:
+    - Exit-retains-filter (via esc and enter), exit-empty, and clear-via-backspace all behave as specified; enter in search mode never confirms/opens.
+  - _Dependencies: 10_
+  - _Requirements: AR-014, AR-015_
+  - _Complexity: Small_
+
+- [ ] 13\. Recompute cursor and offset on query change
+  - On any query change, clamp shared `m.cursor` and the tab's `offset` to the new filtered row count.
+  - Acceptance Criteria:
+    - Cursor and offset stay in bounds as the result set shrinks/grows.
+  - _Dependencies: 6, 11_
+  - _Requirements: CR-016_
+  - _Complexity: Small_
+
+- [ ] 14\. Compose search with the Rules mode filter
+  - Apply the new search together with the existing Rules `f`-mode cycle (`visibleSignatures()`, tui.go 124–136, 405).
+  - Acceptance Criteria:
+    - On Rules, mode filter and search query both constrain the list simultaneously.
+  - _Dependencies: 11_
+  - _Requirements: CR-017_
+  - _Complexity: Small_
+
+- [ ] 15\. Empty-result feedback
+  - Render an explicit "no rows match" empty-state per tab, consistent with tui.go 1256.
+  - Acceptance Criteria:
+    - A zero-match filter shows the empty-state message instead of a blank body.
+  - _Dependencies: 11_
+  - _Requirements: AR-018_
+  - _Complexity: Small_
+
+- [ ] 16\. Suppress action bindings while typing
+  - While in search-input mode, route ALL printable keys to the query and do not invoke action or navigation bindings — in particular `q` (quit), `y` (confirm+send), `p r e c n v f a t x X`, `j`/`k` (cursor), `h`/`l` (tab switch), and space.
+  - Acceptance Criteria:
+    - Typing a query never triggers a destructive or navigational action — including a query containing `q` (must not quit) or `y` (must not confirm+send).
+  - _Dependencies: 9_
+  - _Requirements: CR-019_
+  - _Complexity: Medium_
+
+- [ ] 17\. Tests — search behavior
+  - Cover per-tab search filtering (paralleling the Rules `f`-filter test), Rules search+mode composition, and the "typing does not fire actions" guard.
+  - Acceptance Criteria:
+    - Tests assert filtering, composition, and action suppression.
+  - _Dependencies: 11, 14, 16_
+  - _Requirements: AR-013, CR-017, CR-019_
+  - _Complexity: Medium_
+
+## Workstream C — Theming & palette
+
+- [ ] 18\. Introduce a Palette type and refactor style vars
+  - Define a `Palette` with roles (title, section, error, ok, paused, running, help) and refactor the package-level style vars (tui.go 41–50) to resolve from a palette instance.
+  - Acceptance Criteria:
+    - No style is built from a scattered hardcoded `lipgloss.Color` literal; all resolve through the palette.
+  - _Dependencies: none_
+  - _Requirements: CR-020_
+  - _Complexity: Large_
+
+- [ ] 19\. Define the default palette from current colors
+  - Populate the `default` palette with the exact current 256-color values so it is byte-identical to today's look.
+  - Acceptance Criteria:
+    - Rendering with the default palette is visually identical to the pre-change TUI.
+  - _Dependencies: 18_
+  - _Requirements: AR-022_
+  - _Complexity: Small_
+
+- [ ] 20\. Add named themes and the selector
+  - Add `dark`, `light`, `high-contrast` palettes and a selector keyed on `[tui] theme`.
+  - Acceptance Criteria:
+    - Each named theme is selectable and renders its distinct palette.
+  - _Dependencies: 19, 25_
+  - _Requirements: AR-021_
+  - _Complexity: Medium_
+
+- [ ] 21\. Resolve empty/default/unknown consistently
+  - Resolve empty/absent `theme` and `theme = "default"` to the identical default palette; resolve an unknown name to the default.
+  - Acceptance Criteria:
+    - `""`, `"default"`, and any unknown name all yield the default palette.
+  - _Dependencies: 20_
+  - _Requirements: AR-022, AR-030_
+  - _Complexity: Small_
+
+- [ ] 22\. Apply per-role overrides
+  - Layer optional per-role overrides on top of the selected named theme; unset roles inherit the theme value.
+  - Acceptance Criteria:
+    - An override changes only its role; other roles keep the theme's values.
+  - _Dependencies: 20, 25_
+  - _Requirements: AR-023_
+  - _Complexity: Medium_
+
+- [ ] 23\. Route empty/loading/error states through the palette
+  - Style empty-list, loading (pre-first-data), and error states via the palette, including the `errStyle.Render("error: …")` path (tui.go 1192).
+  - Acceptance Criteria:
+    - All three states render with palette-sourced styles.
+  - _Dependencies: 18_
+  - _Requirements: CR-024_
+  - _Complexity: Small_
+
+- [ ] 24\. Tests — theme resolution and overrides
+  - Cover default==empty==unknown-fallback, each named theme selectable, and per-role override layering.
+  - Acceptance Criteria:
+    - Tests assert resolution equivalence, selection, and override inheritance.
+  - _Dependencies: 21, 22_
+  - _Requirements: AR-021, AR-022, AR-023, AR-030_
+  - _Complexity: Medium_
+
+## Workstream D — Config plumbing
+
+- [ ] 25\. Add TUI theme config fields
+  - Add optional `Theme string` and a per-role override field to `config.TUI` with TOML tags; leave `MaxContentWidth` untouched.
+  - Acceptance Criteria:
+    - New fields parse from `[tui]` and are ignored when absent.
+  - _Dependencies: none_
+  - _Requirements: AR-027, AR-028_
+  - _Complexity: Small_
+
+- [ ] 26\. Verify backward-compatible defaults
+  - Confirm `config.Default()` and existing-file loading treat the new fields as optional; add a test proving an existing `[tui]` file (only `MaxContentWidth`) still loads and renders unchanged.
+  - Acceptance Criteria:
+    - A legacy `[tui]` config loads without error and yields the default palette.
+  - _Dependencies: 25_
+  - _Requirements: CR-029_
+  - _Complexity: Small_
+
+## Workstream E — Status area & non-impact verification
+
+- [ ] 27\. Rework the status area to be durable
+  - Rework `m.message` rendering into a durable, clearly-placed status area that persists an outcome long enough to read after multi-step operations.
+  - Acceptance Criteria:
+    - An action outcome remains readable in a fixed status area after the operation completes.
+  - _Dependencies: none_
+  - _Requirements: CR-025_
+  - _Complexity: Large_
+
+- [ ] 28\. Source ok/error status styles from the palette
+  - Preserve success-vs-error differentiation by sourcing the ok/error styles from the palette (was tui.go 251–253).
+  - Acceptance Criteria:
+    - Success and error outcomes remain visually distinct, now palette-sourced.
+  - _Dependencies: 18, 27_
+  - _Requirements: CR-026_
+  - _Complexity: Small_
+
+- [ ] 29\. Verify no frontend API change
+  - Confirm no `frontend.App` method signature or returned shape changed; the TUI still reads via existing `App` methods (`GetStatus`, `Escalations`, `Audit`, `Signatures`, …).
+  - Acceptance Criteria:
+    - `internal/frontend` has no signature diff; TUI data paths unchanged.
+  - _Dependencies: none_
+  - _Requirements: AR-031_
+  - _Complexity: Small_
+
+## Workstream F — Rules full signature id (new)
+
+- [ ] 30\. Show the full signature id in the Rules list
+  - In `renderSignatures` (tui.go 1249–), replace the truncated `shortSig(r.Signature)` column (tui.go 1267; `shortSig` at 1038–1043) with the full `r.Signature`, and widen/reflow the row column budget (the ~66-cell fixed prefix noted at tui.go 1263) so a full id like `idle:83b2285833fd4c6ebf40a2bc` fits without clipping the trailing columns. Preserve graceful narrow-terminal behavior via the existing width budgeting.
+  - Acceptance Criteria:
+    - The Rules list renders each signature id in full (e.g. `idle:83b2285833fd4c6ebf40a2bc`), not `idle:83b2285833f…`.
+    - Other Rules columns still fit within `contentWidth()` and narrow terminals do not clip the id mid-string without an intentional affordance.
+    - The signature-detail overlay (tui.go 996) is unchanged.
+  - _Dependencies: 2_
+  - _Requirements: CR-032_
+  - _Complexity: Medium_
+
+## Workstream G — Config tab completeness (new)
+
+- [ ] 31\. Expose the missing scalar config fields
+  - Add `llm.pane_excerpt_chars` (config.go 83), `safety.disable_seed` (config.go 44), and `tui.max_content_width` (config.go 162) — plus the new `tui.theme` once task 25 lands — to `ConfigFieldKeys` (frontend.go 450–471), `FieldValue` (474–521), and `SetField` (525–) with type-appropriate validation, so the Config tab and `config set` both display and edit them (CLI parity, FR-022).
+  - Acceptance Criteria:
+    - Each field appears on the Config tab with its current value and is editable via enter/`e` and `config set`.
+    - Invalid values are rejected with a clear message; no existing key changes behavior.
+  - _Dependencies: 25_
+  - _Requirements: CR-033_
+  - _Complexity: Medium_
+
+- [ ] 32\. Render read-only Safety-indicator and capture-delay sections
+  - Extend `buildRuleItems` (tui.go 184–217) with read-only rows: a "Safety indicators" section for `safety.irreversible_indicators` and each `[[safety.indicator_rules]]` entry (pattern + agent scope, config.go 48–59), and a capture-delay section showing each `[[capture_delay]]` rule (config.go 151–155) or the built-in defaults (1000/200 ms, config.go 396–399) when none are configured. Edit/remove keys on these rows show an informational "edited in config.toml" message (mirroring tui.go 1140) and never mutate config. Classifier manifests stay file-only.
+  - Acceptance Criteria:
+    - Configured indicator patterns, indicator rules, and capture-delay rules are visible on the Config tab; the defaults row appears when no capture-delay rule exists.
+    - `enter`/`e`/`x` on the read-only rows produce the informational message and change nothing.
+  - _Dependencies: none_
+  - _Requirements: AR-034, AR-035_
+  - _Complexity: Medium_
+
+- [ ] 33\. Classify field editability and truncate long values
+  - Add a TUI-editable / TUI-read-only classification over the field registry, stored in one place (per-key editable flag or type tag) so new fields default read-only: numeric/boolean/short-enum fields stay editable via the inline prompt; ANY free-text field — argv templates, template strings, paths, other long strings (today: `llm.command`, `llm.rewrite_command`, `llm.rewrite_fallback_template`, `embedding.model_path`; plus per-role palette overrides if displayed) — is TUI-read-only — `enter`/`e` on them (`editSelectedRule`, tui.go 1054–1074) shows an informational "edit in config.toml (or `config set`)" message and never opens the prompt. `SetField` keeps accepting all keys (CLI parity). Truncate each config row's value to the row budget with an ellipsis (via `oneLine`, tui.go 1452) so long commands no longer overflow the row (`buildRuleItems` label, tui.go 189).
+  - Acceptance Criteria:
+    - Read-only fields show the informational message on `enter`/`e` and cannot be edited from the TUI; `config set llm.command …` still works.
+    - Every editable field still opens the prompt and saves; long values render on one line with a trailing ellipsis.
+  - _Dependencies: 31_
+  - _Requirements: CR-036, CR-037_
+  - _Complexity: Medium_
+
+- [ ] 34\. Tests — config completeness, editability, and registry parity
+  - Add a three-way parity test failing when a key is present in one of `ConfigFieldKeys`/`FieldValue`/`SetField` but missing in another (extending the iteration test at frontend_test.go 379); cover display + edit of each newly exposed field, the read-only field classification (message shown, no prompt, no mutation; `SetField` still accepts the key), value truncation, and rendering of the read-only sections (including the defaults row and the no-mutation guarantee).
+  - Acceptance Criteria:
+    - Parity test fails on a deliberately removed case; new-field edit, read-only classification, truncation, and section render tests pass.
+  - _Dependencies: 31, 32, 33_
+  - _Requirements: CR-033, AR-034, AR-035, CR-036, CR-037_
+  - _Complexity: Medium_
+
+## Finalization
+
+- [ ] 35\. Update docs
+  - Update README / config reference for the new `[tui] theme` + per-role override keys, the `/` search keybinding, the full Rules signature-id display, the newly exposed / newly displayed config fields (`llm.pane_excerpt_chars`, `safety.disable_seed`, `tui.max_content_width`, safety indicators, capture delays), and which fields are TUI-read-only (edit via `config.toml` / `config set`).
+  - Acceptance Criteria:
+    - Docs describe the new config keys, search key, Rules id change, and Config tab completeness/editability changes.
+  - _Dependencies: 25, 30, 31, 32, 33_
+  - _Requirements: AR-027, AR-028, AR-021, CR-032, CR-033, CR-036_
+  - _Complexity: Small_
+
+- [ ] 36\. Full test + smoke pass
+  - Run `go test ./internal/tui/... ./internal/config/... ./internal/frontend/...` and confirm the suite passes; manually smoke-test long lists, search, each theme, the status area, the full Rules id, and the completed Config tab (new fields, read-only rows, truncation) in a live pane.
+  - Acceptance Criteria:
+    - All tests pass; manual smoke test confirms every workstream in a live pane.
+  - _Dependencies: 8, 17, 24, 26, 28, 29, 30, 34_
+  - _Requirements: AR-010, CR-017, AR-023, CR-029, CR-026, AR-031, CR-032, CR-033, AR-034, AR-035, CR-036, CR-037_
+  - _Complexity: Medium_

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,7 +160,30 @@ type TUI struct {
 	// (rationale, suggestion, action) in the list views. 0 (the default)
 	// means use the full terminal width, so rows fill a wide monitor.
 	MaxContentWidth int `toml:"max_content_width"`
+	// Theme selects a named TUI palette (see ValidThemes). Empty and
+	// unknown names resolve to "default" — the exact pre-theming look.
+	Theme string `toml:"theme,omitempty"`
+	// Palette overrides individual color roles on top of the selected
+	// theme; unset roles inherit the theme's value.
+	Palette PaletteOverrides `toml:"palette,omitempty"`
 }
+
+// PaletteOverrides are optional per-role color overrides for the TUI
+// palette. Values are terminal color strings lipgloss accepts ("205",
+// "#ff5faf"). Edited via config.toml only — the TUI shows them read-only.
+type PaletteOverrides struct {
+	Title   string `toml:"title,omitempty"`
+	Section string `toml:"section,omitempty"`
+	Error   string `toml:"error,omitempty"`
+	OK      string `toml:"ok,omitempty"`
+	Paused  string `toml:"paused,omitempty"`
+	Running string `toml:"running,omitempty"`
+	Help    string `toml:"help,omitempty"`
+}
+
+// ValidThemes are the named palettes `[tui] theme` accepts. The tui
+// package defines their colors; a test there keeps the two lists in sync.
+var ValidThemes = []string{"default", "dark", "light", "high-contrast"}
 
 // Config is the full operator configuration.
 type Config struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -309,6 +309,68 @@ func TestTUIMaxContentWidthParsed(t *testing.T) {
 	}
 }
 
+func TestTUIThemeAndPaletteParsed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	os.WriteFile(path, []byte(`[tui]
+theme = "dark"
+max_content_width = 120
+
+[tui.palette]
+title = "99"
+error = "#ff5faf"
+`), 0o600)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.Theme != "dark" {
+		t.Errorf("theme = %q, want dark", cfg.TUI.Theme)
+	}
+	if cfg.TUI.MaxContentWidth != 120 {
+		t.Errorf("max_content_width = %d, want 120", cfg.TUI.MaxContentWidth)
+	}
+	if cfg.TUI.Palette.Title != "99" || cfg.TUI.Palette.Error != "#ff5faf" {
+		t.Errorf("palette overrides lost: %+v", cfg.TUI.Palette)
+	}
+	// Unset roles stay empty (inherit the theme's value at render time).
+	if cfg.TUI.Palette.Section != "" || cfg.TUI.Palette.OK != "" ||
+		cfg.TUI.Palette.Paused != "" || cfg.TUI.Palette.Running != "" ||
+		cfg.TUI.Palette.Help != "" {
+		t.Errorf("unset palette roles must stay empty: %+v", cfg.TUI.Palette)
+	}
+}
+
+func TestTUIThemeBackwardCompat(t *testing.T) {
+	// CR-029: pre-theming config files keep loading unchanged.
+	path := filepath.Join(t.TempDir(), "config.toml")
+
+	// Legacy [tui] section with only max_content_width.
+	os.WriteFile(path, []byte("[tui]\nmax_content_width = 140\n"), 0o600)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("legacy [tui] file must load: %v", err)
+	}
+	if cfg.TUI.MaxContentWidth != 140 {
+		t.Errorf("max_content_width = %d, want 140", cfg.TUI.MaxContentWidth)
+	}
+	if cfg.TUI.Theme != "" {
+		t.Errorf("legacy file must leave theme empty, got %q", cfg.TUI.Theme)
+	}
+	if cfg.TUI.Palette != (PaletteOverrides{}) {
+		t.Errorf("legacy file must leave palette zero, got %+v", cfg.TUI.Palette)
+	}
+
+	// No [tui] section at all.
+	os.WriteFile(path, []byte("[learning]\ngraduation_n = 5\n"), 0o600)
+	if cfg, err = Load(path); err != nil {
+		t.Fatalf("file without [tui] must load: %v", err)
+	}
+	if cfg.TUI.MaxContentWidth != 0 || cfg.TUI.Theme != "" ||
+		cfg.TUI.Palette != (PaletteOverrides{}) {
+		t.Errorf("missing [tui] must default to zero TUI config, got %+v", cfg.TUI)
+	}
+}
+
 func TestRewriteConfigKeys(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -445,29 +445,68 @@ func (a *App) UpdateConfig(ctx context.Context, fn func(*config.Config) error) e
 	return a.nudge(ctx, control.KindReload)
 }
 
+// ConfigFieldDef describes one scalar config field: its SetField key and
+// whether the TUI's inline prompt may edit it. Free-text values — argv
+// templates, template strings, paths — are TUI-read-only as a standing
+// rule (CR-036): the one-line prompt round-trip mangles them. `config set`
+// accepts every key regardless of the flag.
+type ConfigFieldDef struct {
+	Key         string
+	TUIEditable bool
+}
+
+// ConfigFields is the single source of truth for the scalar config field
+// registry, in display order (CR-033). A parity test fails when a key here
+// is missing from FieldValue or SetField; a switch case added without a
+// registry entry is unguarded (the field silently disappears from the TUI
+// and `config fields`), so always add new fields here first.
+var ConfigFields = []ConfigFieldDef{
+	{Key: "thresholds.idle", TUIEditable: true},
+	{Key: "thresholds.approval", TUIEditable: true},
+	{Key: "thresholds.choice", TUIEditable: true},
+	{Key: "thresholds.error", TUIEditable: true},
+	{Key: "thresholds.inferred_task_bar", TUIEditable: true},
+	{Key: "learning.graduation_n", TUIEditable: true},
+	{Key: "limits.max_consecutive_auto_prompts", TUIEditable: true},
+	{Key: "limits.max_auto_prompts_per_minute", TUIEditable: true},
+	{Key: "limits.max_error_retries", TUIEditable: true},
+	{Key: "safety.disable_seed", TUIEditable: true},
+	{Key: "llm.command"}, // argv template
+	{Key: "llm.timeout_seconds", TUIEditable: true},
+	{Key: "llm.auto_act", TUIEditable: true},
+	{Key: "llm.pane_excerpt_chars", TUIEditable: true},
+	{Key: "llm.rewrite_command"}, // argv template
+	{Key: "llm.rewrite_timeout_seconds", TUIEditable: true},
+	{Key: "llm.rewrite_fallback_template"}, // template string
+	{Key: "embedding.disabled", TUIEditable: true},
+	{Key: "embedding.model_path"}, // path
+	{Key: "embedding.similarity_threshold", TUIEditable: true},
+	{Key: "embedding.bm25_min_score", TUIEditable: true},
+	{Key: "embedding.gpu_layers", TUIEditable: true},
+	{Key: "tui.max_content_width", TUIEditable: true},
+	{Key: "tui.theme", TUIEditable: true},
+}
+
 // ConfigFieldKeys lists every scalar config field editable via SetField, in
 // display order (shared by the TUI config editor and `config set`).
-var ConfigFieldKeys = []string{
-	"thresholds.idle",
-	"thresholds.approval",
-	"thresholds.choice",
-	"thresholds.error",
-	"thresholds.inferred_task_bar",
-	"learning.graduation_n",
-	"limits.max_consecutive_auto_prompts",
-	"limits.max_auto_prompts_per_minute",
-	"limits.max_error_retries",
-	"llm.command",
-	"llm.timeout_seconds",
-	"llm.auto_act",
-	"llm.rewrite_command",
-	"llm.rewrite_timeout_seconds",
-	"llm.rewrite_fallback_template",
-	"embedding.disabled",
-	"embedding.model_path",
-	"embedding.similarity_threshold",
-	"embedding.bm25_min_score",
-	"embedding.gpu_layers",
+var ConfigFieldKeys = func() []string {
+	keys := make([]string, len(ConfigFields))
+	for i, f := range ConfigFields {
+		keys[i] = f.Key
+	}
+	return keys
+}()
+
+// FieldTUIEditable reports whether the TUI inline prompt may edit key;
+// false means the TUI shows it read-only (config.toml and `config set`
+// still work — CR-036).
+func FieldTUIEditable(key string) bool {
+	for _, f := range ConfigFields {
+		if f.Key == key {
+			return f.TUIEditable
+		}
+	}
+	return false
 }
 
 // FieldValue renders the current value of a SetField key for display.
@@ -492,16 +531,27 @@ func FieldValue(cfg config.Config, key string) string {
 	case "limits.max_error_retries":
 		return strconv.Itoa(cfg.Limits.MaxErrorRetries)
 	case "llm.command":
+		if len(cfg.LLM.Command) == 0 {
+			return "(disabled)"
+		}
 		return JoinCommand(cfg.LLM.Command)
 	case "llm.timeout_seconds":
 		return strconv.Itoa(cfg.LLM.TimeoutSeconds)
 	case "llm.auto_act":
 		return strconv.FormatBool(cfg.LLM.AutoAct)
+	case "llm.pane_excerpt_chars":
+		return strconv.Itoa(cfg.LLM.PaneExcerptChars)
 	case "llm.rewrite_command":
+		if len(cfg.LLM.RewriteCommand) == 0 {
+			return "(disabled)"
+		}
 		return JoinCommand(cfg.LLM.RewriteCommand)
 	case "llm.rewrite_timeout_seconds":
 		return strconv.Itoa(cfg.LLM.RewriteTimeoutSeconds)
 	case "llm.rewrite_fallback_template":
+		if cfg.LLM.RewriteFallbackTemplate == "" {
+			return "(built-in default)"
+		}
 		return cfg.LLM.RewriteFallbackTemplate
 	case "embedding.disabled":
 		return strconv.FormatBool(cfg.Embedding.Disabled)
@@ -516,6 +566,18 @@ func FieldValue(cfg config.Config, key string) string {
 		return fmt.Sprintf("%.2f", cfg.Embedding.BM25MinScore)
 	case "embedding.gpu_layers":
 		return strconv.Itoa(cfg.Embedding.GPULayers)
+	case "safety.disable_seed":
+		return strconv.FormatBool(cfg.Safety.DisableSeed)
+	case "tui.max_content_width":
+		if cfg.TUI.MaxContentWidth == 0 {
+			return "0 (full width)"
+		}
+		return strconv.Itoa(cfg.TUI.MaxContentWidth)
+	case "tui.theme":
+		if cfg.TUI.Theme == "" {
+			return "default"
+		}
+		return cfg.TUI.Theme
 	}
 	return ""
 }
@@ -619,6 +681,46 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 			}
 			cfg.Embedding.GPULayers = v
 			return nil
+		case "llm.pane_excerpt_chars":
+			// 0 is the config's "restore the 5000-char default" sentinel
+			// (fillZeroes) — accept it, like tui.max_content_width does.
+			v, err := strconv.Atoi(value)
+			if err != nil || v < 0 {
+				return fmt.Errorf("llm.pane_excerpt_chars must be a non-negative integer (0 = default), got %q", value)
+			}
+			cfg.LLM.PaneExcerptChars = v
+			return nil
+		case "safety.disable_seed":
+			v, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("safety.disable_seed must be true or false, got %q", value)
+			}
+			cfg.Safety.DisableSeed = v
+			return nil
+		case "tui.max_content_width":
+			v, err := strconv.Atoi(value)
+			if err != nil || v < 0 {
+				return fmt.Errorf("tui.max_content_width must be a non-negative integer (0 = full width), got %q", value)
+			}
+			cfg.TUI.MaxContentWidth = v
+			return nil
+		case "tui.theme":
+			// `config set` rejects unknown names with the valid list (the
+			// CR-033 "pick ONE behavior" choice); a hand-edited config.toml
+			// still degrades gracefully at render time (AR-030).
+			t := strings.ToLower(strings.TrimSpace(value))
+			if t == "" {
+				cfg.TUI.Theme = ""
+				return nil
+			}
+			for _, name := range config.ValidThemes {
+				if t == name {
+					cfg.TUI.Theme = t
+					return nil
+				}
+			}
+			return fmt.Errorf("tui.theme must be one of %s, got %q",
+				strings.Join(config.ValidThemes, ", "), value)
 		}
 		return fmt.Errorf("unknown config field %q", key)
 	})

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/cli"
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/control"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
@@ -377,9 +378,190 @@ func TestSetFieldValidatesAndPersists(t *testing.T) {
 	}
 	// Every editable key renders a value.
 	for _, key := range frontend.ConfigFieldKeys {
-		if key != "llm.command" && frontend.FieldValue(cfg, key) == "" {
+		if frontend.FieldValue(cfg, key) == "" {
 			t.Errorf("FieldValue(%s) is empty", key)
 		}
+	}
+}
+
+// TestConfigFieldRegistryParity is the CR-033 three-way guarantee: every key
+// in the ConfigFields registry must (1) render a display value from the
+// default config and (2) be accepted by SetField with a valid sample value.
+// Adding a key to the registry without teaching FieldValue/SetField about it
+// (or without a sample here) fails this test by name.
+func TestConfigFieldRegistryParity(t *testing.T) {
+	// One valid sample value per registry key. When you add a field to
+	// frontend.ConfigFields, add a sample here or this test fails loudly.
+	samples := map[string]string{
+		"thresholds.idle":                     "0.70",
+		"thresholds.approval":                 "0.85",
+		"thresholds.choice":                   "0.85",
+		"thresholds.error":                    "0.90",
+		"thresholds.inferred_task_bar":        "0.95",
+		"learning.graduation_n":               "5",
+		"limits.max_consecutive_auto_prompts": "5",
+		"limits.max_auto_prompts_per_minute":  "10",
+		"limits.max_error_retries":            "2",
+		"safety.disable_seed":                 "true",
+		"llm.command":                         `claude -p "decide"`,
+		"llm.timeout_seconds":                 "60",
+		"llm.auto_act":                        "true",
+		"llm.pane_excerpt_chars":              "4000",
+		"llm.rewrite_command":                 `claude -p "rewrite: {text}"`,
+		"llm.rewrite_timeout_seconds":         "45",
+		"llm.rewrite_fallback_template":       "Act on: {original_text}",
+		"embedding.disabled":                  "false",
+		"embedding.model_path":                "/models/custom.gguf",
+		"embedding.similarity_threshold":      "0.90",
+		"embedding.bm25_min_score":            "0.35",
+		"embedding.gpu_layers":                "0",
+		"tui.max_content_width":               "140",
+		"tui.theme":                           "dark",
+	}
+
+	registry := make(map[string]bool, len(frontend.ConfigFieldKeys))
+	for _, key := range frontend.ConfigFieldKeys {
+		registry[key] = true
+		if _, ok := samples[key]; !ok {
+			t.Errorf("registry key %q has no sample value in this test — add one to keep the CR-033 parity guarantee", key)
+		}
+	}
+	for key := range samples {
+		if !registry[key] {
+			t.Errorf("sample key %q is not in frontend.ConfigFields — stale sample or missing registry entry", key)
+		}
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
+
+	// (1) Every key renders a non-empty display value from the defaults.
+	def := config.Default()
+	for _, key := range frontend.ConfigFieldKeys {
+		if frontend.FieldValue(def, key) == "" {
+			t.Errorf("FieldValue(Default(), %s) is empty — FieldValue is missing the key", key)
+		}
+	}
+
+	// (2) SetField accepts a valid sample for every key.
+	app, _ := testApp(t)
+	ctx := context.Background()
+	for _, key := range frontend.ConfigFieldKeys {
+		if err := app.SetField(ctx, key, samples[key]); err != nil {
+			t.Errorf("SetField(%s, %q) rejected a valid value: %v", key, samples[key], err)
+		}
+	}
+}
+
+// TestFieldTUIEditableClassification pins CR-036: free-text fields (argv
+// templates, template strings, paths) are read-only in the TUI, everything
+// else in the registry is editable, and unknown keys are never editable.
+func TestFieldTUIEditableClassification(t *testing.T) {
+	readOnly := map[string]bool{
+		"llm.command":                   true,
+		"llm.rewrite_command":           true,
+		"llm.rewrite_fallback_template": true,
+		"embedding.model_path":          true,
+	}
+	for _, key := range frontend.ConfigFieldKeys {
+		want := !readOnly[key]
+		if got := frontend.FieldTUIEditable(key); got != want {
+			t.Errorf("FieldTUIEditable(%s) = %v, want %v", key, got, want)
+		}
+	}
+	// Every expected read-only key must actually exist in the registry.
+	present := make(map[string]bool, len(frontend.ConfigFieldKeys))
+	for _, key := range frontend.ConfigFieldKeys {
+		present[key] = true
+	}
+	for key := range readOnly {
+		if !present[key] {
+			t.Errorf("expected read-only key %q missing from ConfigFields", key)
+		}
+	}
+	if frontend.FieldTUIEditable("nonexistent.field") {
+		t.Error("unknown key must not be TUI-editable")
+	}
+}
+
+func TestSetFieldNewKeysValidation(t *testing.T) {
+	app, _ := testApp(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		key, value string
+		wantErr    bool
+	}{
+		{"tui.theme", "dark", false},
+		{"tui.theme", "solarized", true},
+		{"tui.max_content_width", "140", false},
+		{"tui.max_content_width", "0", false},
+		{"tui.max_content_width", "-1", true},
+		{"tui.max_content_width", "abc", true},
+		{"safety.disable_seed", "true", false},
+		{"safety.disable_seed", "false", false},
+		{"safety.disable_seed", "yes", true},
+		{"llm.pane_excerpt_chars", "0", false}, // 0 = restore-default sentinel (fillZeroes)
+		{"llm.pane_excerpt_chars", "-5", true},
+		{"llm.pane_excerpt_chars", "abc", true},
+		{"llm.pane_excerpt_chars", "4000", false},
+	}
+	for _, c := range cases {
+		err := app.SetField(ctx, c.key, c.value)
+		if (err != nil) != c.wantErr {
+			t.Errorf("SetField(%s, %q) error = %v, wantErr %v", c.key, c.value, err, c.wantErr)
+		}
+	}
+
+	// The unknown-theme error names the valid themes.
+	err := app.SetField(ctx, "tui.theme", "solarized")
+	if err == nil {
+		t.Fatal("unknown theme must be rejected")
+	}
+	for _, name := range config.ValidThemes {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("theme error should list valid name %q, got: %v", name, err)
+		}
+	}
+
+	// Case-insensitive theme names normalize to lowercase on persist.
+	if err := app.SetField(ctx, "tui.theme", "DARK"); err != nil {
+		t.Fatalf("SetField(tui.theme, DARK) should normalize, got %v", err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.Theme != "dark" {
+		t.Errorf("persisted theme = %q, want normalized \"dark\"", cfg.TUI.Theme)
+	}
+	// Empty resets to the default theme.
+	if err := app.SetField(ctx, "tui.theme", ""); err != nil {
+		t.Fatalf("empty theme should reset: %v", err)
+	}
+	if cfg, _ = app.Config(); cfg.TUI.Theme != "" {
+		t.Errorf("empty theme should persist as \"\", got %q", cfg.TUI.Theme)
+	}
+
+	// End each key on a NON-zero accepted value so persistence is positively
+	// asserted (a validator that forgot the assignment would otherwise pass).
+	if err := app.SetField(ctx, "tui.max_content_width", "140"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.SetField(ctx, "safety.disable_seed", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg, err = app.Config(); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.MaxContentWidth != 140 {
+		t.Errorf("tui.max_content_width = %d, want 140", cfg.TUI.MaxContentWidth)
+	}
+	if !cfg.Safety.DisableSeed {
+		t.Error("safety.disable_seed = false, want true (assignment not persisted)")
+	}
+	if cfg.LLM.PaneExcerptChars != 4000 {
+		t.Errorf("llm.pane_excerpt_chars = %d, want 4000", cfg.LLM.PaneExcerptChars)
 	}
 }
 

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -1,0 +1,795 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-runewidth"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// listModel builds a Model with n rows on every list tab (Agents,
+// Escalations, Audit, Rules), each row carrying a distinct, searchable
+// token per tab.
+func listModel(t *testing.T, n, height int) Model {
+	t.Helper()
+	m := Model{width: 100, height: height}
+	msg := refreshMsg{cfg: config.Default()}
+	msg.status.AgentNames = map[string]string{}
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("w1:p%02d", i)
+		msg.status.MonitoredAgents = append(msg.status.MonitoredAgents, domain.AgentTransition{
+			AgentID: id, AgentType: "claude", PaneID: id, Status: "running",
+			At: time.Date(2026, 7, 9, 10, 0, i, 0, time.UTC)})
+		msg.status.AgentNames[id] = fmt.Sprintf("agent-name-%02d", i)
+		msg.escalations = append(msg.escalations, domain.AuditRecord{
+			ID: int64(i + 1), AgentID: id, SituationType: domain.SituationApproval,
+			Status: "escalated", Rationale: fmt.Sprintf("rationale-row-%02d", i),
+			CreatedAt: time.Date(2026, 7, 9, 11, 0, i, 0, time.UTC)})
+		msg.audit = append(msg.audit, domain.AuditRecord{
+			ID: int64(100 + i), AgentID: id, SituationType: domain.SituationChoice,
+			Status: "auto", Action: fmt.Sprintf("action-row-%02d", i),
+			CreatedAt: time.Date(2026, 7, 9, 12, 0, i, 0, time.UTC)})
+		msg.signatures = append(msg.signatures, frontend.SignatureRow{
+			SignatureState: domain.SignatureState{
+				Signature:     fmt.Sprintf("approval:%016d", i),
+				SituationType: domain.SituationApproval, AgentType: "claude",
+				Mode: domain.ModeShadow},
+			TopAction: "1"})
+	}
+	upd, _ := m.Update(msg)
+	return upd.(Model)
+}
+
+// --- List viewport (AR-001..AR-010) ---
+
+func TestListTabsFitPaneWithManyRows(t *testing.T) {
+	cases := []struct {
+		name  string
+		tab   tab
+		setup func(m *Model)
+	}{
+		{name: "agents", tab: tabAgents},
+		{name: "escalations", tab: tabEscalations},
+		{name: "audit", tab: tabAudit},
+		{name: "rules", tab: tabSignatures},
+		{name: "escalations searching", tab: tabEscalations, setup: func(m *Model) {
+			m.searching = true
+			m.query[tabEscalations] = "rationale" // matches every row
+		}},
+		{name: "escalations with active filter", tab: tabEscalations, setup: func(m *Model) {
+			m.query[tabEscalations] = "rationale"
+		}},
+		{name: "escalations with status", tab: tabEscalations, setup: func(m *Model) {
+			m.status = &statusNote{text: "done", at: time.Now()}
+		}},
+		{name: "escalations with message and status", tab: tabEscalations, setup: func(m *Model) {
+			m.message = "hint"
+			m.status = &statusNote{text: "done", at: time.Now()}
+		}},
+		{name: "rules with mode filter", tab: tabSignatures, setup: func(m *Model) {
+			m.sigMode = domain.ModeShadow
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := listModel(t, 40, 12)
+			m.tab = tc.tab
+			if tc.setup != nil {
+				tc.setup(&m)
+			}
+			view := m.View()
+			if rows := strings.Count(view, "\n") + 1; rows > m.height {
+				t.Errorf("%s renders %d rows in a %d-row pane:\n%s", tc.name, rows, m.height, view)
+			}
+			if !strings.Contains(view, "more row(s)") {
+				t.Errorf("%s should show the clipped-rows indicator:\n%s", tc.name, view)
+			}
+		})
+	}
+}
+
+func TestListWindowFollowsCursor(t *testing.T) {
+	m := listModel(t, 40, 12) // page size 6
+	m.tab = tabEscalations
+	if page := m.listPageSize(); page != 6 {
+		t.Fatalf("expected page size 6 at height 12, got %d", page)
+	}
+	view := m.View()
+	if !strings.Contains(view, "rationale-row-00") {
+		t.Errorf("initial window should start at row 0:\n%s", view)
+	}
+	if strings.Contains(view, "rationale-row-06") {
+		t.Errorf("row 6 must be clipped below the initial window:\n%s", view)
+	}
+	if !strings.Contains(view, "… 34 more row(s) — ↓ to scroll") {
+		t.Errorf("expected the more-rows indicator for 34 clipped rows:\n%s", view)
+	}
+
+	// Moving below the window scrolls it down (AR-003).
+	for i := 0; i < 6; i++ {
+		m = press(t, m, "down")
+	}
+	if m.cursor != 6 || m.offsets[tabEscalations] != 1 {
+		t.Fatalf("cursor=%d offset=%d after 6 downs, want cursor=6 offset=1", m.cursor, m.offsets[tabEscalations])
+	}
+	view = m.View()
+	if strings.Contains(view, "rationale-row-00") || !strings.Contains(view, "rationale-row-06") {
+		t.Errorf("window should have scrolled to keep the cursor visible:\n%s", view)
+	}
+
+	// Moving back above the window scrolls it up (AR-004).
+	for i := 0; i < 6; i++ {
+		m = press(t, m, "up")
+	}
+	if m.cursor != 0 || m.offsets[tabEscalations] != 0 {
+		t.Errorf("cursor=%d offset=%d after scrolling back up, want 0/0", m.cursor, m.offsets[tabEscalations])
+	}
+
+	// Over-scrolling clamps at the last row; the indicator disappears.
+	for i := 0; i < 100; i++ {
+		m = press(t, m, "down")
+	}
+	if m.cursor != 39 || m.offsets[tabEscalations] != 34 {
+		t.Errorf("cursor=%d offset=%d at the bottom, want 39/34", m.cursor, m.offsets[tabEscalations])
+	}
+	view = m.View()
+	if !strings.Contains(view, "rationale-row-39") || strings.Contains(view, "more row(s)") {
+		t.Errorf("bottom window should show the last row with no indicator:\n%s", view)
+	}
+}
+
+func TestTabSwitchResetsCursorAndOffset(t *testing.T) {
+	m := listModel(t, 40, 12)
+	m.tab = tabAgents
+	for i := 0; i < 10; i++ {
+		m = press(t, m, "down")
+	}
+	if m.cursor == 0 || m.offsets[tabAgents] == 0 {
+		t.Fatal("precondition: agents tab should be scrolled")
+	}
+	m = press(t, m, "tab")
+	if m.tab != tabEscalations || m.cursor != 0 || m.offsets[tabEscalations] != 0 {
+		t.Errorf("tab switch must reset cursor and the new tab's offset, got tab=%v cursor=%d offset=%d",
+			m.tab, m.cursor, m.offsets[tabEscalations])
+	}
+	// Backwards too.
+	for i := 0; i < 10; i++ {
+		m = press(t, m, "down")
+	}
+	upd, _ := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	m = upd.(Model)
+	if m.tab != tabAgents || m.cursor != 0 || m.offsets[tabAgents] != 0 {
+		t.Errorf("shift+tab must reset cursor and the new tab's offset, got tab=%v cursor=%d offset=%d",
+			m.tab, m.cursor, m.offsets[tabAgents])
+	}
+}
+
+func TestResizeClampsListViewport(t *testing.T) {
+	m := listModel(t, 40, 12)
+	m.tab = tabEscalations
+	for i := 0; i < 100; i++ {
+		m = press(t, m, "down")
+	}
+	if m.offsets[tabEscalations] != 34 {
+		t.Fatalf("precondition: offset should be 34, got %d", m.offsets[tabEscalations])
+	}
+	// Growing the pane makes the old offset invalid; it must clamp so the
+	// last page stays full (CR-007).
+	upd, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	m = upd.(Model)
+	if page := m.listPageSize(); m.offsets[tabEscalations] != 40-page {
+		t.Errorf("offset=%d after resize, want %d (rowCount-page)", m.offsets[tabEscalations], 40-page)
+	}
+	if m.cursor != 39 {
+		t.Errorf("resize must not move the cursor, got %d", m.cursor)
+	}
+}
+
+func TestRefreshClampsCursorToVisibleRows(t *testing.T) {
+	m := listModel(t, 40, 12)
+	m.tab = tabEscalations
+	for i := 0; i < 100; i++ {
+		m = press(t, m, "down")
+	}
+	// A refresh shrinking the list clamps cursor and offset (CR-008).
+	small := listModel(t, 3, 12)
+	upd, _ := m.Update(small.data)
+	m = upd.(Model)
+	if m.cursor != 2 || m.offsets[tabEscalations] != 0 {
+		t.Errorf("refresh should clamp cursor/offset to 3 rows, got cursor=%d offset=%d",
+			m.cursor, m.offsets[tabEscalations])
+	}
+
+	// The refresh clamp operates on the FILTERED count (CR-008): with an
+	// active query matching rows 30–39, a refresh down to 32 rows leaves 2
+	// filtered rows and the cursor must clamp to them, not the raw count.
+	m = listModel(t, 40, 12)
+	m.tab = tabEscalations
+	m.query[tabEscalations] = "rationale-row-3"
+	for i := 0; i < 100; i++ {
+		m = press(t, m, "down")
+	}
+	if m.cursor != 9 {
+		t.Fatalf("precondition: cursor should sit on the last of 10 filtered rows, got %d", m.cursor)
+	}
+	shrunk := listModel(t, 32, 12) // filtered rows left: 30, 31
+	upd, _ = m.Update(shrunk.data)
+	m = upd.(Model)
+	if got := len(m.visibleEscalations()); got != 2 {
+		t.Fatalf("filter should leave 2 rows after the refresh, got %d", got)
+	}
+	if m.cursor != 1 || m.offsets[tabEscalations] != 0 {
+		t.Errorf("refresh must clamp to the filtered count, got cursor=%d offset=%d",
+			m.cursor, m.offsets[tabEscalations])
+	}
+}
+
+func TestSpaceMarkKeepsCursorInWindow(t *testing.T) {
+	// Space marks the row and advances the shared cursor; the advance must
+	// scroll the window like any other cursor move (AR-003) — including the
+	// page shrink from the "N marked" hint line.
+	m := listModel(t, 40, 12)
+	m.tab = tabEscalations
+	for i := 0; i < 10; i++ {
+		m = press(t, m, " ")
+		off, page := m.offsets[tabEscalations], m.listPageSize()
+		if m.cursor < off || m.cursor >= off+page {
+			t.Fatalf("after %d marks cursor %d left the window [%d,%d)", i+1, m.cursor, off, off+page)
+		}
+	}
+	if m.cursor != 10 || len(m.marked) != 10 {
+		t.Errorf("10 spaces should mark 10 rows and advance to row 10, got cursor=%d marked=%d",
+			m.cursor, len(m.marked))
+	}
+}
+
+// --- Search (AR-011..AR-018, CR-019) ---
+
+func TestSlashEntersSearchAndFiltersIncrementally(t *testing.T) {
+	m := Model{width: 100, height: 30}
+	upd, _ := m.Update(refreshMsg{
+		escalations: []domain.AuditRecord{
+			{ID: 1, Status: "escalated", SituationType: domain.SituationApproval, Rationale: "alpha one"},
+			{ID: 2, Status: "escalated", SituationType: domain.SituationApproval, Rationale: "beta two"},
+			{ID: 3, Status: "escalated", SituationType: domain.SituationApproval, Rationale: "ALPHA three"},
+		},
+		cfg: config.Default(),
+	})
+	m = upd.(Model)
+	m.tab = tabEscalations
+
+	m = press(t, m, "/")
+	if !m.searching {
+		t.Fatal("/ on a list tab must enter search-input mode")
+	}
+	if !strings.Contains(m.View(), "search>") {
+		t.Errorf("search-input mode should render the search bar:\n%s", m.View())
+	}
+	// Filtering is case-insensitive and recomputed per keystroke (AR-012/13).
+	m = press(t, m, "a", "l", "p", "h", "a")
+	if m.query[tabEscalations] != "alpha" {
+		t.Fatalf("query = %q, want %q", m.query[tabEscalations], "alpha")
+	}
+	if got := m.visibleEscalations(); len(got) != 2 {
+		t.Fatalf("case-insensitive filter should match 2 rows, got %d", len(got))
+	}
+	view := m.View()
+	if !strings.Contains(view, "alpha one") || !strings.Contains(view, "ALPHA three") ||
+		strings.Contains(view, "beta two") {
+		t.Errorf("filtered list wrong:\n%s", view)
+	}
+	// Backspace edits the query; erasing it fully restores the list (AR-015).
+	for i := 0; i < 5; i++ {
+		upd, _ := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+		m = upd.(Model)
+	}
+	if m.query[tabEscalations] != "" || len(m.visibleEscalations()) != 3 {
+		t.Errorf("backspace-to-empty must restore the full list, query=%q rows=%d",
+			m.query[tabEscalations], len(m.visibleEscalations()))
+	}
+}
+
+func TestSearchKeysDoNotFireActions(t *testing.T) {
+	m := listModel(t, 5, 30)
+	m.tab = tabEscalations
+	m = press(t, m, "/")
+
+	// q must not quit, y must not confirm, x must not delete, j/k/h/l must
+	// not navigate — every printable key edits the query (CR-019).
+	for _, k := range []string{"q", "y", "x", "j", "k", "h", "l", "p", "r", "e", "c", "n", "v", "f", "a", "t", "X"} {
+		upd, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(k)})
+		m = upd.(Model)
+		if cmd != nil {
+			t.Fatalf("key %q while searching must not run a command (quit/confirm/delete)", k)
+		}
+		if !m.searching {
+			t.Fatalf("key %q must not leave search-input mode", k)
+		}
+	}
+	if m.tab != tabEscalations {
+		t.Errorf("h/l while searching must not switch tabs, got %v", m.tab)
+	}
+	if m.prompt != nil || m.detail != nil {
+		t.Error("printable keys while searching must not open prompts or overlays")
+	}
+	if want := "qyxjkhlprecnvfatX"; m.query[tabEscalations] != want {
+		t.Errorf("query = %q, want %q", m.query[tabEscalations], want)
+	}
+	// Space appends to the query too.
+	upd, cmd := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = upd.(Model)
+	if cmd != nil || !strings.HasSuffix(m.query[tabEscalations], " ") {
+		t.Errorf("space must append to the query, got %q", m.query[tabEscalations])
+	}
+}
+
+func TestSearchExitRetainsFilter(t *testing.T) {
+	for _, exit := range []string{"esc", "enter"} {
+		t.Run(exit, func(t *testing.T) {
+			m := listModel(t, 40, 30)
+			m.tab = tabEscalations
+			m = press(t, m, "/", "r", "o", "w", "-", "0", "3")
+			upd, cmd := m.Update(pressKeyMsg(exit))
+			m = upd.(Model)
+			if cmd != nil {
+				t.Fatalf("%s exiting search must not run a command (no confirm)", exit)
+			}
+			if m.searching {
+				t.Fatalf("%s must exit search-input mode", exit)
+			}
+			if m.query[tabEscalations] != "row-03" {
+				t.Fatalf("query must survive %s as the active filter, got %q", exit, m.query[tabEscalations])
+			}
+			if got := m.visibleEscalations(); len(got) != 1 || got[0].Rationale != "rationale-row-03" {
+				t.Errorf("active filter should keep matching, got %d rows", len(got))
+			}
+			if !strings.Contains(m.View(), `filter: "row-03"`) {
+				t.Errorf("active filter line missing:\n%s", m.View())
+			}
+		})
+	}
+}
+
+func TestSearchEscEmptyQueryLeavesNoFilter(t *testing.T) {
+	m := listModel(t, 5, 30)
+	m.tab = tabAgents
+	m = press(t, m, "/", "esc")
+	if m.searching || m.query[tabAgents] != "" {
+		t.Errorf("esc with an empty query must exit with no filter, searching=%v query=%q",
+			m.searching, m.query[tabAgents])
+	}
+	if strings.Contains(m.View(), "filter:") {
+		t.Errorf("no filter line should render:\n%s", m.View())
+	}
+	if len(m.visibleAgents()) != 5 {
+		t.Errorf("full list should show, got %d rows", len(m.visibleAgents()))
+	}
+}
+
+func TestSearchEmptyStateMessages(t *testing.T) {
+	cases := []struct {
+		tab  tab
+		want string
+	}{
+		{tabAgents, "no agents match the filter"},
+		{tabEscalations, "no escalations match the filter"},
+		{tabAudit, "no audit records match the filter"},
+		{tabSignatures, "no signatures match the filter"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			m := listModel(t, 5, 30)
+			m.tab = tc.tab
+			m = press(t, m, "/", "z", "z", "z", "esc")
+			if !strings.Contains(m.View(), tc.want) {
+				t.Errorf("zero matches should render %q:\n%s", tc.want, m.View())
+			}
+		})
+	}
+}
+
+func TestRulesModeFilterComposesWithSearch(t *testing.T) {
+	m := testModel(t) // one shadow (approval/claude), one autonomous (choice/codex)
+	m.tab = tabSignatures
+
+	m = press(t, m, "f") // mode filter: shadow
+	if m.sigMode != domain.ModeShadow || len(m.visibleSignatures()) != 1 {
+		t.Fatal("precondition: f should filter to the shadow rule")
+	}
+	// A query matching only the autonomous rule composes to zero rows.
+	m = press(t, m, "/", "c", "o", "d", "e", "x", "esc")
+	if len(m.visibleSignatures()) != 0 {
+		t.Errorf("mode=shadow + query=codex should match nothing, got %d", len(m.visibleSignatures()))
+	}
+	if !strings.Contains(m.View(), "no signatures match the filter") {
+		t.Errorf("composed zero-match should show the empty state:\n%s", m.View())
+	}
+	// A query matching the shadow rule keeps it under the composed filters.
+	m.query[tabSignatures] = "claude"
+	if got := m.visibleSignatures(); len(got) != 1 || got[0].Mode != domain.ModeShadow {
+		t.Errorf("mode=shadow + query=claude should keep the shadow rule, got %d", len(got))
+	}
+	// Cycling f off keeps the search query applied.
+	m = press(t, m, "f", "f")
+	if m.sigMode != "" {
+		t.Fatalf("f cycle should return to all-modes, got %q", m.sigMode)
+	}
+	if got := m.visibleSignatures(); len(got) != 1 {
+		t.Errorf("search alone should still filter, got %d rows", len(got))
+	}
+}
+
+func TestQueryEditClampsCursorAndOffset(t *testing.T) {
+	m := listModel(t, 40, 12)
+	m.tab = tabEscalations
+	for i := 0; i < 100; i++ {
+		m = press(t, m, "down")
+	}
+	// Filter down to rows 00–09: cursor and offset must clamp per keystroke
+	// (CR-016).
+	m = press(t, m, "/")
+	for _, r := range "rationale-row-0" {
+		m = press(t, m, string(r))
+	}
+	if n := len(m.visibleEscalations()); n != 10 {
+		t.Fatalf("filter should match 10 rows, got %d", n)
+	}
+	if m.cursor >= 10 {
+		t.Errorf("cursor=%d must clamp to the filtered count", m.cursor)
+	}
+	page := m.listPageSize()
+	if off := m.offsets[tabEscalations]; off > 10-page {
+		t.Errorf("offset=%d must clamp to rowCount-page (%d)", off, 10-page)
+	}
+	if off := m.offsets[tabEscalations]; m.cursor < off || m.cursor >= off+page {
+		t.Errorf("cursor %d must stay inside the window [%d,%d)", m.cursor, off, off+page)
+	}
+}
+
+func TestFilteredSelectionConfirms(t *testing.T) {
+	// With a filter active, enter/y confirms the FILTERED row under the
+	// cursor — not the row at the same index of the unfiltered list.
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	h := &captureHerdr{}
+	app := &frontend.App{Store: st, Herdr: h, ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	ctx := context.Background()
+	idA, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:pA", SituationType: domain.SituationApproval, Trigger: "a",
+		Action: "escalated", Status: "escalated", Suggestion: "respond: Apple", CreatedAt: time.Now(),
+	})
+	st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:pB", SituationType: domain.SituationChoice, Trigger: "b",
+		Action: "escalated", Status: "escalated", Suggestion: "respond: Banana",
+		CreatedAt: time.Now().Add(time.Second),
+	})
+
+	m := New(ctx, app)
+	m.width, m.height = 100, 30
+	upd, _ := m.Update(refreshData(ctx, app))
+	m = upd.(Model)
+	m.tab = tabEscalations
+	// Unfiltered, cursor 0 is B (newest first). Filter to A only.
+	m = press(t, m, "/", "a", "p", "p", "r", "o", "v", "a", "l", "esc")
+	if got := m.visibleEscalations(); len(got) != 1 || got[0].ID != idA {
+		t.Fatalf("filter should leave only escalation A, got %+v", got)
+	}
+	if m.cursor != 0 {
+		t.Fatalf("cursor should be 0, got %d", m.cursor)
+	}
+
+	upd, cmd := m.Update(pressKeyMsg("enter"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("enter on the filtered row should issue the confirm command")
+	}
+	res, ok := cmd().(actionResultMsg)
+	if !ok || res.err != nil {
+		t.Fatalf("confirm should succeed, got %+v", res)
+	}
+	if !strings.Contains(res.message, fmt.Sprintf("#%d", idA)) {
+		t.Errorf("should confirm the filtered row #%d, message %q", idA, res.message)
+	}
+	if len(h.sent) != 1 || h.sent[0] != "Apple" {
+		t.Errorf("should deliver A's suggestion, got %v", h.sent)
+	}
+}
+
+// --- Durable status area (CR-025, CR-026) ---
+
+func TestStatusAreaDurableAcrossNavigation(t *testing.T) {
+	m := listModel(t, 5, 30)
+	m.tab = tabEscalations
+
+	upd, _ := m.Update(actionResultMsg{message: "never-auto pattern added"})
+	m = upd.(Model)
+	if m.status == nil || m.status.text != "never-auto pattern added" || m.status.err {
+		t.Fatalf("actionResultMsg should set the durable status, got %+v", m.status)
+	}
+	want := fmt.Sprintf("✓ never-auto pattern added  %s", m.status.at.Format("15:04:05"))
+	if !strings.Contains(m.View(), want) {
+		t.Errorf("view missing status %q:\n%s", want, m.View())
+	}
+
+	// Navigation must not clear it: cursor moves and tab switches.
+	m = press(t, m, "down", "up", "tab", "tab")
+	if !strings.Contains(m.View(), want) {
+		t.Errorf("status must persist across navigation:\n%s", m.View())
+	}
+	// The transient hint line coexists without replacing the status.
+	m.tab = tabSignatures
+	m = press(t, m, "f")
+	view := m.View()
+	if m.message != "filter: shadow" || !strings.Contains(view, "filter: shadow") {
+		t.Errorf("f should set and render the transient filter hint, message=%q", m.message)
+	}
+	if !strings.Contains(view, want) {
+		t.Errorf("transient hints must not clear the status area:\n%s", view)
+	}
+
+	// The next outcome replaces it; errors render with ✗.
+	upd, _ = m.Update(actionResultMsg{err: errors.New("boom")})
+	m = upd.(Model)
+	view = m.View()
+	if !strings.Contains(view, "✗ boom") {
+		t.Errorf("error outcome should render with ✗:\n%s", view)
+	}
+	if strings.Contains(view, "never-auto pattern added") {
+		t.Errorf("new outcome must replace the old status:\n%s", view)
+	}
+}
+
+// --- Rules full signature id (CR-032) ---
+
+func TestRulesListShowsFullSignatureAndAutoSizes(t *testing.T) {
+	m := testModel(t)
+	m.tab = tabSignatures
+	view := m.View()
+	// The column sizes to the widest visible id (25 cells): the widest row
+	// gets a single separator space, the narrower one is padded to align.
+	if !strings.Contains(view, "approval:1234abcd5678efab approval") {
+		t.Errorf("widest full id should render with the next column adjacent:\n%s", view)
+	}
+	if !strings.Contains(view, "choice:ffff0000eeee1111   choice") {
+		t.Errorf("narrower id should pad to the widest id's column:\n%s", view)
+	}
+	if strings.Contains(view, "1234abc…") || strings.Contains(view, "ffff0000e…") {
+		t.Errorf("rules rows must not abbreviate via shortSig:\n%s", view)
+	}
+}
+
+func TestSignatureDetailAndDeletePromptStillShortSig(t *testing.T) {
+	m, _, _ := appModel(t)
+	// Detail overlay title keeps the abbreviated form.
+	upd, cmd := m.Update(pressKeyMsg("v"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("v should load the signature detail")
+	}
+	upd, _ = m.Update(cmd())
+	m = upd.(Model)
+	if m.detail == nil || m.detail.title != "Signature approval:deadbee…" {
+		t.Fatalf("detail title should use shortSig, got %+v", m.detail)
+	}
+	m = press(t, m, "esc")
+	// Delete prompt keeps the abbreviated form too.
+	m = press(t, m, "x")
+	if m.prompt == nil || !strings.Contains(m.prompt.label, "approval:deadbee…") {
+		t.Errorf("delete prompt should use shortSig, got %+v", m.prompt)
+	}
+}
+
+// --- Config tab completeness (CR-033/036/037, AR-034/035) ---
+
+// configModel builds a Model on the Config tab from cfg.
+func configModel(t *testing.T, cfg config.Config) Model {
+	t.Helper()
+	m := Model{width: 100, height: 60}
+	upd, _ := m.Update(refreshMsg{cfg: cfg})
+	m = upd.(Model)
+	m.tab = tabConfig
+	return m
+}
+
+// itemIndex finds the first Config row matching pred.
+func itemIndex(t *testing.T, m Model, pred func(ruleItem) bool) int {
+	t.Helper()
+	for i, it := range m.items {
+		if pred(it) {
+			return i
+		}
+	}
+	t.Fatal("expected config row not found")
+	return -1
+}
+
+func TestConfigShowsIndicatorAndCaptureRows(t *testing.T) {
+	cfg := config.Default()
+	cfg.Safety.IrreversibleIndicators = []string{"drop table"}
+	cfg.Safety.IndicatorRules = []config.IndicatorRule{{Pattern: "rm -rf /", Agents: []string{"claude"}}}
+	m := configModel(t, cfg)
+	view := m.View()
+	for _, want := range []string{
+		"Safety indicators (read-only — edit config.toml)",
+		"indicator #0  drop table",
+		"indicator-rule #0  agents=claude  rm -rf /",
+		"Capture delays (read-only — edit config.toml)",
+		"defaults  start=1000ms event=200ms (built-in)", // no [[capture_delay]] configured
+	} {
+		if !strings.Contains(view, want) {
+			t.Errorf("config tab missing %q:\n%s", want, view)
+		}
+	}
+
+	// With rules configured, each renders and the defaults row disappears.
+	cfg.CaptureDelays = []config.CaptureDelayRule{{AgentType: "claude", StartMs: 500, EventMs: 100}}
+	m = configModel(t, cfg)
+	view = m.View()
+	if !strings.Contains(view, "capture-delay #0  agent=claude start=500ms event=100ms") {
+		t.Errorf("configured capture-delay row missing:\n%s", view)
+	}
+	if strings.Contains(view, "(built-in)") {
+		t.Errorf("built-in defaults row must not render when rules exist:\n%s", view)
+	}
+}
+
+func TestConfigReadOnlyRowsRefuseEditAndRemove(t *testing.T) {
+	cfg := config.Default()
+	cfg.Safety.IrreversibleIndicators = []string{"drop table"}
+	kinds := []string{"indicator", "capture"}
+	keys := []string{"enter", "e", "x"}
+	for _, kind := range kinds {
+		for _, key := range keys {
+			t.Run(kind+"/"+key, func(t *testing.T) {
+				m := configModel(t, cfg)
+				m.cursor = itemIndex(t, m, func(it ruleItem) bool { return it.kind == kind })
+				upd, cmd := m.Update(pressKeyMsg(key))
+				m = upd.(Model)
+				if cmd != nil {
+					t.Fatalf("%s on a %s row must not run a mutation", key, kind)
+				}
+				if m.prompt != nil {
+					t.Fatalf("%s on a %s row must not open a prompt", key, kind)
+				}
+				if !strings.Contains(m.message, "read-only") || !strings.Contains(m.message, "config.toml") {
+					t.Errorf("expected the config.toml pointer message, got %q", m.message)
+				}
+			})
+		}
+	}
+}
+
+func TestConfigTUIReadOnlyFieldsNoPrompt(t *testing.T) {
+	readOnly := []string{"llm.command", "llm.rewrite_command", "llm.rewrite_fallback_template", "embedding.model_path"}
+	for _, key := range readOnly {
+		for _, k := range []string{"enter", "e"} {
+			t.Run(key+"/"+k, func(t *testing.T) {
+				m := configModel(t, config.Default())
+				m.cursor = itemIndex(t, m, func(it ruleItem) bool { return it.kind == "field" && it.key == key })
+				upd, cmd := m.Update(pressKeyMsg(k))
+				m = upd.(Model)
+				if cmd != nil || m.prompt != nil {
+					t.Fatalf("%s on read-only field %s must not open the edit prompt", k, key)
+				}
+				if !strings.Contains(m.message, "read-only in the TUI") ||
+					!strings.Contains(m.message, "hap config set "+key) {
+					t.Errorf("expected the read-only pointer message, got %q", m.message)
+				}
+			})
+		}
+	}
+	// An editable field still opens the prompt.
+	m := configModel(t, config.Default())
+	m.cursor = itemIndex(t, m, func(it ruleItem) bool { return it.kind == "field" && it.key == "llm.timeout_seconds" })
+	m = press(t, m, "enter")
+	if m.prompt == nil || !strings.Contains(m.prompt.label, "set llm.timeout_seconds") {
+		t.Errorf("editable field should open the edit prompt, got %+v", m.prompt)
+	}
+}
+
+func TestConfigLongValueTruncatesToOneLine(t *testing.T) {
+	cfg := config.Default()
+	cfg.LLM.Command = []string{"claude", "--append-system-prompt", strings.Repeat("x", 300)}
+	m := configModel(t, cfg)
+	found := false
+	for _, ln := range strings.Split(m.View(), "\n") {
+		if !strings.Contains(ln, "llm.command") {
+			continue
+		}
+		found = true
+		if n := len([]rune(ln)); n > m.contentWidth() {
+			t.Errorf("llm.command row is %d cells, must fit contentWidth %d: %q", n, m.contentWidth(), ln)
+		}
+		if !strings.Contains(ln, "…") {
+			t.Errorf("long value should truncate with an ellipsis: %q", ln)
+		}
+	}
+	if !found {
+		t.Fatal("llm.command row not rendered")
+	}
+}
+
+// --- Non-list tabs unchanged (AR-032) ---
+
+func TestNonListTabsIgnoreSearch(t *testing.T) {
+	for _, tb := range []tab{tabConfig, tabKill} {
+		t.Run(tabNames[tb], func(t *testing.T) {
+			m := listModel(t, 5, 30)
+			m.tab = tb
+			before := m.View()
+			upd, cmd := m.Update(pressKeyMsg("/"))
+			m = upd.(Model)
+			if cmd != nil || m.searching {
+				t.Fatalf("/ on %s must not enter search mode", tabNames[tb])
+			}
+			for i := range m.query {
+				if m.query[i] != "" {
+					t.Fatalf("/ on %s must not touch any query, got %q", tabNames[tb], m.query[i])
+				}
+			}
+			if m.View() != before {
+				t.Errorf("/ on %s must be a no-op:\n%s", tabNames[tb], m.View())
+			}
+		})
+	}
+	// Config navigation still walks its unfiltered rows.
+	m := configModel(t, config.Default())
+	m = press(t, m, "down", "down")
+	if m.cursor != 2 {
+		t.Errorf("Config cursor navigation should be unchanged, got %d", m.cursor)
+	}
+}
+
+// TestBackspaceClearsActiveFilter covers the normal-mode backspace the
+// filter hint advertises: with a retained filter and search mode closed,
+// backspace clears the whole query and restores the full list.
+func TestBackspaceClearsActiveFilter(t *testing.T) {
+	m := listModel(t, 10, 30)
+	m = press(t, m, "/", "0", "3", "esc")
+	if got := m.rowCount(); got != 1 {
+		t.Fatalf("filter should leave 1 agent visible, got %d", got)
+	}
+	upd, _ := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = upd.(Model)
+	if m.query[tabAgents] != "" || m.rowCount() != 10 {
+		t.Errorf("backspace outside search mode should clear the filter, query=%q rows=%d",
+			m.query[tabAgents], m.rowCount())
+	}
+	// Without an active filter it stays a no-op.
+	before := m.View()
+	upd, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if got := upd.(Model).View(); got != before {
+		t.Errorf("backspace with no filter should be a no-op")
+	}
+}
+
+// TestOneLineTruncatesByDisplayCells pins cell-width truncation: wide runes
+// (CJK) must not overflow the row budget (AR-010).
+func TestOneLineTruncatesByDisplayCells(t *testing.T) {
+	wide := strings.Repeat("好", 20) // 40 display cells
+	got := oneLine(wide, 10)
+	if w := runewidth.StringWidth(got); w > 10 {
+		t.Errorf("oneLine width = %d cells, want <= 10 (%q)", w, got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncated value should end with ellipsis, got %q", got)
+	}
+	if got := oneLine("short", 10); got != "short" {
+		t.Errorf("under-budget value must pass through, got %q", got)
+	}
+}

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -1,0 +1,135 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+)
+
+// palette is the set of color roles every TUI style resolves through
+// (CR-020): one place to look colors up, no scattered literals.
+type palette struct {
+	title   lipgloss.Color
+	section lipgloss.Color
+	err     lipgloss.Color
+	ok      lipgloss.Color
+	paused  lipgloss.Color
+	running lipgloss.Color
+	help    lipgloss.Color // empty = faint only (the original look)
+}
+
+// themes are the named palettes selectable via `[tui] theme` (AR-021).
+// "default" carries the exact 256-color values the TUI shipped with
+// (AR-022) so empty, "default", and unknown names all render identically
+// to the pre-theming TUI. config.ValidThemes mirrors these names; a test
+// keeps the two in sync.
+var themes = map[string]palette{
+	"default": {
+		title:   lipgloss.Color("205"),
+		section: lipgloss.Color("117"),
+		err:     lipgloss.Color("196"),
+		ok:      lipgloss.Color("46"),
+		paused:  lipgloss.Color("196"),
+		running: lipgloss.Color("46"),
+	},
+	"dark": {
+		title:   lipgloss.Color("213"),
+		section: lipgloss.Color("111"),
+		err:     lipgloss.Color("203"),
+		ok:      lipgloss.Color("84"),
+		paused:  lipgloss.Color("203"),
+		running: lipgloss.Color("84"),
+		help:    lipgloss.Color("245"),
+	},
+	"light": {
+		title:   lipgloss.Color("161"),
+		section: lipgloss.Color("25"),
+		err:     lipgloss.Color("124"),
+		ok:      lipgloss.Color("28"),
+		paused:  lipgloss.Color("124"),
+		running: lipgloss.Color("28"),
+		help:    lipgloss.Color("240"),
+	},
+	"high-contrast": {
+		title:   lipgloss.Color("231"),
+		section: lipgloss.Color("226"),
+		err:     lipgloss.Color("201"),
+		ok:      lipgloss.Color("46"),
+		paused:  lipgloss.Color("201"),
+		running: lipgloss.Color("46"),
+		help:    lipgloss.Color("252"),
+	},
+}
+
+// resolvePalette picks the named theme — empty and unknown names fall back
+// to default (AR-022, AR-030) — then layers any per-role overrides on top;
+// unset roles inherit the theme's value (AR-023).
+func resolvePalette(t config.TUI) palette {
+	p, found := themes[strings.ToLower(strings.TrimSpace(t.Theme))]
+	if !found {
+		p = themes["default"]
+	}
+	set := func(dst *lipgloss.Color, v string) {
+		if v != "" {
+			*dst = lipgloss.Color(v)
+		}
+	}
+	o := t.Palette
+	set(&p.title, o.Title)
+	set(&p.section, o.Section)
+	set(&p.err, o.Error)
+	set(&p.ok, o.OK)
+	set(&p.paused, o.Paused)
+	set(&p.running, o.Running)
+	set(&p.help, o.Help)
+	return p
+}
+
+// styles are the concrete lipgloss styles the views render with, all
+// derived from one palette (CR-020, CR-024, CR-026).
+type styles struct {
+	title       lipgloss.Style
+	activeTab   lipgloss.Style
+	inactiveTab lipgloss.Style
+	paused      lipgloss.Style
+	running     lipgloss.Style
+	selected    lipgloss.Style
+	section     lipgloss.Style
+	help        lipgloss.Style
+	err         lipgloss.Style
+	ok          lipgloss.Style
+}
+
+func newStyles(p palette) styles {
+	help := lipgloss.NewStyle().Faint(true)
+	if p.help != "" {
+		help = help.Foreground(p.help)
+	}
+	return styles{
+		title:       lipgloss.NewStyle().Bold(true).Foreground(p.title),
+		activeTab:   lipgloss.NewStyle().Bold(true).Underline(true),
+		inactiveTab: lipgloss.NewStyle().Faint(true),
+		paused:      lipgloss.NewStyle().Bold(true).Foreground(p.paused),
+		running:     lipgloss.NewStyle().Bold(true).Foreground(p.running),
+		selected:    lipgloss.NewStyle().Reverse(true),
+		section:     lipgloss.NewStyle().Bold(true).Foreground(p.section),
+		help:        help,
+		err:         lipgloss.NewStyle().Foreground(p.err),
+		ok:          lipgloss.NewStyle().Foreground(p.ok),
+	}
+}
+
+// defaultStyles serves renders that happen before the first config refresh
+// (and zero-value Models in tests).
+var defaultStyles = newStyles(themes["default"])
+
+// styles returns the palette-resolved styles, falling back to the default
+// palette until config arrives.
+func (m Model) styles() styles {
+	if m.st != nil {
+		return *m.st
+	}
+	return defaultStyles
+}

--- a/internal/tui/palette_test.go
+++ b/internal/tui/palette_test.go
@@ -1,0 +1,174 @@
+package tui
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+)
+
+// TestPaletteDefaultResolution covers AR-022/AR-030: empty, "default",
+// case-variant, and unknown theme names all resolve to the identical
+// default palette carrying the exact pre-theming colors.
+func TestPaletteDefaultResolution(t *testing.T) {
+	want := palette{
+		title:   lipgloss.Color("205"),
+		section: lipgloss.Color("117"),
+		err:     lipgloss.Color("196"),
+		ok:      lipgloss.Color("46"),
+		paused:  lipgloss.Color("196"),
+		running: lipgloss.Color("46"),
+		help:    lipgloss.Color(""),
+	}
+	for _, theme := range []string{"", "default", "DEFAULT", "Default", "  default  ", "solarized"} {
+		got := resolvePalette(config.TUI{Theme: theme})
+		if got != want {
+			t.Errorf("resolvePalette(Theme=%q) = %+v, want default palette %+v", theme, got, want)
+		}
+	}
+}
+
+// TestPaletteNamedThemes checks each named theme is selectable, matches its
+// themes-map entry, and is distinct from default.
+func TestPaletteNamedThemes(t *testing.T) {
+	def := themes["default"]
+	for _, name := range config.ValidThemes {
+		if name == "default" {
+			continue
+		}
+		got := resolvePalette(config.TUI{Theme: name})
+		want, ok := themes[name]
+		if !ok {
+			t.Fatalf("themes map missing %q", name)
+		}
+		if got != want {
+			t.Errorf("resolvePalette(Theme=%q) = %+v, want themes[%q] = %+v", name, got, name, want)
+		}
+		if got.title == def.title {
+			t.Errorf("theme %q title %q equals default's title — themes must be distinct", name, got.title)
+		}
+	}
+}
+
+// TestPaletteOverrideLayering covers AR-023: a per-role override replaces
+// only that role; unset roles inherit the selected theme.
+func TestPaletteOverrideLayering(t *testing.T) {
+	got := resolvePalette(config.TUI{
+		Theme:   "dark",
+		Palette: config.PaletteOverrides{Title: "99"},
+	})
+	if got.title != lipgloss.Color("99") {
+		t.Errorf("title override: got %q, want %q", got.title, "99")
+	}
+	dark := themes["dark"]
+	if got.section != dark.section {
+		t.Errorf("section should inherit dark theme: got %q, want %q", got.section, dark.section)
+	}
+	if got.help != dark.help {
+		t.Errorf("help should inherit dark theme: got %q, want %q", got.help, dark.help)
+	}
+}
+
+// TestPaletteOverrideOnDefaultTheme checks overrides layer over the default
+// theme the same way (empty theme name).
+func TestPaletteOverrideOnDefaultTheme(t *testing.T) {
+	got := resolvePalette(config.TUI{
+		Palette: config.PaletteOverrides{Error: "#ff5faf", Help: "240"},
+	})
+	if got.err != lipgloss.Color("#ff5faf") {
+		t.Errorf("err override: got %q, want %q", got.err, "#ff5faf")
+	}
+	if got.help != lipgloss.Color("240") {
+		t.Errorf("help override: got %q, want %q", got.help, "240")
+	}
+	def := themes["default"]
+	if got.title != def.title || got.section != def.section || got.ok != def.ok {
+		t.Errorf("unset roles should inherit default: got %+v, want inherited from %+v", got, def)
+	}
+}
+
+// TestPaletteThemesMatchValidThemes keeps the tui themes map and
+// config.ValidThemes in sync in both directions.
+func TestPaletteThemesMatchValidThemes(t *testing.T) {
+	fromMap := make([]string, 0, len(themes))
+	for name := range themes {
+		fromMap = append(fromMap, name)
+	}
+	sort.Strings(fromMap)
+
+	fromConfig := append([]string(nil), config.ValidThemes...)
+	sort.Strings(fromConfig)
+
+	if len(fromMap) != len(fromConfig) {
+		t.Fatalf("themes map has %d entries %v; config.ValidThemes has %d %v", len(fromMap), fromMap, len(fromConfig), fromConfig)
+	}
+	for i := range fromMap {
+		if fromMap[i] != fromConfig[i] {
+			t.Fatalf("themes map %v != config.ValidThemes %v", fromMap, fromConfig)
+		}
+	}
+}
+
+// TestPaletteNewStylesWiresPalette checks newStyles derives its styles from
+// the given palette: two palettes differing in a role produce styles whose
+// foregrounds differ for that role, and the help style only gets a
+// foreground when the palette sets one.
+func TestPaletteNewStylesWiresPalette(t *testing.T) {
+	// a uses a distinct color per role so swapped wiring is caught —
+	// e.g. paused vs running share a color in every shipped theme.
+	a := palette{
+		title:   lipgloss.Color("1"),
+		section: lipgloss.Color("2"),
+		err:     lipgloss.Color("3"),
+		ok:      lipgloss.Color("4"),
+		paused:  lipgloss.Color("5"),
+		running: lipgloss.Color("6"),
+	}
+	b := a
+	b.ok = lipgloss.Color("99")
+	b.err = lipgloss.Color("21")
+
+	sa := newStyles(a)
+	sb := newStyles(b)
+
+	roles := []struct {
+		name  string
+		style lipgloss.Style
+		want  lipgloss.Color
+	}{
+		{"title", sa.title, a.title},
+		{"section", sa.section, a.section},
+		{"err", sa.err, a.err},
+		{"ok", sa.ok, a.ok},
+		{"paused", sa.paused, a.paused},
+		{"running", sa.running, a.running},
+	}
+	for _, r := range roles {
+		if r.style.GetForeground() != r.want {
+			t.Errorf("styles.%s foreground = %v, want palette value %q", r.name, r.style.GetForeground(), r.want)
+		}
+	}
+	if sb.ok.GetForeground() == sa.ok.GetForeground() {
+		t.Errorf("ok foreground unchanged (%v) despite palette change", sb.ok.GetForeground())
+	}
+	if sb.err.GetForeground() == sa.err.GetForeground() {
+		t.Errorf("err foreground unchanged (%v) despite palette change", sb.err.GetForeground())
+	}
+
+	// help: default palette leaves it faint-only (no foreground set);
+	// a palette with help set colors it.
+	if fg, ok := sa.help.GetForeground().(lipgloss.Color); ok && fg != "" {
+		t.Errorf("default help style should have no foreground, got %q", fg)
+	}
+	withHelp := a
+	withHelp.help = lipgloss.Color("245")
+	sh := newStyles(withHelp)
+	if sh.help.GetForeground() != withHelp.help {
+		t.Errorf("help foreground = %v, want %q", sh.help.GetForeground(), withHelp.help)
+	}
+	if !sh.help.GetFaint() {
+		t.Error("help style should stay faint even with a foreground color")
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/mattn/go-runewidth"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
@@ -37,18 +36,11 @@ const (
 
 var tabNames = []string{"Agents", "Escalations", "Audit", "Rules", "Config", "Pause/Kill"}
 
-var (
-	titleStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
-	activeTab     = lipgloss.NewStyle().Bold(true).Underline(true)
-	inactiveTab   = lipgloss.NewStyle().Faint(true)
-	pausedStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("196"))
-	runningStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("46"))
-	selectedStyle = lipgloss.NewStyle().Reverse(true)
-	sectionStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("117"))
-	helpStyle     = lipgloss.NewStyle().Faint(true)
-	errStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
-	okStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("46"))
-)
+// isList reports whether t renders a scrollable, searchable row list.
+// Config and Pause/Kill keep their existing unwindowed navigation (AR-032).
+func (t tab) isList() bool {
+	return t == tabAgents || t == tabEscalations || t == tabAudit || t == tabSignatures
+}
 
 type refreshMsg struct {
 	status      frontend.Status
@@ -70,6 +62,15 @@ type sigDetailMsg struct {
 type actionResultMsg struct {
 	message string
 	err     error
+}
+
+// statusNote is a durable action outcome shown in the status area until
+// the next outcome replaces it (CR-025) — unlike the transient m.message
+// hint line, navigation never clears it.
+type statusNote struct {
+	text string
+	err  bool
+	at   time.Time
 }
 
 type tickMsg time.Time
@@ -94,9 +95,11 @@ type detailView struct {
 	confirmID int64
 }
 
-// ruleItem is one navigable row of the Config tab.
+// ruleItem is one navigable row of the Config tab. "indicator" and
+// "capture" rows are read-only (AR-034, AR-035): they render for
+// visibility and refuse edit/remove with a config.toml pointer.
 type ruleItem struct {
-	kind  string // "field" | "pattern" | "source"
+	kind  string // "field" | "pattern" | "source" | "indicator" | "capture"
 	key   string // config field key (fields)
 	index int    // slice index (patterns / sources)
 	value string // pattern text / source path — verified on removal
@@ -119,18 +122,86 @@ type Model struct {
 	detail  *detailView
 	width   int
 	height  int
+
+	offsets   [tabCount]int    // per-list viewport offset (AR-001)
+	query     [tabCount]string // per-tab search filter (AR-013)
+	searching bool             // search-input mode on the active tab (AR-011)
+	status    *statusNote      // durable action outcome (CR-025)
+	st        *styles          // palette-resolved styles; nil = default palette
 }
 
-// visibleSignatures applies the display-side mode filter (f key).
+// matchesQuery reports whether any of the row's visible column values
+// contains tab t's query as a case-insensitive substring (AR-013).
+func (m Model) matchesQuery(t tab, fields ...string) bool {
+	q := strings.ToLower(m.query[t])
+	if q == "" {
+		return true
+	}
+	for _, f := range fields {
+		if strings.Contains(strings.ToLower(f), q) {
+			return true
+		}
+	}
+	return false
+}
+
+// visibleAgents applies the Agents tab search filter.
+func (m Model) visibleAgents() []domain.AgentTransition {
+	if m.query[tabAgents] == "" {
+		return m.data.status.MonitoredAgents
+	}
+	var out []domain.AgentTransition
+	for _, a := range m.data.status.MonitoredAgents {
+		if m.matchesQuery(tabAgents, m.data.status.AgentName(a.AgentID),
+			a.AgentID, a.AgentType, a.Status) {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// visibleEscalations applies the Escalations tab search filter.
+func (m Model) visibleEscalations() []domain.AuditRecord {
+	return m.filterAudit(tabEscalations, m.data.escalations)
+}
+
+// visibleAudit applies the Audit tab search filter.
+func (m Model) visibleAudit() []domain.AuditRecord {
+	return m.filterAudit(tabAudit, m.data.audit)
+}
+
+func (m Model) filterAudit(t tab, rows []domain.AuditRecord) []domain.AuditRecord {
+	if m.query[t] == "" {
+		return rows
+	}
+	var out []domain.AuditRecord
+	for _, r := range rows {
+		if m.matchesQuery(t,
+			fmt.Sprintf("#%d", r.ID), string(r.SituationType), r.Status,
+			m.data.status.AgentName(r.AgentID), r.AgentID, m.agentTypeFor(r),
+			r.Action, r.Rationale, r.Suggestion) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// visibleSignatures applies the display-side mode filter (f key) composed
+// with the Rules tab search query (CR-017).
 func (m Model) visibleSignatures() []frontend.SignatureRow {
-	if m.sigMode == "" {
+	if m.sigMode == "" && m.query[tabSignatures] == "" {
 		return m.data.signatures
 	}
 	var out []frontend.SignatureRow
 	for _, r := range m.data.signatures {
-		if r.Mode == m.sigMode {
-			out = append(out, r)
+		if m.sigMode != "" && r.Mode != m.sigMode {
+			continue
 		}
+		if !m.matchesQuery(tabSignatures, r.Signature, string(r.SituationType),
+			r.AgentType, string(r.Mode), r.TopAction) {
+			continue
+		}
+		out = append(out, r)
 	}
 	return out
 }
@@ -213,6 +284,45 @@ func buildRuleItems(cfg config.Config) []ruleItem {
 			label: label,
 		})
 	}
+	// Read-only visibility rows (AR-034, AR-035): the suspected-irreversible
+	// indicator patterns and the capture-delay rules, previously invisible
+	// outside config.toml.
+	for i, p := range cfg.Safety.IrreversibleIndicators {
+		items = append(items, ruleItem{
+			kind: "indicator", index: i, value: p,
+			label: fmt.Sprintf("indicator #%d  %s", i, p),
+		})
+	}
+	for i, r := range cfg.Safety.IndicatorRules {
+		scope := "*"
+		if len(r.Agents) > 0 {
+			scope = strings.Join(r.Agents, ",")
+		}
+		items = append(items, ruleItem{
+			kind: "indicator", index: len(cfg.Safety.IrreversibleIndicators) + i, value: r.Pattern,
+			label: fmt.Sprintf("indicator-rule #%d  agents=%s  %s", i, scope, r.Pattern),
+		})
+	}
+	if len(cfg.CaptureDelays) == 0 {
+		// No rules configured: show the effective built-in defaults so the
+		// operator can see what timing applies (AR-035).
+		items = append(items, ruleItem{
+			kind: "capture",
+			label: fmt.Sprintf("defaults  start=%dms event=%dms (built-in)",
+				cfg.CaptureDelay("*", true).Milliseconds(), cfg.CaptureDelay("*", false).Milliseconds()),
+		})
+	}
+	for i, r := range cfg.CaptureDelays {
+		at := r.AgentType
+		if at == "" {
+			at = "*"
+		}
+		items = append(items, ruleItem{
+			kind: "capture", index: i,
+			label: fmt.Sprintf("capture-delay #%d  agent=%s start=%dms event=%dms",
+				i, at, r.StartMs, r.EventMs),
+		})
+	}
 	return items
 }
 
@@ -225,13 +335,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.detail.lines = m.detail.build(m.wrapWidth())
 			m.detail.offset = min(m.detail.offset, max(0, len(m.detail.lines)-m.detailPageSize()))
 		}
+		m.clampListViewport()
 		return m, nil
 	case refreshMsg:
 		m.data = msg
 		m.items = buildRuleItems(msg.cfg)
-		if m.cursor >= m.rowCount() {
-			m.cursor = max(0, m.rowCount()-1)
+		// A failed refresh carries a zero config; keep the current palette
+		// rather than flickering back to the default while the error shows.
+		if msg.err == nil {
+			st := newStyles(resolvePalette(msg.cfg.TUI))
+			m.st = &st
 		}
+		m.clampListViewport()
 		// Drop marks whose escalations are no longer pending (deleted,
 		// confirmed, or resolved elsewhere) — marks track ids, not rows.
 		if len(m.marked) > 0 {
@@ -248,21 +363,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case actionResultMsg:
 		if msg.err != nil {
-			m.message = errStyle.Render(msg.err.Error())
+			m.status = &statusNote{text: msg.err.Error(), err: true, at: time.Now()}
 		} else if msg.message != "" {
-			m.message = okStyle.Render(msg.message)
+			m.status = &statusNote{text: msg.message, at: time.Now()}
 		}
+		// The status area shrinks the page by 2 — keep the cursor visible.
+		m.clampListViewport()
 		return m, m.refresh()
 	case tickMsg:
 		return m, tea.Batch(m.refresh(), tick())
 	case sigDetailMsg:
 		if msg.err != nil {
-			m.message = errStyle.Render(msg.err.Error())
+			m.status = &statusNote{text: msg.err.Error(), err: true, at: time.Now()}
 			return m, nil
 		}
 		gradN := m.data.cfg.Learning.GraduationN
 		build := func(width int) []string {
-			return signatureDetailLines(msg.row, msg.history, gradN, width)
+			return m.signatureDetailLines(msg.row, msg.history, gradN, width)
 		}
 		m.detail = &detailView{
 			title: fmt.Sprintf("Signature %s", shortSig(msg.row.Signature)),
@@ -295,11 +412,15 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.detail = nil
 			m.tab = (m.tab + 1) % tabCount
 			m.cursor = 0
+			m.offsets[m.tab] = 0
+			m.searching = false
 			m.message = ""
 		case "shift+tab", "left", "h":
 			m.detail = nil
 			m.tab = (m.tab + tabCount - 1) % tabCount
 			m.cursor = 0
+			m.offsets[m.tab] = 0
+			m.searching = false
 			m.message = ""
 		case "enter":
 			// On an escalation's detail view, Enter confirms+sends the
@@ -351,27 +472,66 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// Search-input mode (AR-011): every printable key edits the query —
+	// action and navigation bindings, `q`/`y` included, never fire while
+	// typing (CR-019). esc and enter both exit, retaining a non-empty
+	// query as the active filter (AR-014, AR-015).
+	if m.searching {
+		switch msg.Type {
+		case tea.KeyCtrlC:
+			return m, tea.Quit
+		case tea.KeyEsc, tea.KeyEnter:
+			m.searching = false
+		case tea.KeyBackspace:
+			if r := []rune(m.query[m.tab]); len(r) > 0 {
+				m.query[m.tab] = string(r[:len(r)-1])
+			}
+		case tea.KeySpace:
+			m.query[m.tab] += " "
+		case tea.KeyRunes:
+			m.query[m.tab] += string(msg.Runes)
+		}
+		m.clampListViewport() // CR-016
+		return m, nil
+	}
+
 	switch msg.String() {
 	case "q", "ctrl+c":
 		return m, tea.Quit
 	case "tab", "right", "l":
 		m.tab = (m.tab + 1) % tabCount
 		m.cursor = 0
+		m.offsets[m.tab] = 0
 		m.message = ""
 	case "shift+tab", "left", "h":
 		m.tab = (m.tab + tabCount - 1) % tabCount
 		m.cursor = 0
+		m.offsets[m.tab] = 0
 		m.message = ""
 	case "up", "k":
 		if m.cursor > 0 {
 			m.cursor--
 		}
+		m.scrollCursorIntoView()
 		m.message = ""
 	case "down", "j":
 		if m.cursor < m.rowCount()-1 {
 			m.cursor++
 		}
+		m.scrollCursorIntoView()
 		m.message = ""
+	case "/":
+		if m.tab.isList() {
+			m.searching = true
+			m.message = ""
+		}
+	case "backspace":
+		// The active-filter hint advertises backspace-to-clear outside
+		// search mode too; a no-op otherwise.
+		if m.tab.isList() && m.query[m.tab] != "" {
+			m.query[m.tab] = ""
+			m.clampListViewport()
+		}
 	case "p":
 		return m, m.do("automation paused", func(ctx context.Context) error { return m.app.Pause(ctx) })
 	case "r":
@@ -413,6 +573,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.sigMode = ""
 			}
 			m.cursor = 0
+			m.offsets[tabSignatures] = 0
 			m.message = "filter: " + orDash(string(m.sigMode))
 		}
 	case "a":
@@ -437,6 +598,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m.removeSelectedRule()
 		case tabAudit:
 			m.message = "audit log is append-only — entries can't be deleted individually"
+			m.scrollCursorIntoView() // the hint line shrinks the page
 		}
 	case "X":
 		switch m.tab {
@@ -460,14 +622,17 @@ func (m Model) do(okMsg string, fn func(context.Context) error) tea.Cmd {
 	}
 }
 
-func (m Model) rowCount() int {
-	switch m.tab {
+// rowCountFor counts tab t's currently visible rows: search-filter-aware
+// for the four list tabs (CR-008); Config and Pause/Kill keep their raw
+// counts so their navigation is untouched (AR-032).
+func (m Model) rowCountFor(t tab) int {
+	switch t {
 	case tabAgents:
-		return len(m.data.status.MonitoredAgents)
+		return len(m.visibleAgents())
 	case tabEscalations:
-		return len(m.data.escalations)
+		return len(m.visibleEscalations())
 	case tabAudit:
-		return len(m.data.audit)
+		return len(m.visibleAudit())
 	case tabSignatures:
 		return len(m.visibleSignatures())
 	case tabConfig:
@@ -478,15 +643,17 @@ func (m Model) rowCount() int {
 	return 0
 }
 
+func (m Model) rowCount() int { return m.rowCountFor(m.tab) }
+
 func (m Model) selectedAudit() *domain.AuditRecord {
 	switch m.tab {
 	case tabEscalations:
-		if m.cursor < len(m.data.escalations) {
-			return &m.data.escalations[m.cursor]
+		if esc := m.visibleEscalations(); m.cursor < len(esc) {
+			return &esc[m.cursor]
 		}
 	case tabAudit:
-		if m.cursor < len(m.data.audit) {
-			return &m.data.audit[m.cursor]
+		if rows := m.visibleAudit(); m.cursor < len(rows) {
+			return &rows[m.cursor]
 		}
 	}
 	return nil
@@ -555,6 +722,10 @@ func (m Model) toggleMarkSelected() (tea.Model, tea.Cmd) {
 	if m.cursor < m.rowCount()-1 {
 		m.cursor++
 	}
+	// The advance can walk the cursor past the window's bottom edge (and
+	// the mark message shrinks the page): keep the cursor row visible
+	// (AR-003).
+	m.scrollCursorIntoView()
 	return m, nil
 }
 
@@ -658,10 +829,11 @@ func (m Model) pruneEscalationsPrompt() (tea.Model, tea.Cmd) {
 // --- Agent rename ---
 
 func (m Model) renameSelected() (tea.Model, tea.Cmd) {
-	if m.cursor >= len(m.data.status.MonitoredAgents) {
+	agents := m.visibleAgents()
+	if m.cursor >= len(agents) {
 		return m, nil
 	}
-	agent := m.data.status.MonitoredAgents[m.cursor]
+	agent := agents[m.cursor]
 	current := m.data.status.AgentName(agent.AgentID)
 	target := agent.AgentID
 	app, ctx := m.app, m.ctx
@@ -687,8 +859,8 @@ func (m Model) renameSelected() (tea.Model, tea.Cmd) {
 func (m Model) viewSelected() (tea.Model, tea.Cmd) {
 	switch m.tab {
 	case tabAgents:
-		if m.cursor < len(m.data.status.MonitoredAgents) {
-			a := m.data.status.MonitoredAgents[m.cursor]
+		if agents := m.visibleAgents(); m.cursor < len(agents) {
+			a := agents[m.cursor]
 			build := func(width int) []string { return m.agentDetailLines(a, width) }
 			m.message = ""
 			m.detail = &detailView{
@@ -735,6 +907,87 @@ func (m Model) detailPageSize() int {
 		chrome++
 	}
 	return max(1, m.height-chrome)
+}
+
+// listPageSize is how many list rows fit under the current pane chrome,
+// mirroring detailPageSize's accounting (AR-002): header title + tabs +
+// blank (3), the more-rows indicator (1), and blank + help (2) — plus the
+// error line, the search/filter lines, and the prompt, hint, and status
+// areas when present.
+func (m Model) listPageSize() int {
+	if m.height <= 0 {
+		return 20
+	}
+	chrome := 6
+	if m.data.err != nil {
+		chrome++
+	}
+	if m.searching || (m.tab.isList() && m.query[m.tab] != "") {
+		chrome++
+	}
+	if m.tab == tabSignatures && m.sigMode != "" {
+		chrome++
+	}
+	if m.prompt != nil {
+		chrome += 2
+	}
+	if m.message != "" {
+		chrome += 2
+	}
+	if m.status != nil {
+		chrome += 2
+	}
+	return max(1, m.height-chrome)
+}
+
+// window clamps the active tab's offset to n rows and returns the visible
+// slice bounds; the caller renders rows[start:end] and the more-rows
+// indicator when end < n (AR-002, AR-009).
+func (m Model) window(n int) (start, end int) {
+	page := m.listPageSize()
+	start = min(m.offsets[m.tab], max(0, n-page))
+	start = max(0, start)
+	end = min(start+page, n)
+	return start, end
+}
+
+// scrollCursorIntoView moves the active list tab's offset so the shared
+// cursor stays visible (AR-003, AR-004).
+func (m *Model) scrollCursorIntoView() {
+	if !m.tab.isList() {
+		return
+	}
+	if m.cursor < m.offsets[m.tab] {
+		m.offsets[m.tab] = m.cursor
+	}
+	if page := m.listPageSize(); m.cursor >= m.offsets[m.tab]+page {
+		m.offsets[m.tab] = m.cursor - page + 1
+	}
+}
+
+// clampListViewport keeps every list tab's offset within
+// [0, rowCount−pageSize] and the shared cursor within the active tab's
+// visible (filtered) rows (CR-007, CR-008, CR-016).
+func (m *Model) clampListViewport() {
+	page := m.listPageSize()
+	for _, t := range []tab{tabAgents, tabEscalations, tabAudit, tabSignatures} {
+		if maxOff := max(0, m.rowCountFor(t)-page); m.offsets[t] > maxOff {
+			m.offsets[t] = maxOff
+		}
+	}
+	if m.cursor >= m.rowCount() {
+		m.cursor = max(0, m.rowCount()-1)
+	}
+	m.scrollCursorIntoView()
+}
+
+// renderMoreRows draws the clipped-rows affordance, matching the detail
+// overlay's more-lines indicator (AR-009).
+func (m Model) renderMoreRows(b *strings.Builder, remaining int) {
+	if remaining > 0 {
+		fmt.Fprintf(b, "%s\n", m.styles().help.Render(
+			fmt.Sprintf("… %d more row(s) — ↓ to scroll", remaining)))
+	}
 }
 
 // wrapWidth is the text width for the detail view.
@@ -793,11 +1046,11 @@ func (m Model) budget(prefixCells int, hasTrailing bool) (primary, trailing int)
 }
 
 // detailField appends a labelled, wrapped block; empty values are skipped.
-func detailField(lines []string, width int, label, value string) []string {
+func (m Model) detailField(lines []string, width int, label, value string) []string {
 	if strings.TrimSpace(value) == "" {
 		return lines
 	}
-	lines = append(lines, sectionStyle.Render(label))
+	lines = append(lines, m.styles().section.Render(label))
 	for _, ln := range wrapText(value, width) {
 		lines = append(lines, "  "+ln)
 	}
@@ -806,23 +1059,23 @@ func detailField(lines []string, width int, label, value string) []string {
 
 func (m Model) agentDetailLines(a domain.AgentTransition, w int) []string {
 	var lines []string
-	lines = detailField(lines, w, "Short name", orDash(m.data.status.AgentName(a.AgentID)))
-	lines = detailField(lines, w, "Agent id", a.AgentID)
-	lines = detailField(lines, w, "Workspace", locationLabel(a.WorkspaceID,
+	lines = m.detailField(lines, w, "Short name", orDash(m.data.status.AgentName(a.AgentID)))
+	lines = m.detailField(lines, w, "Agent id", a.AgentID)
+	lines = m.detailField(lines, w, "Workspace", locationLabel(a.WorkspaceID,
 		func() (string, int, bool) {
 			ws, ok := m.data.status.Workspaces[a.WorkspaceID]
 			return ws.Label, ws.Number, ok
 		}))
-	lines = detailField(lines, w, "Tab", locationLabel(a.TabID,
+	lines = m.detailField(lines, w, "Tab", locationLabel(a.TabID,
 		func() (string, int, bool) {
 			tab, ok := m.data.status.Tabs[a.TabID]
 			return tab.Label, tab.Number, ok
 		}))
-	lines = detailField(lines, w, "Pane", a.PaneID)
-	lines = detailField(lines, w, "Type", a.AgentType)
-	lines = detailField(lines, w, "Status", a.Status)
+	lines = m.detailField(lines, w, "Pane", a.PaneID)
+	lines = m.detailField(lines, w, "Type", a.AgentType)
+	lines = m.detailField(lines, w, "Status", a.Status)
 	if !a.At.IsZero() {
-		lines = detailField(lines, w, "Last transition", a.At.Format(time.RFC3339))
+		lines = m.detailField(lines, w, "Last transition", a.At.Format(time.RFC3339))
 	}
 	return lines
 }
@@ -849,33 +1102,33 @@ func (m Model) auditDetailLines(r domain.AuditRecord, snapshot string, w int) []
 	if n := m.data.status.AgentName(r.AgentID); n != "" {
 		agent = fmt.Sprintf("%s (%s)", n, r.AgentID)
 	}
-	lines = detailField(lines, w, "When", r.CreatedAt.Format(time.RFC3339))
-	lines = detailField(lines, w, "Status", r.Status)
-	lines = detailField(lines, w, "Situation", string(r.SituationType))
-	lines = detailField(lines, w, "Agent", agent)
-	lines = detailField(lines, w, "Agent type", m.agentTypeFor(r))
-	lines = detailField(lines, w, "Confidence", fmt.Sprintf("%.2f", r.Confidence))
-	lines = detailField(lines, w, "Trigger", r.Trigger)
-	lines = detailField(lines, w, "Suggestion", r.Suggestion)
-	lines = detailField(lines, w, "Action", r.Action)
-	lines = detailField(lines, w, "Input", r.Input)
-	lines = detailField(lines, w, "Rationale", r.Rationale)
-	lines = detailField(lines, w, "LLM output", r.LLMOutput)
-	lines = detailField(lines, w, "Signature", r.Signature)
+	lines = m.detailField(lines, w, "When", r.CreatedAt.Format(time.RFC3339))
+	lines = m.detailField(lines, w, "Status", r.Status)
+	lines = m.detailField(lines, w, "Situation", string(r.SituationType))
+	lines = m.detailField(lines, w, "Agent", agent)
+	lines = m.detailField(lines, w, "Agent type", m.agentTypeFor(r))
+	lines = m.detailField(lines, w, "Confidence", fmt.Sprintf("%.2f", r.Confidence))
+	lines = m.detailField(lines, w, "Trigger", r.Trigger)
+	lines = m.detailField(lines, w, "Suggestion", r.Suggestion)
+	lines = m.detailField(lines, w, "Action", r.Action)
+	lines = m.detailField(lines, w, "Input", r.Input)
+	lines = m.detailField(lines, w, "Rationale", r.Rationale)
+	lines = m.detailField(lines, w, "LLM output", r.LLMOutput)
+	lines = m.detailField(lines, w, "Signature", r.Signature)
 	if r.Signature != "" {
 		if row, ok := m.ruleFor(r.Signature); ok {
-			lines = detailField(lines, w, "Matched rule",
+			lines = m.detailField(lines, w, "Matched rule",
 				frontend.RuleSummary(row, m.data.cfg.Learning.GraduationN))
 		} else {
-			lines = detailField(lines, w, "Matched rule",
+			lines = m.detailField(lines, w, "Matched rule",
 				"none yet — learned when the operator confirms or resolves this")
 		}
 	}
 	if r.DecisionID != 0 {
-		lines = detailField(lines, w, "Decision id", fmt.Sprintf("%d", r.DecisionID))
+		lines = m.detailField(lines, w, "Decision id", fmt.Sprintf("%d", r.DecisionID))
 	}
 	if r.CorrectsAuditID != 0 {
-		lines = detailField(lines, w, "Corrects audit", fmt.Sprintf("#%d", r.CorrectsAuditID))
+		lines = m.detailField(lines, w, "Corrects audit", fmt.Sprintf("#%d", r.CorrectsAuditID))
 	}
 	// Current situation: the pane content THIS record was classified from
 	// (per entry). Below it, the matched rule's Original situation — the
@@ -884,13 +1137,13 @@ func (m Model) auditDetailLines(r domain.AuditRecord, snapshot string, w int) []
 	// detail. Legacy rows predate the per-entry column and show only the
 	// provenance block.
 	if r.PaneExcerpt != "" {
-		lines = detailField(lines, w, "Current situation", r.PaneExcerpt)
+		lines = m.detailField(lines, w, "Current situation", r.PaneExcerpt)
 	}
 	if r.Signature != "" {
 		if snapshot != "" {
-			lines = detailField(lines, w, "Original situation", snapshot)
+			lines = m.detailField(lines, w, "Original situation", snapshot)
 		} else {
-			lines = detailField(lines, w, "Original situation", "(not captured yet — recorded on the rule's next sighting)")
+			lines = m.detailField(lines, w, "Original situation", "(not captured yet — recorded on the rule's next sighting)")
 		}
 	}
 	return lines
@@ -991,29 +1244,29 @@ func (m Model) deleteSignaturePrompt() (tea.Model, tea.Cmd) {
 }
 
 // signatureDetailLines renders the full-record overlay for one signature.
-func signatureDetailLines(row frontend.SignatureRow, history []domain.DecisionRecord, graduationN, w int) []string {
+func (m Model) signatureDetailLines(row frontend.SignatureRow, history []domain.DecisionRecord, graduationN, w int) []string {
 	var lines []string
-	lines = detailField(lines, w, "Signature", row.Signature)
-	lines = detailField(lines, w, "Situation", string(row.SituationType))
-	lines = detailField(lines, w, "Agent type", orDash(row.AgentType))
-	lines = detailField(lines, w, "Mode", string(row.Mode))
-	lines = detailField(lines, w, "Streak", fmt.Sprintf("%d/%d confirmations toward graduation", row.ConsecutiveConfirmations, graduationN))
-	lines = detailField(lines, w, "Confidence", fmt.Sprintf("%.2f (cached)", row.CachedConfidence))
+	lines = m.detailField(lines, w, "Signature", row.Signature)
+	lines = m.detailField(lines, w, "Situation", string(row.SituationType))
+	lines = m.detailField(lines, w, "Agent type", orDash(row.AgentType))
+	lines = m.detailField(lines, w, "Mode", string(row.Mode))
+	lines = m.detailField(lines, w, "Streak", fmt.Sprintf("%d/%d confirmations toward graduation", row.ConsecutiveConfirmations, graduationN))
+	lines = m.detailField(lines, w, "Confidence", fmt.Sprintf("%.2f (cached)", row.CachedConfidence))
 	if row.TopAction != "" {
-		lines = detailField(lines, w, "Top action", fmt.Sprintf("%q over %d decision(s)", row.TopAction, row.Decisions))
+		lines = m.detailField(lines, w, "Top action", fmt.Sprintf("%q over %d decision(s)", row.TopAction, row.Decisions))
 	}
 	if row.GuardState != "" {
-		lines = detailField(lines, w, "Guard", row.GuardState)
+		lines = m.detailField(lines, w, "Guard", row.GuardState)
 	}
 	if !row.UpdatedAt.IsZero() {
-		lines = detailField(lines, w, "Updated", row.UpdatedAt.Format(time.RFC3339))
+		lines = m.detailField(lines, w, "Updated", row.UpdatedAt.Format(time.RFC3339))
 	}
 	// Rule provenance: what the pane showed when this signature was first
 	// seen — the situation the learned action answers.
 	if row.PaneExcerpt != "" {
-		lines = detailField(lines, w, "Original situation", row.PaneExcerpt)
+		lines = m.detailField(lines, w, "Original situation", row.PaneExcerpt)
 	} else {
-		lines = detailField(lines, w, "Original situation", "(not captured yet — recorded on the rule's next sighting)")
+		lines = m.detailField(lines, w, "Original situation", "(not captured yet — recorded on the rule's next sighting)")
 	}
 	if len(history) > 0 {
 		var b strings.Builder
@@ -1025,10 +1278,10 @@ func signatureDetailLines(row frontend.SignatureRow, history []domain.DecisionRe
 			fmt.Fprintf(&b, "#%d  %s  %q  source=%s%s\n",
 				d.ID, d.CreatedAt.Format("01-02 15:04:05"), d.ChosenAction, d.Source, marker)
 		}
-		lines = detailField(lines, w, "Recent decisions (newest first)", strings.TrimRight(b.String(), "\n"))
+		lines = m.detailField(lines, w, "Recent decisions (newest first)", strings.TrimRight(b.String(), "\n"))
 	}
 	if a := row.LastAudit; a != nil {
-		lines = detailField(lines, w, "Last audit",
+		lines = m.detailField(lines, w, "Last audit",
 			fmt.Sprintf("#%d (%s) %s — %s", a.ID, a.Status, a.Action, a.Rationale))
 	}
 	return lines
@@ -1053,7 +1306,22 @@ func (m Model) selectedRule() *ruleItem {
 
 func (m Model) editSelectedRule() (tea.Model, tea.Cmd) {
 	item := m.selectedRule()
-	if item == nil || item.kind != "field" {
+	if item == nil {
+		return m, nil
+	}
+	switch item.kind {
+	case "indicator", "capture":
+		m.message = "read-only — edit config.toml (the daemon reloads on save)"
+		return m, nil
+	case "field":
+	default:
+		return m, nil
+	}
+	// Free-text fields (argv templates, template strings, paths) are
+	// read-only in the TUI (CR-036): the one-line prompt round-trip mangles
+	// them. `hap config set` still accepts every key.
+	if !frontend.FieldTUIEditable(item.key) {
+		m.message = fmt.Sprintf("%s is read-only in the TUI — edit config.toml or run: hap config set %s <value>", item.key, item.key)
 		return m, nil
 	}
 	key := item.key
@@ -1136,6 +1404,9 @@ func (m Model) removeSelectedRule() (tea.Model, tea.Cmd) {
 		return m, m.do(fmt.Sprintf("task source #%d removed", idx), func(c context.Context) error {
 			return app.RemoveTaskSource(c, idx, expected)
 		})
+	case "indicator", "capture":
+		m.message = "read-only — edit config.toml (the daemon reloads on save)"
+		return m, nil
 	default:
 		m.message = "config fields are edited (enter), not removed"
 		return m, nil
@@ -1166,13 +1437,14 @@ func (m Model) clearDataPrompt() (tea.Model, tea.Cmd) {
 
 // View renders the pane.
 func (m Model) View() string {
+	st := m.styles()
 	var b strings.Builder
 
-	state := runningStyle.Render("● running")
+	state := st.running.Render("● running")
 	if m.data.status.Paused {
-		state = pausedStyle.Render("■ PAUSED (kill switch)")
+		state = st.paused.Render("■ PAUSED (kill switch)")
 	}
-	fmt.Fprintf(&b, "%s  %s\n", titleStyle.Render("Herd Auto Prompter"), state)
+	fmt.Fprintf(&b, "%s  %s\n", st.title.Render("Herd Auto Prompter"), state)
 
 	var tabs []string
 	for i, name := range tabNames {
@@ -1181,20 +1453,29 @@ func (m Model) View() string {
 			label = fmt.Sprintf(" %s(%d) ", name, len(m.data.escalations))
 		}
 		if tab(i) == m.tab {
-			tabs = append(tabs, activeTab.Render(label))
+			tabs = append(tabs, st.activeTab.Render(label))
 		} else {
-			tabs = append(tabs, inactiveTab.Render(label))
+			tabs = append(tabs, st.inactiveTab.Render(label))
 		}
 	}
 	fmt.Fprintf(&b, "%s\n\n", strings.Join(tabs, "|"))
 
 	if m.data.err != nil {
-		fmt.Fprintf(&b, "%s\n", errStyle.Render("error: "+m.data.err.Error()))
+		fmt.Fprintf(&b, "%s\n", st.err.Render("error: "+m.data.err.Error()))
 	}
 
 	if m.detail != nil {
 		m.renderDetail(&b)
 		return b.String()
+	}
+
+	// Search bar / active-filter line (its height is accounted for in
+	// listPageSize so the body never overflows the pane).
+	if m.searching {
+		fmt.Fprintf(&b, "%s%s█\n", st.section.Render("search> "), m.query[m.tab])
+	} else if m.tab.isList() && m.query[m.tab] != "" {
+		fmt.Fprintf(&b, "%s\n", st.help.Render(
+			fmt.Sprintf("filter: %q — / to edit, backspace to clear", m.query[m.tab])))
 	}
 
 	switch m.tab {
@@ -1218,7 +1499,21 @@ func (m Model) View() string {
 	if m.message != "" {
 		fmt.Fprintf(&b, "\n%s\n", m.message)
 	}
-	fmt.Fprintf(&b, "\n%s", helpStyle.Render(m.helpLine()))
+	// Durable status area (CR-025): the last action outcome stays readable
+	// until the next one replaces it, styled ok/error from the palette
+	// (CR-026).
+	if m.status != nil {
+		mark, style := "✓", st.ok
+		if m.status.err {
+			mark, style = "✗", st.err
+		}
+		// Errors can embed multi-line subprocess output; the status area
+		// budgets exactly one line, so flatten and truncate.
+		text := oneLine(m.status.text, max(20, m.contentWidth()-12))
+		fmt.Fprintf(&b, "\n%s\n", style.Render(
+			fmt.Sprintf("%s %s  %s", mark, text, m.status.at.Format("15:04:05"))))
+	}
+	fmt.Fprintf(&b, "\n%s", st.help.Render(m.helpLine()))
 	return b.String()
 }
 
@@ -1229,16 +1524,19 @@ func (m Model) helpLine() string {
 		}
 		return "↑/↓: scroll  tab: switch tab  esc/q/v: close"
 	}
+	if m.searching {
+		return "type to filter  backspace: erase  esc/enter: apply & close"
+	}
 	common := "tab: switch  ↑/↓: select  p: pause  r: resume  q: quit"
 	switch m.tab {
 	case tabAgents:
-		return "v: details  n: rename agent  " + common
+		return "v: details  n: rename agent  /: search  " + common
 	case tabEscalations:
-		return "enter/y: confirm+send  c: correct  space: mark  x: delete  X: prune old  v: details  " + common
+		return "enter/y: confirm+send  c: correct  space: mark  x: delete  X: prune old  v: details  /: search  " + common
 	case tabAudit:
-		return "c: correct decision  v: details  " + common
+		return "c: correct decision  v: details  /: search  " + common
 	case tabSignatures:
-		return "enter/v: details  x: delete  f: filter mode  " + common
+		return "enter/v: details  x: delete  f: filter mode  /: search  " + common
 	case tabConfig:
 		return "enter/e: edit field  a: add pattern  t: add task source  x: remove  X: clear data  " + common
 	}
@@ -1247,39 +1545,52 @@ func (m Model) helpLine() string {
 
 // renderSignatures draws the learned-signature list (the Rules tab).
 func (m Model) renderSignatures(b *strings.Builder) {
+	st := m.styles()
 	sigs := m.visibleSignatures()
 	if m.sigMode != "" {
-		fmt.Fprintf(b, "%s\n", sectionStyle.Render("filter: mode="+string(m.sigMode)+"  (f cycles)"))
+		fmt.Fprintf(b, "%s\n", st.section.Render("filter: mode="+string(m.sigMode)+"  (f cycles)"))
 	}
 	if len(sigs) == 0 {
 		if len(m.data.signatures) > 0 {
-			fmt.Fprintln(b, "no signatures match the filter — press f to cycle")
+			fmt.Fprintln(b, m.styles().help.Render("no signatures match the filter — f cycles mode, / edits search"))
 			return
 		}
-		fmt.Fprintln(b, "no learned signatures yet — confirm suggestions to teach hap")
+		fmt.Fprintln(b, m.styles().help.Render("no learned signatures yet — confirm suggestions to teach hap"))
 		return
 	}
 	gradN := m.data.cfg.Learning.GraduationN
-	// Prefix up to the action column is ~66 fixed cells.
-	actWidth, _ := m.budget(66, false)
-	for i, r := range sigs {
-		line := fmt.Sprintf("%-18s %-9s %-10s %-11s %d/%d conf=%.2f  %s",
-			shortSig(r.Signature), r.SituationType, orDash(r.AgentType), r.Mode,
+	// The signature column sizes to the widest visible id so the full id
+	// renders untruncated (CR-032); the fixed columns after it are ~48
+	// cells, so the action budget shifts right with the column.
+	sigW := 18
+	for _, r := range sigs {
+		if n := runewidth.StringWidth(r.Signature); n > sigW {
+			sigW = n
+		}
+	}
+	actWidth, _ := m.budget(sigW+48, false)
+	start, end := m.window(len(sigs))
+	for i := start; i < end; i++ {
+		r := sigs[i]
+		line := fmt.Sprintf("%-*s %-9s %-10s %-11s %d/%d conf=%.2f  %s",
+			sigW, r.Signature, r.SituationType, orDash(r.AgentType), r.Mode,
 			r.ConsecutiveConfirmations, gradN, r.CachedConfidence,
 			oneLine(r.TopAction, actWidth))
 		switch {
 		case i == m.cursor:
-			line = selectedStyle.Render(line)
+			line = st.selected.Render(line)
 		case r.Mode == domain.ModeAutonomous:
-			line = okStyle.Render(line)
+			line = st.ok.Render(line)
 		}
 		fmt.Fprintln(b, line)
 	}
+	m.renderMoreRows(b, len(sigs)-end)
 }
 
 // renderDetail draws the open detail overlay in place of the tab body.
 func (m Model) renderDetail(b *strings.Builder) {
-	fmt.Fprintf(b, "%s\n\n", titleStyle.Render(m.detail.title))
+	st := m.styles()
+	fmt.Fprintf(b, "%s\n\n", st.title.Render(m.detail.title))
 	page := m.detailPageSize()
 	lines := m.detail.lines
 	start := min(m.detail.offset, max(0, len(lines)-1))
@@ -1288,25 +1599,32 @@ func (m Model) renderDetail(b *strings.Builder) {
 		fmt.Fprintln(b, ln)
 	}
 	if end < len(lines) {
-		fmt.Fprintf(b, "%s\n", helpStyle.Render(fmt.Sprintf("… %d more line(s) — ↓ to scroll", len(lines)-end)))
+		fmt.Fprintf(b, "%s\n", st.help.Render(fmt.Sprintf("… %d more line(s) — ↓ to scroll", len(lines)-end)))
 	}
-	fmt.Fprintf(b, "\n%s", helpStyle.Render(m.helpLine()))
+	fmt.Fprintf(b, "\n%s", st.help.Render(m.helpLine()))
 }
 
 func (m Model) renderAgents(b *strings.Builder) {
-	agents := m.data.status.MonitoredAgents
+	agents := m.visibleAgents()
 	if len(agents) == 0 {
-		fmt.Fprintln(b, "no agents detected")
+		if len(m.data.status.MonitoredAgents) > 0 {
+			fmt.Fprintln(b, m.styles().help.Render("no agents match the filter — / edits, backspace clears"))
+		} else {
+			fmt.Fprintln(b, m.styles().help.Render("no agents detected"))
+		}
 		return
 	}
-	for i, a := range agents {
+	start, end := m.window(len(agents))
+	for i := start; i < end; i++ {
+		a := agents[i]
 		name := orDash(m.data.status.AgentName(a.AgentID))
 		line := fmt.Sprintf("%-18s %-12s %-12s %s", name, a.AgentID, a.AgentType, a.Status)
 		if i == m.cursor {
-			line = selectedStyle.Render(line)
+			line = m.styles().selected.Render(line)
 		}
 		fmt.Fprintln(b, line)
 	}
+	m.renderMoreRows(b, len(agents)-end)
 }
 
 // ruleFor resolves the learned rule an audit/escalation row is keyed to
@@ -1351,14 +1669,20 @@ func (m Model) agentTypeFor(r domain.AuditRecord) string {
 }
 
 func (m Model) renderEscalations(b *strings.Builder) {
-	esc := m.data.escalations
+	esc := m.visibleEscalations()
 	if len(esc) == 0 {
-		fmt.Fprintln(b, "no pending escalations — the herd is unblocked 🎉")
+		if len(m.data.escalations) > 0 {
+			fmt.Fprintln(b, m.styles().help.Render("no escalations match the filter — / edits, backspace clears"))
+		} else {
+			fmt.Fprintln(b, m.styles().help.Render("no pending escalations — the herd is unblocked 🎉"))
+		}
 		return
 	}
 	// Prefix: "<mark> #%-5d %-8s %-10s %-8s agent=%-14s rule=%-6s " → 71 cells.
 	const escPrefix = 71
-	for i, e := range esc {
+	start, end := m.window(len(esc))
+	for i := start; i < end; i++ {
+		e := esc[i]
 		agent := e.AgentID
 		if n := m.data.status.AgentName(e.AgentID); n != "" {
 			agent = n
@@ -1376,32 +1700,43 @@ func (m Model) renderEscalations(b *strings.Builder) {
 			line += "  → " + oneLine(e.Suggestion, sWidth)
 		}
 		if i == m.cursor {
-			line = selectedStyle.Render(line)
+			line = m.styles().selected.Render(line)
 		}
 		fmt.Fprintln(b, line)
 	}
+	m.renderMoreRows(b, len(esc)-end)
 }
 
 func (m Model) renderAudit(b *strings.Builder) {
+	rows := m.visibleAudit()
+	if len(rows) == 0 {
+		if len(m.data.audit) > 0 {
+			fmt.Fprintln(b, m.styles().help.Render("no audit records match the filter — / edits, backspace clears"))
+		} else {
+			fmt.Fprintln(b, m.styles().help.Render("no audit records yet"))
+		}
+		return
+	}
 	// Prefix up to the action column is ~53 fixed cells + "rule=%-6s " (12).
 	actWidth, _ := m.budget(65, false)
-	for i, r := range m.data.audit {
+	start, end := m.window(len(rows))
+	for i := start; i < end; i++ {
+		r := rows[i]
 		line := fmt.Sprintf("#%-5d %-14s %-9s %-10s conf=%.2f rule=%-6s %s",
 			r.ID, r.CreatedAt.Format("01-02 15:04:05"), r.Status, r.SituationType,
 			r.Confidence, m.ruleMarker(r.Signature), oneLine(r.Action, actWidth))
 		if i == m.cursor {
-			line = selectedStyle.Render(line)
+			line = m.styles().selected.Render(line)
 		}
 		fmt.Fprintln(b, line)
 	}
-	if len(m.data.audit) == 0 {
-		fmt.Fprintln(b, "no audit records yet")
-	}
+	m.renderMoreRows(b, len(rows)-end)
 }
 
 func (m Model) renderConfig(b *strings.Builder) {
+	st := m.styles()
 	if len(m.items) == 0 {
-		fmt.Fprintln(b, "no configuration loaded")
+		fmt.Fprintln(b, m.styles().help.Render("no configuration loaded"))
 		return
 	}
 	lastKind := ""
@@ -1410,57 +1745,75 @@ func (m Model) renderConfig(b *strings.Builder) {
 			lastKind = item.kind
 			switch item.kind {
 			case "field":
-				fmt.Fprintln(b, sectionStyle.Render("Config"))
+				fmt.Fprintln(b, st.section.Render("Config"))
 			case "pattern":
-				fmt.Fprintf(b, "\n%s\n", sectionStyle.Render(fmt.Sprintf(
-					"Never-auto patterns (operator; +%d seed)", len(domain.SeedNeverAutoPatterns))))
+				fmt.Fprintf(b, "\n%s\n", st.section.Render(fmt.Sprintf(
+					"Never-auto patterns (operator; %s)", m.seedLabel())))
 			case "source":
-				fmt.Fprintf(b, "\n%s\n", sectionStyle.Render("Task sources"))
+				fmt.Fprintf(b, "\n%s\n", st.section.Render("Task sources"))
+			case "indicator":
+				fmt.Fprintf(b, "\n%s\n", st.section.Render("Safety indicators (read-only — edit config.toml)"))
+			case "capture":
+				fmt.Fprintf(b, "\n%s\n", st.section.Render("Capture delays (read-only — edit config.toml)"))
 			}
 		}
-		line := "  " + item.label
+		// Long values (argv templates, paths) truncate to one line (CR-037).
+		line := "  " + oneLine(item.label, m.contentWidth()-2)
 		if i == m.cursor {
-			line = selectedStyle.Render(line)
+			line = st.selected.Render(line)
 		}
 		fmt.Fprintln(b, line)
 	}
 	if len(m.data.cfg.Safety.NeverAutoPatterns) == 0 {
-		fmt.Fprintf(b, "\n%s\n", sectionStyle.Render(fmt.Sprintf(
-			"Never-auto patterns: none from operator (+%d seed active) — press a to add",
-			len(domain.SeedNeverAutoPatterns))))
+		fmt.Fprintf(b, "\n%s\n", st.section.Render(fmt.Sprintf(
+			"Never-auto patterns: none from operator (%s) — press a to add", m.seedLabel())))
 	}
 	if len(m.data.cfg.TaskSources) == 0 {
-		fmt.Fprintf(b, "%s\n", sectionStyle.Render("Task sources: none — press t to add"))
+		fmt.Fprintf(b, "%s\n", st.section.Render("Task sources: none — press t to add"))
 	}
+}
+
+// seedLabel names the shipped seed patterns' state: the count when active,
+// or an explicit marker when safety.disable_seed dropped them (so the
+// Config tab never contradicts the new editable field).
+func (m Model) seedLabel() string {
+	if m.data.cfg.Safety.DisableSeed {
+		return "seed disabled"
+	}
+	return fmt.Sprintf("+%d seed active", len(domain.SeedNeverAutoPatterns))
 }
 
 func (m Model) renderKills(b *strings.Builder) {
 	if len(m.data.kills) == 0 {
-		fmt.Fprintln(b, "no pause/kill events recorded")
+		fmt.Fprintln(b, m.styles().help.Render("no pause/kill events recorded"))
 		return
 	}
 	for i, e := range m.data.kills {
 		line := fmt.Sprintf("#%-4d %-20s %-8s by %s",
 			e.ID, e.CreatedAt.Format(time.RFC3339), e.State, e.Author)
 		if i == m.cursor {
-			line = selectedStyle.Render(line)
+			line = m.styles().selected.Render(line)
 		}
 		fmt.Fprintln(b, line)
 	}
 }
 
+// oneLine flattens newlines and truncates to limit display CELLS (not
+// runes): row budgets are in cells, and wide runes (CJK, emoji) arriving
+// verbatim from pane content would otherwise overflow the row and break
+// the pane-height invariant (AR-010).
 func oneLine(s string, limit int) string {
 	s = strings.ReplaceAll(s, "\n", " ")
 	if limit < 1 {
 		limit = 1
 	}
-	if r := []rune(s); len(r) > limit {
-		if limit == 1 {
-			return "…"
-		}
-		return string(r[:limit-1]) + "…"
+	if runewidth.StringWidth(s) <= limit {
+		return s
 	}
-	return s
+	if limit == 1 {
+		return "…"
+	}
+	return runewidth.Truncate(s, limit, "…")
 }
 
 func orDash(s string) string {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -357,7 +357,8 @@ func TestSignaturesTabRendersRows(t *testing.T) {
 	m := testModel(t)
 	m.tab = tabSignatures
 	view := m.View()
-	for _, want := range []string{"choice:ffff0000e…", "approval:1234abc…", "autonomous", "shadow", "5/5", "3/5", "conf=0.93"} {
+	// CR-032: the Rules list renders the FULL signature id, not shortSig.
+	for _, want := range []string{"choice:ffff0000eeee1111", "approval:1234abcd5678efab", "autonomous", "shadow", "5/5", "3/5", "conf=0.93"} {
 		if !strings.Contains(view, want) {
 			t.Errorf("signatures tab missing %q:\n%s", want, view)
 		}

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -81,6 +81,19 @@ gpu_layers = 0              # inert in official builds (Metal/Vulkan compiled ou
 # ── TUI ─────────────────────────────────────────────────────────────
 [tui]
 max_content_width = 0      # cap on variable-length list columns; 0 = full terminal width
+theme = ""                 # named palette: default | dark | light | high-contrast;
+                           # empty/unknown = default (the original look)
+
+# Optional per-role color overrides layered on the selected theme; unset
+# roles inherit the theme. Values are terminal colors ("205", "#ff5faf").
+# [tui.palette]
+# title = "205"
+# section = "117"
+# error = "196"
+# ok = "46"
+# paused = "196"
+# running = "46"
+# help = ""
 
 # ── Declared task lists for idle agents (repeatable) ────────────────
 # Without a declared source, the plugin falls back to inferring the next


### PR DESCRIPTION
Implements the **enhance-tui-ux** spec (committed under `docs/plans/enhance-tui-ux/`; source of truth in MySpec, project "Herdr Auto Pilot").

## What's in here

**A — List viewport & scrolling** (AR-001–010): per-tab viewport offsets on Agents/Escalations/Audit/Rules; the shared cursor stays (no per-tab cursor state); offsets follow the cursor, reset on tab switch, clamp on resize/refresh; "… N more row(s)" affordance; every list tab renders within the pane height.

**B — In-list search** (AR-011–018, CR-019): `/` opens incremental case-insensitive substring search; esc/enter exit retaining the filter; backspace-to-empty (and normal-mode backspace) clears; while typing, ALL printable action keys are suppressed — including `q` (quit) and `y` (confirm+send); composes with the Rules `f` mode cycle; per-tab empty-state messages; selection actions operate on the filtered rows.

**C/D — Theming** (CR-020, AR-021–023, AR-027–030, CR-024): all styles resolve through one palette (`internal/tui/palette.go`); named themes `default`/`dark`/`light`/`high-contrast` via `[tui] theme` + optional `[tui.palette]` per-role overrides; empty/unknown → default = byte-identical original look; legacy `[tui]` configs stay valid.

**E — Durable status area** (CR-025/026): action outcomes persist as `✓/✗ <text> HH:MM:SS` (palette ok/error roles) until the next outcome replaces them; multi-line errors are flattened; transient hints keep the old message line.

**F — Rules full signature ids** (CR-032): the Rules list shows full untruncated ids in an auto-sized column; detail overlay and delete prompt keep `shortSig`.

**G — Config-tab completeness** (CR-033/036/037, AR-034/035): `ConfigFields` registry (single source of truth, `TUIEditable` classification defaulting read-only); new keys `llm.pane_excerpt_chars`, `safety.disable_seed`, `tui.max_content_width`, `tui.theme` — editable in the TUI and via `config set` (CLI gains them automatically through the shared registry); free-text fields (`llm.command`, `llm.rewrite_command`, `llm.rewrite_fallback_template`, `embedding.model_path`) are TUI-read-only with a config.toml pointer (their one-line prompt round-trip mangled real values); read-only Safety-indicator and Capture-delay sections (built-in 1000/200 ms defaults shown when unconfigured); long values truncate by display cells.

## Verification

- Full unit suite: **533/533 pass** (1 expected real-model skip), `-tags "vectors cpu"`.
- Integration suite against a **real herdr**: `TestRealPaneInfo`, `TestRealConfirmDeliversMenuDigit` pass; claude/embedding cases skip as designed.
- `gofmt`, `go vet`, `golangci-lint`: clean.
- Code-review pass fixed: advertised-but-missing backspace-to-clear, rune-vs-cell truncation (CJK overflow), status/hint lines shrinking the page without re-clamping, multi-line error overflow in the status area, palette-styled empty states (CR-024), seed labels contradicting `safety.disable_seed`, and `llm.pane_excerpt_chars` rejecting the 0 restore-default sentinel.

No `frontend.App` signature changes (AR-031); Config/Pause-Kill navigation untouched (AR-032); no keybinding reassigned; `internal/domain` untouched.