### PR TITLE
#1 chore: install libopenblas0 in devcontainer post-create

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,9 @@
   "initializeCommand": "docker pull gelmium/devcontainer:latest;echo DEVCONTAINER_REF=${devcontainerId} > .devcontainer/.env",
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "bash -i -c 'post_create_command' || true",
+  // scripts/devcontainer-postcreate.sh installs hap's native runtime deps
+  // (libopenblas0 for FAISS); keep project setup steps there, not inline.
+  "postCreateCommand": "bash -i -c 'post_create_command' || true; bash scripts/devcontainer-postcreate.sh || true",
 
   // A command to run each time the container is successfully started.
   "postStartCommand": "bash -i -c 'post_start_command' || true",

--- a/scripts/devcontainer-postcreate.sh
+++ b/scripts/devcontainer-postcreate.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Devcontainer post-create setup for hap development.
+#
+# Runs once after the container is created (invoked from
+# .devcontainer/devcontainer.json's postCreateCommand). Keep every step
+# idempotent — a rebuilt container re-runs this.
+#
+#   - libopenblas0: FAISS's runtime BLAS backend. The CGO-linked hap binary
+#     and `go test -tags "vectors cpu"` load libfaiss.so, which needs
+#     libopenblas.so.0 at startup — without it the binary fails with
+#     "error while loading shared libraries: libopenblas.so.0". (Building the
+#     native libs from source via scripts/setup-native.sh installs the fuller
+#     libopenblas-dev; this covers just running a prebuilt/linked binary.)
+set -euo pipefail
+
+# Only apt-based images have these packages; skip quietly elsewhere.
+if command -v apt-get >/dev/null 2>&1; then
+  SUDO=""
+  [ "$(id -u)" -eq 0 ] || SUDO="sudo"
+  echo "==> installing libopenblas0 (FAISS runtime BLAS backend)"
+  $SUDO apt-get update -qq
+  $SUDO apt-get install -y -qq libopenblas0
+fi
+
+echo "devcontainer post-create setup complete"

--- a/scripts/setup-native.sh
+++ b/scripts/setup-native.sh
@@ -67,12 +67,26 @@ echo "==> llama-go static binding (CPU only, static archives)"
 # BUILD_SHARED_LIBS=OFF makes the Makefile copy .a archives — the shared
 # branch hardcodes .so names and breaks on macOS. GPU/BLAS backends are off:
 # hap embeds short strings on CPU and links with the `cpu` build tag.
-LLAMA_CMAKE_ARGS="-DBUILD_SHARED_LIBS=OFF -DGGML_METAL=OFF -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF"
+# GGML_NATIVE=OFF stops ggml passing -march=native, which would bake the
+# BUILDER's CPU features into the archive — a release runner with AVX-512
+# then produces a binary that SIGILLs on load on AVX2-only hosts. On x86 we
+# pin an explicit AVX2 baseline (x86-64-v3, every 2013+ Haswell) so the build
+# is portable yet not scalar-slow; these flags are inert on arm64 (ggml reads
+# them only under its x86 arch guard), and CGO builds each platform on its own
+# native runner, so `uname -m` is the target arch.
+LLAMA_CMAKE_ARGS="-DBUILD_SHARED_LIBS=OFF -DGGML_METAL=OFF -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF -DGGML_NATIVE=OFF"
+case "$(uname -m)" in
+  x86_64 | amd64)
+    LLAMA_CMAKE_ARGS="${LLAMA_CMAKE_ARGS} -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_AVX512=OFF"
+    ;;
+esac
 # The llama-go Makefile only invalidates its cmake cache on GPU-flag
-# mismatches, not shared/static — wipe a build configured for shared libs.
+# mismatches, not shared/static or the native/baseline flags above — wipe a
+# build configured for shared libs OR still carrying -march=native.
 if [ -f submodule/github.com/seed-hypermedia/llama-go/build/CMakeCache.txt ] &&
-  ! grep -q "BUILD_SHARED_LIBS:BOOL=OFF" submodule/github.com/seed-hypermedia/llama-go/build/CMakeCache.txt; then
-  echo "    (wiping shared-lib cmake cache)"
+  { ! grep -q "BUILD_SHARED_LIBS:BOOL=OFF" submodule/github.com/seed-hypermedia/llama-go/build/CMakeCache.txt ||
+    ! grep -q "GGML_NATIVE:BOOL=OFF" submodule/github.com/seed-hypermedia/llama-go/build/CMakeCache.txt; }; then
+  echo "    (wiping stale cmake cache: shared-lib or native config)"
   rm -rf submodule/github.com/seed-hypermedia/llama-go/build submodule/github.com/seed-hypermedia/llama-go/llama.cpp/*.o \
     submodule/github.com/seed-hypermedia/llama-go/*.o submodule/github.com/seed-hypermedia/llama-go/*.a \
     submodule/github.com/seed-hypermedia/llama-go/*.so submodule/github.com/seed-hypermedia/llama-go/*.dylib


### PR DESCRIPTION
Adds `scripts/devcontainer-postcreate.sh` (idempotent, apt-guarded) and invokes it from `postCreateCommand`, so a fresh devcontainer has FAISS's runtime BLAS backend (`libopenblas.so.0`) — without it the CGO-linked `hap` binary and `go test -tags "vectors cpu"` fail to load.

Dev-tooling only; no effect on the released plugin.

**Release note:** `.devcontainer/**` and `scripts/**` are NOT in auto-release's `paths-ignore`, so a normal merge triggers a patch release (v0.3.22). Since this changes nothing user-facing, squash-merge with `[skip release]` in the body to land it without a release.