### PR TITLE
#1 feat: escalation detail actions + retry-LLM for failed consults

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -324,6 +324,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// periodic sweep as a safety net.
 	logging.Guard("startup-corrections", func() error {
 		d.processCorrections(ctx)
+		d.processLLMRetries(ctx)
 		d.expireStaleLLMWork(ctx)
 		return nil
 	})
@@ -338,6 +339,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		case <-sweep.C:
 			logging.Guard("periodic-sweep", func() error {
 				d.processCorrections(ctx)
+				d.processLLMRetries(ctx)
 				d.expireStaleLLMWork(ctx)
 				return nil
 			})
@@ -362,6 +364,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 					d.reloadWith(true)
 				}
 				d.processCorrections(ctx)
+				d.processLLMRetries(ctx)
 				d.expireStaleLLMWork(ctx)
 				return nil
 			})
@@ -983,7 +986,7 @@ func (d *Daemon) consultLLM(ctx context.Context, cfg config.Config, s domain.Sit
 	req := domain.LLMRequest{
 		RequestID: fmt.Sprintf("req-%s-%d", s.AgentID, now.UnixNano()),
 		Signature: sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
-		Status: "pending", CreatedAt: now,
+		AgentID: s.AgentID, Status: "pending", CreatedAt: now,
 	}
 	go func() {
 		outcome := llmOutcome{situation: s, sig: sig, request: req}
@@ -1314,7 +1317,11 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 	// whenever the consulted pane was really idle/done.
 	tr := domain.AgentTransition{AgentID: s.AgentID, PaneID: s.PaneID, Status: s.Status}
 
-	d.opt.Store.UpdateLLMRequestStatus(ctx, res.request.RequestID, "done")
+	// Resolving the request clears the retry guard for this agent; a failed
+	// write leaves it pending until expireStaleLLMWork reclaims it.
+	if err := d.opt.Store.UpdateLLMRequestStatus(ctx, res.request.RequestID, "done"); err != nil {
+		slog.Error("marking LLM request done failed", "request", res.request.RequestID, "error", err)
+	}
 
 	if res.err != nil || res.decision == nil {
 		reason := domain.ReasonLLMNoSubmit
@@ -1616,6 +1623,90 @@ func (d *Daemon) processCorrections(ctx context.Context) {
 	}
 }
 
+// processLLMRetries drains operator-queued LLM-retry requests: for each, it
+// re-drives a fresh consult on the escalation's agent by re-injecting an
+// attention transition for the agent's LIVE pane (the normal
+// read→classify→decide→consult pipeline). Every request is marked processed —
+// a retry is best-effort; the operator re-queues if it doesn't take.
+func (d *Daemon) processLLMRetries(ctx context.Context) {
+	retries, err := d.opt.Store.UnprocessedLLMRetries(ctx)
+	if err != nil {
+		slog.Error("reading llm retries failed", "error", err)
+		return
+	}
+	for _, r := range retries {
+		d.applyLLMRetry(ctx, r)
+		if err := d.opt.Store.MarkLLMRetryProcessed(ctx, r.ID); err != nil {
+			// A duplicate on the next sweep only re-injects a coalesced
+			// capture and re-hits the pending-consult guard — harmless, so
+			// log and keep draining rather than aborting the batch.
+			slog.Error("marking llm retry processed failed", "retry", r.ID, "error", err)
+		}
+	}
+}
+
+// applyLLMRetry re-injects one retry request. It resolves the escalation's
+// agent to its live pane and schedules an attention capture, guarding against
+// stacking a retry onto a consult that is still running.
+func (d *Daemon) applyLLMRetry(ctx context.Context, r domain.LLMRetry) {
+	audit, err := d.opt.Store.GetAudit(ctx, r.AuditID)
+	if err != nil {
+		slog.Error("llm retry: reading audit failed", "retry", r.ID, "audit", r.AuditID, "error", err)
+		return
+	}
+	if audit == nil || audit.AgentID == "" {
+		slog.Warn("llm retry: audit missing or has no agent", "retry", r.ID, "audit", r.AuditID)
+		return
+	}
+	agentID := audit.AgentID
+
+	// Guard: never stack a retry onto a consult that is still in flight for
+	// this agent (a pending llm_requests row). The operator re-queues once it
+	// resolves; expireStaleLLMWork clears an abandoned one after 2×timeout.
+	if pending, err := d.opt.Store.HasPendingLLMConsult(ctx, agentID); err != nil {
+		slog.Error("llm retry: pending-consult check failed", "agent", agentID, "error", err)
+		return
+	} else if pending {
+		slog.Info("llm retry skipped: consult already in flight", "agent", agentID)
+		return
+	}
+
+	// Resolve the agent to its current pane — retry re-reads the LIVE screen,
+	// so the pane may differ from where the escalation first fired.
+	agents, err := d.opt.Herdr.ListAgents(ctx)
+	if err != nil {
+		slog.Error("llm retry: listing agents failed", "agent", agentID, "error", err)
+		return
+	}
+	var paneID string
+	var found bool
+	for _, a := range agents {
+		if a.AgentID == agentID {
+			paneID, found = a.PaneID, true
+			break
+		}
+	}
+	if !found {
+		slog.Info("llm retry: agent no longer present", "agent", agentID)
+		label := agentID
+		if name, nerr := d.opt.Store.EnsureAgentName(ctx, agentID); nerr == nil && name != "" {
+			label = fmt.Sprintf("%s (%s)", name, agentID)
+		}
+		d.notify(ctx, "Herd Auto Prompter: retry skipped",
+			fmt.Sprintf("Agent %s is no longer present — cannot re-invoke the LLM.", label))
+		return
+	}
+
+	// Force an attention capture: "blocked" runs the delayed-capture path
+	// (handleAttention → classify → decideAndAct), which re-consults when the
+	// live pane still needs help. scheduleCapture coalesces per pane, so rapid
+	// double-retries collapse into one capture.
+	slog.Info("llm retry: re-driving consult", "agent", agentID, "pane", paneID)
+	d.scheduleCapture(ctx, domain.AgentTransition{
+		AgentID: agentID, PaneID: paneID, Status: "blocked",
+	})
+}
+
 func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domain.CorrectionRecord) error {
 	audit, err := d.opt.Store.GetAudit(ctx, c.AuditID)
 	if err != nil {
@@ -1718,14 +1809,23 @@ func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domai
 	return d.opt.Store.UpdateAuditStatus(ctx, c.AuditID, "resolved")
 }
 
-// expireStaleLLMWork marks dangling pending LLM decisions expired.
+// expireStaleLLMWork marks dangling pending LLM decisions AND pending consult
+// requests expired. Reclaiming stale requests is load-bearing for the retry
+// guard: a consult whose outcome was never delivered (daemon restart/upgrade,
+// cancelled context) would otherwise leave a "pending" llm_requests row that
+// blocks every future retry for that agent forever.
 func (d *Daemon) expireStaleLLMWork(ctx context.Context) {
 	cfg, _, _ := d.snapshot()
+	cutoff := d.opt.Clock.Now().Add(-2 * cfg.LLMTimeout())
+
+	if _, err := d.opt.Store.ExpireStalePendingLLMRequests(ctx, cutoff); err != nil {
+		slog.Error("expiring stale LLM requests failed", "error", err)
+	}
+
 	pending, err := d.opt.Store.PendingLLMDecisions(ctx)
 	if err != nil {
 		return
 	}
-	cutoff := d.opt.Clock.Now().Add(-2 * cfg.LLMTimeout())
 	for _, p := range pending {
 		if p.CreatedAt.Before(cutoff) {
 			d.opt.Store.UpdateLLMDecisionStatus(ctx, p.ID, "expired")

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -49,6 +49,11 @@ type fakeHerdr struct {
 	// failKeyName fails only SendKey calls for that specific key (e.g.
 	// "left" to break the sweep's reset burst but not its Right sweep).
 	failKeyName string
+	// agents is the current agent set ListAgents reports; listAgentsCalls
+	// counts calls so a test can assert the retry guard short-circuits before
+	// resolving the pane.
+	agents          []domain.AgentTransition
+	listAgentsCalls int
 }
 
 func (f *fakeHerdr) Send(ctx context.Context, paneID, input string) error {
@@ -129,7 +134,22 @@ func (f *fakeHerdr) readLineCalls() []int {
 }
 
 func (f *fakeHerdr) ListAgents(ctx context.Context) ([]domain.AgentTransition, error) {
-	return nil, nil
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listAgentsCalls++
+	return append([]domain.AgentTransition(nil), f.agents...), nil
+}
+
+func (f *fakeHerdr) setAgents(agents []domain.AgentTransition) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.agents = agents
+}
+
+func (f *fakeHerdr) listAgentsCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.listAgentsCalls
 }
 
 func (f *fakeHerdr) ListWorkspaces(ctx context.Context) ([]domain.WorkspaceInfo, error) {
@@ -1270,6 +1290,148 @@ func TestLLMFailureEscalates(t *testing.T) {
 	esc, _ := h.raw.PendingEscalations(ctx)
 	if !contains(esc[0].Rationale, "llm") && !contains(esc[0].Rationale, "LLM") {
 		t.Errorf("escalation should cite the LLM failure: %+v", esc[0])
+	}
+}
+
+func TestRetryLLMReDrivesConsultOnLivePane(t *testing.T) {
+	// A failed consult leaves a retryable escalation; a queued retry re-drives
+	// a fresh consult against the agent's live pane, which this time delivers.
+	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act = true\ntimeout_seconds = 5\n"
+	h := newHarness(t, cfg)
+	h.herdr.setPane(approvalPane)
+	h.llm.configured = true
+
+	var mu sync.Mutex
+	calls := 0
+	h.llm.consult = func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		if n == 1 {
+			// First consult times out → the escalation the operator retries.
+			return nil, errors.New("llm timeout after 5s without submit_decision")
+		}
+		// The retry consult submits and is promoted.
+		id, _ := h.raw.InsertLLMDecision(ctx, domain.LLMDecision{
+			RequestID: req.RequestID, Signature: req.Signature,
+			SituationType: req.SituationType, AgentType: req.AgentType,
+			Action: "1", Rationale: "operator always approves", Status: "pending", CreatedAt: time.Now(),
+		})
+		return &domain.LLMDecision{ID: id, RequestID: req.RequestID, Action: "1",
+			Rationale: "operator always approves", Status: "pending"}, nil
+	}
+
+	ctx := context.Background()
+	// Brand-new signature + configured LLM → consult path.
+	h.push("agent-retry", "blocked")
+	var esc []domain.AuditRecord
+	waitFor(t, 5*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	if !domain.IsRetryableLLMEscalation(&esc[0]) {
+		t.Fatalf("first consult should leave a retryable LLM escalation, got %q", esc[0].Rationale)
+	}
+	// The failed consult cleared its pending request (the guard is reset on
+	// every outcome path, including the failure branch), so a retry is allowed.
+	if pending, _ := h.raw.HasPendingLLMConsult(ctx, "agent-retry"); pending {
+		t.Fatal("a resolved (failed) consult must not leave a pending request")
+	}
+
+	// The agent is still live on its pane: queue a retry and nudge.
+	h.herdr.setAgents([]domain.AgentTransition{{AgentID: "agent-retry", PaneID: "agent-retry", Status: "blocked"}})
+	if _, err := h.raw.InsertLLMRetry(ctx, esc[0].ID, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := control.Nudge(ctx, h.ctlPath, control.KindReload); err != nil {
+		t.Fatal(err)
+	}
+
+	// The retry re-drove the consult, which this time delivered the digit.
+	waitFor(t, 5*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	if got := h.herdr.sentInputs()[0]; got != "1" {
+		t.Errorf("retry consult delivered %q, want \"1\"", got)
+	}
+}
+
+func TestRetryLLMGuardSkipsWhileConsultInFlight(t *testing.T) {
+	// The retry must never stack onto a consult that is still running: with a
+	// pending llm_requests row for the agent, the retry short-circuits BEFORE
+	// resolving the pane, and is still drained from the queue.
+	h := newHarness(t, "")
+	ctx := context.Background()
+	id, _ := h.raw.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "agent-busy", Signature: "sig", Trigger: "agent-status: blocked",
+		SituationType: domain.SituationApproval, Action: "escalated",
+		Rationale: "[llm_timeout] llm timeout", Status: "escalated", CreatedAt: time.Now(),
+	})
+	if _, err := h.raw.StageLLMRequest(ctx, domain.LLMRequest{
+		RequestID: "req-agent-busy-1", Signature: "sig", SituationType: domain.SituationApproval,
+		AgentType: "claude", AgentID: "agent-busy", ContextJSON: "{}", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	h.herdr.setAgents([]domain.AgentTransition{{AgentID: "agent-busy", PaneID: "agent-busy", Status: "blocked"}})
+
+	if _, err := h.raw.InsertLLMRetry(ctx, id, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	// Drain directly for determinism (ListAgents is only ever called while
+	// resolving a retry's pane, so its call count is the guard's witness).
+	h.daemon.processLLMRetries(ctx)
+
+	if n := h.herdr.listAgentsCallCount(); n != 0 {
+		t.Errorf("retry must not resolve the pane while a consult is in flight; ListAgents called %d time(s)", n)
+	}
+	if q, _ := h.raw.UnprocessedLLMRetries(ctx); len(q) != 0 {
+		t.Errorf("a skipped retry should still be drained, got %+v", q)
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Fatal("a guarded retry must not send anything")
+	}
+
+	// Once the consult resolves, a fresh retry is allowed to resolve the pane.
+	if err := h.raw.UpdateLLMRequestStatus(ctx, "req-agent-busy-1", "done"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.raw.InsertLLMRetry(ctx, id, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	h.daemon.processLLMRetries(ctx)
+	if n := h.herdr.listAgentsCallCount(); n == 0 {
+		t.Error("after the consult resolved, the retry should resolve the agent's pane")
+	}
+}
+
+func TestRetryLLMAgentGoneNotifies(t *testing.T) {
+	// A retry for an agent that is no longer present notifies the operator and
+	// takes no action, but is still drained.
+	h := newHarness(t, "")
+	ctx := context.Background()
+	id, _ := h.raw.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "agent-ghost", Signature: "sig", Trigger: "agent-status: blocked",
+		SituationType: domain.SituationApproval, Action: "escalated",
+		Rationale: "[llm_no_submit] llm exited without submitting", Status: "escalated", CreatedAt: time.Now(),
+	})
+	// No live agents (setAgents left empty) and no pending consult.
+	if _, err := h.raw.InsertLLMRetry(ctx, id, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	before := len(h.herdr.notified())
+	h.daemon.processLLMRetries(ctx)
+
+	if n := h.herdr.listAgentsCallCount(); n == 0 {
+		t.Fatal("retry should attempt to resolve the (now absent) agent's pane")
+	}
+	if len(h.herdr.notified()) <= before {
+		t.Error("a retry for a vanished agent should notify the operator")
+	}
+	if q, _ := h.raw.UnprocessedLLMRetries(ctx); len(q) != 0 {
+		t.Errorf("a retry for a gone agent should still be drained, got %+v", q)
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Fatal("no send for a vanished agent")
 	}
 }
 

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -4,7 +4,10 @@
 // internal/ports. This purity is enforced by TestDomainPurity.
 package domain
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // SituationType is the classified kind of an attention-requiring situation.
 type SituationType string
@@ -191,6 +194,20 @@ type AuditRecord struct {
 	CreatedAt   time.Time
 }
 
+// IsRetryableLLMEscalation reports whether an escalation is a candidate for
+// re-invoking the LLM: a still-pending escalation whose consult never produced
+// a decision (it timed out or the CLI exited without submitting). A
+// gated-but-answered escalation (shadow_mode, variance_guard, …) is NOT
+// retryable — re-invoking would hit the same gate. The reason is carried as a
+// "[reason]" prefix on Rationale (see the daemon's escalate()).
+func IsRetryableLLMEscalation(a *AuditRecord) bool {
+	if a == nil || a.Status != "escalated" {
+		return false
+	}
+	return strings.HasPrefix(a.Rationale, "["+string(ReasonLLMTimeout)+"]") ||
+		strings.HasPrefix(a.Rationale, "["+string(ReasonLLMNoSubmit)+"]")
+}
+
 // CorrectionRecord is a front-end-written correction amending an audit entry.
 type CorrectionRecord struct {
 	ID              int64
@@ -240,9 +257,22 @@ type LLMRequest struct {
 	Signature     string
 	SituationType SituationType
 	AgentType     string
-	ContextJSON   string
-	Status        string // pending | done | expired
-	CreatedAt     time.Time
+	// AgentID identifies the agent this consult is for, so a pending row can
+	// be found by agent (the "is a consult still running?" retry guard).
+	AgentID     string
+	ContextJSON string
+	Status      string // pending | done | expired
+	CreatedAt   time.Time
+}
+
+// LLMRetry is a front-end-written request to re-invoke the LLM on an
+// escalation whose consult failed or timed out; the daemon drains it and
+// re-drives a fresh consult on the agent's live pane.
+type LLMRetry struct {
+	ID        int64
+	AuditID   int64
+	Processed bool
+	CreatedAt time.Time
 }
 
 // AgentRate is the per-agent runaway-loop counter state (FR-019).

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -474,6 +474,37 @@ func (a *App) Dismiss(ctx context.Context, auditID int64) error {
 	return nil
 }
 
+// RetryLLM re-invokes the operator LLM on an escalation whose consult failed
+// or timed out. It queues the request; the daemon drains it on the reload
+// nudge and re-drives a fresh consult against the agent's live pane. The
+// caller should gate on HasPendingLLMConsult first (UX), but the daemon
+// re-checks authoritatively before re-consulting.
+func (a *App) RetryLLM(ctx context.Context, auditID int64) error {
+	audit, err := a.Store.GetAudit(ctx, auditID)
+	if err != nil {
+		return err
+	}
+	if audit == nil {
+		return fmt.Errorf("audit record %d not found", auditID)
+	}
+	if !domain.IsRetryableLLMEscalation(audit) {
+		return fmt.Errorf("audit record %d is not a retryable LLM escalation", auditID)
+	}
+	if _, err := a.Store.InsertLLMRetry(ctx, auditID, time.Now()); err != nil {
+		return err
+	}
+	// Best-effort nudge: the request is committed; a dead daemon picks it up
+	// on next startup/sweep.
+	a.nudge(ctx, control.KindReload)
+	return nil
+}
+
+// HasPendingLLMConsult reports whether a consult is still running for the
+// agent — the TUI uses it to disable "retry LLM" while one is in flight.
+func (a *App) HasPendingLLMConsult(ctx context.Context, agentID string) (bool, error) {
+	return a.Store.HasPendingLLMConsult(ctx, agentID)
+}
+
 // DefaultPruneMinutes is how old a pending escalation must be before a
 // prune dismisses it, absent an explicit age (CLI argument / TUI prompt).
 const DefaultPruneMinutes = 360

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -460,6 +460,68 @@ func TestDismissRejectsNonPending(t *testing.T) {
 	}
 }
 
+func TestRetryLLMQueuesForFailedConsult(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "a1", SituationType: domain.SituationApproval, Trigger: "agent-status: blocked",
+		Action: "escalated", Rationale: "[llm_timeout] llm timeout after 2m0s without submit_decision",
+		Status: "escalated", CreatedAt: time.Now(),
+	})
+
+	if err := app.RetryLLM(ctx, id); err != nil {
+		t.Fatal(err)
+	}
+	q, err := st.UnprocessedLLMRetries(ctx)
+	if err != nil || len(q) != 1 || q[0].AuditID != id {
+		t.Fatalf("retry should be queued for audit %d, got %+v %v", id, q, err)
+	}
+	// The escalation is unchanged — a fresh outcome writes its own audit row.
+	if rec, _ := st.GetAudit(ctx, id); rec == nil || rec.Status != "escalated" {
+		t.Errorf("retry must not change the escalation status, got %+v", rec)
+	}
+}
+
+func TestRetryLLMRejectsNonRetryable(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+
+	if err := app.RetryLLM(ctx, 999); err == nil {
+		t.Error("retrying a missing audit record must fail")
+	}
+
+	// A gated-but-answered escalation (shadow_mode) is not an LLM failure:
+	// re-invoking would hit the same gate, so it is not retryable.
+	shadowID, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "a1", SituationType: domain.SituationApproval, Trigger: "t",
+		Action: "escalated", Rationale: "[shadow_mode]", Status: "escalated", CreatedAt: time.Now(),
+	})
+	if err := app.RetryLLM(ctx, shadowID); err == nil {
+		t.Error("retrying a non-LLM-failure escalation must fail")
+	}
+	if q, _ := st.UnprocessedLLMRetries(ctx); len(q) != 0 {
+		t.Errorf("rejected retry must not queue anything, got %+v", q)
+	}
+}
+
+func TestHasPendingLLMConsult(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+
+	if pending, err := app.HasPendingLLMConsult(ctx, "a1"); err != nil || pending {
+		t.Fatalf("no consult staged: got %v %v, want false", pending, err)
+	}
+	if _, err := st.StageLLMRequest(ctx, domain.LLMRequest{
+		RequestID: "req-a1-1", Signature: "sig", SituationType: domain.SituationApproval,
+		AgentType: "claude", AgentID: "a1", ContextJSON: "{}", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if pending, err := app.HasPendingLLMConsult(ctx, "a1"); err != nil || !pending {
+		t.Fatalf("consult in flight: got %v %v, want true", pending, err)
+	}
+}
+
 func TestPruneEscalations(t *testing.T) {
 	app, st := testApp(t)
 	ctx := context.Background()

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -130,11 +130,16 @@ type DaemonStore interface {
 	UpsertErrorRetry(ctx context.Context, e domain.ErrorRetry) error
 	ResetErrorRetry(ctx context.Context, errorSignature string) error
 	MarkCorrectionProcessed(ctx context.Context, id int64) error
+	// MarkLLMRetryProcessed marks a queued LLM-retry request consumed.
+	MarkLLMRetryProcessed(ctx context.Context, id int64) error
 	// EnsureAgentName returns the agent's short name, generating one on
 	// first sight (insert-if-absent only; renames stay operator-owned).
 	EnsureAgentName(ctx context.Context, agentID string) (string, error)
 	StageLLMRequest(ctx context.Context, r domain.LLMRequest) (int64, error)
 	UpdateLLMRequestStatus(ctx context.Context, requestID, status string) error
+	// ExpireStalePendingLLMRequests reclaims pending consult rows whose
+	// outcome was never delivered, so they stop blocking the retry guard.
+	ExpireStalePendingLLMRequests(ctx context.Context, cutoff time.Time) (int64, error)
 	UpdateLLMDecisionStatus(ctx context.Context, id int64, status string) error
 	// UpsertSignatureEmbedding stores the semantic identity (salient text +
 	// vector) a signature was minted from.
@@ -149,6 +154,9 @@ type FrontendStore interface {
 	ReadStore
 
 	InsertCorrection(ctx context.Context, c domain.CorrectionRecord) (int64, error)
+	// InsertLLMRetry queues a request to re-invoke the LLM on an escalation
+	// whose consult failed/timed out; the daemon drains it on reload.
+	InsertLLMRetry(ctx context.Context, auditID int64, now time.Time) (int64, error)
 	InsertKillEvent(ctx context.Context, e domain.KillEvent) (int64, error)
 	// RenameAgent gives an agent a new operator-chosen short name; target
 	// may be the current name or the agent/pane id. Returns an error
@@ -200,6 +208,11 @@ type ReadStore interface {
 	// the (pane-excerpt-heavy) rows.
 	CountPendingEscalations(ctx context.Context) (int64, error)
 	UnprocessedCorrections(ctx context.Context) ([]domain.CorrectionRecord, error)
+	// UnprocessedLLMRetries returns queued LLM-retry requests in order.
+	UnprocessedLLMRetries(ctx context.Context) ([]domain.LLMRetry, error)
+	// HasPendingLLMConsult reports whether a consult is still in flight for
+	// the agent (a pending llm_requests row) — the retry concurrency guard.
+	HasPendingLLMConsult(ctx context.Context, agentID string) (bool, error)
 	GetAgentRate(ctx context.Context, agentID string) (*domain.AgentRate, error)
 	GetErrorRetry(ctx context.Context, errorSignature string) (*domain.ErrorRetry, error)
 	PendingLLMDecisions(ctx context.Context) ([]domain.LLMDecision, error)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -138,6 +138,7 @@ CREATE TABLE IF NOT EXISTS llm_requests (
 	signature TEXT NOT NULL,
 	situation_type TEXT NOT NULL,
 	agent_type TEXT NOT NULL,
+	agent_id TEXT NOT NULL DEFAULT '',
 	context_json TEXT NOT NULL,
 	status TEXT NOT NULL DEFAULT 'pending',
 	created_at INTEGER NOT NULL
@@ -154,6 +155,12 @@ CREATE TABLE IF NOT EXISTS llm_decisions (
 	confident_score INTEGER NOT NULL DEFAULT -1,
 	captured_output TEXT NOT NULL DEFAULT '',
 	status TEXT NOT NULL DEFAULT 'pending',
+	created_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS llm_retries (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	audit_id INTEGER NOT NULL,
+	processed INTEGER NOT NULL DEFAULT 0,
 	created_at INTEGER NOT NULL
 );
 CREATE TABLE IF NOT EXISTS operator (
@@ -197,6 +204,7 @@ func (s *Store) migrate() error {
 		`ALTER TABLE audit_log ADD COLUMN agent_type TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE audit_log ADD COLUMN pane_excerpt TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE llm_decisions ADD COLUMN confident_score INTEGER NOT NULL DEFAULT -1`,
+		`ALTER TABLE llm_requests ADD COLUMN agent_id TEXT NOT NULL DEFAULT ''`,
 	} {
 		if _, err := s.db.Exec(ddl); err != nil &&
 			!strings.Contains(err.Error(), "duplicate column name") {
@@ -358,10 +366,10 @@ func (s *Store) StageLLMRequest(ctx context.Context, r domain.LLMRequest) (int64
 	var id int64
 	err := s.tx(ctx, func(tx *sql.Tx) error {
 		res, err := tx.ExecContext(ctx, `
-			INSERT INTO llm_requests (request_id, signature, situation_type, agent_type, context_json, status, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			INSERT INTO llm_requests (request_id, signature, situation_type, agent_type, agent_id, context_json, status, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 			r.RequestID, r.Signature, string(r.SituationType), r.AgentType,
-			r.ContextJSON, orDefault(r.Status, "pending"), unix(r.CreatedAt))
+			r.AgentID, r.ContextJSON, orDefault(r.Status, "pending"), unix(r.CreatedAt))
 		if err != nil {
 			return err
 		}
@@ -378,6 +386,42 @@ func (s *Store) UpdateLLMRequestStatus(ctx context.Context, requestID, status st
 			`UPDATE llm_requests SET status = ? WHERE request_id = ?`, status, requestID)
 		return err
 	})
+}
+
+// HasPendingLLMConsult reports whether a consult is still in flight for an
+// agent — a staged llm_requests row that has not yet resolved to done/expired.
+// It is the durable "is the LLM still running?" guard for retry: consultLLM
+// stages the row as pending, handleLLMOutcome marks it done, and
+// expireStaleLLMWork expires abandoned ones after 2×timeout.
+func (s *Store) HasPendingLLMConsult(ctx context.Context, agentID string) (bool, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT count(*) FROM llm_requests WHERE agent_id = ? AND status = 'pending'`,
+		agentID).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// ExpireStalePendingLLMRequests marks pending consult requests older than
+// cutoff expired. handleLLMOutcome normally resolves a request to "done", but
+// a consult whose outcome was never delivered (daemon restart/upgrade,
+// cancelled context) would otherwise leave a "pending" row forever — and that
+// row is the retry guard, so it must be reclaimed. Returns the number expired.
+func (s *Store) ExpireStalePendingLLMRequests(ctx context.Context, cutoff time.Time) (int64, error) {
+	var n int64
+	err := s.tx(ctx, func(tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx,
+			`UPDATE llm_requests SET status = 'expired' WHERE status = 'pending' AND created_at < ?`,
+			unix(cutoff))
+		if err != nil {
+			return err
+		}
+		n, err = res.RowsAffected()
+		return err
+	})
+	return n, err
 }
 
 // UpdateLLMDecisionStatus transitions a staged decision (pending → accepted/rejected/expired).
@@ -408,6 +452,23 @@ func (s *Store) InsertCorrection(ctx context.Context, c domain.CorrectionRecord)
 	return id, err
 }
 
+// InsertLLMRetry queues a front-end request to re-invoke the LLM on an
+// escalation; the daemon drains it on the next reload nudge.
+func (s *Store) InsertLLMRetry(ctx context.Context, auditID int64, now time.Time) (int64, error) {
+	var id int64
+	err := s.tx(ctx, func(tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, `
+			INSERT INTO llm_retries (audit_id, processed, created_at)
+			VALUES (?, 0, ?)`, auditID, unix(now))
+		if err != nil {
+			return err
+		}
+		id, err = res.LastInsertId()
+		return err
+	})
+	return id, err
+}
+
 // InsertKillEvent appends a pause/kill/resume toggle (append-only, FR-017).
 func (s *Store) InsertKillEvent(ctx context.Context, e domain.KillEvent) (int64, error) {
 	var id int64
@@ -429,7 +490,7 @@ func (s *Store) InsertKillEvent(ctx context.Context, e domain.KillEvent) (int64,
 func (s *Store) ClearLearnedData(ctx context.Context) error {
 	return s.tx(ctx, func(tx *sql.Tx) error {
 		for _, table := range []string{"signatures", "decisions", "audit_log", "corrections",
-			"agent_rate", "error_retries", "llm_requests", "llm_decisions",
+			"agent_rate", "error_retries", "llm_requests", "llm_decisions", "llm_retries",
 			"signature_embeddings", "signature_snapshots"} {
 			if _, err := tx.ExecContext(ctx, "DELETE FROM "+table); err != nil {
 				return err
@@ -978,6 +1039,39 @@ func (s *Store) UnprocessedCorrections(ctx context.Context) ([]domain.Correction
 	return out, rows.Err()
 }
 
+// UnprocessedLLMRetries returns queued LLM-retry requests in insertion order.
+func (s *Store) UnprocessedLLMRetries(ctx context.Context) ([]domain.LLMRetry, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, audit_id, processed, created_at
+		FROM llm_retries WHERE processed = 0 ORDER BY id ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []domain.LLMRetry
+	for rows.Next() {
+		var r domain.LLMRetry
+		var processed int
+		var created int64
+		if err := rows.Scan(&r.ID, &r.AuditID, &processed, &created); err != nil {
+			return nil, err
+		}
+		r.Processed = processed != 0
+		r.CreatedAt = fromUnix(created)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// MarkLLMRetryProcessed marks a queued LLM-retry request as consumed.
+func (s *Store) MarkLLMRetryProcessed(ctx context.Context, id int64) error {
+	return s.tx(ctx, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx,
+			`UPDATE llm_retries SET processed = 1 WHERE id = ?`, id)
+		return err
+	})
+}
+
 // GetAgentRate returns runaway counters for an agent (zero value when absent).
 func (s *Store) GetAgentRate(ctx context.Context, agentID string) (*domain.AgentRate, error) {
 	row := s.db.QueryRowContext(ctx, `
@@ -1019,13 +1113,13 @@ func (s *Store) GetErrorRetry(ctx context.Context, errorSignature string) (*doma
 // GetLLMRequest returns a staged LLM request by request id, or nil.
 func (s *Store) GetLLMRequest(ctx context.Context, requestID string) (*domain.LLMRequest, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, request_id, signature, situation_type, agent_type, context_json, status, created_at
+		SELECT id, request_id, signature, situation_type, agent_type, agent_id, context_json, status, created_at
 		FROM llm_requests WHERE request_id = ?`, requestID)
 	var r domain.LLMRequest
 	var situationType string
 	var created int64
 	err := row.Scan(&r.ID, &r.RequestID, &r.Signature, &situationType, &r.AgentType,
-		&r.ContextJSON, &r.Status, &created)
+		&r.AgentID, &r.ContextJSON, &r.Status, &created)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1000,3 +1000,136 @@ func TestSignatureSnapshotCascades(t *testing.T) {
 		t.Errorf("ClearLearnedData must clear snapshots, got %q", got)
 	}
 }
+
+func TestLLMRequestAgentIDAndPendingGuard(t *testing.T) {
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+
+	// No consult staged yet: the retry guard reports nothing in flight.
+	if pending, err := s.HasPendingLLMConsult(ctx, "a1"); err != nil || pending {
+		t.Fatalf("HasPendingLLMConsult before staging: got %v %v, want false", pending, err)
+	}
+
+	if _, err := s.StageLLMRequest(ctx, domain.LLMRequest{
+		RequestID: "req-a1-1", Signature: "sig", SituationType: domain.SituationApproval,
+		AgentType: "claude", AgentID: "a1", ContextJSON: "{}", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// agent_id round-trips.
+	if req, err := s.GetLLMRequest(ctx, "req-a1-1"); err != nil || req == nil || req.AgentID != "a1" {
+		t.Fatalf("agent_id round trip: %+v %v", req, err)
+	}
+
+	// A pending row means a consult is in flight for that agent — but only for
+	// that agent.
+	if pending, err := s.HasPendingLLMConsult(ctx, "a1"); err != nil || !pending {
+		t.Fatalf("HasPendingLLMConsult with pending row: got %v %v, want true", pending, err)
+	}
+	if pending, err := s.HasPendingLLMConsult(ctx, "a2"); err != nil || pending {
+		t.Fatalf("HasPendingLLMConsult for a different agent: got %v %v, want false", pending, err)
+	}
+
+	// Resolving the request clears the guard.
+	if err := s.UpdateLLMRequestStatus(ctx, "req-a1-1", "done"); err != nil {
+		t.Fatal(err)
+	}
+	if pending, err := s.HasPendingLLMConsult(ctx, "a1"); err != nil || pending {
+		t.Fatalf("HasPendingLLMConsult after done: got %v %v, want false", pending, err)
+	}
+
+	// An expired (abandoned) request also frees the agent to retry again.
+	if _, err := s.StageLLMRequest(ctx, domain.LLMRequest{
+		RequestID: "req-a1-2", Signature: "sig", SituationType: domain.SituationApproval,
+		AgentType: "claude", AgentID: "a1", ContextJSON: "{}", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateLLMRequestStatus(ctx, "req-a1-2", "expired"); err != nil {
+		t.Fatal(err)
+	}
+	if pending, err := s.HasPendingLLMConsult(ctx, "a1"); err != nil || pending {
+		t.Fatalf("HasPendingLLMConsult after expired: got %v %v, want false", pending, err)
+	}
+}
+
+func TestLLMRetryQueueRoundTrip(t *testing.T) {
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+
+	auditID, err := s.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "a1", Signature: "sig", Trigger: "agent-status: blocked",
+		SituationType: domain.SituationApproval, Action: "escalated",
+		Rationale: "[llm_timeout] llm timeout after 2m0s", Status: "escalated", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Nothing queued yet.
+	if q, err := s.UnprocessedLLMRetries(ctx); err != nil || len(q) != 0 {
+		t.Fatalf("empty retry queue: %+v %v", q, err)
+	}
+
+	retryID, err := s.InsertLLMRetry(ctx, auditID, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := s.UnprocessedLLMRetries(ctx)
+	if err != nil || len(q) != 1 {
+		t.Fatalf("queued retry: %+v %v", q, err)
+	}
+	if q[0].AuditID != auditID || q[0].ID != retryID || q[0].Processed {
+		t.Errorf("retry row wrong: %+v (want audit %d, id %d, unprocessed)", q[0], auditID, retryID)
+	}
+
+	// Consuming it drains the queue.
+	if err := s.MarkLLMRetryProcessed(ctx, retryID); err != nil {
+		t.Fatal(err)
+	}
+	if q, _ := s.UnprocessedLLMRetries(ctx); len(q) != 0 {
+		t.Errorf("retry should be consumed once processed, got %+v", q)
+	}
+}
+
+func TestExpireStalePendingLLMRequestsReleasesGuard(t *testing.T) {
+	// A consult whose outcome was never delivered (crash/upgrade/cancel)
+	// leaves a pending row; without reclamation it would block retry forever.
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+
+	old := time.Now().Add(-10 * time.Minute)
+	fresh := time.Now()
+	if _, err := s.StageLLMRequest(ctx, domain.LLMRequest{
+		RequestID: "req-a1-old", Signature: "sig", SituationType: domain.SituationApproval,
+		AgentType: "claude", AgentID: "a1", ContextJSON: "{}", CreatedAt: old,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.StageLLMRequest(ctx, domain.LLMRequest{
+		RequestID: "req-a2-fresh", Signature: "sig", SituationType: domain.SituationApproval,
+		AgentType: "claude", AgentID: "a2", ContextJSON: "{}", CreatedAt: fresh,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both guards read as in flight before reclamation.
+	if p, _ := s.HasPendingLLMConsult(ctx, "a1"); !p {
+		t.Fatal("stale request should read as pending before expiry")
+	}
+
+	cutoff := time.Now().Add(-5 * time.Minute)
+	n, err := s.ExpireStalePendingLLMRequests(ctx, cutoff)
+	if err != nil || n != 1 {
+		t.Fatalf("expiring stale requests: n=%d err=%v, want 1 expired", n, err)
+	}
+
+	// The stale agent is released; the fresh consult is untouched.
+	if p, _ := s.HasPendingLLMConsult(ctx, "a1"); p {
+		t.Error("stale pending request should be reclaimed, releasing the retry guard")
+	}
+	if p, _ := s.HasPendingLLMConsult(ctx, "a2"); !p {
+		t.Error("a fresh pending request must not be expired")
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -49,7 +49,11 @@ type refreshMsg struct {
 	kills       []domain.KillEvent
 	signatures  []frontend.SignatureRow
 	cfg         config.Config
-	err         error
+	// pendingConsult holds agent ids that currently have an LLM consult in
+	// flight, so "l: retry LLM" is disabled while one is running (the daemon
+	// re-checks authoritatively). Populated only for retryable escalations.
+	pendingConsult map[string]bool
+	err            error
 }
 
 // sigDetailMsg carries an asynchronously loaded signature detail.
@@ -92,7 +96,10 @@ type detailView struct {
 	// confirmID is the escalation's audit id captured at open time, so
 	// enter confirms the record ON SCREEN even if a background refresh
 	// clamped the list cursor. 0 = not a confirmable escalation detail.
-	confirmID int64
+	// The per-entry actions (c/x/l) act on this id too, never the live
+	// cursor. escRetryable snapshots whether "l: retry LLM" is offered.
+	confirmID    int64
+	escRetryable bool
 }
 
 // ruleItem is one navigable row of the Config tab. "indicator" and
@@ -234,6 +241,21 @@ func refreshData(ctx context.Context, app *frontend.App) refreshMsg {
 	msg.escalations, msg.err = app.Escalations(ctx)
 	if msg.err != nil {
 		return msg
+	}
+	// Gate "retry LLM" per agent: a consult already in flight disables it.
+	// Best-effort — a lookup error just leaves the key enabled (the daemon
+	// guards authoritatively before re-consulting).
+	msg.pendingConsult = map[string]bool{}
+	checked := map[string]bool{}
+	for i := range msg.escalations {
+		e := msg.escalations[i]
+		if !domain.IsRetryableLLMEscalation(&e) || checked[e.AgentID] {
+			continue
+		}
+		checked[e.AgentID] = true
+		if pending, perr := app.HasPendingLLMConsult(ctx, e.AgentID); perr == nil && pending {
+			msg.pendingConsult[e.AgentID] = true
+		}
 	}
 	msg.audit, msg.err = app.Audit(ctx, 50)
 	if msg.err != nil {
@@ -406,9 +428,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if m.detail.offset < max(0, len(m.detail.lines)-m.detailPageSize()) {
 				m.detail.offset++
 			}
-		case "tab", "right", "l":
+		case "tab", "right":
 			// Tab-switching works from inside the overlay: close it and
-			// move on, no extra esc needed.
+			// move on, no extra esc needed. (On an escalation detail, `l` is
+			// "retry LLM" instead — vim-right still switches via "right".)
 			m.detail = nil
 			m.tab = (m.tab + 1) % tabCount
 			m.cursor = 0
@@ -431,6 +454,36 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m.confirmAuditID(id)
 			}
 			m.detail = nil
+		case "c":
+			// Per-entry actions mirror the list, acting on the snapshotted
+			// escalation id (confirmID), never the live cursor.
+			if id := m.detail.confirmID; id != 0 {
+				m.detail = nil
+				return m.correctByID(id)
+			}
+		case "x", "delete":
+			if id := m.detail.confirmID; id != 0 {
+				m.detail = nil
+				return m.dismissByID(id)
+			}
+		case "l":
+			// On an escalation detail, `l` retries the LLM on the snapshotted
+			// record; elsewhere it keeps its vim-right "next tab" meaning.
+			if id := m.detail.confirmID; id != 0 {
+				if !m.detail.escRetryable {
+					m.message = "retry LLM: not available for this escalation"
+					m.detail = nil
+					return m, nil
+				}
+				m.detail = nil
+				return m.retryByID(id)
+			}
+			m.detail = nil
+			m.tab = (m.tab + 1) % tabCount
+			m.cursor = 0
+			m.offsets[m.tab] = 0
+			m.searching = false
+			m.message = ""
 		case "esc", "q", "v":
 			m.detail = nil
 		}
@@ -499,6 +552,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "q", "ctrl+c":
 		return m, tea.Quit
 	case "tab", "right", "l":
+		// `l` retries the LLM on the Escalations tab; everywhere else it keeps
+		// its vim-right "next tab" meaning ("tab"/"right" always switch).
+		if msg.String() == "l" && m.tab == tabEscalations {
+			return m.retrySelected()
+		}
 		m.tab = (m.tab + 1) % tabCount
 		m.cursor = 0
 		m.offsets[m.tab] = 0
@@ -672,6 +730,13 @@ func (m Model) selectedAudit() *domain.AuditRecord {
 	return nil
 }
 
+// canRetry reports whether "retry LLM" is offered for an escalation: it must
+// be a retryable LLM failure (timeout / no-submit) with no consult currently
+// in flight for its agent.
+func (m Model) canRetry(rec domain.AuditRecord) bool {
+	return domain.IsRetryableLLMEscalation(&rec) && !m.data.pendingConsult[rec.AgentID]
+}
+
 // --- Escalation / audit actions ---
 
 func (m Model) confirmSelected() (tea.Model, tea.Cmd) {
@@ -695,7 +760,13 @@ func (m Model) correctSelected() (tea.Model, tea.Cmd) {
 	if rec == nil {
 		return m, nil
 	}
-	id := rec.ID
+	return m.correctByID(rec.ID)
+}
+
+// correctByID opens the correction prompt for a specific audit id — used by
+// the list and by the detail overlay (which corrects its snapshotted record,
+// not the live cursor).
+func (m Model) correctByID(id int64) (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	m.message = ""
 	m.prompt = &prompt{
@@ -710,6 +781,39 @@ func (m Model) correctSelected() (tea.Model, tea.Cmd) {
 		},
 	}
 	return m, nil
+}
+
+// dismissByID dismisses one escalation by id — used by the detail overlay.
+// The list uses deleteEscalations for its marked/cursor batch semantics.
+func (m Model) dismissByID(id int64) (tea.Model, tea.Cmd) {
+	return m, m.do(fmt.Sprintf("dismissed #%d", id), func(ctx context.Context) error {
+		return m.app.Dismiss(ctx, id)
+	})
+}
+
+// retryByID re-invokes the LLM on one escalation by id (list and detail).
+func (m Model) retryByID(id int64) (tea.Model, tea.Cmd) {
+	return m, m.do(fmt.Sprintf("retry LLM queued for #%d", id), func(ctx context.Context) error {
+		return m.app.RetryLLM(ctx, id)
+	})
+}
+
+// retrySelected re-invokes the LLM on the escalation under the cursor, with a
+// hint when the row isn't eligible or a consult is already running.
+func (m Model) retrySelected() (tea.Model, tea.Cmd) {
+	rec := m.selectedAudit()
+	if rec == nil {
+		return m, nil
+	}
+	if !domain.IsRetryableLLMEscalation(rec) {
+		m.message = "retry LLM: only for a failed or timed-out LLM escalation"
+		return m, nil
+	}
+	if m.data.pendingConsult[rec.AgentID] {
+		m.message = "retry LLM: a consult is already running for this agent"
+		return m, nil
+	}
+	return m.retryByID(rec.ID)
 }
 
 // toggleMarkSelected flips the multi-select mark on the escalation under the
@@ -898,9 +1002,12 @@ func (m Model) viewSelected() (tea.Model, tea.Cmd) {
 				lines: build(m.wrapWidth()),
 				build: build,
 			}
-			// Only the Escalations detail is confirmable via enter.
+			// Only the Escalations detail is confirmable via enter and
+			// carries the per-entry actions (c/x/l), which act on this
+			// snapshotted id — never the live cursor.
 			if m.tab == tabEscalations {
 				d.confirmID = r.ID
+				d.escRetryable = m.canRetry(r)
 			}
 			m.detail = d
 		}
@@ -1543,7 +1650,12 @@ func (m Model) View() string {
 func (m Model) helpLine() string {
 	if m.detail != nil {
 		if m.detail.confirmID != 0 {
-			return "enter: confirm+send  ↑/↓: scroll  tab: switch tab  esc/q/v: close"
+			retry := ""
+			if m.detail.escRetryable {
+				retry = "  l: retry LLM"
+			}
+			return "enter: confirm+send  c: correct  x: delete" + retry +
+				"  ↑/↓: scroll  tab: switch tab  esc/q/v: close"
 		}
 		return "↑/↓: scroll  tab: switch tab  esc/q/v: close"
 	}
@@ -1558,7 +1670,7 @@ func (m Model) helpLine() string {
 	case tabAgents:
 		return "v: details  n: rename agent  /: search  " + common
 	case tabEscalations:
-		return "enter/y: confirm+send  c: correct  space: mark  x: delete  X: prune old  v: details  /: search  " + common
+		return "enter/y: confirm+send  c: correct  l: retry LLM  space: mark  x: delete  X: prune old  v: details  /: search  " + common
 	case tabAudit:
 		return "c: correct decision  v: details  /: search  " + common
 	case tabSignatures:

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -490,18 +490,24 @@ func TestEscalationsRowWidensWithTerminal(t *testing.T) {
 	wm.tab = tabEscalations
 	wideView := wm.View()
 
-	widestLine := func(v string) int {
+	// Measure the escalation DATA rows (lines behind the mark cell starting
+	// with "#"), not the whole View: the static help/header chrome does not
+	// scale with terminal width and would mask the row growth this asserts.
+	widestRow := func(v string) int {
 		max := 0
 		for _, ln := range strings.Split(v, "\n") {
+			if !strings.HasPrefix(strings.TrimLeft(ln, " ✓"), "#") {
+				continue
+			}
 			if n := len([]rune(ln)); n > max {
 				max = n
 			}
 		}
 		return max
 	}
-	if widestLine(wideView) <= widestLine(narrow) {
+	if widestRow(wideView) <= widestRow(narrow) {
 		t.Errorf("wide terminal (%d) should render longer rows than narrow (%d)",
-			widestLine(wideView), widestLine(narrow))
+			widestRow(wideView), widestRow(narrow))
 	}
 }
 
@@ -1043,5 +1049,227 @@ func TestReembedKey(t *testing.T) {
 	}
 	if res.err == nil || !strings.Contains(res.err.Error(), "hap signatures reembed") {
 		t.Errorf("daemon-down R should surface the CLI remedy, got %v", res.err)
+	}
+}
+
+// retryAppModel builds a Model backed by a real App/store holding one
+// retryable ([llm_timeout]) escalation for agent w1:pA, positioned on the
+// Escalations tab. Returns the model, the store, and the escalation id.
+func retryAppModel(t *testing.T) (Model, *store.Store, *frontend.App, int64) {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	app := &frontend.App{Store: st, Herdr: &captureHerdr{}, ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	ctx := context.Background()
+	id, err := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:pA", SituationType: domain.SituationApproval, Trigger: "t",
+		Action: "escalated", Rationale: "[llm_timeout] llm timeout after 2m0s without submit_decision",
+		Status: "escalated", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := New(ctx, app)
+	m.width, m.height = 100, 30
+	upd, _ := m.Update(refreshData(ctx, app))
+	m = upd.(Model)
+	m.tab = tabEscalations
+	return m, st, app, id
+}
+
+func TestRetryLLMListQueuesForFailedConsult(t *testing.T) {
+	m, st, _, id := retryAppModel(t)
+	ctx := context.Background()
+
+	_, cmd := m.Update(pressKeyMsg("l"))
+	if cmd == nil {
+		t.Fatal("l on a retryable escalation should issue the retry command")
+	}
+	res, ok := cmd().(actionResultMsg)
+	if !ok || res.err != nil {
+		t.Fatalf("retry should succeed, got %+v", res)
+	}
+	q, _ := st.UnprocessedLLMRetries(ctx)
+	if len(q) != 1 || q[0].AuditID != id {
+		t.Errorf("retry should queue for audit %d, got %+v", id, q)
+	}
+}
+
+func TestRetryLLMListGatedForNonFailure(t *testing.T) {
+	// A non-LLM-failure escalation offers no retry: the key reports why and
+	// queues nothing.
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	app := &frontend.App{Store: st, Herdr: &captureHerdr{}, ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	ctx := context.Background()
+	st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:pA", SituationType: domain.SituationApproval, Trigger: "t",
+		Action: "escalated", Rationale: "[shadow_mode]", Status: "escalated", CreatedAt: time.Now(),
+	})
+	m := New(ctx, app)
+	m.width, m.height = 100, 30
+	upd, _ := m.Update(refreshData(ctx, app))
+	m = upd.(Model)
+	m.tab = tabEscalations
+
+	upd, cmd := m.Update(pressKeyMsg("l"))
+	m = upd.(Model)
+	if cmd != nil {
+		t.Error("l on a non-retryable escalation should not issue a command")
+	}
+	if !strings.Contains(m.message, "failed or timed-out") {
+		t.Errorf("expected an ineligibility hint, got %q", m.message)
+	}
+	if q, _ := st.UnprocessedLLMRetries(ctx); len(q) != 0 {
+		t.Errorf("a gated retry must queue nothing, got %+v", q)
+	}
+}
+
+func TestRetryLLMListGatedWhileConsultPending(t *testing.T) {
+	// A retryable escalation whose agent still has a consult in flight is
+	// disabled: the pending lookup folded into refresh suppresses the key.
+	m, st, app, _ := retryAppModel(t)
+	ctx := context.Background()
+	if _, err := st.StageLLMRequest(ctx, domain.LLMRequest{
+		RequestID: "req-w1:pA-1", Signature: "sig", SituationType: domain.SituationApproval,
+		AgentType: "claude", AgentID: "w1:pA", ContextJSON: "{}", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Re-refresh so pendingConsult reflects the in-flight consult.
+	upd, _ := m.Update(refreshData(ctx, app))
+	m = upd.(Model)
+	m.tab = tabEscalations
+
+	upd, cmd := m.Update(pressKeyMsg("l"))
+	m = upd.(Model)
+	if cmd != nil {
+		t.Error("l must be inert while a consult is running")
+	}
+	if !strings.Contains(m.message, "already running") {
+		t.Errorf("expected an in-flight hint, got %q", m.message)
+	}
+	if q, _ := st.UnprocessedLLMRetries(ctx); len(q) != 0 {
+		t.Errorf("a gated retry must queue nothing, got %+v", q)
+	}
+}
+
+func TestDetailViewEscalationActionsAndFooter(t *testing.T) {
+	m, st, _, id := retryAppModel(t)
+	ctx := context.Background()
+
+	m = press(t, m, "v")
+	if m.detail == nil || m.detail.confirmID != id {
+		t.Fatalf("v should open the escalation detail snapshotting #%d, got %+v", id, m.detail)
+	}
+	if !m.detail.escRetryable {
+		t.Fatal("a [llm_timeout] escalation detail should be retryable")
+	}
+	// The detail footer mirrors the list's per-entry actions.
+	footer := m.helpLine()
+	for _, want := range []string{"c: correct", "x: delete", "l: retry LLM"} {
+		if !strings.Contains(footer, want) {
+			t.Errorf("detail footer missing %q: %q", want, footer)
+		}
+	}
+
+	// x dismisses the snapshotted escalation.
+	upd, cmd := m.Update(pressKeyMsg("x"))
+	m = upd.(Model)
+	if m.detail != nil {
+		t.Error("x should close the detail overlay")
+	}
+	if cmd == nil {
+		t.Fatal("x should issue the dismiss command")
+	}
+	if res, ok := cmd().(actionResultMsg); !ok || res.err != nil {
+		t.Fatalf("dismiss should succeed, got %+v", res)
+	}
+	if rec, _ := st.GetAudit(ctx, id); rec == nil || rec.Status != "dismissed" {
+		t.Errorf("detail x should dismiss #%d, got %+v", id, rec)
+	}
+}
+
+func TestDetailViewRetryKeyQueuesForSnapshottedID(t *testing.T) {
+	m, st, _, id := retryAppModel(t)
+	ctx := context.Background()
+
+	m = press(t, m, "v")
+	upd, cmd := m.Update(pressKeyMsg("l"))
+	m = upd.(Model)
+	if m.detail != nil {
+		t.Error("l should close the detail overlay")
+	}
+	if cmd == nil {
+		t.Fatal("l on a retryable escalation detail should issue the retry command")
+	}
+	if res, ok := cmd().(actionResultMsg); !ok || res.err != nil {
+		t.Fatalf("retry should succeed, got %+v", res)
+	}
+	q, _ := st.UnprocessedLLMRetries(ctx)
+	if len(q) != 1 || q[0].AuditID != id {
+		t.Errorf("detail retry should queue for the snapshotted #%d, got %+v", id, q)
+	}
+}
+
+func TestDetailViewCorrectTargetsSnapshottedID(t *testing.T) {
+	m, _, _, id := retryAppModel(t)
+	m = press(t, m, "v")
+	upd, _ := m.Update(pressKeyMsg("c"))
+	m = upd.(Model)
+	if m.detail != nil {
+		t.Error("c should close the detail overlay")
+	}
+	if m.prompt == nil {
+		t.Fatal("c should open the correction prompt")
+	}
+	if !strings.Contains(m.prompt.label, fmt.Sprintf("#%d", id)) {
+		t.Errorf("correction prompt should target the snapshotted #%d, got %q", id, m.prompt.label)
+	}
+}
+
+func TestDetailViewNonRetryableHidesRetryAndStaysOnEscalation(t *testing.T) {
+	// The stock escalation (#41) is not an LLM failure: its detail offers no
+	// retry, and pressing l reports that without leaking into a tab switch.
+	m := testModel(t)
+	m.tab = tabEscalations
+	m = press(t, m, "v")
+	if m.detail == nil || m.detail.escRetryable {
+		t.Fatalf("non-LLM escalation detail must not be retryable, got %+v", m.detail)
+	}
+	if strings.Contains(m.helpLine(), "retry LLM") {
+		t.Error("footer must not advertise retry for a non-retryable escalation")
+	}
+	upd, _ := m.Update(pressKeyMsg("l"))
+	m = upd.(Model)
+	if m.tab != tabEscalations {
+		t.Errorf("l on an escalation detail must not switch tabs, got %v", m.tab)
+	}
+	if !strings.Contains(m.message, "not available") {
+		t.Errorf("expected an unavailable hint, got %q", m.message)
+	}
+}
+
+func TestDetailViewVimLStillSwitchesTabsOffEscalations(t *testing.T) {
+	// On a non-escalation detail (Agents), l keeps its vim-right meaning.
+	m := press(t, testModel(t), "v") // Agents tab detail
+	if m.detail == nil {
+		t.Fatal("detail should be open on Agents")
+	}
+	upd, _ := m.Update(pressKeyMsg("l"))
+	m = upd.(Model)
+	if m.detail != nil {
+		t.Error("l should close the Agents detail (vim-right)")
+	}
+	if m.tab != tabEscalations {
+		t.Errorf("l should advance Agents → Escalations, got %v", m.tab)
 	}
 }


### PR DESCRIPTION
## What & why

Two gaps in the Escalation TUI:

1. **The detail overlay was action-poor** — opening an escalation with `v` only allowed `enter` (confirm+send); `c: correct` / `x: delete` were unreachable once the overlay was open. The detail view now exposes the same per-entry actions as the list.
2. **A failed/timed-out LLM consult was a dead end** — `rule=shadow [llm_timeout] llm timeout after 2m0s without submit_decision` just sat there with no way to re-invoke the LLM. Added **`l: retry LLM`**.

## Detail-view actions (list + detail)

`c: correct`, `x: delete`, `enter: confirm+send`, `l: retry LLM` — all act on the **snapshotted** record (`confirmID`), never the live cursor, so a background refresh can't retarget them. Footer updated.

## `l: retry LLM`

- Offered only for LLM-failure escalations (`[llm_timeout]` / `[llm_no_submit]`) and disabled while a consult is in flight for that agent.
- **Re-reads the live pane**: the daemon resolves agent→pane via `HerdrPort.ListAgents` and re-injects an attention transition through the normal `scheduleCapture → classify → decide → consult` pipeline, so all safety gates (kill switch, never-auto, rate, retry ceiling) still apply. A vanished agent notifies the operator instead of acting.
- **Concurrency guard**: reuses the durable `llm_requests` "pending" status (`HasPendingLLMConsult`). The TUI greys the key; the daemon re-checks authoritatively before re-consulting.

Flow: TUI `l` → `App.RetryLLM` writes an `llm_retries` queue row + reload nudge → daemon `processLLMRetries`/`applyLLMRetry` drains it (guard → resolve pane → re-inject transition).

## Guard-lockout fix (from code review)

An *interrupted* consult (daemon restart/ctx-cancel between staging and outcome) would leave a `pending` `llm_requests` row forever and permanently lock out retry for that agent. `expireStaleLLMWork` now also reclaims stale `pending` requests (2×`llm.timeout`); `ClearLearnedData` purges `llm_retries`; the previously-discarded `done`-write error is now logged.

## Plumbing

- **store**: `llm_retries` queue table + methods, `agent_id` on `llm_requests` (additive migration), `HasPendingLLMConsult`, `ExpireStalePendingLLMRequests`
- **domain**: `LLMRequest.AgentID`, `LLMRetry`, `IsRetryableLLMEscalation` (stays pure)
- **daemon**: `consultLLM` stamps `AgentID`; `processLLMRetries` drained on nudge/startup/sweep
- **frontend**: `App.RetryLLM`, `App.HasPendingLLMConsult`
- **tui**: detail `c/x/l` keys, list `l` binding (vim-`l` kept as next-tab off the Escalations tab), retryable+pending gating folded into the 2s refresh
- **ports**: interface additions

## Testing

- **18/18 packages pass**, `golangci-lint` clean (run via subagent).
- New unit tests: store (queue round-trip, agent_id/pending guard, stale-request reclamation), daemon (re-drive consult, guard-skip + guard-release, agent-gone notify), frontend (`RetryLLM` gating, `HasPendingLLMConsult`), tui (list + detail keys, snapshotted-id actions, retryable/pending gating, vim-`l` preserved off-Escalations).
- Not run here: the gated real-herdr integration suite (`go test -tags integration ./test/integration/`) — recommended before merge per CONTRIBUTING/CLAUDE.md.

https://claude.ai/code/session_01LrSLG2M8HF2zS8Y6gtH8kv