### PR TITLE
#1 chore: tune runaway-guard default limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ inferred_task_bar = 0.90   # higher bar for tasks inferred from pane history
 graduation_n = 5           # consecutive confirmations to graduate
 
 [limits]
-max_consecutive_auto_prompts = 5   # per agent, without human interaction
-max_auto_prompts_per_minute = 10   # per agent
+max_consecutive_auto_prompts = 10  # per agent, without human interaction
+max_auto_prompts_per_minute = 3    # per agent
 max_error_retries = 2              # per error signature
 
 # Semantic rule matching: situations are matched to learned rules by

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -235,8 +235,8 @@ func Default() Config {
 		},
 		Learning: Learning{GraduationN: 5},
 		Limits: Limits{
-			MaxConsecutiveAutoPrompts: 5,
-			MaxAutoPromptsPerMinute:   10,
+			MaxConsecutiveAutoPrompts: 10,
+			MaxAutoPromptsPerMinute:   3,
 			MaxErrorRetries:           2,
 		},
 		// RewriteTimeoutSeconds stays zero here: Load seeds from Default

--- a/internal/daemon/capture_test.go
+++ b/internal/daemon/capture_test.go
@@ -91,10 +91,14 @@ func TestCaptureTimersArePerPane(t *testing.T) {
 	h.push("agent-capA", "blocked")
 	h.push("agent-capB", "blocked")
 	waitFor(t, 5*time.Second, func() bool { return len(h.herdr.readLineCalls()) == 2 })
-	esc, err := h.raw.PendingEscalations(context.Background())
-	if err != nil || len(esc) != 2 {
-		t.Fatalf("both panes must escalate, got %d (%v)", len(esc), err)
-	}
+	// Both reads have fired, but each escalation is persisted AFTER its read
+	// returns — poll for the DB writes instead of reading once (checking
+	// immediately raced the second escalation on stalled runners). waitFor
+	// t.Fatals if the second escalation never lands.
+	waitFor(t, 5*time.Second, func() bool {
+		esc, err := h.raw.PendingEscalations(context.Background())
+		return err == nil && len(esc) == 2
+	})
 }
 
 func TestCaptureCanceledByWorkingTransition(t *testing.T) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -797,8 +797,10 @@ func TestPanicInjectionAtAdapterBoundaries(t *testing.T) {
 
 func TestRunawayGuardPausesAgent(t *testing.T) {
 	// FR-019 end to end: the 6th consecutive auto-prompt is blocked and the
-	// agent pauses until human interaction.
-	h := newHarness(t, "")
+	// agent pauses until human interaction. Pin explicit limits so the test
+	// exercises the CONSECUTIVE guard specifically, independent of the
+	// defaults (and with the per-minute cap held high so it never interferes).
+	h := newHarness(t, "[limits]\nmax_consecutive_auto_prompts = 5\nmax_auto_prompts_per_minute = 1000\n")
 	h.herdr.setPane(approvalPane)
 	h.seedAutonomous(approvalPane, domain.SituationApproval, "1")
 

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -33,8 +33,8 @@ irreversible_indicators = []     # extra suspected-irreversible patterns, all ag
 
 # ── Rate limits ─────────────────────────────────────────────────────
 [limits]
-max_consecutive_auto_prompts = 5   # per agent, without human interaction
-max_auto_prompts_per_minute = 10   # per agent
+max_consecutive_auto_prompts = 10  # per agent, without human interaction
+max_auto_prompts_per_minute = 3    # per agent
 max_error_retries = 2              # per error signature
 
 # ── Operator LLM (consulted on unknown situations) ──────────────────


### PR DESCRIPTION
## What

Adjust the default runaway-guard rate limits in `config.Default()`:

| Limit | Old default | New default |
|---|---|---|
| `max_consecutive_auto_prompts` | 5 | **10** |
| `max_auto_prompts_per_minute` | 10 | **3** |

## Why

The per-minute cap of 10 was high enough that it effectively never fired inside its own 1-minute rolling window, so it wasn't a meaningful backstop. Lowering it to **3** makes the per-minute guard actually engage on a looping agent, while raising the consecutive cap to **10** gives a longer no-human-interaction streak before the guard escalates and pauses the agent.

Both still apply to every automated action (learned auto-acts and LLM auto-acts alike): over either limit → escalate with `[rate_limited]` and pause the agent until human check-in.

## Test change

`TestRunawayGuardPausesAgent` used the default (empty) config and expected the 6th consecutive prompt to be blocked — which depended on the old default of 5, and the new per-minute=3 would trip *before* the consecutive guard. Pinned explicit limits (`max_consecutive_auto_prompts = 5`, `max_auto_prompts_per_minute = 1000`) in that test so it keeps exercising the **consecutive** guard specifically, independent of the defaults.

Also updated `sample/config.toml` and the README `[limits]` example.

## Testing

- Full suite (593 tests) green, `golangci-lint` clean (via subagent). Verified specifically that no other daemon test auto-sends >3 prompts/minute on the default config and trips the new per-minute cap.

https://claude.ai/code/session_01LrSLG2M8HF2zS8Y6gtH8kv