### PR TITLE
#60 fix: scope llama.cpp AVX2-baseline build flags to x86 only

### DIFF
--- a/scripts/setup-native.sh
+++ b/scripts/setup-native.sh
@@ -67,25 +67,37 @@ echo "==> llama-go static binding (CPU only, static archives)"
 # BUILD_SHARED_LIBS=OFF makes the Makefile copy .a archives — the shared
 # branch hardcodes .so names and breaks on macOS. GPU/BLAS backends are off:
 # hap embeds short strings on CPU and links with the `cpu` build tag.
-# GGML_NATIVE=OFF stops ggml passing -march=native, which would bake the
-# BUILDER's CPU features into the archive — a release runner with AVX-512
-# then produces a binary that SIGILLs on load on AVX2-only hosts. On x86 we
-# pin an explicit AVX2 baseline (x86-64-v3, every 2013+ Haswell) so the build
-# is portable yet not scalar-slow; these flags are inert on arm64 (ggml reads
-# them only under its x86 arch guard), and CGO builds each platform on its own
-# native runner, so `uname -m` is the target arch.
-LLAMA_CMAKE_ARGS="-DBUILD_SHARED_LIBS=OFF -DGGML_METAL=OFF -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF -DGGML_NATIVE=OFF"
+# x86 ONLY: GGML_NATIVE=OFF stops ggml passing -march=native, which would bake
+# the BUILDER's CPU features into the archive — a release runner with AVX-512
+# then produces an amd64 binary that SIGILLs on load on AVX2-only hosts. We pin
+# an explicit AVX2 baseline (x86-64-v3, every 2013+ Haswell) so portability
+# isn't scalar-slow. arm64 is deliberately left on ggml's default tuning: its
+# build runs on Apple Silicon / arm servers that are forward-compatible, and
+# scoping the change to x86 keeps it clear of the arm64 embedder abort tracked
+# in #60. CGO builds each platform on its own native runner, so `uname -m` is
+# the target arch.
+LLAMA_CMAKE_ARGS="-DBUILD_SHARED_LIBS=OFF -DGGML_METAL=OFF -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF"
+LLAMA_NATIVE_OFF=0
 case "$(uname -m)" in
   x86_64 | amd64)
-    LLAMA_CMAKE_ARGS="${LLAMA_CMAKE_ARGS} -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_AVX512=OFF"
+    LLAMA_CMAKE_ARGS="${LLAMA_CMAKE_ARGS} -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_AVX512=OFF"
+    LLAMA_NATIVE_OFF=1
     ;;
 esac
-# The llama-go Makefile only invalidates its cmake cache on GPU-flag
-# mismatches, not shared/static or the native/baseline flags above — wipe a
-# build configured for shared libs OR still carrying -march=native.
-if [ -f submodule/github.com/seed-hypermedia/llama-go/build/CMakeCache.txt ] &&
-  { ! grep -q "BUILD_SHARED_LIBS:BOOL=OFF" submodule/github.com/seed-hypermedia/llama-go/build/CMakeCache.txt ||
-    ! grep -q "GGML_NATIVE:BOOL=OFF" submodule/github.com/seed-hypermedia/llama-go/build/CMakeCache.txt; }; then
+# The llama-go Makefile only invalidates its cmake cache on GPU-flag mismatches,
+# not shared/static or the native→baseline switch — wipe when the cached config
+# disagrees with what we want now: a build configured for shared libs, or whose
+# cached GGML_NATIVE setting differs from this arch's target (x86 wants it OFF;
+# arm64 wants ggml's default, so a leftover x86/global OFF must be re-configured).
+LLAMA_CACHE=submodule/github.com/seed-hypermedia/llama-go/build/CMakeCache.txt
+llama_cache_stale=0
+if [ -f "$LLAMA_CACHE" ]; then
+  grep -q "BUILD_SHARED_LIBS:BOOL=OFF" "$LLAMA_CACHE" || llama_cache_stale=1
+  cache_native_off=0
+  if grep -q "GGML_NATIVE:BOOL=OFF" "$LLAMA_CACHE"; then cache_native_off=1; fi
+  [ "$cache_native_off" = "$LLAMA_NATIVE_OFF" ] || llama_cache_stale=1
+fi
+if [ "$llama_cache_stale" = 1 ]; then
   echo "    (wiping stale cmake cache: shared-lib or native config)"
   rm -rf submodule/github.com/seed-hypermedia/llama-go/build submodule/github.com/seed-hypermedia/llama-go/llama.cpp/*.o \
     submodule/github.com/seed-hypermedia/llama-go/*.o submodule/github.com/seed-hypermedia/llama-go/*.a \


### PR DESCRIPTION
## What

Follow-up to #56, which made the native llama.cpp build portable by setting `GGML_NATIVE=OFF` + pinning an AVX2 baseline. That change applied `GGML_NATIVE=OFF` to **every** arch, so it also dropped `-mcpu=native` on the arm64 (linux-arm64 / darwin-arm64) release builds.

This scopes the change to **x86 only**:

- `GGML_NATIVE=OFF` and the AVX2 baseline (`-mavx -mavx2 -mfma -mf16c`, AVX-512 off) now live inside the `x86_64|amd64` case; **arm64 reverts to exactly its pre-#56 default tuning**.
- The cmake-cache wipe now compares the cached `GGML_NATIVE` setting to this arch's target in **both directions**, so an arm64 tree previously configured with the global `OFF` is re-configured back to native (and x86 still picks up the baseline). `set -e`-safe greps.

## Why

The AVX-512 SIGILL that #56 fixes is x86-only. There's no reason to alter arm64 codegen, and doing so blindly is risky while the arm64 embedder is already unstable — see #60 (the `GGML_ASSERT` `get_rows` abort / SIGABRT crash-loop on Apple Silicon).

## Scope note

This does **not** fix the #60 arm64 embedder abort itself. That crash is a `get_rows` token-id bounds assert in the shipped llama.cpp build — a submodule-revision issue, independent of SIMD flags — and needs its own fix (bump `seed-hypermedia/llama-go` to a revision without the assert + a release-CI embed smoke test, plus the daemon-resilience UX asks in #60). This PR only ensures the #56 build-flag change is not a variable on arm64.

## Verification

- **x86_64:** cmake configures ggml-cpu as `-msse4.2;-mf16c;-mfma;-mbmi2;-mavx;-mavx2` (no `-march=native`, no AVX-512); rebuilt `libggml-cpu.a` has **0 AVX-512/ZMM** instructions; real-model embedder + match suites pass (paraphrase cosine **0.913** / unrelated **0.229**).
- **arm64 + cache-wipe migration:** shell dry-run across fresh / native / stale-global-OFF / shared for both arches — correct wipe decision every case, no `set -e` abort.