### PR TITLE
#60 feat: daemon heartbeat + captured stderr — make a hung/degraded daemon visible

### DIFF
--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/cli"
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/daemon"
+	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
 	"github.com/0xGosu/herdr-auto-pilot/internal/daemonlock"
 	"github.com/0xGosu/herdr-auto-pilot/internal/embedder"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
@@ -84,7 +86,11 @@ func main() {
 	}
 
 	if err := run(verb, args); err != nil {
-		fmt.Fprintln(os.Stderr, "error:", err)
+		// `hap status` on an unhealthy daemon already printed the human detail;
+		// exit non-zero for scripts without a redundant "error:" line.
+		if !errors.Is(err, cli.ErrUnhealthy) {
+			fmt.Fprintln(os.Stderr, "error:", err)
+		}
 		os.Exit(1)
 	}
 }
@@ -134,6 +140,7 @@ func buildApp(paths config.Paths) (*frontend.App, func(), error) {
 		ConfigPath:  paths.File(),
 		ControlPath: paths.ControlSocketPath(),
 		Author:      "operator",
+		StateDir:    paths.StateDir,
 		DaemonInfo: func() (bool, int, string) {
 			return daemonlock.Info(paths)
 		},
@@ -210,6 +217,7 @@ func runDaemon(ctx context.Context, paths config.Paths, args []string) error {
 		LLMFactory:        llmFactory,
 		EmbedderFactory:   embedderFactory,
 		MatchIndexDir:     filepath.Join(paths.StateDir, "match-index"),
+		StateDir:          paths.StateDir,
 	})
 	if err != nil {
 		return err
@@ -229,7 +237,15 @@ func ensureDaemon(paths config.Paths) error {
 		}
 		cmd := exec.Command(self, "daemon")
 		cmd.Stdout = nil
-		cmd.Stderr = nil
+		// Capture the detached daemon's stderr to a file. A native abort in
+		// the embedder (llama.cpp GGML_ASSERT → SIGABRT) prints there and is
+		// invisible to Go recovery; without this it went to /dev/null and the
+		// only crash evidence vanished. Best-effort: a nil file means the
+		// child inherits no stderr (today's behaviour), never a failed launch.
+		if stderrLog := daemonhealth.OpenStderrLog(paths.StateDir); stderrLog != nil {
+			cmd.Stderr = stderrLog
+			defer stderrLog.Close() // the child dup'd the fd at Start
+		}
 		cmd.Stdin = nil
 		daemonlock.Detach(cmd)
 		if err := cmd.Start(); err != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"bufio"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -17,10 +18,17 @@ import (
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
 	"github.com/0xGosu/herdr-auto-pilot/internal/daemonlock"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
 )
+
+// ErrUnhealthy signals that `hap status` found the daemon in an unhealthy
+// state (hung — a held lock with a stale heartbeat). status prints the human
+// detail itself; main maps this sentinel to a non-zero exit WITHOUT an
+// "error:" prefix, so scripted health checks can detect it.
+var ErrUnhealthy = errors.New("daemon unhealthy")
 
 // Run dispatches one CLI verb against the shared front-end layer.
 func Run(ctx context.Context, app *frontend.App, out io.Writer, verb string, args []string) error {
@@ -347,24 +355,60 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 		state = "PAUSED (kill switch active)"
 	}
 	fmt.Fprintf(out, "automation:          %s\n", state)
+	// health is the daemon's heartbeat record (absent for a daemon older than
+	// heartbeat support, or one not running); hung is a held lock with a stale
+	// beat — a live-but-wedged daemon, the case flock alone can't reveal.
+	var health daemonhealth.Health
+	var haveHealth, hung bool
 	if app.DaemonInfo != nil {
 		running, pid, ver := app.DaemonInfo()
+		if running && app.StateDir != "" {
+			// Only trust a heartbeat written by THIS lock holder. A hard abort
+			// skips the daemon's cleanup, so a fresh same-version daemon can be
+			// holding the lock while a dead predecessor's stale record still
+			// sits on disk — attributing it here would false-flag the new
+			// daemon NOT RESPONDING during its startup window. flock guarantees
+			// the pid is live, so matching pids means the record is genuinely
+			// this daemon's (bar astronomically-unlikely pid reuse in that window).
+			if h, ok := daemonhealth.Read(app.StateDir); ok && h.PID == pid {
+				health, haveHealth = h, true
+			}
+		}
+		now := time.Now()
+		hung = running && haveHealth && health.Stale(now)
+		label := fmt.Sprintf("running %s (pid %d)", daemonlock.VersionLabel(ver), pid)
 		switch {
 		case !running:
 			fmt.Fprintf(out, "daemon:              not running\n")
-		case ver == buildinfo.Version:
-			fmt.Fprintf(out, "daemon:              running %s (pid %d)\n", daemonlock.VersionLabel(ver), pid)
-		default:
+		case hung:
+			// A held lock with a dead heartbeat: alive but not progressing (or
+			// mid-crash-loop). Point at the captured stderr for the reason; if
+			// it is also a different binary, keep the --ensure remedy visible.
+			line := fmt.Sprintf("%s — NOT RESPONDING (last heartbeat %s ago); recent output: %s",
+				label, roundDuration(health.Age(now)), daemonhealth.StderrLogPath(app.StateDir))
+			if ver != buildinfo.Version {
+				line += fmt.Sprintf(" [also STALE: binary is %s; run: hap daemon --ensure]", buildinfo.Version)
+			}
+			fmt.Fprintf(out, "daemon:              %s\n", line)
+		case ver != buildinfo.Version:
 			// A holder from another binary keeps old bugs alive; make the
 			// mismatch and the remedy impossible to miss.
-			fmt.Fprintf(out, "daemon:              running %s (pid %d) — STALE, binary is %s; run: hap daemon --ensure\n",
-				daemonlock.VersionLabel(ver), pid, buildinfo.Version)
+			fmt.Fprintf(out, "daemon:              %s — STALE, binary is %s; run: hap daemon --ensure\n",
+				label, buildinfo.Version)
+		default:
+			fmt.Fprintf(out, "daemon:              %s\n", label)
 		}
 	}
 	fmt.Fprintf(out, "pending escalations: %d\n", st.PendingEscalations)
 	fmt.Fprintf(out, "monitored agents:    %d\n", len(st.MonitoredAgents))
 	if st.Embedding != "" {
 		fmt.Fprintf(out, "semantic matching:   %s\n", st.Embedding)
+	}
+	// The config-derived line above says what SHOULD be running; the daemon's
+	// live heartbeat can report the embedder soft-degraded (embed calls latched
+	// to text fallback), which that line would otherwise hide.
+	if haveHealth && health.Embedder == daemonhealth.EmbedderDegraded {
+		fmt.Fprintf(out, "embedder health:     DEGRADED at runtime — %s\n", health.EmbedderNote())
 	}
 	if st.Drift.Detected {
 		// Same shape as the STALE-daemon line: the mismatch and the remedy
@@ -376,7 +420,21 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 		fmt.Fprintf(out, "last kill event:     %s by %s at %s\n",
 			st.LatestKill.State, st.LatestKill.Author, st.LatestKill.CreatedAt.Format(time.RFC3339))
 	}
+	// A hung daemon is a failure state: exit non-zero so scripted checks and
+	// the operator notice, even though the status body already explained it.
+	if hung {
+		return ErrUnhealthy
+	}
 	return nil
+}
+
+// roundDuration renders a heartbeat age compactly for status output ("45s",
+// "2m0s"), dropping sub-second noise and flooring at zero.
+func roundDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	return d.Round(time.Second).String()
 }
 
 func agents(ctx context.Context, app *frontend.App, out io.Writer) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
 	"github.com/0xGosu/herdr-auto-pilot/internal/cli"
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
@@ -63,6 +65,108 @@ func TestStatusShowsDaemonLine(t *testing.T) {
 	out, _ = run(t, app, "status")
 	if !strings.Contains(out, "STALE") || !strings.Contains(out, "hap daemon --ensure") {
 		t.Errorf("version mismatch must flag STALE with the remedy, got:\n%s", out)
+	}
+}
+
+func TestStatusHungDaemonUnhealthy(t *testing.T) {
+	app, _ := testApp(t)
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	app.DaemonInfo = func() (bool, int, string) { return true, 4242, buildinfo.Version }
+
+	// A held lock but a heartbeat well past the stale threshold = hung.
+	if err := daemonhealth.Write(stateDir, daemonhealth.Health{
+		PID: 4242, Version: buildinfo.Version,
+		HeartbeatAt: time.Now().Add(-2 * daemonhealth.StaleAfter),
+		Embedder:    daemonhealth.EmbedderReady,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "status")
+	if !errors.Is(err, cli.ErrUnhealthy) {
+		t.Fatalf("hung daemon must return ErrUnhealthy for a non-zero exit, got err=%v", err)
+	}
+	if !strings.Contains(out, "NOT RESPONDING") {
+		t.Errorf("hung daemon must be flagged NOT RESPONDING, got:\n%s", out)
+	}
+	if !strings.Contains(out, "daemon.stderr.log") {
+		t.Errorf("hung daemon should point at the captured stderr log, got:\n%s", out)
+	}
+}
+
+func TestStatusIgnoresStaleHealthFromDeadInstance(t *testing.T) {
+	app, _ := testApp(t)
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	// The lock is held by a fresh daemon (pid 4242); a crashed predecessor
+	// (pid 9999) left a stale record its hard abort never cleaned up. That
+	// record must NOT be attributed to the live daemon (else a false
+	// NOT RESPONDING during the new daemon's startup window).
+	app.DaemonInfo = func() (bool, int, string) { return true, 4242, buildinfo.Version }
+	if err := daemonhealth.Write(stateDir, daemonhealth.Health{
+		PID: 9999, Version: buildinfo.Version,
+		HeartbeatAt: time.Now().Add(-2 * daemonhealth.StaleAfter),
+		Embedder:    daemonhealth.EmbedderReady,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "status")
+	if err != nil {
+		t.Fatalf("a stale record from a DIFFERENT pid must not read as hung, got err=%v", err)
+	}
+	if strings.Contains(out, "NOT RESPONDING") {
+		t.Errorf("dead predecessor's heartbeat must not be attributed to the live daemon, got:\n%s", out)
+	}
+	if !strings.Contains(out, "running "+buildinfo.Version+" (pid 4242)") {
+		t.Errorf("should fall back to a healthy running line, got:\n%s", out)
+	}
+}
+
+func TestStatusFreshHeartbeatHealthy(t *testing.T) {
+	app, _ := testApp(t)
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	app.DaemonInfo = func() (bool, int, string) { return true, 4242, buildinfo.Version }
+
+	if err := daemonhealth.Write(stateDir, daemonhealth.Health{
+		PID: 4242, Version: buildinfo.Version,
+		HeartbeatAt: time.Now(), Embedder: daemonhealth.EmbedderReady,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "status")
+	if err != nil {
+		t.Fatalf("fresh heartbeat must be healthy, got err=%v", err)
+	}
+	if strings.Contains(out, "NOT RESPONDING") {
+		t.Errorf("a fresh heartbeat must not read as hung, got:\n%s", out)
+	}
+}
+
+func TestStatusEmbedderDegradedSurfaced(t *testing.T) {
+	app, _ := testApp(t)
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	app.DaemonInfo = func() (bool, int, string) { return true, 4242, buildinfo.Version }
+
+	if err := daemonhealth.Write(stateDir, daemonhealth.Health{
+		PID: 4242, Version: buildinfo.Version,
+		HeartbeatAt: time.Now(), Embedder: daemonhealth.EmbedderDegraded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "status")
+	// Degraded is a working fallback, NOT an unhealthy exit — but it must be
+	// surfaced so the operator knows semantic matching is off.
+	if err != nil {
+		t.Fatalf("a degraded embedder is not an unhealthy exit, got err=%v", err)
+	}
+	if !strings.Contains(out, "DEGRADED") {
+		t.Errorf("runtime-degraded embedder must be surfaced, got:\n%s", out)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -21,6 +21,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/classify"
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/control"
+	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/logging"
 	"github.com/0xGosu/herdr-auto-pilot/internal/match"
@@ -50,7 +51,10 @@ type Options struct {
 	// MatchIndexDir is where the disposable bleve match index lives
 	// (typically <state>/match-index). Empty disables semantic matching.
 	MatchIndexDir string
-	Clock         ports.Clock
+	// StateDir is where the daemon writes its heartbeat/health record
+	// (daemonhealth). Empty disables health writing (tests that don't care).
+	StateDir string
+	Clock    ports.Clock
 	// ReadTaskFile reads a declared task-source file (os.ReadFile in prod).
 	ReadTaskFile func(path string) ([]byte, error)
 	// PaneReadLines is how much recent pane content classification sees.
@@ -304,9 +308,59 @@ func (d *Daemon) snapshot() (config.Config, *domain.NeverAutoList, *classify.Cla
 	return d.cfg, d.neverAuto, d.classifier
 }
 
+// embedderState reports the current semantic-matching health for the heartbeat
+// record. A hard native abort never reaches here (it kills the process first);
+// this only distinguishes disabled / starting / soft-degraded / ready.
+func (d *Daemon) embedderState() daemonhealth.EmbedderState {
+	d.mu.RLock()
+	disabled := d.cfg.Embedding.Disabled
+	d.mu.RUnlock()
+	if disabled {
+		return daemonhealth.EmbedderDisabled
+	}
+	if emb := d.embedderPort(); emb != nil {
+		if deg, ok := emb.(interface{ Degraded() bool }); ok && deg.Degraded() {
+			return daemonhealth.EmbedderDegraded
+		}
+	}
+	if d.semanticReady.Load() {
+		return daemonhealth.EmbedderReady
+	}
+	return daemonhealth.EmbedderStarting
+}
+
+// writeHealth refreshes the heartbeat file (best-effort; a failed write is
+// logged once at debug and never disturbs the loop). No-op without a StateDir.
+func (d *Daemon) writeHealth(startedAt time.Time) {
+	if d.opt.StateDir == "" {
+		return
+	}
+	h := daemonhealth.Health{
+		PID:         os.Getpid(),
+		Version:     buildinfo.Version,
+		StartedAt:   startedAt,
+		HeartbeatAt: d.opt.Clock.Now(),
+		Embedder:    d.embedderState(),
+	}
+	if err := daemonhealth.Write(d.opt.StateDir, h); err != nil {
+		slog.Debug("heartbeat write failed", "error", err)
+	}
+}
+
 // Run drives the daemon until ctx is done. It never panics: every handler
 // runs under the fail-safe guard (NFR-004).
 func (d *Daemon) Run(ctx context.Context) error {
+	// Heartbeat first: publish a fresh health record (stamped with THIS pid)
+	// as the very first action, before the slower socket/subscriber setup, so
+	// a status check during startup sees this daemon's beat — not a dead
+	// predecessor's stale file left by a hard abort. Refreshed on a ticker
+	// below; removed on clean shutdown so a graceful stop reads as gone.
+	startedAt := d.opt.Clock.Now()
+	d.writeHealth(startedAt)
+	if d.opt.StateDir != "" {
+		defer func() { _ = daemonhealth.Remove(d.opt.StateDir) }()
+	}
+
 	// Control socket: reload/wake nudges from front-ends and mcp.
 	var ctl *control.Server
 	if d.opt.ControlSocketPath != "" {
@@ -356,11 +410,19 @@ func (d *Daemon) Run(ctx context.Context) error {
 	sweep := time.NewTicker(time.Minute)
 	defer sweep.Stop()
 
+	// Heartbeat ticker: refresh the health record (written once above at
+	// startup) so out-of-process status/TUI can tell a live, progressing
+	// daemon from a hung one.
+	heartbeat := time.NewTicker(daemonhealth.HeartbeatInterval)
+	defer heartbeat.Stop()
+
 	slog.Info("daemon running", "version", buildinfo.Version)
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
+		case <-heartbeat.C:
+			d.writeHealth(startedAt)
 		case <-sweep.C:
 			logging.Guard("periodic-sweep", func() error {
 				d.processCorrections(ctx)

--- a/internal/daemon/health_test.go
+++ b/internal/daemon/health_test.go
@@ -1,0 +1,118 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
+)
+
+// degradableEmbedder is a minimal EmbedderPort whose Degraded() the daemon
+// type-asserts; EmbedText is never called by embedderState.
+type degradableEmbedder struct{ degraded bool }
+
+func (degradableEmbedder) EmbedText(context.Context, string) ([]float32, error) {
+	return nil, nil
+}
+func (degradableEmbedder) ModelID() string  { return "fake" }
+func (degradableEmbedder) Dims() int        { return 0 }
+func (degradableEmbedder) Close() error     { return nil }
+func (e degradableEmbedder) Degraded() bool { return e.degraded }
+
+func TestEmbedderStateMapping(t *testing.T) {
+	// disabled wins over everything, even a "ready" latch.
+	d := &Daemon{}
+	d.cfg = config.Config{Embedding: config.Embedding{Disabled: true}}
+	d.semanticReady.Store(true)
+	if got := d.embedderState(); got != daemonhealth.EmbedderDisabled {
+		t.Errorf("disabled config: got %q, want disabled", got)
+	}
+
+	// enabled, no embedder yet, not ready → starting.
+	d = &Daemon{}
+	if got := d.embedderState(); got != daemonhealth.EmbedderStarting {
+		t.Errorf("pre-init: got %q, want starting", got)
+	}
+
+	// enabled + ready, embedder healthy → ready.
+	d.embedder = degradableEmbedder{degraded: false}
+	d.semanticReady.Store(true)
+	if got := d.embedderState(); got != daemonhealth.EmbedderReady {
+		t.Errorf("ready: got %q, want ready", got)
+	}
+
+	// a degraded embedder overrides ready.
+	d.embedder = degradableEmbedder{degraded: true}
+	if got := d.embedderState(); got != daemonhealth.EmbedderDegraded {
+		t.Errorf("degraded latch: got %q, want degraded", got)
+	}
+}
+
+// TestDaemonWritesAndClearsHeartbeat verifies the daemon publishes a fresh
+// heartbeat on startup (so out-of-process status can trust "running") and
+// removes it on clean shutdown (so a graceful stop reads as gone, not hung).
+func TestDaemonWritesAndClearsHeartbeat(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	// Embedding disabled → deterministic embedder state in the record, and no
+	// native model load in a unit test.
+	if err := os.WriteFile(cfgPath, []byte("[embedding]\ndisabled = true\n"+tinyCaptureDelay), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := store.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { raw.Close() })
+
+	ctlPath := filepath.Join(testutil.SocketDir(t), "control.sock")
+	d, err := New(Options{
+		ConfigPath:        cfgPath,
+		ControlSocketPath: ctlPath,
+		StateDir:          dir,
+		Store:             raw,
+		Herdr:             &fakeHerdr{},
+		Events:            &fakeEvents{ch: make(chan domain.AgentTransition, 8)},
+		Notify:            &fakeHerdr{},
+		LLM:               &fakeLLM{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go d.Run(ctx)
+
+	var h daemonhealth.Health
+	waitFor(t, 2*time.Second, func() bool {
+		var ok bool
+		h, ok = daemonhealth.Read(dir)
+		return ok
+	})
+	if h.PID != os.Getpid() {
+		t.Errorf("heartbeat pid = %d, want this process %d", h.PID, os.Getpid())
+	}
+	if h.Embedder != daemonhealth.EmbedderDisabled {
+		t.Errorf("embedder state = %q, want %q", h.Embedder, daemonhealth.EmbedderDisabled)
+	}
+	if h.Stale(time.Now()) {
+		t.Error("a just-written heartbeat must not read as stale")
+	}
+
+	// Clean shutdown drops the file so status reads "not running", not hung.
+	cancel()
+	waitFor(t, 2*time.Second, func() bool {
+		_, ok := daemonhealth.Read(dir)
+		return !ok
+	})
+	if _, ok := daemonhealth.Read(dir); ok {
+		t.Error("heartbeat file must be removed on clean shutdown")
+	}
+}

--- a/internal/daemonhealth/health.go
+++ b/internal/daemonhealth/health.go
@@ -1,0 +1,142 @@
+// Package daemonhealth persists a small heartbeat/health record that the live
+// daemon updates while it runs, so out-of-process commands (`hap status`, the
+// TUI) can tell a healthy, progressing daemon from a hung or degraded one.
+//
+// The flock in internal/daemonlock only answers "does some process hold the
+// lock" — the OS releases it the instant the holder dies, so a truly dead pid
+// never reads as running. What flock CANNOT reveal is a daemon that is alive
+// but wedged (no forward progress) or one whose embedder has fallen back to
+// text matching. A periodically-refreshed heartbeat file closes that gap: a
+// stale heartbeat under a held lock means "hung", and the embedder field
+// surfaces the soft-degraded state. (A hard native abort — the #60 SIGABRT —
+// kills the process before it can write anything, so that case is caught by
+// the captured stderr log and the restart tracker, not this file.)
+package daemonhealth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// HeartbeatInterval is how often the running daemon refreshes its heartbeat.
+const HeartbeatInterval = 10 * time.Second
+
+// StaleAfter is how long a heartbeat may age before `hap status` treats a
+// lock-holding daemon as hung. Three missed beats — tolerant of a brief GC or
+// scheduling hiccup, still well under a human's patience.
+const StaleAfter = 35 * time.Second
+
+// EmbedderState is the daemon's semantic-matching health, as last written.
+type EmbedderState string
+
+const (
+	// EmbedderReady means the model loaded and the match index is serving.
+	EmbedderReady EmbedderState = "ready"
+	// EmbedderDegraded means embed calls latched into failure — matching has
+	// fallen back to BM25/exact text (the SOFT degrade; a hard abort never
+	// gets to write this).
+	EmbedderDegraded EmbedderState = "degraded"
+	// EmbedderDisabled means semantic matching is off by config.
+	EmbedderDisabled EmbedderState = "disabled"
+	// EmbedderStarting means the background init has not reported yet.
+	EmbedderStarting EmbedderState = "starting"
+)
+
+// Health is the persisted heartbeat record. It is written atomically by the
+// daemon and read (best-effort, may be absent) by status/TUI.
+type Health struct {
+	PID         int           `json:"pid"`
+	Version     string        `json:"version"`
+	StartedAt   time.Time     `json:"started_at"`
+	HeartbeatAt time.Time     `json:"heartbeat_at"`
+	Embedder    EmbedderState `json:"embedder"`
+}
+
+// FileName is the health file's basename inside the state dir.
+const FileName = "daemon.health.json"
+
+// Path returns the health file path for a state directory.
+func Path(stateDir string) string { return filepath.Join(stateDir, FileName) }
+
+// Write atomically persists h to the state dir (temp file + rename, matching
+// config.Save), so a concurrent reader never sees a torn record.
+func Write(stateDir string, h Health) error {
+	data, err := json.Marshal(h)
+	if err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(stateDir, ".daemon-health-*.json")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, Path(stateDir))
+}
+
+// Read returns the persisted health record and whether one was found. A
+// missing file yields ok=false with no error; a malformed file also yields
+// ok=false (a corrupt heartbeat is treated as "no signal", never fatal).
+func Read(stateDir string) (Health, bool) {
+	data, err := os.ReadFile(Path(stateDir))
+	if err != nil {
+		return Health{}, false
+	}
+	var h Health
+	if err := json.Unmarshal(data, &h); err != nil {
+		return Health{}, false
+	}
+	return h, true
+}
+
+// Remove deletes the health file (best-effort, on clean shutdown). A missing
+// file is not an error.
+func Remove(stateDir string) error {
+	err := os.Remove(Path(stateDir))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+// Stale reports whether the heartbeat is older than StaleAfter relative to
+// now. A zero heartbeat (never written) is stale.
+func (h Health) Stale(now time.Time) bool {
+	if h.HeartbeatAt.IsZero() {
+		return true
+	}
+	return now.Sub(h.HeartbeatAt) > StaleAfter
+}
+
+// Age returns how long ago the heartbeat was written, floored at zero.
+func (h Health) Age(now time.Time) time.Duration {
+	d := now.Sub(h.HeartbeatAt)
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
+// EmbedderNote returns a human-facing suffix describing a non-ready embedder,
+// or "" when ready/unknown (nothing to warn about).
+func (h Health) EmbedderNote() string {
+	switch h.Embedder {
+	case EmbedderDegraded:
+		return fmt.Sprintf("%s (embedder fell back to text matching; run: hap config set embedding.disabled true to silence)", h.Embedder)
+	default:
+		return string(h.Embedder)
+	}
+}

--- a/internal/daemonhealth/health_test.go
+++ b/internal/daemonhealth/health_test.go
@@ -1,0 +1,174 @@
+package daemonhealth
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	want := Health{
+		PID:         4242,
+		Version:     "v9.9.9",
+		StartedAt:   now.Add(-time.Minute),
+		HeartbeatAt: now,
+		Embedder:    EmbedderReady,
+	}
+	if err := Write(dir, want); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, ok := Read(dir)
+	if !ok {
+		t.Fatal("Read: ok=false after Write")
+	}
+	if got.PID != want.PID || got.Version != want.Version || got.Embedder != want.Embedder {
+		t.Errorf("round trip mismatch: got %+v want %+v", got, want)
+	}
+	if !got.HeartbeatAt.Equal(want.HeartbeatAt) {
+		t.Errorf("HeartbeatAt: got %v want %v", got.HeartbeatAt, want.HeartbeatAt)
+	}
+}
+
+func TestReadMissingFile(t *testing.T) {
+	if _, ok := Read(t.TempDir()); ok {
+		t.Error("Read of missing file: ok=true, want false")
+	}
+}
+
+func TestReadMalformedFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(Path(dir), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := Read(dir); ok {
+		t.Error("Read of malformed file: ok=true, want false (corrupt heartbeat = no signal)")
+	}
+}
+
+func TestWriteIsAtomic(t *testing.T) {
+	// After a successful Write the state dir holds exactly the health file —
+	// no leftover temp file from the temp+rename dance.
+	dir := t.TempDir()
+	if err := Write(dir, Health{PID: 1}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != FileName {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("state dir = %v, want just [%s]", names, FileName)
+	}
+}
+
+func TestStale(t *testing.T) {
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		heartbeat time.Time
+		wantStale bool
+	}{
+		{"fresh", now.Add(-5 * time.Second), false},
+		{"just under threshold", now.Add(-(StaleAfter - time.Second)), false},
+		{"just over threshold", now.Add(-(StaleAfter + time.Second)), true},
+		{"never written (zero)", time.Time{}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := Health{HeartbeatAt: tc.heartbeat}
+			if got := h.Stale(now); got != tc.wantStale {
+				t.Errorf("Stale = %v, want %v", got, tc.wantStale)
+			}
+		})
+	}
+}
+
+func TestRemove(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, Health{PID: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Remove(dir); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := os.Stat(Path(dir)); !os.IsNotExist(err) {
+		t.Error("file still present after Remove")
+	}
+	// Removing an absent file is not an error.
+	if err := Remove(dir); err != nil {
+		t.Errorf("Remove of missing file: %v", err)
+	}
+}
+
+func TestEmbedderNoteDegradedActionable(t *testing.T) {
+	note := Health{Embedder: EmbedderDegraded}.EmbedderNote()
+	if note == string(EmbedderDegraded) {
+		t.Error("degraded note should include a remediation hint")
+	}
+	if got := (Health{Embedder: EmbedderReady}).EmbedderNote(); got != string(EmbedderReady) {
+		t.Errorf("ready note = %q, want plain %q", got, EmbedderReady)
+	}
+}
+
+func TestOpenStderrLogAppendsThenRotates(t *testing.T) {
+	dir := t.TempDir()
+
+	// First open creates the file at the expected path.
+	f := OpenStderrLog(dir)
+	if f == nil {
+		t.Fatal("OpenStderrLog returned nil on a fresh dir")
+	}
+	if _, err := f.WriteString("first crash\n"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	if _, err := os.Stat(StderrLogPath(dir)); err != nil {
+		t.Fatalf("stderr log not created: %v", err)
+	}
+
+	// A second open below the cap appends (keeps prior content).
+	f = OpenStderrLog(dir)
+	if _, err := f.WriteString("second crash\n"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	data, _ := os.ReadFile(StderrLogPath(dir))
+	if !strings.Contains(string(data), "first crash") || !strings.Contains(string(data), "second crash") {
+		t.Errorf("below cap should append, got: %q", data)
+	}
+
+	// Grow past the cap, then open again → prior content rotates to .old and
+	// the live log starts fresh (the crash-loop disk guard).
+	if err := os.WriteFile(StderrLogPath(dir), make([]byte, StderrLogCap+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f = OpenStderrLog(dir)
+	if f == nil {
+		t.Fatal("OpenStderrLog returned nil after growth")
+	}
+	f.Close()
+	if _, err := os.Stat(StderrLogPath(dir) + ".old"); err != nil {
+		t.Errorf("oversized log should rotate to .old: %v", err)
+	}
+	if fi, err := os.Stat(StderrLogPath(dir)); err != nil || fi.Size() != 0 {
+		t.Errorf("post-rotation live log should be fresh/empty, size err=%v", err)
+	}
+}
+
+func TestAgeFlooredAtZero(t *testing.T) {
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	// A heartbeat slightly in the future (clock skew) floors to zero, not negative.
+	if got := (Health{HeartbeatAt: now.Add(time.Second)}).Age(now); got != 0 {
+		t.Errorf("Age with future heartbeat = %v, want 0", got)
+	}
+	if got := (Health{HeartbeatAt: now.Add(-3 * time.Second)}).Age(now); got != 3*time.Second {
+		t.Errorf("Age = %v, want 3s", got)
+	}
+}

--- a/internal/daemonhealth/stderr.go
+++ b/internal/daemonhealth/stderr.go
@@ -1,0 +1,39 @@
+package daemonhealth
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// StderrLogName is the basename of the captured daemon stderr log. The
+// detached daemon's stderr is redirected here so a native abort in the
+// embedder (llama.cpp GGML_ASSERT → SIGABRT) — invisible to Go recovery —
+// leaves a post-mortem trail instead of going to /dev/null.
+const StderrLogName = "daemon.stderr.log"
+
+// StderrLogCap bounds the captured stderr log. Past it the file is rotated to
+// a single ".old" sibling on the next open, so a crash-loop cannot fill the
+// disk while the most recent abort is always retained.
+const StderrLogCap = 256 * 1024
+
+// StderrLogPath returns the captured stderr log path for a state directory.
+func StderrLogPath(stateDir string) string {
+	return filepath.Join(stateDir, StderrLogName)
+}
+
+// OpenStderrLog opens the daemon stderr log for appending, first rotating it to
+// a ".old" sibling if it has grown past StderrLogCap. The returned file is
+// meant to be handed to exec.Cmd.Stderr; the caller closes its copy after the
+// child starts (the child dup'd the fd). Returns nil on any error — capture is
+// a best-effort diagnostic aid, never a reason to fail the daemon spawn.
+func OpenStderrLog(stateDir string) *os.File {
+	p := StderrLogPath(stateDir)
+	if fi, err := os.Stat(p); err == nil && fi.Size() > StderrLogCap {
+		_ = os.Rename(p, p+".old")
+	}
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil
+	}
+	return f
+}

--- a/internal/embedder/embedder.go
+++ b/internal/embedder/embedder.go
@@ -178,6 +178,11 @@ func (l *Llama) ModelID() string { return filepath.Base(l.modelPath) }
 // Dims is the embedding dimensionality (0 before the first success).
 func (l *Llama) Dims() int { return int(l.dims.Load()) }
 
+// Degraded reports whether the failure latch has tripped (embed calls now
+// short-circuit to text matching). Exposed for the daemon's health heartbeat;
+// callers type-assert this optional accessor rather than widening EmbedderPort.
+func (l *Llama) Degraded() bool { return l.degraded.Load() }
+
 // Close releases the model. It must never block the caller (the daemon
 // select loop calls it on reload/shutdown), so when a native embed call is
 // in flight — possibly hung, which is why the stall guard exists — the

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -57,6 +57,10 @@ type App struct {
 	// DaemonInfo reports the running daemon's identity from the lock file
 	// (daemonlock.Info in prod); nil hides the daemon line in status.
 	DaemonInfo func() (running bool, pid int, version string)
+	// StateDir is the daemon state directory; front-ends read the daemon's
+	// heartbeat/health record (daemonhealth) and reference the captured
+	// stderr log from here. Empty skips the health-derived status lines.
+	StateDir string
 	// NewEmbedder builds the embedder for ReembedStandalone; nil defaults
 	// to the production embedder. Tests inject fakes.
 	NewEmbedder func(cfg config.Embedding) ports.EmbedderPort


### PR DESCRIPTION
First of three PRs for the daemon-resilience/UX half of #60. This one makes a crashed/hung/degraded daemon **visible** — it does **not** prevent the arm64 embedder abort itself (that needs the track-1 llama.cpp submodule bump).

## Problem
A native abort in the embedder (llama.cpp `GGML_ASSERT` → SIGABRT) kills the daemon in a way Go can't catch. Today the detached daemon's stderr goes to `/dev/null` and `hap status` has no signal beyond the flock — so the crash-loop in #60 surfaced nothing.

## This PR
- **`internal/daemonhealth`** — a small heartbeat/health record (`pid`, `version`, `started_at`, `heartbeat_at`, `embedder`) written atomically to the state dir; plus `OpenStderrLog` (rotates at 256 KB).
- **daemon** — writes the heartbeat as the first action in `Run` (stamped with its pid), refreshes every 10s from the select loop, removes it on clean shutdown. `embedderState()` → ready/degraded/disabled/starting via a new `embedder.Degraded()` accessor (type-asserted; no `EmbedderPort` change).
- **`cmd/hap`** — daemon spawn redirects stderr to `daemon.stderr.log` instead of `/dev/null`; `main` maps `cli.ErrUnhealthy` → non-zero exit without an `error:` line.
- **`hap status`** — reads the heartbeat, but **only when its pid matches the current lock holder** (so a dead predecessor's stale record can't false-flag a fresh daemon during startup). Reports `NOT RESPONDING` (non-zero exit) for a held-lock-but-stale-heartbeat daemon and points at the captured stderr; surfaces a runtime-degraded embedder; keeps the `--ensure` remedy when a hung daemon is also a version mismatch.

## Design notes
- `flock` already makes a truly-dead pid read as *not running*, so this targets what flock can't reveal: a live-but-**wedged** daemon (stale heartbeat) and a **soft-degraded** embedder. The hard SIGABRT case is caught by the captured stderr + (next PR) the restart tracker.
- The heartbeat write is a small atomic temp+rename in the select loop every 10s — deliberately synchronous (sub-ms, infrequent); can be offloaded later if needed.

## Follow-ups (later PRs)
- PR 2: crash-loop detection in `--ensure` + auto-fallback to `embedding.disabled` (a latched breaker with reset/un-latch semantics).
- PR 3: TUI banner distinguishing healthy / degraded / down/crash-looping.

## Tests
160 pass, 0 fail (`vectors cpu`). daemonhealth round-trip/atomicity/staleness/rotation; daemon writes & clears the heartbeat and maps embedder state; status flags hung, ignores a dead instance's record (pid mismatch), surfaces degraded, exits non-zero.