### PR TITLE
feat: embedding re-compute (hap signatures reembed) + configurable pane_salient_chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ model_path = ""            # "" = bundled <plugin>/models/all-minilm-l6-v2-q8_0.
 similarity_threshold = 0.90 # min cosine similarity to reuse a learned signature
 bm25_min_score = 0.35       # min normalized BM25 similarity for the text fallback, (0,1]
 gpu_layers = 0              # inert in official builds (GPU backends compiled out)
+# pane_salient_chars = 800  # fallback signature window for idle/unclassified
+                            # situations (trailing N characters of pane content).
+                            # Changing it (or upgrading past the 400→800 default
+                            # bump) re-keys idle/unclassified rules once, so they
+                            # re-learn; structured approval/choice/error rules
+                            # are unaffected.
 
 # TUI appearance. `theme` picks a named palette: default, dark, light,
 # high-contrast. Empty or unknown names resolve to default — the exact

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -52,6 +52,8 @@ Operate:
   audit [--limit N]     show the audit log
   signatures [list|show <sig>|delete <sig> [--yes]]   learned signatures (alias: sigs)
                         list filters: --type T --mode M --agent-type A --min-conf C
+  signatures reembed [--force]   re-compute stored embeddings after an
+                        embedding model change (via the daemon when running)
   pause | resume        global pause/kill switch
   kill-history          pause/kill event history
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -82,12 +82,80 @@ func signatures(ctx context.Context, app *frontend.App, out io.Writer, args []st
 		return signaturesShow(ctx, app, out, args)
 	case "delete":
 		return signaturesDelete(ctx, app, out, args)
+	case "reembed":
+		return signaturesReembed(ctx, app, out, args)
 	}
 	// Bare `signatures --type X` style: treat unknown leading flag as list.
 	if strings.HasPrefix(sub, "-") {
 		return signaturesList(ctx, app, out, append([]string{sub}, args...))
 	}
