### PR TITLE
#1 feat: {agent_name} template var in all substitutable strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ inferred_task_bar = 0.90   # higher bar for tasks inferred from pane history
 graduation_n = 5           # consecutive confirmations to graduate
 
 [limits]
-max_consecutive_auto_prompts = 5   # per agent, without human interaction
-max_auto_prompts_per_minute = 10   # per agent
+max_consecutive_auto_prompts = 10  # per agent, without human interaction
+max_auto_prompts_per_minute = 3    # per agent
 max_error_retries = 2              # per error signature
 
 # Semantic rule matching: situations are matched to learned rules by

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ agent = "brave-otter" # agent short name, pane id, or type ("" = any)
 workspace = ""        # workspace name; "" or "*" = any, "*" wildcards work
                       # ("codex-*" = starts with, "*-vscode3" = ends with)
 path = "/home/me/project/docs/tasks.md"
-# Optional per-source prompt format ({next_task_content}, {task_list_path}):
+# Optional per-source prompt format ({next_task_content}, {task_list_path}, {agent_name}):
 next_task_template = "Your next task is {next_task_content}. Read the full tasks list at {task_list_path}. Verify task dependencies before starting. When there is no task available, focus on improving the test coverage of this project."
 ```
 
@@ -404,7 +404,8 @@ timeout_seconds = 180
 ```
 
 Placeholders: `{self}` (this plugin binary), `{request_id}`, `{db}`,
