### PR TITLE
#1 fix: gate approval/choice to blocked, tighten choice+error classifiers

### DIFF
--- a/internal/classify/classify.go
+++ b/internal/classify/classify.go
@@ -31,34 +31,27 @@ func DefaultRules() []config.ClassifierRule {
 			},
 		},
 		{
+			// Plain numbered-menu regexes were removed: any narrated numbered
+			// list tripped them. Textual cues stay here; Claude's structural
+			// MCQ forms are detected via domain.ClaudeMCQForm at the choice
+			// position in Classify (tab header/footer, or the single-question
+			// "enter to select" footer).
 			AgentType: "*", Situation: "choice",
 			Regex: []string{
-				`(?m)^\s*[❯>]?\s*1[.)]\s+\S.*\n\s*[❯>]?\s*2[.)]\s+\S`,
-				// Claude AskUserQuestion / plan-mode MCQ forms: every variant
-				// (single and multi-tab) renders this footer. The navigation
-				// tail is required so an agent merely printing/narrating
-				// "enter to select" (fzf-style help text in dev output) does
-				// not classify as a live menu.
-				`(?im)^.*enter to select.*(·|\bnavigate\b).*$`,
-				// MCQ layout with an indented description line under each
-				// option: allow a bounded run of description lines between
-				// option 1 and option 2 ({0,4} keeps long narrated markdown
-				// lists from false-positiving as a live menu).
-				`(?m)^\s*[❯>]?\s*1[.)]\s+\S.*\n(?:[ \t]+\S.*\n){0,4}\s*[❯>]?\s*2[.)]\s+\S`,
 				`(?i)(select|choose|pick) (an option|one of|from the following)`,
 				`(?i)which (option|approach|one) (would you|should)`,
-				`(?m)^\s*\[1\]\s+\S.*\n\s*\[2\]\s+\S`,
 			},
 		},
 		{
-			AgentType: "*", Situation: "error",
-			Regex: []string{
-				`(?im)^\s*(error|fatal|panic|exception)[:\s]`,
-				`(?i)(command|build|test|request) failed`,
-				`(?i)(retry|try again|skip|abort)\?`,
-				`(?i)\b(stack trace|traceback)\b`,
-				`(?i)exit (code|status) [1-9]`,
-			},
+			// Generic error regexes (line-start error/fatal/panic, "… failed",
+			// "retry/skip/abort?", stack trace, "exit code N") were removed:
+			// they tripped on ordinary error-shaped narration (a printed stack
+			// trace, a build log). Claude's blocking conditions (usage limit,
+			// interrupt prompt) are detected structurally via
+			// domain.ClaudeErrorForm at the error position in Classify. Other
+			// agent types get error rules in future.
+			AgentType: "claude", Situation: "error",
+			Regex: nil,
 		},
 		{
 			AgentType: "*", Situation: "idle",
@@ -123,15 +116,41 @@ func New(operatorRules []config.ClassifierRule) *Classifier {
 func (c *Classifier) Classify(agentType, agentStatus, pane string) domain.Situation {
 	s := domain.Situation{AgentType: agentType, Content: pane, Type: domain.SituationUnclassifiable}
 
+	// Approval and choice are BLOCKED situations (constitution taxonomy): only
+	// a blocked agent is actually waiting on a prompt, so their content rules
+	// are gated on herdr reporting the agent blocked.
+	blocked := agentStatus == "blocked"
+
 	for _, r := range c.rules {
 		if r.agentType != "*" && !strings.EqualFold(r.agentType, agentType) {
 			continue
 		}
-		if matchRule(r, pane) {
-			s.Type = r.situation
-			enrich(&s)
-			return s
+		matched := matchRule(r, pane)
+		// Claude's MCQ selection prompts render structurally (a tab header or
+		// an "Enter to select" navigation footer), not as a plain numbered
+		// menu. Detect them at the choice rule's position so approval still
+		// wins and error is still evaluated after choice (rule order encodes
+		// priority, classify.go docs).
+		if !matched && r.situation == domain.SituationChoice && strings.EqualFold(agentType, "claude") {
+			matched = domain.ClaudeMCQForm(pane)
 		}
+		// Claude's error/retry situations (usage-limit stop, interrupt prompt)
+		// are detected structurally at the error position, after choice, so
+		// rule priority (approval > choice > error) is preserved.
+		if !matched && r.situation == domain.SituationError && strings.EqualFold(agentType, "claude") {
+			_, matched = domain.ClaudeErrorForm(pane)
+		}
+		if !matched {
+			continue
+		}
+		// A numbered list or "select an option" phrase in ordinary
+		// working/idle output must never read as a live prompt.
+		if (r.situation == domain.SituationApproval || r.situation == domain.SituationChoice) && !blocked {
+			continue
+		}
+		s.Type = r.situation
+		enrich(&s)
+		return s
 	}
 
 	// No content rule matched. An idle/done agent with unremarkable output
@@ -186,6 +205,10 @@ func enrich(s *domain.Situation) {
 	case domain.SituationError:
 		if m := errorLineRE.FindStringSubmatch(s.Content); m != nil {
 			s.ErrorSummary = domain.MaskVolatile(strings.TrimSpace(m[1]))
+		} else if kind, ok := domain.ClaudeErrorForm(s.Content); ok {
+			// Claude's built-in error forms carry no "error:"-prefixed line;
+			// use the stable kind so paraphrases share one signature.
+			s.ErrorSummary = kind
 		}
 	}
 }

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -218,6 +218,131 @@ func TestNarratedNumberedListNotChoice(t *testing.T) {
 	}
 }
 
+func TestApprovalAndChoiceOnlyWhenBlocked(t *testing.T) {
+	// Approval and choice are BLOCKED situations: the same content at a
+	// non-blocked status must NOT classify as approval/choice.
+	c := New(nil)
+	approval := "Do you want to proceed?\n❯ 1. Yes\n  2. No\n"
+	choice := "Which option would you like?\n"
+	for _, status := range []string{"working", "idle", "done"} {
+		if s := c.Classify("claude", status, approval); s.Type == domain.SituationApproval {
+			t.Errorf("approval content at status %q must not classify approval", status)
+		}
+		if s := c.Classify("claude", status, choice); s.Type == domain.SituationChoice {
+			t.Errorf("choice content at status %q must not classify choice", status)
+		}
+	}
+	// The same content when blocked still classifies.
+	if s := c.Classify("claude", "blocked", approval); s.Type != domain.SituationApproval {
+		t.Errorf("blocked approval content = %v, want approval", s.Type)
+	}
+	if s := c.Classify("claude", "blocked", choice); s.Type != domain.SituationChoice {
+		t.Errorf("blocked choice content = %v, want choice", s.Type)
+	}
+}
+
+func TestClaudeMCQAtNonBlockedNotChoice(t *testing.T) {
+	// A Claude MCQ form (structural, no textual keyword) at a non-blocked
+	// status must not read as a live choice.
+	c := New(nil)
+	data, err := os.ReadFile(filepath.Join("testdata", "transcripts", "choice_claude_mcq_tabs_v2.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s := c.Classify("claude", "idle", string(data)); s.Type == domain.SituationChoice {
+		t.Errorf("MCQ form at idle status must not classify choice, got %v", s.Type)
+	}
+}
+
+func TestBlockedMCQWithErrorNarrationClassifiesChoice(t *testing.T) {
+	// Rule order is approval > choice > error. A blocked Claude MCQ whose
+	// content ALSO carries a real error signal (an interrupt line that
+	// ClaudeErrorForm matches) must still classify as choice — the MCQ signal
+	// is evaluated at the choice position, before the error rule. The question
+	// is deliberately not approval-shaped so choice-beats-error is the only
+	// thing under test.
+	pane := "⎿  Interrupted · What should Claude do instead?\n\n" +
+		"How should the fix be submitted?\n" +
+		"❯ 1. Retry the build\n  2. Skip and continue\n\n" +
+		"Enter to select · ↑/↓ to navigate · Esc to cancel\n"
+	// Sanity: the interrupt line alone WOULD classify as error, so choice
+	// really is winning over a live error signal.
+	if _, ok := domain.ClaudeErrorForm(pane); !ok {
+		t.Fatal("test setup: pane must contain a live error signal")
+	}
+	c := New(nil)
+	if s := c.Classify("claude", "blocked", pane); s.Type != domain.SituationChoice {
+		t.Fatalf("blocked MCQ with error signal = %v, want choice", s.Type)
+	}
+}
+
+func TestPlainNumberedListNotChoice(t *testing.T) {
+	// Numbered-menu regexes were removed: a bare numbered list with no MCQ
+	// footer and no "select an option" keyword must not classify as choice,
+	// even when blocked.
+	c := New(nil)
+	pane := "Here is what I changed:\n1. Fixed the parser\n2. Added a test\n3. Updated docs\n"
+	if s := c.Classify("claude", "blocked", pane); s.Type == domain.SituationChoice {
+		t.Errorf("plain numbered list must not classify choice, got %v", s.Type)
+	}
+}
+
+func TestClaudeErrorSituations(t *testing.T) {
+	c := New(nil)
+	for _, name := range []string{"error_claude_limit.txt", "error_claude_interrupted.txt"} {
+		data, err := os.ReadFile(filepath.Join("testdata", "transcripts", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s := c.Classify("claude", "blocked", string(data)); s.Type != domain.SituationError {
+			t.Errorf("%s: type = %v, want error", name, s.Type)
+		}
+		// Error detection is claude-scoped: the same content on another agent
+		// type must NOT classify as error (no rule for it yet).
+		if s := c.Classify("codex", "blocked", string(data)); s.Type == domain.SituationError {
+			t.Errorf("%s on non-claude agent must not classify error, got %v", name, s.Type)
+		}
+	}
+}
+
+func TestGenericErrorNarrationNotError(t *testing.T) {
+	// The generic error regexes were removed: a printed build failure /
+	// stack trace (ordinary agent narration) must no longer read as a live
+	// error situation.
+	c := New(nil)
+	pane := "$ go build ./...\nserver/handler.go:42: undefined: parseRequest\n" +
+		"ERROR: build failed with exit code 1\npanic: nil pointer\n"
+	if s := c.Classify("claude", "blocked", pane); s.Type == domain.SituationError {
+		t.Errorf("narrated build failure must not classify error, got %v", s.Type)
+	}
+}
+
+func TestClaudeMCQFormIsClaudeScoped(t *testing.T) {
+	// The structural MCQ signal is claude-only: the identical form on another
+	// agent type, even when blocked, must not classify as choice (guards the
+	// agentType == "claude" gate at the choice position).
+	c := New(nil)
+	data, err := os.ReadFile(filepath.Join("testdata", "transcripts", "choice_claude_mcq_tabs_v2.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s := c.Classify("codex", "blocked", string(data)); s.Type == domain.SituationChoice {
+		t.Errorf("MCQ form on non-claude agent must not classify choice, got %v", s.Type)
+	}
+}
+
+func TestApprovalWinsOverMCQFooter(t *testing.T) {
+	// Priority invariant: a blocked claude pane that matches BOTH an approval
+	// regex and the MCQ "Enter to select" footer must classify as approval —
+	// the MCQ choice signal must never outrank approval.
+	c := New(nil)
+	pane := "Do you want to proceed with the edit?\n" +
+		"❯ 1. Yes\n  2. No\n\nEnter to select · ↑/↓ to navigate · Esc to cancel\n"
+	if s := c.Classify("claude", "blocked", pane); s.Type != domain.SituationApproval {
+		t.Fatalf("approval must win over MCQ footer, got %v", s.Type)
+	}
+}
+
 func TestApprovalFixturesStillApproval(t *testing.T) {
 	// Regression: permission menus also render numbered options; approval
 	// must keep winning (rule order encodes priority).

--- a/internal/classify/testdata/classifications.golden
+++ b/internal/classify/testdata/classifications.golden
@@ -4,6 +4,8 @@ choice_claude_mcq.txt status=blocked type=choice verb= options=5
 choice_claude_mcq_tabs.txt status=blocked type=choice verb= options=5
 choice_claude_mcq_tabs_v2.txt status=blocked type=choice verb= options=3
 choice_library.txt status=blocked type=choice verb= options=3
-error_build.txt status=blocked type=error verb= options=0
+error_build.txt status=blocked type=unclassifiable verb= options=0
+error_claude_interrupted.txt status=blocked type=error verb= options=0
+error_claude_limit.txt status=blocked type=error verb= options=0
 idle_finished.txt status=idle type=idle verb= options=0
 unclassifiable_blocked.txt status=blocked type=unclassifiable verb= options=0

--- a/internal/classify/testdata/transcripts/error_claude_interrupted.txt
+++ b/internal/classify/testdata/transcripts/error_claude_interrupted.txt
@@ -1,0 +1,3 @@
+⏺ Running the full test suite…
+
+  ⎿  Interrupted · What should Claude do instead?

--- a/internal/classify/testdata/transcripts/error_claude_limit.txt
+++ b/internal/classify/testdata/transcripts/error_claude_limit.txt
@@ -1,0 +1,3 @@
+⏺ Continuing the refactor of the reconciliation consumer…
+
+  ⎿  You've hit your limit · resets 6pm (UTC)

--- a/internal/daemon/command_start_test.go
+++ b/internal/daemon/command_start_test.go
@@ -43,8 +43,11 @@ func TestConsultFirstFlagPerAgent(t *testing.T) {
 
 	// Three distinct situation types → three distinct signatures for the same
 	// agent, so each is a fresh consult (no same-signature escalation dedup).
-	errorPane := "ERROR: build failed with exit status 2\nRetry, skip, or abort?\n"
-	choicePane := "Which framework?\n❯ 1. React\n  2. Vue\n  3. Svelte\n"
+	// A Claude error situation (interrupt prompt); the choice pane uses the
+	// "which … option/approach" phrasing since bare numbered menus no longer
+	// classify as choice.
+	errorPane := "⎿  Interrupted · What should Claude do instead?\n"
+	choicePane := "Which option should we use?\n❯ 1. React\n  2. Vue\n  3. Svelte\n"
 
 	consult := func(agent, pane string, wantLen int) {
 		t.Helper()

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1230,7 +1230,9 @@ func TestIdleWithoutTaskSourceEscalates(t *testing.T) {
 
 func TestErrorRetryCeilingEndToEnd(t *testing.T) {
 	// FR-014: up to 2 automated retries per error signature; 3rd escalates.
-	errorPane := "ERROR: build failed with exit status 2\nRetry, skip, or abort?\n"
+	// A Claude error/retry situation (interrupt prompt) — generic build-log
+	// text no longer classifies as error (it is ordinary narration).
+	errorPane := "⎿  Interrupted · What should Claude do instead?\n"
 	h := newHarness(t, "")
 	h.herdr.setPane(errorPane)
 	h.seedAutonomous(errorPane, domain.SituationError, "retry")

--- a/internal/domain/claudeerror.go
+++ b/internal/domain/claudeerror.go
@@ -1,0 +1,41 @@
+package domain
+
+import "regexp"
+
+// Claude Code surfaces a few blocking conditions that need operator attention
+// rather than an auto-answer: a usage-limit stop ("You've hit your limit ·
+// resets 1am") and an interrupt prompt ("Interrupted · What should Claude do
+// instead?"). These are the error/retry situations for claude — deliberately
+// narrow so ordinary error-shaped narration (a printed stack trace, a build
+// log, an "exit code 1" line) is NOT classified as a live error.
+var (
+	// claudeLimitRE tolerates a straight or curly apostrophe and an optional
+	// "usage" qualifier ("You've hit your limit" / "you've hit your usage limit").
+	claudeLimitRE = regexp.MustCompile(`(?i)you['’]?ve hit your (?:usage )?limit`)
+	// claudeInterruptedRE keys on the distinctive interrupt-prompt tail; the
+	// bounded gap tolerates the "·" separator (and minor spacing drift) while
+	// staying on one line so it can't span unrelated narration.
+	claudeInterruptedRE = regexp.MustCompile(`(?i)interrupted\b.{0,12}what should claude do instead`)
+)
+
+// Stable ErrorSummary labels for Claude's built-in error forms — used as the
+// error signature (`error:<kind>`) so paraphrased instances (different reset
+// times, preceding narration) dedup to one learned signature.
+const (
+	ClaudeErrorLimit       = "usage-limit"
+	ClaudeErrorInterrupted = "interrupted"
+)
+
+// ClaudeErrorForm reports whether pane content shows one of Claude Code's
+// blocking error/interrupt conditions, and which kind. It is the error-
+// classification signal for claude; other agent types get their own rules in
+// future. kind is "" exactly when ok is false.
+func ClaudeErrorForm(pane string) (kind string, ok bool) {
+	switch {
+	case claudeLimitRE.MatchString(pane):
+		return ClaudeErrorLimit, true
+	case claudeInterruptedRE.MatchString(pane):
+		return ClaudeErrorInterrupted, true
+	}
+	return "", false
+}

--- a/internal/domain/claudeerror_test.go
+++ b/internal/domain/claudeerror_test.go
@@ -1,0 +1,43 @@
+package domain
+
+import "testing"
+
+func TestClaudeErrorForm(t *testing.T) {
+	cases := []struct {
+		name string
+		pane string
+		want bool
+	}{
+		{"limit reset am", "⎿ You've hit your limit · resets 1am\n", true},
+		{"limit reset utc", "⎿  You've hit your limit · resets 6pm (UTC)\n", true},
+		{"limit curly apostrophe", "You’ve hit your limit\n", true},
+		{"limit usage qualifier", "you've hit your usage limit for today\n", true},
+		{"interrupted prompt", "⎿  Interrupted · What should Claude do instead?\n", true},
+		// Ordinary error-shaped narration must NOT match (the whole point of
+		// the tightening).
+		{"narrated build failure", "ERROR: build failed with exit code 1\nThe build failed. Retry, skip, or abort?\n", false},
+		{"narrated stack trace", "panic: nil pointer\ngoroutine 1 [running]:\nmain.main()\n", false},
+		{"narrated interrupt word", "the download was interrupted midway and resumed\n", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, got := ClaudeErrorForm(tc.pane)
+			if got != tc.want {
+				t.Errorf("ClaudeErrorForm ok = %v, want %v", got, tc.want)
+			}
+			if got != (kind != "") {
+				t.Errorf("kind %q inconsistent with ok %v", kind, got)
+			}
+		})
+	}
+}
+
+func TestClaudeErrorFormKind(t *testing.T) {
+	if kind, _ := ClaudeErrorForm("You've hit your limit · resets 1am\n"); kind != ClaudeErrorLimit {
+		t.Errorf("limit kind = %q, want %q", kind, ClaudeErrorLimit)
+	}
+	if kind, _ := ClaudeErrorForm("Interrupted · What should Claude do instead?\n"); kind != ClaudeErrorInterrupted {
+		t.Errorf("interrupted kind = %q, want %q", kind, ClaudeErrorInterrupted)
+	}
+}

--- a/internal/domain/mcqform.go
+++ b/internal/domain/mcqform.go
@@ -24,6 +24,27 @@ var (
 	digitTokenRE   = regexp.MustCompile(`^[1-9]$`)
 )
 
+// mcqSingleFooterRE matches Claude's single-question selection footer — the
+// "Enter to select" line plus its navigation tail (a "·" separator or the
+// word "navigate"). The tail keeps an agent merely narrating "press enter to
+// select" (fzf-style help text in dev output) from reading as a live prompt.
+// The single-question form carries no tab header, so this footer is the only
+// structural signal it is a live menu.
+var mcqSingleFooterRE = regexp.MustCompile(`(?im)^.*enter to select.*(·|\bnavigate\b).*$`)
+
+// ClaudeMCQForm reports whether pane content shows any of Claude Code's
+// on-screen MCQ selection prompts: the multi-tab AskUserQuestion form (a tab
+// header plus its navigation footer, via MultiTabForm) or the single-question
+// form (an "Enter to select … navigate" footer). This is the choice-
+// classification signal for claude, replacing brittle numbered-line matching
+// that any narrated list would trip.
+func ClaudeMCQForm(pane string) bool {
+	if _, ok := MultiTabForm(pane); ok {
+		return true
+	}
+	return mcqSingleFooterRE.MatchString(pane)
+}
+
 // MultiTabForm reports whether pane content shows the multi-tab MCQ variant
 // and how many tabs it has (checkbox entries plus the Submit entry). Both
 // the tab header and the tab-navigation footer are required, so a narrated

--- a/internal/domain/mcqform_test.go
+++ b/internal/domain/mcqform_test.go
@@ -76,6 +76,29 @@ func TestMultiTabFormRejectsNarratedCheckboxes(t *testing.T) {
 	}
 }
 
+func TestClaudeMCQForm(t *testing.T) {
+	singleQuestion := "How do you want to submit?\n❯ 1. All 4\n  2. Hold\n\nEnter to select · ↑/↓ to navigate · Esc to cancel\n"
+	cases := []struct {
+		name string
+		pane string
+		want bool
+	}{
+		{"multi-tab v1 footer", mcqTabFrame, true},
+		{"multi-tab v2 footer", mcqTabFrameV2, true},
+		{"single-question footer", singleQuestion, true},
+		{"narrated checkbox no footer", "Plan status:\n←  ☐ step one  ✔ done  →\nall good\n", false},
+		{"plain numbered list", "Summary:\n1. Refactored the consumer\n2. Updated the spec\n", false},
+		{"narrated enter to select without nav tail", "run help: press Enter to select an entry\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClaudeMCQForm(tc.pane); got != tc.want {
+				t.Errorf("ClaudeMCQForm = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestParseDigitSeries(t *testing.T) {
 	cases := []struct {
 		in   string


### PR DESCRIPTION
## Summary

Tightens situation classification (`internal/classify` + `internal/domain`) to cut false positives, per operator request.

- **Approval & choice only when `blocked`.** Both are BLOCKED situations (constitution taxonomy). A numbered list or "select an option" phrase in ordinary working/idle output no longer reads as a live prompt.
- **Choice: removed brittle numbered-line regexes** (`1. / 2.`, `[1] / [2]`) — any narrated numbered list tripped them. Claude's MCQ forms (single-question + multi-tab AskUserQuestion) are now detected structurally via `domain.ClaudeMCQForm` (tab header/footer, or the single-question "enter to select" footer), evaluated **at the choice position** so priority stays `approval > choice > error`.
- **Error: removed the generic regexes** (line-start `error/panic`, "… failed", "retry/skip/abort?", stack trace, "exit code N") — they matched ordinary error-shaped narration. Error is now **claude-scoped** and detected via new `domain.ClaudeErrorForm` (usage-limit stop + interrupt prompt), with a stable `ErrorSummary` (`usage-limit`/`interrupted`) so paraphrases share one signature. Other agent types get error rules later.

## Behavior changes
- A generic build log (`ERROR: build failed…`) is now **unclassifiable → escalates** for claude, rather than auto-classified as error.
- Non-claude agents no longer get choice/error auto-classification from the removed generic patterns (fail-safe: escalate). Operator classifier rules can restore per-agent coverage.

## Tests
- New: `TestClaudeMCQForm`, `TestClaudeErrorForm`/`TestClaudeErrorFormKind`, blocked-gating tests, non-claude-scoped negatives, `approval-beats-MCQ-footer`, choice-beats-error, plain-numbered-list-not-choice, generic-error-narration-not-error. New golden fixtures for the two Claude error forms.
- Full CI suite (`go test -tags "vectors cpu" ./...`) passes — all 18 packages including daemon (96) and frontend (39). Two daemon tests updated to use a Claude interrupt pane.

## Follow-up (manual, not in CI)
The gating keys on herdr reporting `status == "blocked"` for a live prompt. The real-herdr integration cases (`TestRealConfirmDeliversMenuDigit`, `TestRealClaudeConsult`) are the definitive check and are worth running once before relying on this in production.