### PR TITLE
#1 fix: bundle OpenBLAS runtime chain with FAISS native libs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,9 +110,56 @@ jobs:
           # Inter-library resolution must work from the bundle dir alone.
           if [ "${EXT}" = "so" ]; then
             sudo apt-get install -y -qq patchelf
-            for f in *.so; do
+            # FAISS is built against OpenBLAS (its BLAS backend) plus libgomp,
+            # and OpenBLAS in turn pulls in libgfortran + libquadmath. None of
+            # these are guaranteed present on a target box (a bare Debian has
+            # no libopenblas.so.0), so bundle the whole chain beside FAISS.
+            # Copy by SONAME — the NEEDED string the loader matches on — not
+            # the readlink -f real filename (libopenblasp-r*.so would not
+            # resolve). Paths come from the runner's ldconfig so the
+            # pthread-vs-openmp OpenBLAS variant doesn't matter.
+            copy_soname() {
+              local p
+              p="$(ldconfig -p | awk -v s="$1" '$1==s {print $NF; exit}')"
+              [ -n "$p" ] || { echo "cannot locate $1 on runner" >&2; exit 1; }
+              cp -L "$p" "./$1"
+            }
+            for so in libopenblas.so.0 libgfortran.so.5 libquadmath.so.0 libgomp.so.1; do
+              copy_soname "$so"
+            done
+            # DT_RUNPATH is NOT transitive: each bundled lib needs its own
+            # $ORIGIN so it can find the next link in the chain. Glob *.so*
+            # (not *.so) to catch versioned sonames like libgfortran.so.5.
+            for f in *.so*; do
+              [ -f "$f" ] || continue
               patchelf --set-rpath '$ORIGIN' "$f"
             done
+            # Prove the bundle is self-contained: after patchelf, nothing may
+            # resolve outside lib/ except an explicit base-system allowlist.
+            # Fails the release on any drift (e.g. a future FAISS bump adding
+            # an unbundled dep), instead of silently reshipping a broken lib/.
+            allow='libc\.so|libm\.so|libpthread\.so|libdl\.so|librt\.so|ld-linux|libstdc\+\+\.so|libgcc_s\.so'
+            # Match against the canonical dir: the loader resolves symlinks
+            # when it expands $ORIGIN, so ldd prints realpaths — a symlinked
+            # cwd would make correctly-bundled deps look like leaks.
+            libdir="$(realpath "$PWD")"
+            bad=0
+            for f in *.so*; do
+              [ -f "$f" ] || continue
+              # Capture ldd (and its exit): a non-parseable lib must fail the
+              # guard, not pass vacuously by reading zero lines.
+              deps="$(ldd "$f")" || { echo "ldd failed on $f" >&2; bad=1; continue; }
+              while read -r name arrow path _; do
+                [ "$arrow" = "=>" ] || continue          # skip vdso / ld.so lines
+                printf '%s' "$name" | grep -qE "$allow" && continue
+                case "$path" in
+                  "$libdir/"*) : ;;                       # good: resolved inside lib/
+                  not) echo "UNRESOLVED $name (needed by $f)" >&2; bad=1 ;;
+                  *) echo "LEAK $name -> $path (needed by $f)" >&2; bad=1 ;;
+                esac
+              done <<< "$deps"
+            done
+            [ "$bad" = 0 ] || { echo "native bundle is not self-contained" >&2; exit 1; }
           else
             install_name_tool -id '@rpath/libfaiss.dylib' libfaiss.dylib
             install_name_tool -id '@rpath/libfaiss_c.dylib' libfaiss_c.dylib

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -184,6 +184,21 @@ func TestClaudeMCQMultiTabFormReportsTabCount(t *testing.T) {
 	}
 }
 
