### PR TITLE
feat: add first-interaction LLM templates (command_start, rewrite_command_start)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,8 +283,9 @@ Simple fields — numbers, booleans, and the `tui.theme` enum, including
 `llm.pane_excerpt_chars`, `safety.disable_seed`, and
 `tui.max_content_width` — edit inline (`enter`) or via
 `hap config set <key> <value>`. Free-text fields (`llm.command`,
-`llm.rewrite_command`, `llm.rewrite_fallback_template`,
-`embedding.model_path`) show read-only in the TUI, because a one-line
+`llm.command_start`, `llm.rewrite_command`, `llm.rewrite_command_start`,
+`llm.rewrite_fallback_template`, `embedding.model_path`) show read-only in
+the TUI, because a one-line
 prompt mangles quoted argv values — edit them in `config.toml` or with
 `config set`, which accepts every key. The safety indicator patterns and
 `[[capture_delay]]` rules also display read-only on the tab (capture
@@ -339,6 +340,23 @@ command = [
 timeout_seconds = 120
 auto_act_confidence_threshold = 999   # auto-act only when the LLM's confidence (0-100) is >= this; 999 = never (surface for your confirmation)
 pane_excerpt_chars = 5000   # pane excerpt size in the consult context (default 5000)
+```
+
+An optional **`command_start`** runs *instead of* `command` on an agent's
+**first consult** — the first time the plugin needs the LLM for that agent
+this daemon lifetime. Every later consult uses `command`. A genuinely new
+agent almost always starts in a new pane, so it primes on its own; a herdr
+subscriber reconnect does **not** re-fire it, so a long-running agent's
+kickoff prompt won't repeat mid-session. It takes the same placeholders and
+MCP flow as `command`; use it for a priming/kickoff prompt or a stronger
+model on the first touch. Omitting it (or leaving it empty) reuses
+`command`, so the feature is opt-in — and `command_start` alone never
+enables the fallback (`command` is what gates it):
+
+```toml
+[llm]
+command       = [ "claude", "-p", "...ongoing consult prompt...", "--model", "haiku" ]
+command_start = [ "claude", "-p", "...first-touch kickoff prompt...", "--model", "opus" ]
 ```
 
 `get_context` hands the model the classified situation (type, options,
@@ -442,6 +460,10 @@ rewrite_command = [
 rewrite_timeout_seconds = 30   # omitted: inherits timeout_seconds
 # Wraps the original when the rewrite fails (never blocks the send):
 rewrite_fallback_template = "You must act based on the following: {original_text}"
+# Optional: runs instead of rewrite_command on the agent's FIRST rewrite
+# (same first-interaction boundary as command_start, tracked independently;
+# empty inherits rewrite_command):
+# rewrite_command_start = [ "claude", "-p", "...first-rewrite prompt...", "--model", "haiku" ]
 ```
 
 Placeholders in `rewrite_command`: `{text}` (the literal reply a rule

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -173,13 +173,15 @@ func runDaemon(ctx context.Context, paths config.Paths, args []string) error {
 	// llm.command/timeout edits apply without a daemon restart.
 	llmFactory := func(cfg config.Config) ports.LLMPort {
 		return &llm.Adapter{
-			CommandTemplate: cfg.LLM.Command,
-			Timeout:         cfg.LLMTimeout(),
-			DBPath:          paths.DBPath(),
-			ControlPath:     paths.ControlSocketPath(),
-			Store:           st,
-			RewriteTemplate: cfg.LLM.RewriteCommand,
-			RewriteTimeout:  cfg.RewriteTimeout(),
+			CommandTemplate:      cfg.LLM.Command,
+			CommandStartTemplate: cfg.LLM.CommandStart,
+			Timeout:              cfg.LLMTimeout(),
+			DBPath:               paths.DBPath(),
+			ControlPath:          paths.ControlSocketPath(),
+			Store:                st,
+			RewriteTemplate:      cfg.LLM.RewriteCommand,
+			RewriteStartTemplate: cfg.LLM.RewriteCommandStart,
+			RewriteTimeout:       cfg.RewriteTimeout(),
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,7 +71,13 @@ type LLM struct {
 	// {request_id}, {db}, {control}, and {agent_name} (the agent's short
 	// name) placeholders. Empty means no LLM is configured (low-confidence
 	// situations escalate).
-	Command        []string `toml:"command"`
+	Command []string `toml:"command"`
+	// CommandStart is the argv template used on the FIRST consult per agent
+	// (a fresh agent in a pane, until superseded on the next "detected"
+	// discovery). Same placeholders as Command. Empty inherits Command, so
+	// the feature is opt-in and existing configs are unaffected. A CommandStart
+	// with no Command does NOT enable the LLM — Command alone gates that.
+	CommandStart   []string `toml:"command_start"`
 	TimeoutSeconds int      `toml:"timeout_seconds"`
 	// AutoActConfidenceThreshold gates acting on an LLM suggestion
 	// automatically (subject to every safety control and the learned-history
@@ -97,6 +103,11 @@ type LLM struct {
 	// rewritten text is read from the CLI's stdout. Empty means literal
 	// text is sent unchanged.
 	RewriteCommand []string `toml:"rewrite_command"`
+	// RewriteCommandStart is the argv template used on the FIRST rewrite per
+	// agent (same first-interaction boundary as CommandStart). Same
+	// placeholders as RewriteCommand. Empty inherits RewriteCommand, so the
+	// feature is opt-in; it is tracked independently of CommandStart's "first".
+	RewriteCommandStart []string `toml:"rewrite_command_start"`
 	// RewriteTimeoutSeconds bounds one rewrite run; zero or omitted
 	// inherits timeout_seconds.
 	RewriteTimeoutSeconds int `toml:"rewrite_timeout_seconds"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -468,6 +468,50 @@ rewrite_fallback_template = "Do this: {original_text}"
 	}
 }
 
+func TestCommandStartConfigKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+
+	// Omitted: both start variants default empty (inherit at use time).
+	os.WriteFile(path, []byte("[llm]\ncommand = [\"claude\"]\n"), 0o600)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.LLM.CommandStart) != 0 {
+		t.Errorf("command_start should default empty, got %v", cfg.LLM.CommandStart)
+	}
+	if len(cfg.LLM.RewriteCommandStart) != 0 {
+		t.Errorf("rewrite_command_start should default empty, got %v", cfg.LLM.RewriteCommandStart)
+	}
+
+	// Explicit values are honored and survive a Save/Load round trip.
+	os.WriteFile(path, []byte(`[llm]
+command = ["claude", "-p", "ongoing"]
+command_start = ["claude", "-p", "first: {agent_name}", "--model", "opus"]
+rewrite_command = ["claude", "-p", "rewrite: {text}"]
+rewrite_command_start = ["claude", "-p", "first rewrite: {text}"]
+`), 0o600)
+	if cfg, err = Load(path); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.LLM.CommandStart) != 5 || cfg.LLM.CommandStart[2] != "first: {agent_name}" {
+		t.Errorf("command_start lost: %v", cfg.LLM.CommandStart)
+	}
+	if len(cfg.LLM.RewriteCommandStart) != 3 || cfg.LLM.RewriteCommandStart[2] != "first rewrite: {text}" {
+		t.Errorf("rewrite_command_start lost: %v", cfg.LLM.RewriteCommandStart)
+	}
+	if err := Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	rt, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rt.LLM.CommandStart) != 5 || len(rt.LLM.RewriteCommandStart) != 3 {
+		t.Errorf("round trip lost start keys: %+v", rt.LLM)
+	}
+}
+
 func TestEmbeddingDefaultsAndOverride(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 

--- a/internal/daemon/command_start_test.go
+++ b/internal/daemon/command_start_test.go
@@ -1,0 +1,125 @@
+package daemon
+
+// Tests for the first-interaction command variants (llm.command_start /
+// llm.rewrite_command_start): the daemon flags the FIRST consult and FIRST
+// rewrite per agent with req.First and marks every later one false. The flag
+// is keyed by agent and is NOT reset on "detected" (a subscriber reconnect
+// must not re-fire the kickoff prompt); a genuinely new agent arrives with a
+// new id and primes naturally.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+func TestConsultFirstFlagPerAgent(t *testing.T) {
+	// Default confidence threshold (999) means every consult escalates, which
+	// leaves nothing sent and no rate/learning side effects — a clean way to
+	// drive repeated consults for one agent.
+	h := newHarness(t, "[llm]\ncommand = [\"fake\"]\ntimeout_seconds = 5\n")
+	h.llm.configured = true
+	var mu sync.Mutex
+	type call struct {
+		agent string
+		first bool
+	}
+	var calls []call
+	h.llm.consult = func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+		mu.Lock()
+		calls = append(calls, call{req.AgentID, req.First})
+		mu.Unlock()
+		return nil, errors.New("escalate") // no submission → the daemon escalates
+	}
+	got := func() []call {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]call(nil), calls...)
+	}
+
+	// Three distinct situation types → three distinct signatures for the same
+	// agent, so each is a fresh consult (no same-signature escalation dedup).
+	errorPane := "ERROR: build failed with exit status 2\nRetry, skip, or abort?\n"
+	choicePane := "Which framework?\n❯ 1. React\n  2. Vue\n  3. Svelte\n"
+
+	consult := func(agent, pane string, wantLen int) {
+		t.Helper()
+		h.herdr.setPane(pane)
+		h.push(agent, "blocked")
+		waitFor(t, 5*time.Second, func() bool { return len(got()) == wantLen })
+	}
+
+	consult("agent-cf", approvalPane, 1) // first consult for this agent
+	consult("agent-cf", errorPane, 2)    // later consult → not first
+
+	// A subscriber reconnect replays the pane as "detected"; it must NOT
+	// re-prime command_start for an agent already mid-session.
+	h.push("agent-cf", "detected")
+	time.Sleep(50 * time.Millisecond) // let the transition drain
+	consult("agent-cf", choicePane, 3)
+
+	// A genuinely new agent (new pane id) primes naturally — no reset needed.
+	consult("agent-cf2", approvalPane, 4)
+
+	want := []call{
+		{"agent-cf", true},
+		{"agent-cf", false},
+		{"agent-cf", false}, // after "detected": still not first
+		{"agent-cf2", true}, // new agent: first
+	}
+	seq := got()
+	if len(seq) != len(want) {
+		t.Fatalf("consult sequence = %v, want %v", seq, want)
+	}
+	for i := range want {
+		if seq[i] != want[i] {
+			t.Errorf("consult #%d = %+v, want %+v (full: %v)", i+1, seq[i], want[i], seq)
+		}
+	}
+}
+
+func TestRewriteFirstFlagPerAgent(t *testing.T) {
+	// A benign rewritten reply keeps the send flowing; high limits keep the
+	// runaway guard out of the way across the repeated auto-sends.
+	cfg := "[limits]\nmax_consecutive_auto_prompts = 100\nmax_auto_prompts_per_minute = 100\n"
+	h, fr := newHarnessRewriter(t, cfg,
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			return "yes please", nil
+		})
+
+	// Distinct free-text approvals → distinct signatures for the same agent;
+	// each resolves to a literal "y" send that goes through the rewriter.
+	drive := func(agent, pane string, wantSends int) {
+		t.Helper()
+		h.herdr.setPane(pane)
+		h.seedAutonomous(pane, domain.SituationApproval, "y")
+		h.push(agent, "blocked")
+		waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == wantSends })
+	}
+
+	drive("agent-rwstart", "Do you want to continue? (y/n)\n", 1)
+	drive("agent-rwstart", "Proceed with the build? (y/n)\n", 2)
+
+	// A reconnect ("detected") must NOT re-prime rewrite_command_start.
+	h.push("agent-rwstart", "detected")
+	time.Sleep(50 * time.Millisecond)
+	drive("agent-rwstart", "Save your changes? (y/n)\n", 3)
+
+	// A new agent primes naturally.
+	drive("agent-rwstart2", "Ship it? (y/n)\n", 4)
+
+	calls := fr.rewriteCalls()
+	if len(calls) != 4 {
+		t.Fatalf("expected 4 rewrites, got %d: %+v", len(calls), calls)
+	}
+	want := []bool{true, false, false, true}
+	for i, c := range calls {
+		if c.First != want[i] {
+			t.Errorf("rewrite #%d First = %v, want %v (all: %+v)", i+1, c.First, want[i], calls)
+		}
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -94,6 +94,19 @@ type Daemon struct {
 	pendingCapture map[string]*captureEntry
 	captureStarted map[string]bool
 
+	// firstConsult / firstRewrite mark agents whose first LLM consult /
+	// rewrite has fired, so the first interaction can use command_start /
+	// rewrite_command_start and every later one uses the base template. Keyed
+	// by agentID (== paneID in herdr), tracked independently of each other.
+	// NOT reset on "detected": that event also fires on every subscriber
+	// reconnect (pane-topology change), which would re-fire the kickoff
+	// prompt mid-session for long-running agents. A genuinely new agent
+	// almost always arrives in a new pane (new key → first=true naturally);
+	// the rare pane-id reuse forgoes re-priming rather than re-prime on every
+	// reconnect. Both guarded by mu.
+	firstConsult map[string]bool
+	firstRewrite map[string]bool
+
 	// configured flips after the first successful reload so reloadEmbedder
 	// can tell first load from a config change.
 	configured bool
@@ -192,6 +205,8 @@ func New(opt Options) (*Daemon, error) {
 		delayedTr:       make(chan domain.AgentTransition, 256),
 		pendingCapture:  map[string]*captureEntry{},
 		captureStarted:  map[string]bool{},
+		firstConsult:    map[string]bool{},
+		firstRewrite:    map[string]bool{},
 		lastAutoSend:    map[string]time.Time{},
 		lastAutoNoop:    map[string]time.Time{},
 		rewriteInFlight: map[string]rewriteFlight{},
@@ -984,10 +999,16 @@ func (d *Daemon) consultLLM(ctx context.Context, cfg config.Config, s domain.Sit
 	sig domain.SignatureResult, now time.Time) {
 
 	llm := d.llmPort()
+	// The first consult for this agent selects command_start (when
+	// configured); mark it consumed here on the main loop, before the goroutine.
+	d.mu.Lock()
+	first := !d.firstConsult[s.AgentID]
+	d.firstConsult[s.AgentID] = true
+	d.mu.Unlock()
 	req := domain.LLMRequest{
 		RequestID: fmt.Sprintf("req-%s-%d", s.AgentID, now.UnixNano()),
 		Signature: sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
-		AgentID: s.AgentID, Status: "pending", CreatedAt: now,
+		AgentID: s.AgentID, Status: "pending", CreatedAt: now, First: first,
 	}
 	go func() {
 		outcome := llmOutcome{situation: s, sig: sig, request: req}
@@ -1130,6 +1151,11 @@ func (d *Daemon) startRewrite(ctx context.Context, rw ports.RewriterPort, s doma
 	token := d.rewriteSeq
 	rctx, cancel := context.WithCancel(ctx)
 	d.rewriteInFlight[s.AgentID] = rewriteFlight{signature: sig.Signature, token: token, cancel: cancel}
+	// The first rewrite for this agent selects rewrite_command_start (when
+	// configured); consumed here, past the duplicate-drop, under the same
+	// lock. Tracked independently of the consult "first".
+	first := !d.firstRewrite[s.AgentID]
+	d.firstRewrite[s.AgentID] = true
 	d.mu.Unlock()
 
 	go func() {
@@ -1147,6 +1173,7 @@ func (d *Daemon) startRewrite(ctx context.Context, rw ports.RewriterPort, s doma
 			req := domain.RewriteRequest{
 				Text: dec.Input, SituationType: s.Type, AgentType: s.AgentType,
 				PaneExcerpt: d.paneExcerpt(rctx, cfg, s), AgentName: agentName,
+				First: first,
 			}
 			text, err := rw.Rewrite(rctx, req)
 			outcome.rewritten = text

--- a/internal/domain/rewrite.go
+++ b/internal/domain/rewrite.go
@@ -18,6 +18,10 @@ type RewriteRequest struct {
 	PaneExcerpt string
 	// AgentName is the agent's short name, for {agent_name}.
 	AgentName string
+	// First marks this as the agent's first rewrite this daemon lifetime,
+	// selecting llm.rewrite_command_start when configured. Tracked
+	// independently of the consult "first".
+	First bool
 }
 
 // DefaultRewriteFallbackTemplate wraps the original text when the rewrite

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -271,6 +271,10 @@ type LLMRequest struct {
 	ContextJSON string
 	Status      string // pending | done | expired
 	CreatedAt   time.Time
+	// First marks this as the agent's first consult this daemon lifetime,
+	// selecting llm.command_start when configured. Transient: it drives adapter
+	// template selection and is not persisted with the staged request.
+	First bool
 }
 
 // LLMRetry is a front-end-written request to re-invoke the LLM on an

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -619,11 +619,13 @@ var ConfigFields = []ConfigFieldDef{
 	{Key: "limits.max_auto_prompts_per_minute", TUIEditable: true},
 	{Key: "limits.max_error_retries", TUIEditable: true},
 	{Key: "safety.disable_seed", TUIEditable: true},
-	{Key: "llm.command"}, // argv template
+	{Key: "llm.command"},       // argv template
+	{Key: "llm.command_start"}, // argv template (first consult; inherits command)
 	{Key: "llm.timeout_seconds", TUIEditable: true},
 	{Key: "llm.auto_act_confidence_threshold", TUIEditable: true},
 	{Key: "llm.pane_excerpt_chars", TUIEditable: true},
-	{Key: "llm.rewrite_command"}, // argv template
+	{Key: "llm.rewrite_command"},       // argv template
+	{Key: "llm.rewrite_command_start"}, // argv template (first rewrite; inherits rewrite_command)
 	{Key: "llm.rewrite_timeout_seconds", TUIEditable: true},
 	{Key: "llm.rewrite_fallback_template"}, // template string
 	{Key: "embedding.disabled", TUIEditable: true},
@@ -689,6 +691,11 @@ func FieldValue(cfg config.Config, key string) string {
 			return "(disabled)"
 		}
 		return JoinCommand(cfg.LLM.Command)
+	case "llm.command_start":
+		if len(cfg.LLM.CommandStart) == 0 {
+			return "(inherits command)"
+		}
+		return JoinCommand(cfg.LLM.CommandStart)
 	case "llm.timeout_seconds":
 		return strconv.Itoa(cfg.LLM.TimeoutSeconds)
 	case "llm.auto_act_confidence_threshold":
@@ -703,6 +710,11 @@ func FieldValue(cfg config.Config, key string) string {
 			return "(disabled)"
 		}
 		return JoinCommand(cfg.LLM.RewriteCommand)
+	case "llm.rewrite_command_start":
+		if len(cfg.LLM.RewriteCommandStart) == 0 {
+			return "(inherits rewrite_command)"
+		}
+		return JoinCommand(cfg.LLM.RewriteCommandStart)
 	case "llm.rewrite_timeout_seconds":
 		return strconv.Itoa(cfg.LLM.RewriteTimeoutSeconds)
 	case "llm.rewrite_fallback_template":
@@ -802,12 +814,26 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 			}
 			cfg.LLM.Command = argv // empty disables the LLM fallback
 			return nil
+		case "llm.command_start":
+			argv, err := SplitCommand(value)
+			if err != nil {
+				return fmt.Errorf("llm.command_start: %w", err)
+			}
+			cfg.LLM.CommandStart = argv // empty inherits llm.command
+			return nil
 		case "llm.rewrite_command":
 			argv, err := SplitCommand(value)
 			if err != nil {
 				return fmt.Errorf("llm.rewrite_command: %w", err)
 			}
 			cfg.LLM.RewriteCommand = argv // empty disables the rewrite
+			return nil
+		case "llm.rewrite_command_start":
+			argv, err := SplitCommand(value)
+			if err != nil {
+				return fmt.Errorf("llm.rewrite_command_start: %w", err)
+			}
+			cfg.LLM.RewriteCommandStart = argv // empty inherits llm.rewrite_command
 			return nil
 		case "llm.rewrite_timeout_seconds":
 			return setInt(&cfg.LLM.RewriteTimeoutSeconds)

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -611,7 +611,9 @@ func TestSetFieldValidatesAndPersists(t *testing.T) {
 		{"llm.auto_act_confidence_threshold", "-1", true},
 		{"llm.auto_act_confidence_threshold", "maybe", true},
 		{"llm.command", `claude -p "decide for me"`, false},
+		{"llm.command_start", `claude -p "first: {agent_name}" --model opus`, false},
 		{"llm.rewrite_command", `claude -p "rewrite: {text}" --model haiku`, false},
+		{"llm.rewrite_command_start", `claude -p "first rewrite: {text}"`, false},
 		{"llm.rewrite_command", `claude -p "unbalanced`, true},
 		{"llm.rewrite_timeout_seconds", "45", false},
 		{"llm.rewrite_timeout_seconds", "zero", true},
@@ -639,6 +641,19 @@ func TestSetFieldValidatesAndPersists(t *testing.T) {
 	}
 	if len(cfg.LLM.RewriteCommand) != 5 || cfg.LLM.RewriteCommand[2] != "rewrite: {text}" {
 		t.Errorf("llm.rewrite_command quote handling: %v", cfg.LLM.RewriteCommand)
+	}
+	if len(cfg.LLM.CommandStart) != 5 || cfg.LLM.CommandStart[2] != "first: {agent_name}" {
+		t.Errorf("llm.command_start quote handling: %v", cfg.LLM.CommandStart)
+	}
+	if len(cfg.LLM.RewriteCommandStart) != 3 || cfg.LLM.RewriteCommandStart[2] != "first rewrite: {text}" {
+		t.Errorf("llm.rewrite_command_start quote handling: %v", cfg.LLM.RewriteCommandStart)
+	}
+	// Empty start variants render an inherit placeholder, not a blank cell.
+	if got := frontend.FieldValue(config.Config{}, "llm.command_start"); got != "(inherits command)" {
+		t.Errorf("empty command_start display = %q, want inherit placeholder", got)
+	}
+	if got := frontend.FieldValue(config.Config{}, "llm.rewrite_command_start"); got != "(inherits rewrite_command)" {
+		t.Errorf("empty rewrite_command_start display = %q, want inherit placeholder", got)
 	}
 	if cfg.LLM.RewriteTimeoutSeconds != 45 ||
 		cfg.LLM.RewriteFallbackTemplate != "Act on: {original_text}" {
@@ -673,10 +688,12 @@ func TestConfigFieldRegistryParity(t *testing.T) {
 		"limits.max_error_retries":            "2",
 		"safety.disable_seed":                 "true",
 		"llm.command":                         `claude -p "decide"`,
+		"llm.command_start":                   `claude -p "first: decide"`,
 		"llm.timeout_seconds":                 "60",
 		"llm.auto_act_confidence_threshold":   "70",
 		"llm.pane_excerpt_chars":              "4000",
 		"llm.rewrite_command":                 `claude -p "rewrite: {text}"`,
+		"llm.rewrite_command_start":           `claude -p "first rewrite: {text}"`,
 		"llm.rewrite_timeout_seconds":         "45",
 		"llm.rewrite_fallback_template":       "Act on: {original_text}",
 		"embedding.disabled":                  "false",
@@ -784,7 +801,9 @@ func TestPaneSalientCharsFieldDisplay(t *testing.T) {
 func TestFieldTUIEditableClassification(t *testing.T) {
 	readOnly := map[string]bool{
 		"llm.command":                   true,
+		"llm.command_start":             true,
 		"llm.rewrite_command":           true,
+		"llm.rewrite_command_start":     true,
 		"llm.rewrite_fallback_template": true,
 		"embedding.model_path":          true,
 	}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -24,16 +24,22 @@ type Adapter struct {
 	// CommandTemplate is the argv template from config; placeholders:
 	// {self} → this binary, {request_id}, {db}, {control}, {agent_name}.
 	CommandTemplate []string
-	Timeout         time.Duration
-	DBPath          string
-	ControlPath     string
-	Store           ports.ReadStore
+	// CommandStartTemplate is used instead of CommandTemplate on an agent's
+	// first consult (req.First); empty falls back to CommandTemplate.
+	CommandStartTemplate []string
+	Timeout              time.Duration
+	DBPath               string
+	ControlPath          string
+	Store                ports.ReadStore
 	// SelfPath overrides the {self} placeholder (defaults to os.Executable).
 	SelfPath string
 	// RewriteTemplate is the argv template for the one-shot outbound-text
 	// rewrite (llm.rewrite_command); placeholders {text}, {situation_type},
 	// {agent_type}, {agent_name}, {pane_excerpt}. Empty disables rewriting.
 	RewriteTemplate []string
+	// RewriteStartTemplate is used instead of RewriteTemplate on an agent's
+	// first rewrite (req.First); empty falls back to RewriteTemplate.
+	RewriteStartTemplate []string
 	// RewriteTimeout bounds one rewrite run (<=0 falls back to Timeout).
 	RewriteTimeout time.Duration
 }
@@ -56,8 +62,14 @@ func (a *Adapter) Consult(ctx context.Context, req domain.LLMRequest) (*domain.L
 			return nil, fmt.Errorf("resolve self path: %w", err)
 		}
 	}
-	argv := make([]string, len(a.CommandTemplate))
-	for i, arg := range a.CommandTemplate {
+	// The first consult for an agent uses command_start when configured;
+	// an empty start template falls back to the base command.
+	tmpl := a.CommandTemplate
+	if req.First && len(a.CommandStartTemplate) > 0 {
+		tmpl = a.CommandStartTemplate
+	}
+	argv := make([]string, len(tmpl))
+	for i, arg := range tmpl {
 		arg = strings.ReplaceAll(arg, "{self}", self)
 		arg = strings.ReplaceAll(arg, "{request_id}", req.RequestID)
 		arg = strings.ReplaceAll(arg, "{db}", a.DBPath)

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -160,6 +160,51 @@ func TestTemplatePlaceholderExpansion(t *testing.T) {
 	}
 }
 
+func TestConsultUsesCommandStartOnFirst(t *testing.T) {
+	st, db := testStore(t)
+	out := filepath.Join(t.TempDir(), "argv.txt")
+	// The script appends its first arg (the marker) so the chosen template
+	// is observable across calls.
+	script := writeScript(t, `echo "$1" >> `+out+"\n")
+	run := func(a *Adapter, reqID string, first bool) {
+		t.Helper()
+		req := domain.LLMRequest{RequestID: reqID, First: first, CreatedAt: time.Now()}
+		st.StageLLMRequest(context.Background(), req)
+		st.InsertLLMDecision(context.Background(), domain.LLMDecision{
+			RequestID: reqID, Action: "ok", Status: "pending", CreatedAt: time.Now(),
+		})
+		if _, err := a.Consult(context.Background(), req); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	a := &Adapter{
+		CommandTemplate:      []string{script, "base"},
+		CommandStartTemplate: []string{script, "start"},
+		Timeout:              5 * time.Second,
+		DBPath:               db, Store: st, SelfPath: "/bin/true",
+	}
+	run(a, "req-1", true)  // first consult → command_start
+	run(a, "req-2", false) // later consult → command
+	if data, _ := os.ReadFile(out); string(data) != "start\nbase\n" {
+		t.Errorf("marker sequence = %q, want start then base", data)
+	}
+
+	// With no start template configured, First=true still uses the base
+	// command — the feature is opt-in.
+	out2 := filepath.Join(t.TempDir(), "argv2.txt")
+	script2 := writeScript(t, `echo "$1" >> `+out2+"\n")
+	b := &Adapter{
+		CommandTemplate: []string{script2, "base"},
+		Timeout:         5 * time.Second,
+		DBPath:          db, Store: st, SelfPath: "/bin/true",
+	}
+	run(b, "req-3", true)
+	if data, _ := os.ReadFile(out2); string(data) != "base\n" {
+		t.Errorf("empty start template must fall back to base, got %q", data)
+	}
+}
+
 // chdirDeleted moves the test process into a directory and deletes it,
 // simulating a daemon whose start directory was removed after launch.
 func chdirDeleted(t *testing.T) {

--- a/internal/llm/rewrite.go
+++ b/internal/llm/rewrite.go
@@ -37,7 +37,11 @@ func (a *Adapter) Rewrite(ctx context.Context, req domain.RewriteRequest) (strin
 	// shapes, and substituted pane text is untrusted — it must not be able
 	// to perturb the repair (same fixes as Consult: claude/agy want the
 	// prompt right after -p/--print, codex needs the exec subcommand).
-	template := NormalizeLLMCommand(a.RewriteTemplate)
+	base := a.RewriteTemplate
+	if req.First && len(a.RewriteStartTemplate) > 0 {
+		base = a.RewriteStartTemplate
+	}
+	template := NormalizeLLMCommand(base)
 	argv := make([]string, len(template))
 	for i, arg := range template {
 		arg = strings.ReplaceAll(arg, "{text}", req.Text)

--- a/internal/llm/rewrite_test.go
+++ b/internal/llm/rewrite_test.go
@@ -62,6 +62,40 @@ printf 'name=%s\n' "$HAP_AGENT_NAME" >> `+argvFile+"\necho rewritten reply\n")
 	}
 }
 
+func TestRewriteUsesStartTemplateOnFirst(t *testing.T) {
+	// The script echoes its first arg (the marker) as the rewritten result.
+	script := writeScript(t, `printf '%s' "$1"`+"\n")
+	a := &Adapter{
+		RewriteTemplate:      []string{script, "base"},
+		RewriteStartTemplate: []string{script, "start"},
+		RewriteTimeout:       5 * time.Second,
+	}
+	first, err := a.Rewrite(context.Background(), domain.RewriteRequest{Text: "x", First: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != "start" {
+		t.Errorf("first rewrite marker = %q, want start", first)
+	}
+	later, err := a.Rewrite(context.Background(), domain.RewriteRequest{Text: "x", First: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if later != "base" {
+		t.Errorf("later rewrite marker = %q, want base", later)
+	}
+
+	// No start template → First=true falls back to the base template.
+	b := &Adapter{RewriteTemplate: []string{script, "base"}, RewriteTimeout: 5 * time.Second}
+	got, err := b.Rewrite(context.Background(), domain.RewriteRequest{Text: "x", First: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "base" {
+		t.Errorf("empty start template must fall back to base, got %q", got)
+	}
+}
+
 func TestRewriteStderrExcludedFromResult(t *testing.T) {
 	script := writeScript(t, "echo 'diagnostic noise' >&2\necho '  the reply  '\n")
 	a := &Adapter{RewriteTemplate: []string{script}, RewriteTimeout: 5 * time.Second}

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -675,7 +675,7 @@ func TestConfigReadOnlyRowsRefuseEditAndRemove(t *testing.T) {
 }
 
 func TestConfigTUIReadOnlyFieldsNoPrompt(t *testing.T) {
-	readOnly := []string{"llm.command", "llm.rewrite_command", "llm.rewrite_fallback_template", "embedding.model_path"}
+	readOnly := []string{"llm.command", "llm.command_start", "llm.rewrite_command", "llm.rewrite_command_start", "llm.rewrite_fallback_template", "embedding.model_path"}
 	for _, key := range readOnly {
 		for _, k := range []string{"enter", "e"} {
 			t.Run(key+"/"+k, func(t *testing.T) {
@@ -708,7 +708,8 @@ func TestConfigLongValueTruncatesToOneLine(t *testing.T) {
 	m := configModel(t, cfg)
 	found := false
 	for _, ln := range strings.Split(m.View(), "\n") {
-		if !strings.Contains(ln, "llm.command") {
+		// Trailing space keeps this from also matching "llm.command_start".
+		if !strings.Contains(ln, "llm.command ") {
 			continue
 		}
 		found = true

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -55,6 +55,20 @@ command = [
   "--model", "opus",
 ]
 
+# ── First-consult variant (optional) ──
+# command_start runs INSTEAD of command on an agent's very first consult
+# this daemon lifetime (a new agent normally starts in a new pane and primes
+# on its own; a subscriber reconnect does NOT re-fire it). Same
+# placeholders/tools as command; use it for a priming/kickoff prompt or a
+# stronger model on the first touch. Omit or leave empty to reuse command.
+# command_start = [
+#   "claude", "-p",
+#   "This is your first interaction with this agent. ...same MCP flow as command...",
+#   "--mcp-config", '{"mcpServers":{"hap":{"command":"{self}","args":["mcp"],"env":{"HAP_REQUEST_ID":"{request_id}"}}}}',
+#   "--allowedTools", "mcp__hap__get_context,mcp__hap__submit_decision",
+#   "--model", "opus",
+# ]
+
 # ── OpenAI Codex CLI recipe (commented; swap in to use codex) ──
 # The `exec` subcommand is required for headless runs (the plugin inserts
 # it if you forget), and the bypass flag is needed because Codex's approval
@@ -85,6 +99,17 @@ rewrite_command = [
   "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
   "--model", "haiku",
 ]
+
+# ── First-rewrite variant (optional) ──
+# rewrite_command_start runs INSTEAD of rewrite_command on an agent's first
+# rewrite this daemon lifetime (same first-interaction boundary as
+# command_start, tracked independently). Same placeholders as
+# rewrite_command. Omit or leave empty to reuse rewrite_command.
+# rewrite_command_start = [
+#   "claude", "-p",
+#   "First rewrite for this agent. Rewrite this instruction given its screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
+#   "--model", "haiku",
+# ]
 
 # ── Rewrite recipe — OpenAI Codex (commented; swap in to use codex) ──
 # rewrite_command = [


### PR DESCRIPTION
## 📌 Background

This feature enables distinct LLM prompts for an agent's first interaction versus subsequent ones, allowing for priming/kickoff prompts or stronger models on initial contact while using lighter models for ongoing consultation.

## 🔧 Reason for Changes

Users often want to:
- Prime a new agent with context or instructions on first contact
- Use a stronger/more expensive model for the initial consult, then switch to a faster/cheaper model for follow-ups
- Distinguish between "first rewrite" and "ongoing rewrites" with different prompts

The implementation tracks the first consult and first rewrite **per agent** (by `AgentID`), not globally. Critically, the "first" flag is **not reset on "detected"** events (subscriber reconnects), so a long-running agent's kickoff prompt won't re-fire mid-session. A genuinely new agent arrives with a new pane ID and naturally primes on its own.

## ✅ Changes Implemented

- **Config schema** (`internal/config/config.go`): Added `CommandStart` and `RewriteCommandStart` fields to the `LLM` struct; both default empty and inherit their base templates when not configured.

- **Domain types** (`internal/domain/types.go`, `internal/domain/rewrite.go`): Added `First` boolean flag to `LLMRequest` and `RewriteRequest` to signal first-interaction status.

- **Daemon tracking** (`internal/daemon/daemon.go`): 
  - Added `firstConsult` and `firstRewrite` maps (keyed by `AgentID`) to track which agents have had their first interaction.
  - Modified `consultLLM()` to set `req.First` based on whether the agent has been seen before, then mark it as seen.
  - Modified `startRewrite()` to do the same for rewrites, tracked independently.

- **LLM adapter** (`internal/llm/llm.go`):
  - Added `CommandStartTemplate` field; `Consult()` now selects it when `req.First` is true and the template is configured, otherwise falls back to `CommandTemplate`.

- **Rewrite adapter** (`internal/llm/rewrite.go`):
  - Added `RewriteStartTemplate` field; `Rewrite()` now selects it when `req.First` is true and the template is configured, otherwise falls back to `RewriteTemplate`.

- **Main entry point** (`cmd/hap/main.go`): Wired `CommandStart` and `RewriteCommandStart` from config into the LLM adapter.

- **Frontend/TUI** (`internal/frontend/frontend.go`, `internal/tui/list_test.go`):
  - Added config field definitions for `llm.command_start` and `llm.rewrite_command_start`.
  - Display empty start templates as "(inherits command)" / "(inherits rewrite_command)" in the TUI.
  - Added `SetField()` handlers to parse and persist the new fields.

- **Documentation** (`README.md`, `sample/config.toml`): Documented the new optional templates with examples and behavior notes.

## 🔍 Testing Results

- **Unit tests added** (`internal/daemon/command_start_test.go`):
  - `TestConsultFirstFlagPerAgent`: Verifies that the first consult for an agent sets `req.First = true`, subsequent consults set it to `false`, and "detected" events do not re-prime the flag.
  - `TestRewriteFirstFlagPerAgent`: Same verification for rewrites, tracked independently.

- **LLM adapter tests** (`internal/llm/llm_test.go`):
  - `TestConsultUsesCommandStartOnFirst`: Confirms that `Consult()` selects `CommandStartTemplate` when `req.First = true` and the template is configured, and falls back to `CommandTemplate` when the start template is empty.

- **Rewrite adapter tests** (`internal/llm/rewrite_test.go`):
  - `TestRewriteUsesStartTemplateOnFirst`:

https://claude.ai/code/session_0129YzR1Ar7cYbe62GgcK1Q4