-`{control}`. Common misconfigurations of known CLIs are auto-repaired at
+`{control}`, `{agent_name}` (the agent's short name). Common
+misconfigurations of known CLIs are auto-repaired at
 launch (claude/agy: prompt moved next to `-p`/`--print`; codex: missing
 `exec` inserted) — an unrecognized shape is left untouched. Every LLM
 suggestion is re-gated through the same never-auto patterns, kill switch, and rate
@@ -444,15 +445,15 @@ rewrite_fallback_template = "You must act based on the following: {original_text
 ```
 
 Placeholders in `rewrite_command`: `{text}` (the literal reply a rule
-resolved to), `{situation_type}`, `{agent_type}`, `{pane_excerpt}` (last
-`pane_excerpt_chars` characters of the live pane). The same CLI auto-repair
-as `llm.command` applies (on the raw template, before substitution). No
-shell is involved — each element is one argv entry — but `{text}` and
-`{pane_excerpt}` carry untrusted pane content: embed them inside a prompt
-string (as in the example) rather than as standalone argv elements, so a
-value starting with `-` can never be parsed as a flag; the same values are
-also available as `HAP_REWRITE_TEXT` / `HAP_SITUATION_TYPE` /
-`HAP_AGENT_TYPE` env vars.
+resolved to), `{situation_type}`, `{agent_type}`, `{agent_name}` (the
+agent's short name), `{pane_excerpt}` (last `pane_excerpt_chars` characters
+of the live pane). The same CLI auto-repair as `llm.command` applies (on the
+raw template, before substitution). No shell is involved — each element is
+one argv entry — but `{text}` and `{pane_excerpt}` carry untrusted pane
+content: embed them inside a prompt string (as in the example) rather than as
+standalone argv elements, so a value starting with `-` can never be parsed as
+a flag; the same values are also available as `HAP_REWRITE_TEXT` /
+`HAP_SITUATION_TYPE` / `HAP_AGENT_TYPE` / `HAP_AGENT_NAME` env vars.
 
 Invariants:
 
@@ -460,8 +461,9 @@ Invariants:
   the menu untouched. Only literal free text goes through the rewriter.
 - **A rewrite failure never blocks the send**: on error, timeout, or empty
   output the original text is delivered wrapped in
-  `rewrite_fallback_template` (`{original_text}` placeholder; empty or
-  placeholder-less templates fall back to the built-in default).
+  `rewrite_fallback_template` (`{original_text}`, `{agent_name}`
+  placeholders; empty or `{original_text}`-less templates fall back to the
+  built-in default).
 - **Safety controls still apply to the rewritten text**: output matching
   the never-auto patterns or the irreversible-operation heuristic is
   discarded in favor of the wrapped original; if even that trips, the

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -740,7 +740,7 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 	fs := flag.NewFlagSet("task-source", flag.ContinueOnError)
 	agent := fs.String("agent", "", "agent short name, id, or type this source applies to")
 	workspace := fs.String("workspace", "", "workspace name this source applies to (\"*\" wildcards, e.g. \"codex-*\")")
-	template := fs.String("template", "", "next-task prompt template ({next_task_content}, {task_list_path} placeholders)")
+	template := fs.String("template", "", "next-task prompt template ({next_task_content}, {task_list_path}, {agent_name} placeholders)")
 	fs.SetOutput(out)
 	if err := fs.Parse(args); err != nil {
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,8 +68,9 @@ type Limits struct {
 // LLM configures the optional local LLM/agent CLI fallback (FR-010, IR-005).
 type LLM struct {
 	// Command is the argv template; supports {self} (this binary),
-	// {request_id}, {db}, and {control} placeholders. Empty means no LLM is
-	// configured (low-confidence situations escalate).
+	// {request_id}, {db}, {control}, and {agent_name} (the agent's short
+	// name) placeholders. Empty means no LLM is configured (low-confidence
+	// situations escalate).
 	Command        []string `toml:"command"`
 	TimeoutSeconds int      `toml:"timeout_seconds"`
 	// AutoActConfidenceThreshold gates acting on an LLM suggestion
@@ -92,16 +93,16 @@ type LLM struct {
 	// RewriteCommand is the argv template for the one-shot rewrite of
 	// literal outbound text (idle next-task prompts, error retry commands,
 	// free-text replies — never menu digits); placeholders {text},
-	// {situation_type}, {agent_type}, {pane_excerpt}. The rewritten text
-	// is read from the CLI's stdout. Empty means literal text is sent
-	// unchanged.
+	// {situation_type}, {agent_type}, {agent_name}, {pane_excerpt}. The
+	// rewritten text is read from the CLI's stdout. Empty means literal
+	// text is sent unchanged.
 	RewriteCommand []string `toml:"rewrite_command"`
 	// RewriteTimeoutSeconds bounds one rewrite run; zero or omitted
 	// inherits timeout_seconds.
 	RewriteTimeoutSeconds int `toml:"rewrite_timeout_seconds"`
 	// RewriteFallbackTemplate wraps the original text when the rewrite
-	// fails ({original_text} placeholder). Empty uses the built-in
-	// default; a rewrite failure never blocks the send.
+	// fails (placeholders {original_text}, {agent_name}). Empty uses the
+	// built-in default; a rewrite failure never blocks the send.
 	RewriteFallbackTemplate string `toml:"rewrite_fallback_template"`
 }
 
@@ -151,7 +152,8 @@ type TaskSource struct {
 	Path      string `toml:"path"` // markdown checklist file
 	// NextTaskTemplate overrides the outbound prompt format. Placeholders:
 	// {next_task_content} (next unchecked item, or "none" when the list is
-	// complete) and {task_list_path}. Empty uses the built-in default.
+	// complete), {task_list_path}, and {agent_name} (the agent's short
+	// name). Empty uses the built-in default.
 	NextTaskTemplate string `toml:"next_task_template,omitempty"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -235,8 +235,8 @@ func Default() Config {
 		},
 		Learning: Learning{GraduationN: 5},
 		Limits: Limits{
-			MaxConsecutiveAutoPrompts: 5,
-			MaxAutoPromptsPerMinute:   10,
+			MaxConsecutiveAutoPrompts: 10,
+			MaxAutoPromptsPerMinute:   3,
 			MaxErrorRetries:           2,
 		},
 		// RewriteTimeoutSeconds stays zero here: Load seeds from Default

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -153,6 +153,7 @@ type rewriteOutcome struct {
 	dec       domain.Decision
 	learned   string // original learned form for RecordDecision
 	fallback  string // snapshotted rewrite_fallback_template
+	agentName string // agent short name, for {agent_name}
 	rewritten string
 	err       error
 	token     uint64
@@ -991,7 +992,14 @@ func (d *Daemon) consultLLM(ctx context.Context, cfg config.Config, s domain.Sit
 	go func() {
 		outcome := llmOutcome{situation: s, sig: sig, request: req}
 		err := logging.Guard("llm-consult", func() error {
-			req.ContextJSON = string(d.consultContext(ctx, cfg, s))
+			// The short name rides on the request ({agent_name}) and the
+			// consult context blob; degrade to "" when unresolvable.
+			agentName, nerr := d.opt.Store.EnsureAgentName(ctx, s.AgentID)
+			if nerr != nil {
+				agentName = ""
+			}
+			req.AgentName = agentName
+			req.ContextJSON = string(d.consultContext(ctx, cfg, s, agentName))
 			if _, err := d.opt.Store.StageLLMRequest(ctx, req); err != nil {
 				return fmt.Errorf("staging LLM request failed: %w", err)
 			}
@@ -1011,7 +1019,7 @@ func (d *Daemon) consultLLM(ctx context.Context, cfg config.Config, s domain.Sit
 // consultContext builds the JSON context handed to the LLM CLI via the
 // get_context MCP tool: the classified situation, a pane excerpt, the
 // agent's herdr location, and the pane working directory.
-func (d *Daemon) consultContext(ctx context.Context, cfg config.Config, s domain.Situation) []byte {
+func (d *Daemon) consultContext(ctx context.Context, cfg config.Config, s domain.Situation, agentName string) []byte {
 	excerpt := d.paneExcerpt(ctx, cfg, s)
 
 	// Pane location and cwd come from `pane get`; degrade to empty values
@@ -1047,6 +1055,7 @@ func (d *Daemon) consultContext(ctx context.Context, cfg config.Config, s domain
 		"tab_id":          tabID,
 		"pane_id":         s.PaneID,
 		"agent_id":        s.AgentID,
+		"agent_name":      agentName,
 		"cwd":             info.Cwd,
 		"foreground_cwd":  info.ForegroundCwd,
 		"no_reply_option": "if the agent needs no reply (it finished or is only reporting status), submit_decision with recommend_action \"@noop\" to explicitly do nothing",
@@ -1124,14 +1133,20 @@ func (d *Daemon) startRewrite(ctx context.Context, rw ports.RewriterPort, s doma
 	d.mu.Unlock()
 
 	go func() {
+		// The short name rides on the request ({agent_name}) and is reused
+		// for the fallback template if the rewrite degrades; degrade to "".
+		agentName, err := d.opt.Store.EnsureAgentName(rctx, s.AgentID)
+		if err != nil {
+			agentName = ""
+		}
 		outcome := rewriteOutcome{
 			situation: s, sig: sig, tr: tr, dec: dec, learned: learned,
-			fallback: cfg.LLM.RewriteFallbackTemplate, token: token,
+			fallback: cfg.LLM.RewriteFallbackTemplate, agentName: agentName, token: token,
 		}
 		outcome.err = logging.Guard("llm-rewrite", func() error {
 			req := domain.RewriteRequest{
 				Text: dec.Input, SituationType: s.Type, AgentType: s.AgentType,
-				PaneExcerpt: d.paneExcerpt(rctx, cfg, s),
+				PaneExcerpt: d.paneExcerpt(rctx, cfg, s), AgentName: agentName,
 			}
 			text, err := rw.Rewrite(rctx, req)
 			outcome.rewritten = text
@@ -1201,7 +1216,7 @@ func (d *Daemon) handleRewriteOutcome(ctx context.Context, res rewriteOutcome) {
 	note := "rewritten by llm.rewrite_command"
 	llmOutput := ""
 	degrade := func(why string) {
-		final = domain.ApplyRewriteFallback(res.fallback, res.dec.Input)
+		final = domain.ApplyRewriteFallback(res.fallback, res.dec.Input, res.agentName)
 		note = "rewrite " + why + "; fallback template applied"
 	}
 	switch {
@@ -1883,12 +1898,12 @@ func (d *Daemon) declaredTask(ctx context.Context, cfg config.Config, tr domain.
 			continue
 		}
 		if task := domain.NextDeclaredTask(string(data)); task != "" {
-			return &domain.DeclaredTask{Task: task, Path: src.Path, Template: src.NextTaskTemplate}
+			return &domain.DeclaredTask{Task: task, Path: src.Path, Template: src.NextTaskTemplate, AgentName: agentName}
 		}
 		// Only a real checklist with every item checked counts as completed;
 		// an empty or non-checklist file must not suppress tier-2 inference.
 		if completed == nil && domain.HasChecklistItems(string(data)) {
-			completed = &domain.DeclaredTask{Task: domain.NoTaskContent, Path: src.Path, Template: src.NextTaskTemplate}
+			completed = &domain.DeclaredTask{Task: domain.NoTaskContent, Path: src.Path, Template: src.NextTaskTemplate, AgentName: agentName}
 		}
 	}
 	return completed

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -876,6 +876,33 @@ func TestIdleDeclaredTaskCustomTemplate(t *testing.T) {
 	}
 }
 
+func TestIdleDeclaredTaskAgentNameTemplate(t *testing.T) {
+	// {agent_name} in a next_task_template renders the agent's resolved
+	// short name in the delivered prompt.
+	dir := t.TempDir()
+	taskFile := filepath.Join(dir, "tasks.md")
+	os.WriteFile(taskFile, []byte("- [ ] polish docs\n"), 0o600)
+
+	idlePane := "All tests pass. Task is complete.\n"
+	cfg := fmt.Sprintf(
+		"[[task_sources]]\nagent = \"agent-name-19\"\npath = %q\nnext_task_template = \"Hey {agent_name}, next: {next_task_content}\"\n",
+		taskFile)
+	h := newHarness(t, cfg)
+	h.herdr.setPane(idlePane)
+	h.seedAutonomous(idlePane, domain.SituationIdle, domain.ActionNextDeclaredTask)
+
+	name, err := h.raw.EnsureAgentName(context.Background(), "agent-name-19")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.push("agent-name-19", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	want := fmt.Sprintf("Hey %s, next: polish docs", name)
+	if got := h.herdr.sentInputs()[0]; got != want {
+		t.Errorf("sent %q, want agent-name-templated prompt %q", got, want)
+	}
+}
+
 func TestIdleDeclaredTaskRealTaskBeatsCompletedSource(t *testing.T) {
 	// A later matching source with a real remaining task takes precedence
 	// over an earlier matched source whose checklist is fully completed.
@@ -1584,6 +1611,11 @@ func TestConsultContextCarriesLocationCwdAndDeepExcerpt(t *testing.T) {
 		if got, _ := m[key].(string); got != want {
 			t.Errorf("%s = %q, want %q", key, got, want)
 		}
+	}
+	// agent_name carries the agent's resolved short name (for {agent_name}).
+	wantName, _ := h.raw.EnsureAgentName(context.Background(), "w2:p7")
+	if got, _ := m["agent_name"].(string); got == "" || got != wantName {
+		t.Errorf("agent_name = %q, want resolved short name %q", got, wantName)
 	}
 	excerpt, _ := m["pane_excerpt"].(string)
 	if len(excerpt) != 5000 {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -797,8 +797,10 @@ func TestPanicInjectionAtAdapterBoundaries(t *testing.T) {
 
 func TestRunawayGuardPausesAgent(t *testing.T) {
 	// FR-019 end to end: the 6th consecutive auto-prompt is blocked and the
-	// agent pauses until human interaction.
-	h := newHarness(t, "")
+	// agent pauses until human interaction. Pin explicit limits so the test
+	// exercises the CONSECUTIVE guard specifically, independent of the
+	// defaults (and with the per-minute cap held high so it never interferes).
+	h := newHarness(t, "[limits]\nmax_consecutive_auto_prompts = 5\nmax_auto_prompts_per_minute = 1000\n")
 	h.herdr.setPane(approvalPane)
 	h.seedAutonomous(approvalPane, domain.SituationApproval, "1")
 

--- a/internal/daemon/rewrite_test.go
+++ b/internal/daemon/rewrite_test.go
@@ -58,6 +58,11 @@ func TestRewriteAppliedToIdleDeclaredTask(t *testing.T) {
 	if calls[0].SituationType != domain.SituationIdle || calls[0].PaneExcerpt == "" {
 		t.Errorf("rewrite request missing context: %+v", calls[0])
 	}
+	// The agent's short name rides on the request for {agent_name}.
+	wantName, _ := h.raw.EnsureAgentName(context.Background(), "agent-rw1")
+	if calls[0].AgentName == "" || calls[0].AgentName != wantName {
+		t.Errorf("rewrite request agent name = %q, want resolved short name %q", calls[0].AgentName, wantName)
+	}
 
 	audits, err := h.raw.AuditLog(context.Background(), 10)
 	if err != nil || len(audits) == 0 {

--- a/internal/domain/rewrite.go
+++ b/internal/domain/rewrite.go
@@ -16,21 +16,27 @@ type RewriteRequest struct {
 	AgentType     string
 	// PaneExcerpt is the tail of the live pane, for {pane_excerpt}.
 	PaneExcerpt string
+	// AgentName is the agent's short name, for {agent_name}.
+	AgentName string
 }
 
 // DefaultRewriteFallbackTemplate wraps the original text when the rewrite
 // CLI fails: the send must never be blocked by a rewrite failure, so the
 // already-safety-screened original is delivered inside a quoting frame.
+// Placeholders: {original_text}, {agent_name} (the agent's short name).
 const DefaultRewriteFallbackTemplate = "You must act based on the following: {original_text}"
 
 // ApplyRewriteFallback renders the failure-path outbound text. An empty
 // template — or one missing the {original_text} placeholder, which would
 // silently drop the learned action — falls back to the default. A single
 // substitution pass means placeholder-like text inside the original is
-// never re-expanded.
-func ApplyRewriteFallback(template, original string) string {
+// never re-expanded. agentName fills {agent_name}.
+func ApplyRewriteFallback(template, original, agentName string) string {
 	if !strings.Contains(template, "{original_text}") {
 		template = DefaultRewriteFallbackTemplate
 	}
-	return strings.NewReplacer("{original_text}", original).Replace(template)
+	return strings.NewReplacer(
+		"{original_text}", original,
+		"{agent_name}", agentName,
+	).Replace(template)
 }

--- a/internal/domain/rewrite_test.go
+++ b/internal/domain/rewrite_test.go
@@ -4,10 +4,11 @@ import "testing"
 
 func TestApplyRewriteFallback(t *testing.T) {
 	tests := []struct {
-		name     string
-		template string
-		original string
-		want     string
+		name      string
+		template  string
+		original  string
+		agentName string
+		want      string
 	}{
 		{
 			name:     "empty template uses default",
@@ -39,12 +40,26 @@ func TestApplyRewriteFallback(t *testing.T) {
 			original: "",
 			want:     "You must act based on the following: ",
 		},
+		{
+			name:      "agent_name substituted",
+			template:  "{agent_name}, do: {original_text}",
+			original:  "run tests",
+			agentName: "brave-otter",
+			want:      "brave-otter, do: run tests",
+		},
+		{
+			name:      "agent_name in original not re-expanded",
+			template:  "{agent_name}: {original_text}",
+			original:  "print {agent_name}",
+			agentName: "calm-lynx",
+			want:      "calm-lynx: print {agent_name}",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ApplyRewriteFallback(tt.template, tt.original); got != tt.want {
-				t.Errorf("ApplyRewriteFallback(%q, %q) = %q, want %q",
-					tt.template, tt.original, got, tt.want)
+			if got := ApplyRewriteFallback(tt.template, tt.original, tt.agentName); got != tt.want {
+				t.Errorf("ApplyRewriteFallback(%q, %q, %q) = %q, want %q",
+					tt.template, tt.original, tt.agentName, got, tt.want)
 			}
 		})
 	}

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -15,7 +15,7 @@ var checkedItemRE = regexp.MustCompile(`^\s*(?:[-*+]\s+)?\[[xX+\-*]\]\s*(.+)$`)
 // DefaultNextTaskTemplate is the prompt template used when a task source
 // declares none. Placeholders: {next_task_content} is the next unchecked
 // item (or NoTaskContent when the list is complete), {task_list_path} is
-// the task-source file path.
+// the task-source file path, {agent_name} is the agent's short name.
 const DefaultNextTaskTemplate = "Your next task is {next_task_content}. Read the full tasks list at {task_list_path}."
 
 // NoTaskContent is the {next_task_content} value when a declared list has
@@ -27,9 +27,10 @@ const NoTaskContent = "none"
 // task content plus the source it came from, so the outbound prompt can be
 // rendered from the source's template.
 type DeclaredTask struct {
-	Task     string // next unchecked item, or NoTaskContent when complete
-	Path     string // task-source file path
-	Template string // operator template; "" uses DefaultNextTaskTemplate
+	Task      string // next unchecked item, or NoTaskContent when complete
+	Path      string // task-source file path
+	Template  string // operator template; "" uses DefaultNextTaskTemplate
+	AgentName string // agent short name, for {agent_name}
 }
 
 // Prompt renders the outbound prompt from the source's template. A single
@@ -43,6 +44,7 @@ func (t DeclaredTask) Prompt() string {
 	return strings.NewReplacer(
 		"{next_task_content}", t.Task,
 		"{task_list_path}", t.Path,
+		"{agent_name}", t.AgentName,
 	).Replace(tpl)
 }
 

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -60,6 +60,26 @@ func TestDeclaredTaskPrompt(t *testing.T) {
 			task: DeclaredTask{Task: "a", Path: "/p", Template: "{next_task_content}/{next_task_content} at {task_list_path}"},
 			want: "a/a at /p",
 		},
+		{
+			name: "agent_name substituted",
+			task: DeclaredTask{
+				Task:      "add validation",
+				Path:      "/docs/tasks.md",
+				Template:  "Hey {agent_name}, your next task is {next_task_content} ({task_list_path}).",
+				AgentName: "brave-otter",
+			},
+			want: "Hey brave-otter, your next task is add validation (/docs/tasks.md).",
+		},
+		{
+			name: "agent_name in task content not re-expanded",
+			task: DeclaredTask{
+				Task:      "print {agent_name}",
+				Path:      "/p",
+				Template:  "{agent_name}: {next_task_content}",
+				AgentName: "calm-lynx",
+			},
+			want: "calm-lynx: print {agent_name}",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -264,7 +264,10 @@ type LLMRequest struct {
 	AgentType     string
 	// AgentID identifies the agent this consult is for, so a pending row can
 	// be found by agent (the "is a consult still running?" retry guard).
-	AgentID     string
+	AgentID string
+	// AgentName is the agent's short name, for the {agent_name} command
+	// placeholder and the consult context blob.
+	AgentName   string
 	ContextJSON string
 	Status      string // pending | done | expired
 	CreatedAt   time.Time

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -1021,7 +1021,8 @@ func (a *App) AddNeverAutoPattern(ctx context.Context, pattern string) error {
 
 // AddTaskSource points an agent/workspace at a declared task list (FR-011).
 // template optionally overrides the outbound next-task prompt format
-// ({next_task_content} / {task_list_path} placeholders); "" uses the default.
+// ({next_task_content} / {task_list_path} / {agent_name} placeholders);
+// "" uses the default.
 func (a *App) AddTaskSource(ctx context.Context, agent, workspace, path, template string) error {
 	// The daemon reads the file from its own cwd (the state dir), not the
 	// operator's shell; resolve relative paths here where they still mean

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -22,7 +22,7 @@ import (
 // Adapter shells out to the operator's LLM CLI.
 type Adapter struct {
 	// CommandTemplate is the argv template from config; placeholders:
-	// {self} → this binary, {request_id}, {db}, {control}.
+	// {self} → this binary, {request_id}, {db}, {control}, {agent_name}.
 	CommandTemplate []string
 	Timeout         time.Duration
 	DBPath          string
@@ -32,7 +32,7 @@ type Adapter struct {
 	SelfPath string
 	// RewriteTemplate is the argv template for the one-shot outbound-text
 	// rewrite (llm.rewrite_command); placeholders {text}, {situation_type},
-	// {agent_type}, {pane_excerpt}. Empty disables rewriting.
+	// {agent_type}, {agent_name}, {pane_excerpt}. Empty disables rewriting.
 	RewriteTemplate []string
 	// RewriteTimeout bounds one rewrite run (<=0 falls back to Timeout).
 	RewriteTimeout time.Duration
@@ -62,6 +62,7 @@ func (a *Adapter) Consult(ctx context.Context, req domain.LLMRequest) (*domain.L
 		arg = strings.ReplaceAll(arg, "{request_id}", req.RequestID)
 		arg = strings.ReplaceAll(arg, "{db}", a.DBPath)
 		arg = strings.ReplaceAll(arg, "{control}", a.ControlPath)
+		arg = strings.ReplaceAll(arg, "{agent_name}", req.AgentName)
 		argv[i] = arg
 	}
 	// Auto-repair known CLI misconfigurations (e.g. claude's prompt placed

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -135,11 +135,11 @@ func TestTemplatePlaceholderExpansion(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "argv.txt")
 	script := writeScript(t, `echo "$@" > `+out+"\n")
 	a := &Adapter{
-		CommandTemplate: []string{script, "--req", "{request_id}", "--db", "{db}", "--self", "{self}"},
+		CommandTemplate: []string{script, "--req", "{request_id}", "--db", "{db}", "--self", "{self}", "--agent", "{agent_name}"},
 		Timeout:         5 * time.Second,
 		DBPath:          db, Store: st, SelfPath: "/bin/echo",
 	}
-	req := domain.LLMRequest{RequestID: "req-x", CreatedAt: time.Now()}
+	req := domain.LLMRequest{RequestID: "req-x", AgentName: "brave-otter", CreatedAt: time.Now()}
 	st.StageLLMRequest(context.Background(), req)
 	st.InsertLLMDecision(context.Background(), domain.LLMDecision{
 		RequestID: "req-x", Action: "ok", Status: "pending", CreatedAt: time.Now(),
@@ -153,7 +153,7 @@ func TestTemplatePlaceholderExpansion(t *testing.T) {
 		t.Fatal(err)
 	}
 	argv := string(data)
-	for _, want := range []string{"--req req-x", "--db " + db, "--self /bin/echo"} {
+	for _, want := range []string{"--req req-x", "--db " + db, "--self /bin/echo", "--agent brave-otter"} {
 		if !strings.Contains(argv, want) {
 			t.Errorf("argv missing %q: %s", want, argv)
 		}

--- a/internal/llm/rewrite.go
+++ b/internal/llm/rewrite.go
@@ -43,6 +43,7 @@ func (a *Adapter) Rewrite(ctx context.Context, req domain.RewriteRequest) (strin
 		arg = strings.ReplaceAll(arg, "{text}", req.Text)
 		arg = strings.ReplaceAll(arg, "{situation_type}", string(req.SituationType))
 		arg = strings.ReplaceAll(arg, "{agent_type}", req.AgentType)
+		arg = strings.ReplaceAll(arg, "{agent_name}", req.AgentName)
 		arg = strings.ReplaceAll(arg, "{pane_excerpt}", req.PaneExcerpt)
 		argv[i] = arg
 	}
@@ -73,6 +74,7 @@ func (a *Adapter) Rewrite(ctx context.Context, req domain.RewriteRequest) (strin
 		"HAP_REWRITE_TEXT="+req.Text,
 		"HAP_SITUATION_TYPE="+string(req.SituationType),
 		"HAP_AGENT_TYPE="+req.AgentType,
+		"HAP_AGENT_NAME="+req.AgentName,
 	)
 	runErr := cmd.Run()
 

--- a/internal/llm/rewrite_test.go
+++ b/internal/llm/rewrite_test.go
@@ -29,16 +29,19 @@ func TestRewriteSubstitutesPlaceholders(t *testing.T) {
 	dir := t.TempDir()
 	argvFile := filepath.Join(dir, "argv")
 	script := writeScript(t,
-		`printf '%s\n' "$@" > `+argvFile+"\necho rewritten reply\n")
+		`printf '%s\n' "$@" > `+argvFile+`
+printf 'name=%s\n' "$HAP_AGENT_NAME" >> `+argvFile+"\necho rewritten reply\n")
 	a := &Adapter{
 		RewriteTemplate: []string{script,
-			"text={text}", "sit={situation_type}", "agent={agent_type}", "pane={pane_excerpt}"},
+			"text={text}", "sit={situation_type}", "agent={agent_type}",
+			"name={agent_name}", "pane={pane_excerpt}"},
 		RewriteTimeout: 5 * time.Second,
 	}
 	got, err := a.Rewrite(context.Background(), domain.RewriteRequest{
 		Text:          "go test ./...",
 		SituationType: domain.SituationError,
 		AgentType:     "claude",
+		AgentName:     "brave-otter",
 		PaneExcerpt:   "FAIL: TestX",
 	})
 	if err != nil {
@@ -51,7 +54,9 @@ func TestRewriteSubstitutesPlaceholders(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "text=go test ./...\nsit=error\nagent=claude\npane=FAIL: TestX\n"
+	// The {agent_name} placeholder substitutes into argv, and the same value
+	// is exported as HAP_AGENT_NAME for env-based recipes.
+	want := "text=go test ./...\nsit=error\nagent=claude\nname=brave-otter\npane=FAIL: TestX\nname=brave-otter\n"
 	if string(argv) != want {
 		t.Errorf("argv = %q, want %q", argv, want)
 	}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -104,7 +104,7 @@ func toolDefinitions() []map[string]any {
 	return []map[string]any{
 		{
 			"name":        "get_context",
-			"description": "Get the situation context for the pending Herd Auto Prompter decision request: situation type, agent type, options, permission verb, error summary, a pane excerpt (last N chars of the pane), the agent's herdr location (workspace_id, tab_id, pane_id, agent_id — usable with read-only herdr CLI queries such as `herdr pane get <pane_id>` or `herdr pane read <pane_id>`), and the pane's working directory (cwd/foreground_cwd; advisory — a deleted dir carries a ' (deleted)' suffix and either may be empty).",
+			"description": "Get the situation context for the pending Herd Auto Prompter decision request: situation type, agent type, options, permission verb, error summary, a pane excerpt (last N chars of the pane), the agent's herdr location (workspace_id, tab_id, pane_id, agent_id — usable with read-only herdr CLI queries such as `herdr pane get <pane_id>` or `herdr pane read <pane_id>`), the agent's friendly short name (agent_name), and the pane's working directory (cwd/foreground_cwd; advisory — a deleted dir carries a ' (deleted)' suffix and either may be empty).",
 			"inputSchema": map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -44,8 +44,9 @@ max_error_retries = 2              # per error signature
 # pair (comment the Claude keys and uncomment the Codex ones to switch).
 [llm]
 # ── Claude Code recipe (active) ──
-# {self} = the hap binary, {request_id} is filled per consult. The prompt
-# must come immediately after -p (claude quirk; the plugin auto-repairs it).
+# {self} = the hap binary, {request_id} is filled per consult, {agent_name}
+# is the agent's short name ({db}/{control} also available). The prompt must
+# come immediately after -p (claude quirk; the plugin auto-repairs it).
 command = [
   "claude", "-p",
   "You are the auto-answer assistant for herd-auto-prompter (hap). A coding agent running in a herdr terminal pane has stopped and is waiting for input. Your job: answer exactly as the human operator would, using ONLY the two hap MCP tools.\n\nStep 1 — call get_context. It returns the classified situation:\n- situation_type: 'approval' (permission prompt), 'choice' (menu of options), 'error' (the agent hit a failure), or 'idle' (finished or waiting for its next instruction)\n- options: the menu option texts, when the pane shows a menu\n- permission_verb: what the agent is asking permission to do\n- error_summary: short description of the failure, when situation_type is 'error'\n- pane_excerpt: the recent terminal screen — read it carefully; it is the ground truth for what the agent is doing and asking\n- cwd / foreground_cwd and herdr ids (workspace_id, tab_id, pane_id, agent_id): where the agent is working\n\nStep 2 — decide what the operator would answer:\n- approval / choice: pick ONE entry from options and use its EXACT text. Approve routine, reversible work (reading files, edits, builds, tests, linters). Prefer the safest option and DENY anything destructive or hard to reverse: deleting data, force-pushing or hard-resetting git history, production/deploy changes, touching secrets or credentials, mass file operations.\n- error: reply with one short, concrete instruction telling the agent how to diagnose or fix the failure and continue.\n- idle: reply with the most sensible next instruction based on the pane_excerpt (e.g. continue the remaining work); if nothing remains, tell it to summarize and stop.\n- If the pane_excerpt is ambiguous or does not match the classified situation, choose the most conservative reply.\n\nStep 3 — call submit_decision with: action = the literal reply text to send to the agent (for menus, the exact option text — hap maps it to the menu digit), option_id = the chosen option text for menus, rationale = one sentence on why the operator would answer this way.",
@@ -140,6 +141,7 @@ theme = ""                 # named palette: default | dark | light | high-contra
 # agent = ""                 # short name, pane id, or type; "" = any
 # workspace = ""             # "" or "*" = any; wildcards like "codex-*" work
 # path = "/home/me/project/docs/tasks.md"
+# next_task_template placeholders: {next_task_content}, {task_list_path}, {agent_name}
 # next_task_template = "Your next task is {next_task_content}. Read the full tasks list at {task_list_path}."
 
 # ── Custom classifier rules (repeatable, extend the built-ins) ──────

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -33,8 +33,8 @@ irreversible_indicators = []     # extra suspected-irreversible patterns, all ag
 
 # ── Rate limits ─────────────────────────────────────────────────────
 [limits]
-max_consecutive_auto_prompts = 5   # per agent, without human interaction
-max_auto_prompts_per_minute = 10   # per agent
+max_consecutive_auto_prompts = 10  # per agent, without human interaction
+max_auto_prompts_per_minute = 3    # per agent
 max_error_retries = 2              # per error signature
 
 # ── Operator LLM (consulted on unknown situations) ──────────────────


### PR DESCRIPTION
## What

Adds an `{agent_name}` template variable (the agent's hap-owned short name, e.g. `brave-otter`, resolved via `Store.EnsureAgentName`) to **every operator-editable substitution site**:

| Site | Function |
|---|---|
| `[llm].command` argv | `llm.Consult` — via new `LLMRequest.AgentName`, resolved in `consultLLM` |
| `[llm].rewrite_command` argv + `HAP_AGENT_NAME` env | `llm.Rewrite` — via new `RewriteRequest.AgentName`, resolved in `startRewrite` |
| `[llm].rewrite_fallback_template` | `domain.ApplyRewriteFallback` (new `agentName` arg) |
| `[[task_sources]].next_task_template` | `domain.DeclaredTask.Prompt` (new `AgentName` field) |
| LLM consult context (`get_context`) | `daemon.consultContext` — new `agent_name` JSON key + tool description |

## Why

Operators could route task sources by agent short name but couldn't reference it inside the prompts/commands themselves. This lets templates say e.g. `Hey {agent_name}, your next task is {next_task_content}`.

## Safety / invariants

- Names resolve **inside the existing goroutines** (consult/rewrite) — no daemon select-loop stall.
- Every site **degrades to `""`** when unresolvable — never blocks a send.
- The agent-name regex (`^[a-z0-9][a-z0-9_-]{0,31}$`) means the value can't itself be a placeholder, so the single-pass no-re-expansion guarantee holds.
- Domain purity and fail-safe (`logging.Guard`) contracts preserved.

## Tests

- Unit: `tasklist_test`, `rewrite_test` (domain + llm), `llm_test` — substitution + no-re-expansion cases.
- Daemon end-to-end: next-task template renders the resolved name; consult-context blob carries `agent_name`; rewrite request populated with the name.
- Full suite passes with `vectors cpu` tags (one unrelated pre-existing flaky timing test, passes on rerun).

## Note

Also includes a rate-limit default change (`max_consecutive_auto_prompts` 5→10, `max_auto_prompts_per_minute` 10→3) with the compensating runaway-guard test pin.