+func TestClaudeMCQMultiTabV2FooterReportsTabCount(t *testing.T) {
+	// Regression for #50: the Claude Code v2.1.207 footer says "Tab to switch
+	// questions", not "Tab/Arrow keys to navigate". A genuine 3-tab form
+	// (Test scope / Daemon / Submit) must still report its tab count.
+	c := New(nil)
+	data, err := os.ReadFile(filepath.Join("testdata", "transcripts", "choice_claude_mcq_tabs_v2.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := c.Classify("claude", "blocked", string(data))
+	if s.TabCount != 3 {
+		t.Errorf("tab count = %d, want 3 (2 questions + Submit)", s.TabCount)
+	}
+}
+
 func TestNarratedNumberedListNotChoice(t *testing.T) {
 	// A narrated markdown list whose first item wraps into a long indented
 	// continuation block (> 4 lines, no MCQ footer) must NOT classify as a

--- a/internal/classify/testdata/classifications.golden
+++ b/internal/classify/testdata/classifications.golden
@@ -2,6 +2,7 @@ approval_permission.txt status=blocked type=approval verb=proceed options=3
 approval_yn.txt status=blocked type=approval verb= options=0
 choice_claude_mcq.txt status=blocked type=choice verb= options=5
 choice_claude_mcq_tabs.txt status=blocked type=choice verb= options=5
+choice_claude_mcq_tabs_v2.txt status=blocked type=choice verb= options=3
 choice_library.txt status=blocked type=choice verb= options=3
 error_build.txt status=blocked type=error verb= options=0
 idle_finished.txt status=idle type=idle verb= options=0

--- a/internal/classify/testdata/transcripts/choice_claude_mcq_tabs_v2.txt
+++ b/internal/classify/testdata/transcripts/choice_claude_mcq_tabs_v2.txt
@@ -1,0 +1,30 @@
+ ▐▛███▜▌   Claude Code v2.1.207
+▝▜█████▛▘  Opus 4.8 with high effort · Claude Max
+  ▘▘ ▝▝    ~/workspace/0xgosu/herdr-auto-pilot
+
+ ⚠ 3 MCP servers need authentication · run /mcp
+
+❯ /hap based on this skill help me to test the features of this plugin
+
+⏺ Calling 1 tool, running 5 shell commands…
+  ⎿  $ pgrep -fl "hap daemon" || echo "no hap daemon process"; echo "---status recheck---"; hap status 2>&1 | grep -i daemon
+
+⏺ Daemon dead — no process. Read-only feature surface already exercised successfully. Deeper tests (auto-answer, escalation, LLM consult) need daemon live; mutating tests touch your 6 live agents.
+
+  Two decisions are yours:
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────
+←  ☐ Test scope  ☐ Daemon  ✔ Submit  →
+
+How deep should the feature test go?
+
+❯ 1. Read-only + config
+  2. Full end-to-end
+  3. Read-only only
+
+                                  Notes: press n to add notes
+
+───────────────────────────────────────────────────────────────────────────────────────────
+  Chat about this
+
+Enter to select · ↑/↓ to navigate · n to add notes · Tab to switch questions · Esc to cancel

--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -13,7 +13,10 @@ import (
 // Three-tab AskUserQuestion form (2 questions + Submit), one frame per tab
 // exactly as `pane read --source visible` would return them.
 const mcqHeader = "←  ☐ Q one  ☐ Q two  ✔ Submit  →"
-const mcqFooter = "Enter to select · Tab/Arrow keys to navigate · Esc to cancel"
+
+// v2.1.207 footer wording — "Tab to switch questions" (issue #50). The old
+// "Tab/Arrow keys to navigate" form is still covered by the domain fixtures.
+const mcqFooter = "Enter to select · ↑/↓ to navigate · Tab to switch questions · Esc to cancel"
 
 var mcqFrames = []string{
 	"scrollback narration up here\n──────\n" + mcqHeader + "\n\nWhich storage backend should we use?\n\n" +

--- a/internal/domain/mcqform.go
+++ b/internal/domain/mcqform.go
@@ -12,19 +12,21 @@ import (
 //
 //	←  ☐ New name  ☐ Rename depth  ☐ Config compat  ☐ Conciseness  ✔ Submit  →
 //
-// and a footer that names Tab/Arrow navigation. The pane shows ONE question
-// at a time; the header is the only signal that more tabs exist.
+// and a footer that names tab navigation ("Tab/Arrow keys to navigate" on
+// older builds, "Tab to switch questions" since Claude Code v2.1.207). The
+// pane shows ONE question at a time; the header is the only signal that more
+// tabs exist.
 var (
 	mcqTabHeaderRE = regexp.MustCompile(`(?m)^\s*←.*[☐✔].*→\s*$`)
 	mcqTabEntryRE  = regexp.MustCompile(`[☐✔]`)
-	mcqTabFooterRE = regexp.MustCompile(`(?i)tab/arrow keys to navigate`)
+	mcqTabFooterRE = regexp.MustCompile(`(?i)(tab/arrow keys to navigate|tab to switch questions)`)
 	mcqFooterRE    = regexp.MustCompile(`(?im)^.*enter to select.*$`)
 	digitTokenRE   = regexp.MustCompile(`^[1-9]$`)
 )
 
 // MultiTabForm reports whether pane content shows the multi-tab MCQ variant
 // and how many tabs it has (checkbox entries plus the Submit entry). Both
-// the tab header and the Tab/Arrow footer are required, so a narrated
+// the tab header and the tab-navigation footer are required, so a narrated
 // checkbox list can not false-positive. The LAST header occurrence is the
 // live render: a consuming "recent" read can carry earlier renders (or an
 // older form) above the current one.

--- a/internal/domain/mcqform_test.go
+++ b/internal/domain/mcqform_test.go
@@ -24,10 +24,37 @@ New name for the "allowlist" concept (config key, reason token, labels)?
 Enter to select · Tab/Arrow keys to navigate · Esc to cancel
 `
 
+// mcqTabFrameV2 uses the Claude Code v2.1.207 footer wording — the tab-switch
+// hint moved from "Tab/Arrow keys to navigate" to "Tab to switch questions"
+// (issue #50). The header is unchanged, so only the footer regex must adapt.
+const mcqTabFrameV2 = `⏺ Daemon dead — no process. Two decisions are yours:
+───────────────────────────────
+←  ☐ Test scope  ☐ Daemon  ✔ Submit  →
+
+How deep should the feature test go?
+
+❯ 1. Read-only + config
+  2. Full end-to-end
+  3. Read-only only
+───────────────────────────────
+  Chat about this
+
+Enter to select · ↑/↓ to navigate · n to add notes · Tab to switch questions · Esc to cancel
+`
+
 func TestMultiTabFormDetectsTabs(t *testing.T) {
 	tabs, ok := MultiTabForm(mcqTabFrame)
 	if !ok || tabs != 5 {
 		t.Fatalf("MultiTabForm = (%d,%v), want (5,true)", tabs, ok)
+	}
+}
+
+func TestMultiTabFormDetectsV2Footer(t *testing.T) {
+	// Regression for #50: the v2.1.207 "Tab to switch questions" footer must
+	// still detect the 3-tab form (Test scope / Daemon / Submit).
+	tabs, ok := MultiTabForm(mcqTabFrameV2)
+	if !ok || tabs != 3 {
+		t.Fatalf("MultiTabForm(v2 footer) = (%d,%v), want (3,true)", tabs, ok)
 	}
 }
 

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -1433,7 +1433,7 @@ func TestResolveDigitSeriesDeliversKeystrokes(t *testing.T) {
 	// tab (Submit included) — never the series as literal text.
 	app, st := testApp(t)
 	fake := &fakeKeyHerdr{fakeHerdr: fakeHerdr{
-		pane: "←  ☐ Q one  ☐ Q two  ✔ Submit  →\n\nWhich backend?\n❯ 1. sqlite\n  2. postgres\n\nEnter to select · Tab/Arrow keys to navigate · Esc to cancel\n",
+		pane: "←  ☐ Q one  ☐ Q two  ✔ Submit  →\n\nWhich backend?\n❯ 1. sqlite\n  2. postgres\n\nEnter to select · ↑/↓ to navigate · Tab to switch questions · Esc to cancel\n",
 	}}
 	app.Herdr = fake
 	ctx := context.Background()


### PR DESCRIPTION
## Problem

`herdr plugin install 0xGosu/herdr-auto-pilot` succeeds but `hap` fails to start on a box without OpenBLAS installed (e.g. a bare Debian):

```
bin/hap: error while loading shared libraries: libopenblas.so.0: cannot open shared object file: No such file or directory
```

The release tarball bundled only `libfaiss.so` / `libfaiss_c.so`, but FAISS is linked against `libopenblas.so.0` (its BLAS backend), which in turn pulls in `libgfortran.so.5` + `libquadmath.so.0`, plus `libgomp.so.1`. On the CI runner those are present (installed via `libopenblas-dev`), so the gap was invisible — but they're not guaranteed on a target machine.

## Fix

In the release workflow's **Bundle native runtime libraries** step (Linux branch):

- Copy the full native chain (`libopenblas.so.0`, `libgfortran.so.5`, `libquadmath.so.0`, `libgomp.so.1`) into `bundle/lib/`, resolved **by SONAME via `ldconfig`** (not `readlink -f` — the loader matches the NEEDED name; and this makes the pthread-vs-openmp OpenBLAS variant irrelevant).
- Set `$ORIGIN` runpath on **every** lib, globbing `*.so*` so versioned sonames like `.so.5` are covered — the old `*.so` glob missed them. `DT_RUNPATH` is **non-transitive**, so each lib needs its own so it can find the next link in the chain.
- Add a **self-containment check**: after patchelf, walk `ldd` over every bundled lib and fail the release if any NEEDED lib resolves outside `lib/`, except a base-system allowlist (`libc`, `libm`, `libpthread`, `libdl`, `librt`, `ld-linux`, `libstdc++`, `libgcc_s`). This turns "I hope I bundled them all" into a hard CI gate — a future FAISS bump adding a new dep fails loudly instead of silently reshipping a broken tarball.

## Validation

The workflow itself only runs on a release tag, so the bundling logic was verified locally:

- Built the corrected self-contained `lib/` from the released FAISS libs + the OpenBLAS chain, applied the exact patchelf + verification logic → self-containment check passes (`bad=0`).
- **Gold-standard:** ran `hap --version` inside a clean `debian:trixie-slim` container with **no** OpenBLAS installed (`ldconfig -p | grep openblas` → none) — it loads and prints `v0.3.18`. That's the exact environment the reported install failed in.

macOS branch is unchanged (its libomp bundling already followed this pattern).

## Note for existing installs

Anyone already hit by this can unblock immediately with `apt-get install -y libopenblas0`; after this release the tarball is self-contained and needs no system package.

---

## Also in this PR: fix #50 — multi-tab MCQ footer drift

Claude Code **v2.1.207** renders the AskUserQuestion / plan-mode multi-tab footer as `↑/↓ to navigate … Tab to switch questions`, but `mcqTabFooterRE` still required the literal `Tab/Arrow keys to navigate`. The tab header matched but the footer did not, so `MultiTabForm` returned `false` for genuine multi-tab forms — `TabCount` was never set and the daemon Right-arrow tab sweep never ran. A 3-tab form was captured and answered as a single menu (only question 1 seen; Submit never reached).

**Fix:** broaden `mcqTabFooterRE` to accept both the old and the v2.1.207 wording; the `☐`/`✔` tab header is still required alongside the footer so narrated prose cannot false-positive.

**Tests:** new domain fixture+test and a classify golden transcript (`choice_claude_mcq_tabs_v2.txt`, 3 tabs) for the new footer; the daemon-sweep and frontend fixtures now use the live v2.1.207 footer, with the old wording still covered by the existing domain/classify fixtures. Full suite green under `-tags "vectors cpu"`.

Closes #50.
