### PR TITLE
#1 chore: release 0.3.21 (re-release with arch-adaptive native bundle)

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.3.20"
+version = "0.3.21"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Recovery release. The arch-adaptive native-bundle fix (#54) is on main but was workflow-only, so it did not trigger auto-release; the manifest still points at unreleased 0.3.20 and installs 404.

Bumping the manifest to 0.3.21 makes this merge take auto-release's untagged-manifest path — it tags this commit v0.3.21 directly, and the tag-driven release.yml (now with the fixed bundle step) builds and publishes on all three targets.

Merge subject must NOT carry `[skip release]`/`[skip ci]`.