-	return fmt.Errorf("usage: signatures [list|show <sig-or-prefix>|delete <sig-or-prefix> [--yes]]")
+	return fmt.Errorf("usage: signatures [list|show <sig-or-prefix>|delete <sig-or-prefix> [--yes]|reembed [--force]]")
+}
+
+// signaturesReembed re-computes stored signature embeddings for the
+// currently configured model: via a daemon nudge when one is running (the
+// daemon owns signature_embeddings writes), in-process otherwise.
+func signaturesReembed(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
+	fs := flag.NewFlagSet("signatures reembed", flag.ContinueOnError)
+	force := fs.Bool("force", false, "re-run even when no drift is detected (retries a previously failed pass)")
+	fs.SetOutput(out)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	drift, err := app.EmbeddingDrift(ctx)
+	if err != nil {
+		return err
+	}
+	if drift.ModelID == "" {
+		return fmt.Errorf("embedding is disabled in config — nothing to re-embed")
+	}
+	if drift.ModelMissing {
+		return fmt.Errorf("embedding model %s not found — fix embedding.model_path first", drift.ModelID)
+	}
+	if !drift.Detected && !*force {
+		fmt.Fprintf(out, "all %d stored signature embeddings match model %s — nothing to do (--force re-runs anyway)\n",
+			drift.Total, drift.ModelID)
+		return nil
+	}
+	if drift.Detected {
+		fmt.Fprintf(out, "%d of %d stored signature embeddings need re-compute for model %s\n",
+			drift.Stale, drift.Total, drift.ModelID)
+	}
+
+	if app.DaemonInfo != nil {
+		if running, _, ver := app.DaemonInfo(); running {
+			// A daemon from an older binary ignores the reembed nudge
+			// (unknown control kind), so "nudged" would wait forever.
+			// Replacing it re-embeds anyway: startup reconciles the rows.
+			if ver != buildinfo.Version {
+				return fmt.Errorf("daemon is STALE (running %s, binary is %s) — run: hap daemon --ensure (its startup re-embeds automatically)",
+					daemonlock.VersionLabel(ver), buildinfo.Version)
+			}
+			if err := app.RequestReembed(ctx); err != nil {
+				return err
+			}
+			fmt.Fprintln(out, "daemon nudged — re-embedding runs in the background; check: hap status")
+			return nil
+		}
+	}
+
+	res, err := app.ReembedStandalone(ctx, func(done, total int, sig string, rowErr error) {
+		if rowErr != nil {
+			fmt.Fprintf(out, "  %s: %v\n", sig, rowErr)
+		} else if done%25 == 0 || done == total {
+			fmt.Fprintf(out, "  %d/%d\n", done, total)
+		}
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "re-embedded %d, kept %d, downgraded %d (text-only) — model %s\n",
+		res.Reembedded, res.Kept, res.Downgraded, drift.ModelID)
+	if res.PersistFailed > 0 {
+		fmt.Fprintf(out, "WARNING: %d re-embedded row(s) failed to persist and stay stale — re-run: hap signatures reembed\n",
+			res.PersistFailed)
+	}
+	return nil
 }
 
 func signaturesList(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
@@ -297,6 +365,12 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 	fmt.Fprintf(out, "monitored agents:    %d\n", len(st.MonitoredAgents))
 	if st.Embedding != "" {
 		fmt.Fprintf(out, "semantic matching:   %s\n", st.Embedding)
+	}
+	if st.Drift.Detected {
+		// Same shape as the STALE-daemon line: the mismatch and the remedy
+		// in one glance.
+		fmt.Fprintf(out, "embedding drift:     %d of %d rules embedded with a previous model; run: hap signatures reembed\n",
+			st.Drift.Stale, st.Drift.Total)
 	}
 	if st.LatestKill != nil {
 		fmt.Fprintf(out, "last kill event:     %s by %s at %s\n",

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,8 +12,10 @@ import (
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
 	"github.com/0xGosu/herdr-auto-pilot/internal/cli"
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store"
 )
 
@@ -324,5 +327,153 @@ func TestEscalationsAndAuditShowMatchedRule(t *testing.T) {
 	}
 	if !strings.Contains(out, "rule=shadow") || !strings.Contains(out, "rule=-") {
 		t.Errorf("audit rows should carry the rule mode marker (or dash), got:\n%s", out)
+	}
+}
+
+// cliFakeEmbedder backs the standalone reembed path in CLI tests.
+type cliFakeEmbedder struct{ id string }
+
+func (f *cliFakeEmbedder) EmbedText(context.Context, string) ([]float32, error) {
+	return []float32{1, 0, 0}, nil
+}
+func (f *cliFakeEmbedder) ModelID() string { return f.id }
+func (f *cliFakeEmbedder) Dims() int       { return 3 }
+func (f *cliFakeEmbedder) Close() error    { return nil }
+
+// setupReembedApp seeds one stale + one current embedding row and points
+// the config at an existing dummy model file.
+func setupReembedApp(t *testing.T, app *frontend.App, st *store.Store) {
+	t.Helper()
+	ctx := context.Background()
+	modelPath := filepath.Join(t.TempDir(), "test-model.gguf")
+	if err := os.WriteFile(modelPath, []byte("gguf"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := fmt.Sprintf("[embedding]\nmodel_path = %q\n", modelPath)
+	if err := os.WriteFile(app.ConfigPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range []domain.SignatureEmbedding{
+		{Signature: "approval:legacy", SituationType: domain.SituationApproval,
+			AgentType: "claude", Model: "old-model.gguf", Dims: 2, Vector: []float32{1, 0},
+			Salient: "permission:legacy", CreatedAt: time.Now()},
+		{Signature: "approval:current", SituationType: domain.SituationApproval,
+			AgentType: "claude", Model: "test-model.gguf", Dims: 3, Vector: []float32{1, 0, 0},
+			Salient: "permission:current", CreatedAt: time.Now()},
+	} {
+		if err := st.UpsertSignatureEmbedding(ctx, e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	app.NewEmbedder = func(config.Embedding) ports.EmbedderPort {
+		return &cliFakeEmbedder{id: "test-model.gguf"}
+	}
+}
+
+func TestSignaturesReembedStandalone(t *testing.T) {
+	app, st := testApp(t)
+	setupReembedApp(t, app, st)
+	app.DaemonInfo = func() (bool, int, string) { return false, 0, "" }
+
+	out, err := run(t, app, "signatures", "reembed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "1 of 2 stored signature embeddings need re-compute") {
+		t.Errorf("missing drift summary, got:\n%s", out)
+	}
+	if !strings.Contains(out, "re-embedded 1, kept 1, downgraded 0") {
+		t.Errorf("missing result summary, got:\n%s", out)
+	}
+
+	// A second run has nothing to do without --force.
+	out, err = run(t, app, "signatures", "reembed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "nothing to do") {
+		t.Errorf("clean state should read nothing to do, got:\n%s", out)
+	}
+
+	// --force re-runs anyway (the degraded-latch retry path).
+	out, err = run(t, app, "signatures", "reembed", "--force")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "re-embedded") {
+		t.Errorf("--force should run the pass, got:\n%s", out)
+	}
+}
+
+func TestSignaturesReembedNudgesRunningDaemon(t *testing.T) {
+	app, st := testApp(t)
+	setupReembedApp(t, app, st)
+	app.DaemonInfo = func() (bool, int, string) { return true, 4242, buildinfo.Version }
+
+	out, err := run(t, app, "signatures", "reembed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "daemon nudged") {
+		t.Errorf("running daemon should be nudged, got:\n%s", out)
+	}
+	// The CLI did not write the rows itself — the daemon owns them.
+	if n, _ := st.CountStaleSignatureEmbeddings(context.Background(), "test-model.gguf"); n != 1 {
+		t.Errorf("stale rows = %d, want 1 (untouched by the CLI)", n)
+	}
+}
+
+func TestSignaturesReembedRefusesStaleDaemon(t *testing.T) {
+	app, st := testApp(t)
+	setupReembedApp(t, app, st)
+	// A running daemon from an older binary would silently ignore the
+	// reembed nudge, so the CLI must refuse and point at --ensure.
+	app.DaemonInfo = func() (bool, int, string) { return true, 4242, "v0.0.1" }
+
+	_, err := run(t, app, "signatures", "reembed")
+	if err == nil || !strings.Contains(err.Error(), "hap daemon --ensure") {
+		t.Errorf("stale daemon must refuse with the --ensure remedy, got %v", err)
+	}
+	// The rows are untouched — the CLI did not fall through to standalone.
+	if n, _ := st.CountStaleSignatureEmbeddings(context.Background(), "test-model.gguf"); n != 1 {
+		t.Errorf("stale rows = %d, want 1 (untouched)", n)
+	}
+}
+
+func TestSignaturesReembedMissingModel(t *testing.T) {
+	app, st := testApp(t)
+	setupReembedApp(t, app, st)
+	cfg := "[embedding]\nmodel_path = \"/nonexistent/model.gguf\"\n"
+	if err := os.WriteFile(app.ConfigPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := run(t, app, "signatures", "reembed")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("missing model must error with the config remedy, got %v", err)
+	}
+}
+
+func TestStatusShowsEmbeddingDrift(t *testing.T) {
+	app, st := testApp(t)
+	setupReembedApp(t, app, st)
+
+	out, err := run(t, app, "status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "embedding drift:") ||
+		!strings.Contains(out, "1 of 2 rules embedded with a previous model") ||
+		!strings.Contains(out, "run: hap signatures reembed") {
+		t.Errorf("status must flag embedding drift with the remedy, got:\n%s", out)
+	}
+
+	// No drift → no line.
+	app2, _ := testApp(t)
+	out, err = run(t, app2, "status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "embedding drift:") {
+		t.Errorf("driftless status must not show the drift line, got:\n%s", out)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,16 @@ type Embedding struct {
 	BM25MinScore float64 `toml:"bm25_min_score"`
 	// GPULayers offloads model layers to the GPU (0 = CPU only).
 	GPULayers int `toml:"gpu_layers"`
+	// PaneSalientChars bounds the fallback salient window: for situations
+	// with no structured salient field (idle, and any unclassified content),
+	// the signature and its embedding are minted from the trailing this-many
+	// characters of pane content. 0 → the built-in default
+	// (domain.DefaultPaneSalientChars). Widening it captures more context
+	// (still well within the embedding model's window); changing it re-keys
+	// idle/unclassified signatures whose content exceeds the old window, so
+	// those rules re-learn (structured approval/choice/error rules are
+	// unaffected).
+	PaneSalientChars int `toml:"pane_salient_chars"`
 }
 
 // TaskSource points an agent or workspace at a declared next-task list (FR-011).
@@ -178,6 +188,7 @@ type PaletteOverrides struct {
 	OK      string `toml:"ok,omitempty"`
 	Paused  string `toml:"paused,omitempty"`
 	Running string `toml:"running,omitempty"`
+	Warn    string `toml:"warn,omitempty"`
 	Help    string `toml:"help,omitempty"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,6 +35,24 @@ func TestLoadPartialConfigFillsDefaults(t *testing.T) {
 	if cfg.Learning.GraduationN != Default().Learning.GraduationN {
 		t.Errorf("graduation N default lost: %d", cfg.Learning.GraduationN)
 	}
+	// PaneSalientChars is unset here: 0 is the valid "use the built-in
+	// default" sentinel (the domain layer applies DefaultPaneSalientChars),
+	// so fillZeroes must leave it at 0 rather than freezing a value.
+	if cfg.Embedding.PaneSalientChars != 0 {
+		t.Errorf("unset pane_salient_chars should stay 0 (use-default), got %d", cfg.Embedding.PaneSalientChars)
+	}
+}
+
+func TestPaneSalientCharsRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	os.WriteFile(path, []byte("[embedding]\npane_salient_chars = 1200\n"), 0o600)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Embedding.PaneSalientChars != 1200 {
+		t.Errorf("explicit pane_salient_chars lost: %d", cfg.Embedding.PaneSalientChars)
+	}
 }
 
 func TestLoadMalformedTOMLRejectedSafely(t *testing.T) {

--- a/internal/control/control.go
+++ b/internal/control/control.go
@@ -20,6 +20,11 @@ type Kind string
 const (
 	KindReload Kind = "reload"
 	KindWake   Kind = "wake"
+	// KindReembed asks the daemon to rebuild a FRESH embedder (clearing any
+	// degraded-failure latch) and re-embed stored signatures from their
+	// salient text. Daemons predating this kind log and ignore it — the
+	// stale-daemon remedy (`hap daemon --ensure`) applies.
+	KindReembed Kind = "reembed"
 )
 
 type message struct {
@@ -72,7 +77,7 @@ func (s *Server) accept() {
 					slog.Warn("malformed control nudge ignored", "error", err)
 					continue
 				}
-				if m.Kind != KindReload && m.Kind != KindWake {
+				if m.Kind != KindReload && m.Kind != KindWake && m.Kind != KindReembed {
 					slog.Warn("unknown control nudge kind ignored", "kind", m.Kind)
 					continue
 				}

--- a/internal/control/control_test.go
+++ b/internal/control/control_test.go
@@ -52,6 +52,39 @@ func TestNudgeRoundTrip(t *testing.T) {
 	t.Fatal("nudge never reached the handler")
 }
 
+func TestReembedNudgeRoundTrip(t *testing.T) {
+	path := filepath.Join(testutil.SocketDir(t), "ctl.sock")
+	var mu sync.Mutex
+	var got []Kind
+	srv, err := NewServer(path, func(k Kind) {
+		mu.Lock()
+		got = append(got, k)
+		mu.Unlock()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	if err := Nudge(context.Background(), path, KindReembed); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(got)
+		mu.Unlock()
+		if n == 1 {
+			if got[0] != KindReembed {
+				t.Errorf("kind = %v, want %v", got[0], KindReembed)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("reembed nudge never reached the handler")
+}
+
 func TestSocketOwnerOnlyPermissions(t *testing.T) {
 	path := filepath.Join(testutil.SocketDir(t), "ctl.sock")
 	srv, err := NewServer(path, func(Kind) {})

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -209,7 +209,15 @@ func New(opt Options) (*Daemon, error) {
 
 // reload re-reads TOML config and rebuilds derived state (classifier,
 // never-auto list). Malformed config keeps the previous good state.
-func (d *Daemon) reload() error {
+func (d *Daemon) reload() error { return d.reloadWith(false) }
+
+// reloadWith(forceEmbedder=true) additionally rebuilds the embedder from a
+// FRESH instance even when the [embedding] config is unchanged — a new
+// instance starts with a clean degraded-failure latch, so a re-embed
+// request can retry a model that previously failed. (With a static
+// Options.Embedder — tests — there is nothing to swap; the pass still
+// re-runs initSemantic.)
+func (d *Daemon) reloadWith(forceEmbedder bool) error {
 	cfg, err := config.Load(d.opt.ConfigPath)
 	if err != nil {
 		slog.Error("config reload failed; keeping previous config", "error", err)
@@ -243,7 +251,7 @@ func (d *Daemon) reload() error {
 	d.llm = llmPort
 	d.mu.Unlock()
 
-	d.reloadEmbedder(prev, cfg, first)
+	d.reloadEmbedder(prev, cfg, first || forceEmbedder)
 	slog.Info("configuration loaded", "path", d.opt.ConfigPath)
 	return nil
 }
@@ -345,8 +353,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 			})
 		case kind := <-d.nudges:
 			logging.Guard("nudge", func() error {
-				if kind == control.KindReload {
+				switch kind {
+				case control.KindReload:
 					d.reload()
+				case control.KindReembed:
+					// Operator-requested re-compute: force a fresh embedder
+					// (clean degraded latch) and re-run the semantic init.
+					d.reloadWith(true)
 				}
 				d.processCorrections(ctx)
 				d.expireStaleLLMWork(ctx)
@@ -560,7 +573,7 @@ func (d *Daemon) decideAndAct(ctx context.Context, situation domain.Situation,
 
 	cfg, allow, _ := d.snapshot()
 
-	sig := domain.ComputeSignature(situation)
+	sig := domain.ComputeSignatureN(situation, cfg.Embedding.PaneSalientChars)
 	// Semantic resolution may remap the key onto an existing learned
 	// signature (embedding / BM25 match on the masked salient content);
 	// sig.Raw always keeps the literal content hash.
@@ -1259,7 +1272,7 @@ func (d *Daemon) handleRewriteOutcome(ctx context.Context, res rewriteOutcome) {
 		// Compare raw content hashes: the staged signature may have been
 		// semantically remapped onto another key, but Raw always reflects
 		// the pane content as read, so equal Raw means the pane held still.
-		if freshSig := domain.ComputeSignature(current); freshSig.Raw != res.sig.Raw {
+		if freshSig := domain.ComputeSignatureN(current, cfg.Embedding.PaneSalientChars); freshSig.Raw != res.sig.Raw {
 			slog.Info("signature changed during rewrite; dropping send", "agent", s.AgentID)
 			return
 		}
@@ -1513,7 +1526,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 			reject(domain.ReasonLLMNoSubmit, "stale: form changed during consult")
 			return
 		}
-	} else if freshSig := domain.ComputeSignature(current); freshSig.Raw != res.sig.Raw {
+	} else if freshSig := domain.ComputeSignatureN(current, cfg.Embedding.PaneSalientChars); freshSig.Raw != res.sig.Raw {
 		// Compare raw content hashes: the staged signature may have been
 		// semantically remapped onto another key, but Raw always reflects
 		// the pane content as read, so equal Raw means the pane did not

--- a/internal/daemon/semantic.go
+++ b/internal/daemon/semantic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/logging"
 	"github.com/0xGosu/herdr-auto-pilot/internal/match"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/reembed"
 )
 
 // initSemantic builds the match index from the persisted semantic identities
@@ -24,50 +25,32 @@ func (d *Daemon) initSemantic(ctx context.Context, gen int64) {
 		return
 	}
 
-	rows, err := d.opt.Store.ListSignatureEmbeddings(ctx)
+	// Warm the embedder and re-embed rows minted by another model (or with
+	// stale dims) from their stored salient text, so a model swap keeps
+	// every signature matchable. Warm failure is not fatal: the index still
+	// serves BM25 text matching (dims 0).
+	res, err := reembed.Reconcile(ctx, d.opt.Store, d.embedderPort(),
+		func(_, _ int, sig string, rowErr error) {
+			if rowErr != nil {
+				slog.Warn("re-embedding stored signature failed; row serves text matching only",
+					"signature", sig, "error", rowErr)
+			}
+		},
+		// A newer reload owns the table once the generation moves on; stop
+		// so this run cannot overwrite the newer run's fresh vectors.
+		func() bool { return d.semanticGen.Load() != gen })
 	if err != nil {
 		slog.Warn("semantic index load failed; matching stays exact-hash", "error", err)
 		return
 	}
-
-	// Warm the embedder to learn the model's dimensionality. Failure is not
-	// fatal: the index still serves BM25 text matching (dims 0).
-	dims := 0
-	emb := d.embedderPort()
-	if emb != nil {
-		if _, err := emb.EmbedText(ctx, "warmup"); err != nil {
-			slog.Warn("embedder unavailable; semantic matching falls back to text search", "error", err)
-		} else {
-			dims = emb.Dims()
-		}
-	}
-
-	// Vectors from another model (or stale dims) are re-embedded from their
-	// stored salient text so a model swap keeps every signature matchable.
-	if dims > 0 {
-		for i := range rows {
-			r := &rows[i]
-			if r.Model == emb.ModelID() && len(r.Vector) == dims {
-				continue
-			}
-			vec, err := emb.EmbedText(ctx, r.Salient)
-			if err != nil {
-				slog.Warn("re-embedding stored signature failed; row serves text matching only",
-					"signature", r.Signature, "error", err)
-				r.Vector, r.Dims, r.Model = nil, 0, ""
-				continue
-			}
-			r.Vector, r.Dims, r.Model = vec, dims, emb.ModelID()
-			if err := d.opt.Store.UpsertSignatureEmbedding(ctx, *r); err != nil {
-				slog.Warn("persisting re-embedded signature failed", "signature", r.Signature, "error", err)
-			}
-		}
+	if res.WarmErr != nil {
+		slog.Warn("embedder unavailable; semantic matching falls back to text search", "error", res.WarmErr)
 	}
 
 	if d.semanticGen.Load() != gen {
 		return // superseded by a newer reload; let its run own the index
 	}
-	if err := d.matcher.Rebuild(rows, dims); err != nil {
+	if err := d.matcher.Rebuild(res.Rows, res.Dims); err != nil {
 		slog.Warn("semantic index rebuild failed; matching stays exact-hash", "error", err)
 		return
 	}
@@ -75,7 +58,7 @@ func (d *Daemon) initSemantic(ctx context.Context, gen int64) {
 		return // a newer reload raced past; it decides readiness
 	}
 	d.semanticReady.Store(true)
-	slog.Info("semantic matching ready", "signatures", len(rows), "vector_dims", dims)
+	slog.Info("semantic matching ready", "signatures", len(res.Rows), "vector_dims", res.Dims)
 }
 
 // resolveSignature maps a freshly computed signature to its learning key:

--- a/internal/daemon/semantic_test.go
+++ b/internal/daemon/semantic_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store"
 	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
 )
@@ -21,6 +23,7 @@ type fakeEmbedder struct {
 	vectors map[string][]float32
 	calls   int
 	fail    bool
+	closed  bool
 }
 
 func (f *fakeEmbedder) EmbedText(ctx context.Context, text string) ([]float32, error) {
@@ -40,12 +43,24 @@ func (f *fakeEmbedder) EmbedText(ctx context.Context, text string) ([]float32, e
 
 func (f *fakeEmbedder) ModelID() string { return "fake-model" }
 func (f *fakeEmbedder) Dims() int       { return 4 }
-func (f *fakeEmbedder) Close() error    { return nil }
+
+func (f *fakeEmbedder) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+	return nil
+}
 
 func (f *fakeEmbedder) callCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.calls
+}
+
+func (f *fakeEmbedder) wasClosed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closed
 }
 
 // semanticHarness builds a daemon with a real store + matcher and a fake
@@ -300,4 +315,101 @@ func TestInitSemanticRebuildsFromStoreAndReembedsForeignModels(t *testing.T) {
 	if sig.Signature != "approval:legacy" {
 		t.Errorf("resolved to %s, want approval:legacy", sig.Signature)
 	}
+}
+
+// TestReembedNudgeSwapsEmbedderAndRetriesDegraded covers the KindReembed
+// path (reloadWith(true)): a failed re-embed pass — the shape a degraded
+// embedder latch leaves behind — is retried with a FRESH embedder even
+// though the [embedding] config never changed, while a plain reload keeps
+// the existing (possibly latched) instance.
+func TestReembedNudgeSwapsEmbedderAndRetriesDegraded(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	raw, err := store.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { raw.Close() })
+
+	if err := raw.UpsertSignatureEmbedding(ctx, domain.SignatureEmbedding{
+		Signature: "approval:legacy", SituationType: domain.SituationApproval,
+		AgentType: "claude", Model: "old-model", Dims: 2, Vector: []float32{1, 0},
+		Salient: "permission:push to remote", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The factory hands out whatever `current` points at, like the prod
+	// factory building an embedder from live config.
+	failing := &fakeEmbedder{fail: true}
+	var mu sync.Mutex
+	current := ports.EmbedderPort(failing)
+	factoryCalls := 0
+	factory := func(config.Config) ports.EmbedderPort {
+		mu.Lock()
+		defer mu.Unlock()
+		factoryCalls++
+		return current
+	}
+
+	d, err := New(Options{
+		ConfigPath:        filepath.Join(dir, "config.toml"),
+		ControlSocketPath: filepath.Join(testutil.SocketDir(t), "c.sock"),
+		Store:             raw,
+		Herdr:             &fakeHerdr{},
+		Events:            &fakeEvents{ch: make(chan domain.AgentTransition, 4)},
+		Notify:            &fakeHerdr{},
+		EmbedderFactory:   factory,
+		MatchIndexDir:     filepath.Join(dir, "match-index"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if d.matcher != nil {
+			d.matcher.Close()
+		}
+	})
+	waitFor(t, 5*time.Second, func() bool { return d.semanticReady.Load() })
+
+	// The failing embedder left the row on the old model (text-only pass).
+	rows, _ := raw.ListSignatureEmbeddings(ctx)
+	if len(rows) != 1 || rows[0].Model != "old-model" {
+		t.Fatalf("row should be untouched after a failed pass: %+v", rows)
+	}
+
+	// A plain reload must NOT rebuild the embedder (config unchanged): the
+	// factory is not consulted again, so a degraded instance would persist.
+	if err := d.reload(); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	calls := factoryCalls
+	mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("plain reload rebuilt the embedder (factory calls = %d, want 1)", calls)
+	}
+
+	// The forced path (KindReembed) swaps in a fresh instance and re-embeds.
+	working := &fakeEmbedder{}
+	mu.Lock()
+	current = working
+	mu.Unlock()
+	if err := d.reloadWith(true); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	calls = factoryCalls
+	mu.Unlock()
+	if calls != 2 {
+		t.Fatalf("forced reload must rebuild the embedder (factory calls = %d, want 2)", calls)
+	}
+	if !failing.wasClosed() {
+		t.Error("the replaced embedder must be closed")
+	}
+
+	waitFor(t, 5*time.Second, func() bool {
+		rows, err := raw.ListSignatureEmbeddings(ctx)
+		return err == nil && len(rows) == 1 && rows[0].Model == "fake-model" && rows[0].Dims == 4
+	})
 }

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -164,7 +164,8 @@ func (d *Daemon) handleSweepOutcome(ctx context.Context, res sweepOutcome) {
 	d.releasePane(res.situation.AgentID)
 	now := d.opt.Clock.Now()
 	if res.degraded {
-		sig := domain.ComputeSignature(res.situation)
+		cfg, _, _ := d.snapshot()
+		sig := domain.ComputeSignatureN(res.situation, cfg.Embedding.PaneSalientChars)
 		d.escalate(ctx, res.situation, sig, domain.Decision{
 			Action: domain.ActionEscalate, Reason: domain.ReasonHerdrUnreachable,
 			Rationale: "sweep failed: " + res.reason + "; partial capture, answer in pane",

--- a/internal/domain/signature.go
+++ b/internal/domain/signature.go
@@ -57,6 +57,12 @@ const overMaskMinContent = 12
 // may consist of placeholders before the situation is deemed over-masked.
 const overMaskMaxRatio = 0.6
 
+// DefaultPaneSalientChars is the fallback window: for situations with no
+// structured salient field (idle, and any unclassified content), the
+// signature is minted from the last this-many characters of pane content.
+// Operators can widen or narrow it via embedding.pane_salient_chars.
+const DefaultPaneSalientChars = 800
+
 // SignatureResult is the output of signature generation.
 type SignatureResult struct {
 	// Signature is the learning key situations are matched under. Semantic
@@ -73,7 +79,15 @@ type SignatureResult struct {
 // type + agent type + salient decision content, with volatile tokens masked,
 // scoped per agent type. It applies the over-masking floor (FR-003a).
 func ComputeSignature(s Situation) SignatureResult {
-	salient := salientContent(s)
+	return ComputeSignatureN(s, DefaultPaneSalientChars)
+}
+
+// ComputeSignatureN is ComputeSignature with an explicit fallback content
+// window: salientChars bounds the trailing pane-content characters used for
+// idle and unclassified situations; salientChars <= 0 falls back to
+// DefaultPaneSalientChars.
+func ComputeSignatureN(s Situation, salientChars int) SignatureResult {
+	salient := salientContent(s, salientChars)
 	masked := MaskVolatile(salient)
 
 	if verdict := overMaskVerdict(masked); verdict != GuardOK {
@@ -93,9 +107,9 @@ func ComputeSignature(s Situation) SignatureResult {
 
 // salientContent extracts the decision-relevant content per situation type:
 // the normalized option set for choices, the permission verb/action for
-// approvals, the error summary for errors, and a trimmed head of the pane
-// content otherwise.
-func salientContent(s Situation) string {
+// approvals, the error summary for errors, and the trailing salientChars
+// characters of the pane content otherwise.
+func salientContent(s Situation, salientChars int) string {
 	switch s.Type {
 	case SituationChoice:
 		opts := make([]string, len(s.Options))
@@ -113,10 +127,14 @@ func salientContent(s Situation) string {
 			return "error:" + s.ErrorSummary
 		}
 	}
+	if salientChars <= 0 {
+		salientChars = DefaultPaneSalientChars
+	}
 	content := s.Content
-	const head = 400
-	if len(content) > head {
-		content = content[len(content)-head:]
+	// Trailing salientChars characters (rune-aware, so a multibyte glyph is
+	// never split at the window boundary — matches the "chars" naming).
+	if r := []rune(content); len(r) > salientChars {
+		content = string(r[len(r)-salientChars:])
 	}
 	return content
 }

--- a/internal/domain/signature_test.go
+++ b/internal/domain/signature_test.go
@@ -154,3 +154,36 @@ func TestComputeSignatureRawMirrorsKey(t *testing.T) {
 			over.Signature, over.Raw)
 	}
 }
+
+func TestComputeSignatureNWindow(t *testing.T) {
+	// salientContent keeps the TRAILING salientChars of pane content, so the
+	// distinguishing text goes in the PREFIX with a long shared suffix: a
+	// narrow (tail) window sees only the shared suffix, a wide window reaches
+	// back into the differing prefix.
+	suffix := strings.Repeat("status ok ", 60) // ~600 chars of shared real words
+	a := sit(SituationIdle, "claude", "the build finished successfully "+suffix)
+	b := sit(SituationIdle, "claude", "the build failed with three errs "+suffix)
+
+	// Narrow window (only the shared suffix fits) → identical salient.
+	if narrowA, narrowB := ComputeSignatureN(a, 20), ComputeSignatureN(b, 20); narrowA.Salient != narrowB.Salient {
+		t.Fatalf("narrow window premise broken: %q vs %q", narrowA.Salient, narrowB.Salient)
+	}
+
+	// Wide window (spans back into the differing prefix) → distinct signatures.
+	wideA := ComputeSignatureN(a, 800)
+	wideB := ComputeSignatureN(b, 800)
+	if wideA.Verdict != GuardOK || wideB.Verdict != GuardOK {
+		t.Fatalf("wide window should yield valid signatures: %v / %v", wideA.Verdict, wideB.Verdict)
+	}
+	if wideA.Raw == wideB.Raw {
+		t.Errorf("wider window must distinguish prefixes a narrow one cannot see: both = %q", wideA.Raw)
+	}
+
+	// salientChars <= 0 falls back to the default window (same as ComputeSignature).
+	if got, want := ComputeSignatureN(a, 0).Raw, ComputeSignature(a).Raw; got != want {
+		t.Errorf("salientChars<=0 should match the default: %q vs %q", got, want)
+	}
+	if DefaultPaneSalientChars != 800 {
+		t.Errorf("DefaultPaneSalientChars = %d, want 800", DefaultPaneSalientChars)
+	}
+}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -4,6 +4,8 @@
 // name rows, TOML) directly, then nudge the daemon's control socket to
 // reload; front-ends never write daemon-owned hot-path rows (agent_names
 // is insert-if-absent from both sides and not part of that partition).
+// One maintenance exception: ReembedStandalone rewrites the daemon-owned
+// signature_embeddings rows, and only when no daemon is running.
 package frontend
 
 import (
@@ -21,6 +23,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/embedder"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/reembed"
 )
 
 // menuReadLines is how much of a pane the confirm/resolve path re-reads to
@@ -54,6 +57,9 @@ type App struct {
 	// DaemonInfo reports the running daemon's identity from the lock file
 	// (daemonlock.Info in prod); nil hides the daemon line in status.
 	DaemonInfo func() (running bool, pid int, version string)
+	// NewEmbedder builds the embedder for ReembedStandalone; nil defaults
+	// to the production embedder. Tests inject fakes.
+	NewEmbedder func(cfg config.Embedding) ports.EmbedderPort
 }
 
 // nudge wakes the daemon; a failed nudge is surfaced but non-fatal (the
@@ -84,6 +90,9 @@ type Status struct {
 	// "model missing (<path>)", or "ready (N signatures, <model>)". The
 	// daemon's live health (a degraded embedder) shows in its log instead.
 	Embedding string
+	// Drift reports stored embeddings minted by a different model than the
+	// currently configured one (best-effort; zero-valued on check failure).
+	Drift EmbeddingDrift
 }
 
 // GetStatus returns the operator-facing status summary.
@@ -122,7 +131,15 @@ func (a *App) GetStatus(ctx context.Context) (Status, error) {
 	if names, err := a.Store.AgentNames(ctx); err == nil {
 		st.AgentNames = names
 	}
-	st.Embedding = a.embeddingStatus(ctx)
+	// One config load serves both embedding summaries so they cannot
+	// disagree about a mid-edit config within a single status snapshot.
+	if cfg, err := config.Load(a.ConfigPath); err != nil {
+		st.Embedding = "unknown (config unreadable)"
+	} else {
+		st.Embedding = a.embeddingStatus(ctx, cfg)
+		// Best-effort: a drift-check failure must not break status.
+		st.Drift, _ = a.embeddingDrift(ctx, cfg)
+	}
 	// Name any live agent the daemon has not named yet (a brand-new agent,
 	// or one that predates the daemon): the operator should never have to
 	// stare at a bare pane id. Insert-if-absent, so this can never clobber
@@ -148,11 +165,7 @@ func (st Status) AgentName(agentID string) string { return st.AgentNames[agentID
 
 // embeddingStatus summarizes semantic-matching availability from config,
 // model presence on disk, and the persisted signature-embedding count.
-func (a *App) embeddingStatus(ctx context.Context) string {
-	cfg, err := config.Load(a.ConfigPath)
-	if err != nil {
-		return "unknown (config unreadable)"
-	}
+func (a *App) embeddingStatus(ctx context.Context, cfg config.Config) string {
 	if cfg.Embedding.Disabled {
 		return "disabled"
 	}
@@ -168,6 +181,110 @@ func (a *App) embeddingStatus(ctx context.Context) string {
 		return fmt.Sprintf("ready (%s)", filepath.Base(modelPath))
 	}
 	return fmt.Sprintf("ready (%d signatures, %s)", count, filepath.Base(modelPath))
+}
+
+// EmbeddingDrift reports whether stored signature embeddings were produced
+// by a different model than the currently configured one. Detection is by
+// model id (gguf basename): replacing the model file IN PLACE under the
+// same name is not detected here (a dims change is still caught by the
+// daemon's reconcile at its next index init; a same-dims in-place swap
+// silently mixes vector spaces).
+type EmbeddingDrift struct {
+	Detected     bool   // stale rows exist and embedding is enabled
+	ModelID      string // basename of the resolved model path
+	ModelMissing bool   // model file absent — a re-embed cannot run yet
+	Total        int64  // all signature_embeddings rows
+	Stale        int64  // rows a re-embed would rewrite
+}
+
+// EmbeddingDrift checks stored embeddings against the configured model.
+// Zero-valued (Detected=false) when embedding is disabled.
+func (a *App) EmbeddingDrift(ctx context.Context) (EmbeddingDrift, error) {
+	cfg, err := config.Load(a.ConfigPath)
+	if err != nil {
+		return EmbeddingDrift{}, fmt.Errorf("load config: %w", err)
+	}
+	return a.embeddingDrift(ctx, cfg)
+}
+
+// embeddingDrift is EmbeddingDrift against an already loaded config.
+func (a *App) embeddingDrift(ctx context.Context, cfg config.Config) (EmbeddingDrift, error) {
+	var d EmbeddingDrift
+	if cfg.Embedding.Disabled {
+		return d, nil
+	}
+	modelPath := embedder.ResolveModelPath(cfg.Embedding)
+	d.ModelID = filepath.Base(modelPath)
+	if _, err := os.Stat(modelPath); err != nil {
+		d.ModelMissing = true
+	}
+	var err error
+	if d.Total, err = a.Store.CountSignatureEmbeddings(ctx); err != nil {
+		return d, err
+	}
+	if d.Stale, err = a.Store.CountStaleSignatureEmbeddings(ctx, d.ModelID); err != nil {
+		return d, err
+	}
+	d.Detected = d.Stale > 0
+	return d, nil
+}
+
+// RequestReembed asks the running daemon to rebuild a fresh embedder and
+// re-embed stored signatures (control.KindReembed). Errors with the CLI
+// remedy when no daemon is running.
+func (a *App) RequestReembed(ctx context.Context) error {
+	if a.DaemonInfo != nil {
+		if running, _, _ := a.DaemonInfo(); !running {
+			return fmt.Errorf("daemon not running — run: hap signatures reembed")
+		}
+	}
+	return a.nudge(ctx, control.KindReembed)
+}
+
+// ReembedStandalone re-embeds stored signatures in this process. Only safe
+// when no daemon is running (the daemon is the owner-writer of
+// signature_embeddings), so it refuses otherwise. A daemon starting
+// mid-run is harmless: upserts are idempotent per signature and its own
+// semantic init reconciles again — worst case duplicate work. The bleve
+// match index is left alone (a disposable cache the daemon wipes and
+// rebuilds at start). progress may be nil.
+func (a *App) ReembedStandalone(ctx context.Context, progress reembed.RowFunc) (reembed.Result, error) {
+	var res reembed.Result
+	if a.DaemonInfo != nil {
+		if running, pid, _ := a.DaemonInfo(); running {
+			return res, fmt.Errorf("daemon is running (pid %d) — use: hap signatures reembed (it nudges the daemon), or stop the daemon first", pid)
+		}
+	}
+	cfg, err := config.Load(a.ConfigPath)
+	if err != nil {
+		return res, fmt.Errorf("load config: %w", err)
+	}
+	if cfg.Embedding.Disabled {
+		return res, fmt.Errorf("embedding is disabled in config — nothing to re-embed")
+	}
+	ws, ok := a.Store.(reembed.Store)
+	if !ok {
+		return res, fmt.Errorf("store lacks write access for re-embedding")
+	}
+	var emb ports.EmbedderPort
+	if a.NewEmbedder != nil {
+		emb = a.NewEmbedder(cfg.Embedding)
+	} else {
+		emb = embedder.New(cfg.Embedding)
+	}
+	defer emb.Close()
+	res, err = reembed.Reconcile(ctx, ws, emb, progress, nil)
+	if err != nil {
+		return res, err
+	}
+	if res.WarmErr != nil {
+		return res, fmt.Errorf("embedding model unavailable, nothing re-embedded: %w", res.WarmErr)
+	}
+	// Best-effort: if a daemon appeared mid-run, have it reload the index.
+	if nudgeErr := a.nudge(ctx, control.KindReembed); nudgeErr != nil {
+		_ = nudgeErr // no daemon to pick it up; the next start reconciles
+	}
+	return res, nil
 }
 
 // Names returns the agent id → short name mapping.
@@ -483,6 +600,7 @@ var ConfigFields = []ConfigFieldDef{
 	{Key: "embedding.similarity_threshold", TUIEditable: true},
 	{Key: "embedding.bm25_min_score", TUIEditable: true},
 	{Key: "embedding.gpu_layers", TUIEditable: true},
+	{Key: "embedding.pane_salient_chars", TUIEditable: true},
 	{Key: "tui.max_content_width", TUIEditable: true},
 	{Key: "tui.theme", TUIEditable: true},
 }
@@ -524,6 +642,11 @@ func FieldValue(cfg config.Config, key string) string {
 		return fmt.Sprintf("%.2f", cfg.Thresholds.InferredTaskBar)
 	case "learning.graduation_n":
 		return strconv.Itoa(cfg.Learning.GraduationN)
+	case "embedding.pane_salient_chars":
+		if cfg.Embedding.PaneSalientChars <= 0 {
+			return fmt.Sprintf("%d (default)", domain.DefaultPaneSalientChars)
+		}
+		return strconv.Itoa(cfg.Embedding.PaneSalientChars)
 	case "limits.max_consecutive_auto_prompts":
 		return strconv.Itoa(cfg.Limits.MaxConsecutiveAutoPrompts)
 	case "limits.max_auto_prompts_per_minute":
@@ -619,6 +742,8 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 			return setFloat(&cfg.Thresholds.InferredTaskBar)
 		case "learning.graduation_n":
 			return setInt(&cfg.Learning.GraduationN)
+		case "embedding.pane_salient_chars":
+			return setInt(&cfg.Embedding.PaneSalientChars)
 		case "limits.max_consecutive_auto_prompts":
 			return setInt(&cfg.Limits.MaxConsecutiveAutoPrompts)
 		case "limits.max_auto_prompts_per_minute":

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/control"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store"
 	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
 )
@@ -33,6 +36,207 @@ func testApp(t *testing.T) (*frontend.App, *store.Store) {
 		Author:     "operator",
 		// no ControlPath: nudges are skipped (daemon absent is legal)
 	}, st
+}
+
+// fakeEmbedder is a canned embedder for the standalone re-embed path.
+type fakeEmbedder struct {
+	fail bool
+	dims int
+	id   string
+}
+
+func (f *fakeEmbedder) EmbedText(context.Context, string) ([]float32, error) {
+	if f.fail {
+		return nil, errors.New("induced embed failure")
+	}
+	v := make([]float32, f.dims)
+	v[0] = 1
+	return v, nil
+}
+func (f *fakeEmbedder) ModelID() string { return f.id }
+func (f *fakeEmbedder) Dims() int       { return f.dims }
+func (f *fakeEmbedder) Close() error    { return nil }
+
+// seedEmbeddingRow persists one semantic identity row minted by `model`.
+func seedEmbeddingRow(t *testing.T, st *store.Store, sig, model string, vec []float32) {
+	t.Helper()
+	if err := st.UpsertSignatureEmbedding(context.Background(), domain.SignatureEmbedding{
+		Signature: sig, SituationType: domain.SituationApproval, AgentType: "claude",
+		Model: model, Dims: len(vec), Vector: vec,
+		Salient: "permission:" + sig, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeEmbeddingConfig points [embedding] model_path at a real temp file so
+// the drift check sees the model as present.
+func writeEmbeddingConfig(t *testing.T, app *frontend.App) string {
+	t.Helper()
+	modelPath := filepath.Join(t.TempDir(), "test-model.gguf")
+	if err := os.WriteFile(modelPath, []byte("gguf"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgTOML := fmt.Sprintf("[embedding]\nmodel_path = %q\n", modelPath)
+	if err := os.WriteFile(app.ConfigPath, []byte(cfgTOML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return modelPath
+}
+
+func TestEmbeddingDrift(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	writeEmbeddingConfig(t, app)
+
+	// No rows yet: no drift.
+	d, err := app.EmbeddingDrift(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Detected || d.ModelMissing || d.ModelID != "test-model.gguf" {
+		t.Errorf("empty store must not drift: %+v", d)
+	}
+
+	seedEmbeddingRow(t, st, "current", "test-model.gguf", []float32{1, 0, 0})
+	seedEmbeddingRow(t, st, "legacy", "old-model.gguf", []float32{1, 0})
+	d, err = app.EmbeddingDrift(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.Detected || d.Stale != 1 || d.Total != 2 {
+		t.Errorf("drift = %+v, want Detected with 1 of 2 stale", d)
+	}
+
+	// GetStatus carries the same check.
+	st2, err := app.GetStatus(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st2.Drift.Detected || st2.Drift.Stale != 1 {
+		t.Errorf("status drift = %+v, want detected", st2.Drift)
+	}
+
+	// Missing model file → ModelMissing, drift still counted.
+	cfgTOML := "[embedding]\nmodel_path = \"/nonexistent/other-model.gguf\"\n"
+	if err := os.WriteFile(app.ConfigPath, []byte(cfgTOML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	d, err = app.EmbeddingDrift(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.ModelMissing || !d.Detected || d.Stale != 2 {
+		t.Errorf("missing model: %+v, want ModelMissing with 2 stale", d)
+	}
+
+	// Disabled embedding → zero-valued.
+	if err := os.WriteFile(app.ConfigPath, []byte("[embedding]\ndisabled = true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	d, err = app.EmbeddingDrift(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Detected || d.ModelID != "" {
+		t.Errorf("disabled embedding must report zero drift: %+v", d)
+	}
+}
+
+func TestRequestReembedRequiresDaemon(t *testing.T) {
+	app, _ := testApp(t)
+	ctx := context.Background()
+
+	app.DaemonInfo = func() (bool, int, string) { return false, 0, "" }
+	err := app.RequestReembed(ctx)
+	if err == nil || !strings.Contains(err.Error(), "hap signatures reembed") {
+		t.Errorf("daemon-down error must point at the CLI remedy, got %v", err)
+	}
+
+	// Daemon up: the KindReembed nudge reaches the control socket.
+	sock := filepath.Join(testutil.SocketDir(t), "ctl.sock")
+	var mu sync.Mutex
+	var kinds []control.Kind
+	srv, err := control.NewServer(sock, func(k control.Kind) {
+		mu.Lock()
+		kinds = append(kinds, k)
+		mu.Unlock()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	app.ControlPath = sock
+	app.DaemonInfo = func() (bool, int, string) { return true, 42, "test" }
+	if err := app.RequestReembed(ctx); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(kinds)
+		mu.Unlock()
+		if n > 0 {
+			if kinds[0] != control.KindReembed {
+				t.Errorf("nudge kind = %v, want %v", kinds[0], control.KindReembed)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("reembed nudge never reached the daemon socket")
+}
+
+func TestReembedStandalone(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	writeEmbeddingConfig(t, app)
+	seedEmbeddingRow(t, st, "legacy", "old-model.gguf", []float32{1, 0})
+	seedEmbeddingRow(t, st, "current", "test-model.gguf", []float32{1, 0, 0})
+	app.NewEmbedder = func(config.Embedding) ports.EmbedderPort {
+		return &fakeEmbedder{dims: 3, id: "test-model.gguf"}
+	}
+
+	// Refused while a daemon runs (it owns signature_embeddings writes).
+	app.DaemonInfo = func() (bool, int, string) { return true, 42, "test" }
+	if _, err := app.ReembedStandalone(ctx, nil); err == nil {
+		t.Fatal("standalone re-embed must refuse while a daemon is running")
+	}
+
+	app.DaemonInfo = func() (bool, int, string) { return false, 0, "" }
+	res, err := app.ReembedStandalone(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Reembedded != 1 || res.Kept != 1 || res.Downgraded != 0 {
+		t.Errorf("Reembedded/Kept/Downgraded = %d/%d/%d, want 1/1/0",
+			res.Reembedded, res.Kept, res.Downgraded)
+	}
+	d, err := app.EmbeddingDrift(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Detected {
+		t.Errorf("drift must clear after standalone re-embed: %+v", d)
+	}
+
+	// An unavailable model fails loudly instead of silently doing nothing.
+	app.NewEmbedder = func(config.Embedding) ports.EmbedderPort {
+		return &fakeEmbedder{fail: true}
+	}
+	seedEmbeddingRow(t, st, "legacy2", "old-model.gguf", []float32{1, 0})
+	if _, err := app.ReembedStandalone(ctx, nil); err == nil ||
+		!strings.Contains(err.Error(), "embedding model unavailable") {
+		t.Errorf("warm failure must surface, got %v", err)
+	}
+
+	// Disabled embedding is an explicit error, not a silent no-op.
+	if err := os.WriteFile(app.ConfigPath, []byte("[embedding]\ndisabled = true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.ReembedStandalone(ctx, nil); err == nil {
+		t.Error("disabled embedding must error")
+	}
 }
 
 func TestPauseResumeAppendsKillEvents(t *testing.T) {
@@ -399,6 +603,7 @@ func TestConfigFieldRegistryParity(t *testing.T) {
 		"thresholds.error":                    "0.90",
 		"thresholds.inferred_task_bar":        "0.95",
 		"learning.graduation_n":               "5",
+		"embedding.pane_salient_chars":        "800",
 		"limits.max_consecutive_auto_prompts": "5",
 		"limits.max_auto_prompts_per_minute":  "10",
 		"limits.max_error_retries":            "2",
@@ -450,6 +655,34 @@ func TestConfigFieldRegistryParity(t *testing.T) {
 		if err := app.SetField(ctx, key, samples[key]); err != nil {
 			t.Errorf("SetField(%s, %q) rejected a valid value: %v", key, samples[key], err)
 		}
+	}
+}
+
+func TestPaneSalientCharsFieldDisplay(t *testing.T) {
+	// Unset (0) renders the effective built-in default, not a bare "0".
+	def := config.Default()
+	got := frontend.FieldValue(def, "embedding.pane_salient_chars")
+	if !strings.Contains(got, "default") || !strings.Contains(got, "800") {
+		t.Errorf("unset pane_salient_chars should show the default, got %q", got)
+	}
+	// An explicit value renders plainly.
+	def.Embedding.PaneSalientChars = 1200
+	if got := frontend.FieldValue(def, "embedding.pane_salient_chars"); got != "1200" {
+		t.Errorf("explicit pane_salient_chars display = %q, want 1200", got)
+	}
+
+	// SetField round-trips through the store and rejects non-positive values.
+	app, _ := testApp(t)
+	ctx := context.Background()
+	if err := app.SetField(ctx, "embedding.pane_salient_chars", "1000"); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ := app.Config()
+	if cfg.Embedding.PaneSalientChars != 1000 {
+		t.Errorf("SetField did not persist pane_salient_chars, got %d", cfg.Embedding.PaneSalientChars)
+	}
+	if err := app.SetField(ctx, "embedding.pane_salient_chars", "0"); err == nil {
+		t.Error("pane_salient_chars must reject 0 (use omission for the default)")
 	}
 }
 

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -106,9 +106,11 @@ type RewriterPort interface {
 }
 
 // StorePort is the persistence boundary. Write-ownership is partitioned:
-// daemon-exclusive writers for signatures/agent_rate/error_retries/decisions
-// and daemon-emitted audit rows; front-ends write corrections/kill_events;
-// the mcp process writes llm_decisions only.
+// daemon-exclusive writers for signatures/agent_rate/error_retries/decisions,
+// daemon-emitted audit rows, and signature_embeddings (with one maintenance
+// exception: `hap signatures reembed` rewrites signature_embeddings from the
+// CLI process when no daemon is running); front-ends write
+// corrections/kill_events; the mcp process writes llm_decisions only.
 type StorePort interface {
 	DaemonStore
 	FrontendStore
@@ -220,6 +222,9 @@ type ReadStore interface {
 	ListSignatureEmbeddings(ctx context.Context) ([]domain.SignatureEmbedding, error)
 	// CountSignatureEmbeddings reports how many semantic identity rows exist.
 	CountSignatureEmbeddings(ctx context.Context) (int64, error)
+	// CountStaleSignatureEmbeddings counts rows a re-embed under the given
+	// model id would rewrite (other-model vectors and text-only rows).
+	CountStaleSignatureEmbeddings(ctx context.Context, model string) (int64, error)
 	// GetSignatureSnapshot returns the pane excerpt a signature was first
 	// seen with, or "" when none was captured (pre-snapshot rules).
 	GetSignatureSnapshot(ctx context.Context, signature string) (string, error)

--- a/internal/reembed/reembed.go
+++ b/internal/reembed/reembed.go
@@ -1,0 +1,117 @@
+// Package reembed reconciles persisted signature-embedding rows with the
+// currently configured embedding model: rows minted by another model (or
+// carrying no vector) are re-embedded from their stored masked salient
+// text so a model swap keeps every learned signature matchable. Shared by
+// the daemon's initSemantic and the standalone `hap signatures reembed`
+// maintenance path.
+package reembed
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+)
+
+// Store is the minimal persistence surface Reconcile needs (satisfied by
+// *store.Store and ports.StorePort).
+type Store interface {
+	ListSignatureEmbeddings(ctx context.Context) ([]domain.SignatureEmbedding, error)
+	UpsertSignatureEmbedding(ctx context.Context, e domain.SignatureEmbedding) error
+}
+
+// RowFunc observes per-row outcomes for progress reporting and logging;
+// may be nil. A non-nil err means the row failed to re-embed and was
+// downgraded to text-only matching.
+type RowFunc func(done, total int, signature string, err error)
+
+// Result summarizes one reconcile pass.
+type Result struct {
+	// Rows carries every row with its post-reconcile vectors, ready for a
+	// match-index rebuild.
+	Rows []domain.SignatureEmbedding
+	// Dims is the live model's dimensionality; 0 when the embedder was
+	// unavailable (WarmErr says why) and vectors were left untouched.
+	Dims int
+	// WarmErr is the warmup failure that kept the pass text-only, nil on a
+	// healthy embedder.
+	WarmErr error
+
+	Kept          int // already current model + dims; not re-embedded
+	Reembedded    int // re-embedded and persisted under the live model
+	Downgraded    int // embed failed; row now serves text matching only
+	PersistFailed int // re-embedded but the upsert failed; SQLite row stays stale
+}
+
+// Reconcile lists all signature-embedding rows, warms emb to learn the
+// model's dimensionality, and re-embeds every stale row from its Salient
+// text, upserting each change. Per-row failures downgrade that row and
+// continue — only the initial list read errors the whole pass. A nil (or
+// unwarmable) embedder leaves every row untouched: the index still serves
+// BM25 text matching. A non-nil stale callback is consulted between rows:
+// once it reports true the pass stops embedding and persisting (a newer
+// pass owns the table now) and returns what it has.
+func Reconcile(ctx context.Context, st Store, emb ports.EmbedderPort, onRow RowFunc, stale func() bool) (Result, error) {
+	var res Result
+	rows, err := st.ListSignatureEmbeddings(ctx)
+	if err != nil {
+		return res, fmt.Errorf("load signature embeddings: %w", err)
+	}
+	res.Rows = rows
+
+	if emb == nil {
+		res.WarmErr = fmt.Errorf("no embedder configured")
+		return res, nil
+	}
+	if _, err := emb.EmbedText(ctx, "warmup"); err != nil {
+		res.WarmErr = err
+		return res, nil
+	}
+	res.Dims = emb.Dims()
+	if res.Dims <= 0 {
+		res.WarmErr = fmt.Errorf("embedder reported no dimensionality after warmup")
+		return res, nil
+	}
+
+	total := len(rows)
+	for i := range rows {
+		if stale != nil && stale() {
+			return res, nil // superseded: the newer pass owns the table
+		}
+		r := &rows[i]
+		if r.Model == emb.ModelID() && len(r.Vector) == res.Dims {
+			res.Kept++
+			notify(onRow, i+1, total, r.Signature, nil)
+			continue
+		}
+		vec, err := emb.EmbedText(ctx, r.Salient)
+		if err != nil {
+			r.Vector, r.Dims, r.Model = nil, 0, ""
+			res.Downgraded++
+			notify(onRow, i+1, total, r.Signature, fmt.Errorf("re-embed: %w", err))
+			continue
+		}
+		r.Vector, r.Dims, r.Model = vec, res.Dims, emb.ModelID()
+		if stale != nil && stale() {
+			return res, nil // don't persist under a superseded generation
+		}
+		if err := st.UpsertSignatureEmbedding(ctx, *r); err != nil {
+			// The row's fresh vector remains in Rows for callers that feed
+			// them into an index rebuild, but the persisted copy stays on
+			// the old model and the drift count keeps flagging it.
+			res.PersistFailed++
+			notify(onRow, i+1, total, r.Signature, fmt.Errorf("persist re-embedded signature: %w", err))
+			continue
+		}
+		res.Reembedded++
+		notify(onRow, i+1, total, r.Signature, nil)
+	}
+	return res, nil
+}
+
+func notify(onRow RowFunc, done, total int, signature string, err error) {
+	if onRow != nil {
+		onRow(done, total, signature, err)
+	}
+}

--- a/internal/reembed/reembed_test.go
+++ b/internal/reembed/reembed_test.go
@@ -1,0 +1,248 @@
+package reembed_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/reembed"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// fakeEmb is a canned-vector embedder: failAll fails every call (warm
+// included); failText fails only that exact text, so warm succeeds.
+type fakeEmb struct {
+	mu       sync.Mutex
+	dims     int
+	id       string
+	failAll  bool
+	failText string
+	calls    int
+}
+
+func (f *fakeEmb) EmbedText(_ context.Context, text string) ([]float32, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.failAll || (f.failText != "" && text == f.failText) {
+		return nil, errors.New("induced embed failure")
+	}
+	v := make([]float32, f.dims)
+	v[0] = 1
+	return v, nil
+}
+
+func (f *fakeEmb) ModelID() string { return f.id }
+func (f *fakeEmb) Dims() int       { return f.dims }
+func (f *fakeEmb) Close() error    { return nil }
+
+func openStore(t *testing.T) *store.Store {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return st
+}
+
+func seedRow(t *testing.T, st *store.Store, sig, model string, vec []float32, salient string) {
+	t.Helper()
+	if err := st.UpsertSignatureEmbedding(context.Background(), domain.SignatureEmbedding{
+		Signature: sig, SituationType: domain.SituationApproval, AgentType: "claude",
+		Model: model, Dims: len(vec), Vector: vec,
+		Salient: salient, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcileReembedsStaleKeepsCurrent(t *testing.T) {
+	ctx := context.Background()
+	st := openStore(t)
+	seedRow(t, st, "approval:current", "new-model", []float32{1, 0, 0}, "permission:current")
+	seedRow(t, st, "approval:foreign", "old-model", []float32{1, 0}, "permission:foreign")
+	seedRow(t, st, "approval:textonly", "", nil, "permission:textonly")
+
+	emb := &fakeEmb{dims: 3, id: "new-model"}
+	var seen []string
+	res, err := reembed.Reconcile(ctx, st, emb, func(done, total int, sig string, rowErr error) {
+		if total != 3 {
+			t.Errorf("RowFunc total = %d, want 3", total)
+		}
+		if rowErr != nil {
+			t.Errorf("unexpected row error for %s: %v", sig, rowErr)
+		}
+		seen = append(seen, sig)
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Kept != 1 || res.Reembedded != 2 || res.Downgraded != 0 {
+		t.Errorf("Kept/Reembedded/Downgraded = %d/%d/%d, want 1/2/0",
+			res.Kept, res.Reembedded, res.Downgraded)
+	}
+	if res.Dims != 3 || res.WarmErr != nil {
+		t.Errorf("Dims = %d WarmErr = %v, want 3/nil", res.Dims, res.WarmErr)
+	}
+	if len(seen) != 3 {
+		t.Errorf("RowFunc saw %d rows, want 3", len(seen))
+	}
+
+	rows, err := st.ListSignatureEmbeddings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range rows {
+		if r.Model != "new-model" || r.Dims != 3 || len(r.Vector) != 3 {
+			t.Errorf("row %s not on the live model: model=%q dims=%d", r.Signature, r.Model, r.Dims)
+		}
+	}
+	if n, _ := st.CountStaleSignatureEmbeddings(ctx, "new-model"); n != 0 {
+		t.Errorf("stale count after reconcile = %d, want 0", n)
+	}
+}
+
+func TestReconcileCurrentRowsSkipEmbedCalls(t *testing.T) {
+	st := openStore(t)
+	seedRow(t, st, "approval:a", "new-model", []float32{1, 0, 0}, "permission:a")
+	seedRow(t, st, "approval:b", "new-model", []float32{0, 1, 0}, "permission:b")
+
+	emb := &fakeEmb{dims: 3, id: "new-model"}
+	res, err := reembed.Reconcile(context.Background(), st, emb, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Kept != 2 || res.Reembedded != 0 {
+		t.Errorf("Kept/Reembedded = %d/%d, want 2/0", res.Kept, res.Reembedded)
+	}
+	if emb.calls != 1 { // warmup only
+		t.Errorf("embed calls = %d, want 1 (warmup only)", emb.calls)
+	}
+}
+
+func TestReconcileEmbedFailureDowngradesAndContinues(t *testing.T) {
+	ctx := context.Background()
+	st := openStore(t)
+	seedRow(t, st, "approval:bad", "old-model", []float32{1, 0}, "permission:bad")
+	seedRow(t, st, "approval:good", "old-model", []float32{0, 1}, "permission:good")
+
+	emb := &fakeEmb{dims: 3, id: "new-model", failText: "permission:bad"}
+	var rowErrs int
+	res, err := reembed.Reconcile(ctx, st, emb, func(_, _ int, sig string, rowErr error) {
+		if rowErr != nil {
+			rowErrs++
+			if sig != "approval:bad" {
+				t.Errorf("row error on %s, want approval:bad", sig)
+			}
+		}
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Downgraded != 1 || res.Reembedded != 1 || rowErrs != 1 {
+		t.Errorf("Downgraded/Reembedded/rowErrs = %d/%d/%d, want 1/1/1",
+			res.Downgraded, res.Reembedded, rowErrs)
+	}
+	// The downgraded row is text-only in the returned rows (for the index)...
+	for _, r := range res.Rows {
+		if r.Signature == "approval:bad" && (r.Vector != nil || r.Model != "") {
+			t.Errorf("downgraded row still carries a vector: %+v", r)
+		}
+	}
+	// ...while its persisted copy keeps the old identity, so the drift
+	// count still flags it for a retry.
+	if n, _ := st.CountStaleSignatureEmbeddings(ctx, "new-model"); n != 1 {
+		t.Errorf("stale count = %d, want 1 (failed row stays stale)", n)
+	}
+}
+
+// upsertFailStore wraps a store and fails every UpsertSignatureEmbedding,
+// exercising the PersistFailed accounting.
+type upsertFailStore struct{ *store.Store }
+
+func (u upsertFailStore) UpsertSignatureEmbedding(context.Context, domain.SignatureEmbedding) error {
+	return errors.New("induced persist failure")
+}
+
+func TestReconcilePersistFailureCountedSeparately(t *testing.T) {
+	ctx := context.Background()
+	st := openStore(t)
+	seedRow(t, st, "approval:legacy", "old-model", []float32{1, 0}, "permission:legacy")
+
+	emb := &fakeEmb{dims: 3, id: "new-model"}
+	res, err := reembed.Reconcile(ctx, upsertFailStore{st}, emb, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.PersistFailed != 1 || res.Reembedded != 0 {
+		t.Errorf("PersistFailed/Reembedded = %d/%d, want 1/0", res.PersistFailed, res.Reembedded)
+	}
+	// The persisted row is untouched, so it still reads as stale.
+	if n, _ := st.CountStaleSignatureEmbeddings(ctx, "new-model"); n != 1 {
+		t.Errorf("stale count = %d, want 1 (persist failed)", n)
+	}
+	// ...but the in-memory row carries the fresh vector for an index rebuild.
+	for _, r := range res.Rows {
+		if r.Signature == "approval:legacy" && (r.Model != "new-model" || len(r.Vector) != 3) {
+			t.Errorf("returned row should hold the fresh vector: %+v", r)
+		}
+	}
+}
+
+func TestReconcileStaleCallbackStopsBeforePersist(t *testing.T) {
+	ctx := context.Background()
+	st := openStore(t)
+	seedRow(t, st, "approval:a", "old-model", []float32{1, 0}, "permission:a")
+	seedRow(t, st, "approval:b", "old-model", []float32{0, 1}, "permission:b")
+
+	emb := &fakeEmb{dims: 3, id: "new-model"}
+	// Report stale immediately: the pass must not persist anything.
+	res, err := reembed.Reconcile(ctx, st, emb, nil, func() bool { return true })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Reembedded != 0 {
+		t.Errorf("Reembedded = %d, want 0 (superseded before any persist)", res.Reembedded)
+	}
+	if n, _ := st.CountStaleSignatureEmbeddings(ctx, "new-model"); n != 2 {
+		t.Errorf("stale count = %d, want 2 (nothing written)", n)
+	}
+}
+
+func TestReconcileWarmFailureLeavesRowsUntouched(t *testing.T) {
+	ctx := context.Background()
+	st := openStore(t)
+	seedRow(t, st, "approval:legacy", "old-model", []float32{1, 0}, "permission:legacy")
+
+	emb := &fakeEmb{dims: 3, id: "new-model", failAll: true}
+	res, err := reembed.Reconcile(ctx, st, emb, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.WarmErr == nil || res.Dims != 0 {
+		t.Fatalf("WarmErr = %v Dims = %d, want warm failure and dims 0", res.WarmErr, res.Dims)
+	}
+	rows, _ := st.ListSignatureEmbeddings(ctx)
+	if len(rows) != 1 || rows[0].Model != "old-model" || rows[0].Dims != 2 {
+		t.Errorf("rows must be untouched on warm failure: %+v", rows)
+	}
+}
+
+func TestReconcileNilEmbedderIsTextOnly(t *testing.T) {
+	st := openStore(t)
+	seedRow(t, st, "approval:legacy", "old-model", []float32{1, 0}, "permission:legacy")
+
+	res, err := reembed.Reconcile(context.Background(), st, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.WarmErr == nil || res.Dims != 0 || len(res.Rows) != 1 {
+		t.Errorf("nil embedder: WarmErr=%v Dims=%d rows=%d, want error/0/1",
+			res.WarmErr, res.Dims, len(res.Rows))
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,8 +2,11 @@
 // busy_timeout, transactional writes). Write ownership is partitioned per
 // the solution's Concurrency & Durability Model: the daemon exclusively
 // writes hot-path rows (signatures, agent_rate, error_retries, decisions,
-// its audit rows); front-ends write corrections/kill_events; the mcp
-// process writes llm_decisions only.
+// its audit rows, signature_embeddings); front-ends write
+// corrections/kill_events; the mcp process writes llm_decisions only. One
+// maintenance exception: `hap signatures reembed` rewrites
+// signature_embeddings from the CLI process when no daemon is running
+// (verified via the daemon lock).
 package store
 
 import (
@@ -495,6 +498,17 @@ func (s *Store) CountSignatureEmbeddings(ctx context.Context) (int64, error) {
 	var n int64
 	err := s.db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM signature_embeddings`).Scan(&n)
+	return n, err
+}
+
+// CountStaleSignatureEmbeddings counts semantic identity rows whose vector
+// was not produced by the given model — including text-only rows (no
+// vector) — i.e. rows a re-embed pass would rewrite.
+func (s *Store) CountStaleSignatureEmbeddings(ctx context.Context, model string) (int64, error) {
+	var n int64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM signature_embeddings
+		 WHERE model <> ? OR vector IS NULL OR dims <= 0`, model).Scan(&n)
 	return n, err
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -769,6 +769,38 @@ func TestSignatureEmbeddingRoundTrip(t *testing.T) {
 	}
 }
 
+func TestCountStaleSignatureEmbeddings(t *testing.T) {
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// One row on the current model, one from another model, one text-only.
+	for _, e := range []domain.SignatureEmbedding{
+		{Signature: "approval:current", SituationType: domain.SituationApproval,
+			AgentType: "claude", Model: "minilm", Dims: 3, Vector: []float32{1, 0, 0},
+			Salient: "permission:a", CreatedAt: now},
+		{Signature: "approval:foreign", SituationType: domain.SituationApproval,
+			AgentType: "claude", Model: "old-model", Dims: 2, Vector: []float32{1, 0},
+			Salient: "permission:b", CreatedAt: now},
+		{Signature: "choice:textonly", SituationType: domain.SituationChoice,
+			AgentType: "codex", Salient: "options:no;yes", CreatedAt: now},
+	} {
+		if err := s.UpsertSignatureEmbedding(ctx, e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if n, err := s.CountStaleSignatureEmbeddings(ctx, "minilm"); err != nil || n != 2 {
+		t.Errorf("stale for minilm = %d (%v), want 2 (foreign + text-only)", n, err)
+	}
+	if n, err := s.CountStaleSignatureEmbeddings(ctx, "third-model"); err != nil || n != 3 {
+		t.Errorf("stale for third-model = %d (%v), want 3", n, err)
+	}
+	if n, err := s.CountStaleSignatureEmbeddings(ctx, "old-model"); err != nil || n != 2 {
+		t.Errorf("stale for old-model = %d (%v), want 2 (current + text-only)", n, err)
+	}
+}
+
 func TestDecodeVectorRejectsCorruptBlob(t *testing.T) {
 	if _, err := decodeVector([]byte{1, 2, 3}, 1); err == nil {
 		t.Error("length mismatch should error")

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -17,6 +17,7 @@ type palette struct {
 	ok      lipgloss.Color
 	paused  lipgloss.Color
 	running lipgloss.Color
+	warn    lipgloss.Color
 	help    lipgloss.Color // empty = faint only (the original look)
 }
 
@@ -33,6 +34,7 @@ var themes = map[string]palette{
 		ok:      lipgloss.Color("46"),
 		paused:  lipgloss.Color("196"),
 		running: lipgloss.Color("46"),
+		warn:    lipgloss.Color("214"),
 	},
 	"dark": {
 		title:   lipgloss.Color("213"),
@@ -41,6 +43,7 @@ var themes = map[string]palette{
 		ok:      lipgloss.Color("84"),
 		paused:  lipgloss.Color("203"),
 		running: lipgloss.Color("84"),
+		warn:    lipgloss.Color("215"),
 		help:    lipgloss.Color("245"),
 	},
 	"light": {
@@ -50,6 +53,7 @@ var themes = map[string]palette{
 		ok:      lipgloss.Color("28"),
 		paused:  lipgloss.Color("124"),
 		running: lipgloss.Color("28"),
+		warn:    lipgloss.Color("130"),
 		help:    lipgloss.Color("240"),
 	},
 	"high-contrast": {
@@ -59,6 +63,7 @@ var themes = map[string]palette{
 		ok:      lipgloss.Color("46"),
 		paused:  lipgloss.Color("201"),
 		running: lipgloss.Color("46"),
+		warn:    lipgloss.Color("208"),
 		help:    lipgloss.Color("252"),
 	},
 }
@@ -83,6 +88,7 @@ func resolvePalette(t config.TUI) palette {
 	set(&p.ok, o.OK)
 	set(&p.paused, o.Paused)
 	set(&p.running, o.Running)
+	set(&p.warn, o.Warn)
 	set(&p.help, o.Help)
 	return p
 }
@@ -100,6 +106,7 @@ type styles struct {
 	help        lipgloss.Style
 	err         lipgloss.Style
 	ok          lipgloss.Style
+	warn        lipgloss.Style
 }
 
 func newStyles(p palette) styles {
@@ -118,6 +125,7 @@ func newStyles(p palette) styles {
 		help:        help,
 		err:         lipgloss.NewStyle().Foreground(p.err),
 		ok:          lipgloss.NewStyle().Foreground(p.ok),
+		warn:        lipgloss.NewStyle().Bold(true).Foreground(p.warn),
 	}
 }
 

--- a/internal/tui/palette_test.go
+++ b/internal/tui/palette_test.go
@@ -20,6 +20,7 @@ func TestPaletteDefaultResolution(t *testing.T) {
 		ok:      lipgloss.Color("46"),
 		paused:  lipgloss.Color("196"),
 		running: lipgloss.Color("46"),
+		warn:    lipgloss.Color("214"),
 		help:    lipgloss.Color(""),
 	}
 	for _, theme := range []string{"", "default", "DEFAULT", "Default", "  default  ", "solarized"} {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -536,6 +536,19 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.do("automation paused", func(ctx context.Context) error { return m.app.Pause(ctx) })
 	case "r":
 		return m, m.do("automation resumed", func(ctx context.Context) error { return m.app.Resume(ctx) })
+	case "R":
+		switch d := m.data.status.Drift; {
+		case !d.Detected:
+			m.message = "no embedding drift detected — rules already match the configured model"
+		case d.ModelMissing:
+			// Match the CLI's refusal: a re-embed cannot run without the
+			// model file, so a "requested" toast would be a lie.
+			m.message = "embedding model not found — fix embedding.model_path first"
+		default:
+			return m, m.do("re-compute requested — daemon is re-embedding in the background",
+				func(ctx context.Context) error { return m.app.RequestReembed(ctx) })
+		}
+		return m, nil
 	case "enter", "y":
 		switch m.tab {
 		case tabEscalations:
@@ -1463,6 +1476,16 @@ func (m Model) View() string {
 	if m.data.err != nil {
 		fmt.Fprintf(&b, "%s\n", st.err.Render("error: "+m.data.err.Error()))
 	}
+	// Embedding-model drift banner: stored rule embeddings were minted by a
+	// different model than the configured one, so semantic matching misses
+	// until they are re-computed. Suppressed while the model file itself is
+	// missing — a re-embed cannot run yet, and the semantic-matching status
+	// line already reports the missing model.
+	if d := m.data.status.Drift; d.Detected && !d.ModelMissing {
+		fmt.Fprintf(&b, "%s\n", st.warn.Render(fmt.Sprintf(
+			"⚠ embedding model changed — %d of %d rules need re-compute; press R or run: hap signatures reembed",
+			d.Stale, d.Total)))
+	}
 
 	if m.detail != nil {
 		m.renderDetail(&b)
@@ -1528,6 +1551,9 @@ func (m Model) helpLine() string {
 		return "type to filter  backspace: erase  esc/enter: apply & close"
 	}
 	common := "tab: switch  ↑/↓: select  p: pause  r: resume  q: quit"
+	if d := m.data.status.Drift; d.Detected && !d.ModelMissing {
+		common = "R: re-embed  " + common
+	}
 	switch m.tab {
 	case tabAgents:
 		return "v: details  n: rename agent  /: search  " + common

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -958,3 +958,90 @@ func TestEscalationDetailSnapshotFallback(t *testing.T) {
 		t.Errorf("missing snapshot should render the fallback line:\n%s", m.View())
 	}
 }
+
+// driftModel builds a model whose refresh carries an embedding-drift report.
+func driftModel(t *testing.T, drift frontend.EmbeddingDrift) Model {
+	t.Helper()
+	m := Model{width: 100, height: 30}
+	upd, _ := m.Update(refreshMsg{status: frontend.Status{Drift: drift}})
+	return upd.(Model)
+}
+
+func TestDriftBannerRenders(t *testing.T) {
+	m := driftModel(t, frontend.EmbeddingDrift{
+		Detected: true, ModelID: "new-model.gguf", Stale: 3, Total: 5,
+	})
+	view := m.View()
+	if !strings.Contains(view, "embedding model changed") ||
+		!strings.Contains(view, "3 of 5 rules need re-compute") ||
+		!strings.Contains(view, "hap signatures reembed") {
+		t.Errorf("drift banner missing or incomplete:\n%s", view)
+	}
+	if !strings.Contains(m.helpLine(), "R: re-embed") {
+		t.Errorf("help line should advertise R while drifted, got %q", m.helpLine())
+	}
+
+	// The banner stays out of the way while the model file is missing (a
+	// re-embed cannot run yet) and when there is no drift.
+	missing := driftModel(t, frontend.EmbeddingDrift{
+		Detected: true, ModelMissing: true, Stale: 3, Total: 5,
+	})
+	if strings.Contains(missing.View(), "embedding model changed") {
+		t.Error("banner must be suppressed while the model file is missing")
+	}
+	clean := driftModel(t, frontend.EmbeddingDrift{})
+	if strings.Contains(clean.View(), "embedding model changed") {
+		t.Error("banner must be absent without drift")
+	}
+	if strings.Contains(clean.helpLine(), "R: re-embed") {
+		t.Error("help line must not advertise R without drift")
+	}
+}
+
+func TestReembedKey(t *testing.T) {
+	// Without drift, R is a no-op with a hint.
+	m := driftModel(t, frontend.EmbeddingDrift{})
+	upd, cmd := m.Update(pressKeyMsg("R"))
+	m = upd.(Model)
+	if cmd != nil || !strings.Contains(m.message, "no embedding drift") {
+		t.Errorf("driftless R should only hint, message=%q cmd=%v", m.message, cmd)
+	}
+
+	// Drift with a missing model file: R refuses with the CLI remedy
+	// instead of a misleading "requested" toast.
+	m = driftModel(t, frontend.EmbeddingDrift{Detected: true, ModelMissing: true, Stale: 1, Total: 1})
+	upd, cmd = m.Update(pressKeyMsg("R"))
+	m = upd.(Model)
+	if cmd != nil || !strings.Contains(m.message, "embedding.model_path") {
+		t.Errorf("missing-model R should refuse with the config remedy, message=%q cmd=%v", m.message, cmd)
+	}
+
+	// With drift but no daemon, the resulting action surfaces the CLI
+	// remedy through the normal action-outcome path.
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	app := &frontend.App{
+		Store:      st,
+		ConfigPath: filepath.Join(dir, "config.toml"),
+		DaemonInfo: func() (bool, int, string) { return false, 0, "" },
+	}
+	m = driftModel(t, frontend.EmbeddingDrift{Detected: true, Stale: 1, Total: 1})
+	m.app = app
+	m.ctx = context.Background()
+	upd, cmd = m.Update(pressKeyMsg("R"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("drifted R must produce a command")
+	}
+	res, ok := cmd().(actionResultMsg)
+	if !ok {
+		t.Fatalf("command result = %T, want actionResultMsg", cmd())
+	}
+	if res.err == nil || !strings.Contains(res.err.Error(), "hap signatures reembed") {
+		t.Errorf("daemon-down R should surface the CLI remedy, got %v", res.err)
+	}
+}

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -39,10 +39,13 @@ max_error_retries = 2              # per error signature
 
 # ── Operator LLM (consulted on unknown situations) ──────────────────
 # Omit this whole section to escalate unknown situations directly to you.
+# Two recipes are shown below — Claude Code is active; the OpenAI Codex
+# equivalent is commented out. Enable ONE `command` / `rewrite_command`
+# pair (comment the Claude keys and uncomment the Codex ones to switch).
 [llm]
-# Claude Code recipe; {self} = the hap binary, {request_id} is filled per
-# consult. The prompt must come immediately after -p (claude quirk; the
-# plugin also auto-repairs it).
+# ── Claude Code recipe (active) ──
+# {self} = the hap binary, {request_id} is filled per consult. The prompt
+# must come immediately after -p (claude quirk; the plugin auto-repairs it).
 command = [
   "claude", "-p",
   "You are the auto-answer assistant for herd-auto-prompter (hap). A coding agent running in a herdr terminal pane has stopped and is waiting for input. Your job: answer exactly as the human operator would, using ONLY the two hap MCP tools.\n\nStep 1 — call get_context. It returns the classified situation:\n- situation_type: 'approval' (permission prompt), 'choice' (menu of options), 'error' (the agent hit a failure), or 'idle' (finished or waiting for its next instruction)\n- options: the menu option texts, when the pane shows a menu\n- permission_verb: what the agent is asking permission to do\n- error_summary: short description of the failure, when situation_type is 'error'\n- pane_excerpt: the recent terminal screen — read it carefully; it is the ground truth for what the agent is doing and asking\n- cwd / foreground_cwd and herdr ids (workspace_id, tab_id, pane_id, agent_id): where the agent is working\n\nStep 2 — decide what the operator would answer:\n- approval / choice: pick ONE entry from options and use its EXACT text. Approve routine, reversible work (reading files, edits, builds, tests, linters). Prefer the safest option and DENY anything destructive or hard to reverse: deleting data, force-pushing or hard-resetting git history, production/deploy changes, touching secrets or credentials, mass file operations.\n- error: reply with one short, concrete instruction telling the agent how to diagnose or fix the failure and continue.\n- idle: reply with the most sensible next instruction based on the pane_excerpt (e.g. continue the remaining work); if nothing remains, tell it to summarize and stop.\n- If the pane_excerpt is ambiguous or does not match the classified situation, choose the most conservative reply.\n\nStep 3 — call submit_decision with: action = the literal reply text to send to the agent (for menus, the exact option text — hap maps it to the menu digit), option_id = the chosen option text for menus, rationale = one sentence on why the operator would answer this way.",
@@ -50,15 +53,44 @@ command = [
   "--allowedTools", "mcp__hap__get_context,mcp__hap__submit_decision",
   "--model", "opus",
 ]
-timeout_seconds = 120
+
+# ── OpenAI Codex CLI recipe (commented; swap in to use codex) ──
+# The `exec` subcommand is required for headless runs (the plugin inserts
+# it if you forget), and the bypass flag is needed because Codex's approval
+# policy auto-denies MCP tool calls when headless — hap's own safety
+# controls still re-gate every submission. Codex sanitizes the MCP server's
+# environment, so the db/control paths must be passed explicitly via
+# {db}/{control}.
+# command = [
+#   "codex", "exec", "--skip-git-repo-check",
+#   "--dangerously-bypass-approvals-and-sandbox",
+#   "-c", 'mcp_servers.hap.command="{self}"',
+#   "-c", 'mcp_servers.hap.args=["mcp"]',
+#   "-c", 'mcp_servers.hap.env.HAP_REQUEST_ID="{request_id}"',
+#   "-c", 'mcp_servers.hap.env.HAP_DB_PATH="{db}"',
+#   "-c", 'mcp_servers.hap.env.HAP_CONTROL_PATH="{control}"',
+#   "You are the auto-answer assistant for herd-auto-prompter (hap). A coding agent running in a herdr terminal pane has stopped and is waiting for input. Your job: answer exactly as the human operator would, using ONLY the two hap MCP tools.\n\nStep 1 — call get_context. It returns the classified situation:\n- situation_type: 'approval' (permission prompt), 'choice' (menu of options), 'error' (the agent hit a failure), or 'idle' (finished or waiting for its next instruction)\n- options: the menu option texts, when the pane shows a menu\n- permission_verb: what the agent is asking permission to do\n- error_summary: short description of the failure, when situation_type is 'error'\n- pane_excerpt: the recent terminal screen — read it carefully; it is the ground truth for what the agent is doing and asking\n- cwd / foreground_cwd and herdr ids (workspace_id, tab_id, pane_id, agent_id): where the agent is working\n\nStep 2 — decide what the operator would answer:\n- approval / choice: pick ONE entry from options and use its EXACT text. Approve routine, reversible work (reading files, edits, builds, tests, linters). Prefer the safest option and DENY anything destructive or hard to reverse: deleting data, force-pushing or hard-resetting git history, production/deploy changes, touching secrets or credentials, mass file operations.\n- error: reply with one short, concrete instruction telling the agent how to diagnose or fix the failure and continue.\n- idle: reply with the most sensible next instruction based on the pane_excerpt (e.g. continue the remaining work); if nothing remains, tell it to summarize and stop.\n- If the pane_excerpt is ambiguous or does not match the classified situation, choose the most conservative reply.\n\nStep 3 — call submit_decision with: action = the literal reply text to send to the agent (for menus, the exact option text — hap maps it to the menu digit), option_id = the chosen option text for menus, rationale = one sentence on why the operator would answer this way.",
+# ]
+
+timeout_seconds = 120              # codex is slower to start; 180 is a safer value there
 auto_act = false                   # false: LLM suggestions are surfaced for your confirmation
 pane_excerpt_chars = 5000          # pane context included in the consult
 
+# ── Rewrite recipe — Claude Code (active) ──
+# A one-shot text transform, no MCP round-trip: the CLI runs once and its
+# stdout is the rewritten text.
 rewrite_command = [
   "claude", "-p",
   "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
   "--model", "haiku",
 ]
+
+# ── Rewrite recipe — OpenAI Codex (commented; swap in to use codex) ──
+# rewrite_command = [
+#   "codex", "exec", "--skip-git-repo-check",
+#   "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
+# ]
+
 rewrite_timeout_seconds = 60       # omitted: inherits timeout_seconds
 rewrite_fallback_template = "You must act based on the following: {original_text}"
 
@@ -77,6 +109,12 @@ bm25_min_score = 0.35       # text-fallback floor when the model is unavailable,
 gpu_layers = 0              # inert in official builds (Metal/Vulkan compiled out; the
                             # bundled MiniLM runs in ms on CPU) — only meaningful if you
                             # rebuild llama-go with GPU on and use a larger model
+# pane_salient_chars controls the fallback signature window: for idle/
+# unclassified situations the signature (and its embedding) is minted from
+# the trailing N characters of pane content. Omit or 0 → built-in default (800).
+# Changing it re-keys idle/unclassified rules once (they re-learn); structured
+# approval/choice/error rules are unaffected.
+# pane_salient_chars = 800
 
 # ── TUI ─────────────────────────────────────────────────────────────
 [tui]


### PR DESCRIPTION
## Summary

Two related embedding features:

### 1. Embedding re-compute — `hap signatures reembed`
When the embedding model changes (`[embedding] model_path`), stored rule signature embeddings become incompatible (different vector size/model). This adds detection + a re-compute path.

- **Drift detection** (read-only): `frontend.EmbeddingDrift` + `store.CountStaleSignatureEmbeddings` compare each stored row's model id against the configured model. Surfaced in `hap status` and a TUI warning banner (press `R`).
- **`hap signatures reembed [--force]`**: when a daemon is running, sends a new `control.KindReembed` nudge — the daemon rebuilds a *fresh* embedder (clearing the degraded-failure latch) and re-embeds stale rows from their stored masked `salient` text; when no daemon runs, the CLI re-embeds in-process, guarded by the daemon lock (a documented exception to the `signature_embeddings` write-ownership partition).
- **`internal/reembed`**: the row-reconcile loop is extracted from the daemon's `initSemantic` into a shared package used by both paths, with `PersistFailed` accounting and a generation guard so a superseded pass cannot overwrite fresher vectors.

### 2. Configurable salient window — `[embedding] pane_salient_chars`
The fallback signature window for idle/unclassified situations was a hardcoded `const head = 400`. This makes it configurable and raises the default.

- New `[embedding] pane_salient_chars` (parallels `llm.pane_excerpt_chars`): the trailing N **characters** of pane content used to mint idle/unclassified signatures. Default raised **400 → 800**. `0` = use the built-in default.
- Rune-aware slicing (never splits a multibyte glyph at the window boundary), threaded through every signature-computation call site via `domain.ComputeSignatureN`.
- Changing it re-keys idle/unclassified rules once (they re-learn); structured approval/choice/error rules are unaffected.

## Testing

- Full unit suite passes with the required build tags: `go test -tags "vectors cpu" ./... -count=1` — **18/18 packages, ~410 tests**.
- `golangci-lint run --build-tags "vectors,cpu"` — **0 issues**; `gofmt` clean.
- New tests cover: the reconcile loop (kept/re-embedded/downgraded/persist-failed/warm-failure/generation-stop), drift detection, `KindReembed` round-trip, CLI reembed (daemon up/down/stale/missing-model), the TUI banner + `R` key, config round-trip + use-default sentinel, and the rune-aware window (narrow vs wide).
- Both features reviewed by an independent code-review pass; findings addressed.

## Notes

- The `400 → 800` default (and any future change) re-keys existing idle/unclassified rules once — documented in `README.md`, `sample/config.toml`, and the config field comment.
