### PR TITLE
#60 feat: crash-loop breaker — auto-disable embedder, then stop respawning

### DIFF
--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
 	"github.com/0xGosu/herdr-auto-pilot/internal/cli"
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/crashguard"
 	"github.com/0xGosu/herdr-auto-pilot/internal/daemon"
 	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
 	"github.com/0xGosu/herdr-auto-pilot/internal/daemonlock"
@@ -169,6 +170,45 @@ func runDaemon(ctx context.Context, paths config.Paths, args []string) error {
 	}
 	defer lock.Release()
 
+	// Crash-loop breaker: record this boot and decide whether to degrade
+	// BEFORE building the daemon — a native embedder abort kills us inside
+	// daemon.New (model load), so the only lever is the persisted boot history.
+	bootCfg, _ := config.Load(paths.File())
+	guard, _ := crashguard.Read(paths.StateDir)
+	guard, decision := crashguard.Evaluate(guard, time.Now(), embeddingDigest(bootCfg))
+	if err := crashguard.Write(paths.StateDir, guard); err != nil {
+		// A failed write means this boot is not recorded, so the breaker cannot
+		// accumulate toward its threshold — it is effectively disarmed until the
+		// disk recovers. Log loudly rather than swallow it; continuing is still
+		// right (a guard-file write failure must not itself block the daemon).
+		slog.Error("crashguard write failed; crash-loop breaker impaired this boot", "error", err)
+	}
+	if decision.GiveUp {
+		// Looping even with the embedder disabled — degrading can't help.
+		// Exit without running; ensureDaemon declines future respawns until
+		// the [embedding] config changes.
+		slog.Error("daemon not starting: unrecoverable crash-loop", "reason", decision.Reason)
+		return nil
+	}
+	if decision.DisableEmbedding {
+		slog.Warn("crash-loop mitigation: starting with the embedder disabled (BM25 fallback)", "reason", decision.Reason)
+	}
+	// Reset the boot history once we survive past the window (loop broken). If
+	// we crash first this never fires, so the count keeps climbing toward the
+	// mitigation threshold. This read-modify-write can race an embedder-reload
+	// that clears the latch (both are in-process, un-serialized by the flock):
+	// worst case it briefly resurrects a just-cleared latch, which the next
+	// reload's digest check re-clears — bounded and self-healing, never an
+	// incorrect give-up (that path creates no timer).
+	survived := time.AfterFunc(crashguard.Window, func() {
+		if g, ok := crashguard.Read(paths.StateDir); ok {
+			if g2, changed := g.Survived(); changed {
+				_ = crashguard.Write(paths.StateDir, g2)
+			}
+		}
+	})
+	defer survived.Stop()
+
 	st, err := store.Open(paths.DBPath())
 	if err != nil {
 		return err
@@ -194,9 +234,34 @@ func runDaemon(ctx context.Context, paths config.Paths, args []string) error {
 
 	// The embedder is likewise rebuilt whenever the [embedding] section
 	// changes; nil (disabled) leaves BM25/exact matching.
+	//
+	// The FIRST build honors the authoritative boot decision directly, rather
+	// than re-deriving suppression from the crashguard file — if it re-derived,
+	// any future divergence between how bootCfg and the factory's cfg normalize
+	// the [embedding] section would make the mitigation boot rebuild the very
+	// embedder that is aborting. Later builds (config reloads) consult the
+	// persisted latch so that editing the [embedding] config re-enables
+	// semantic matching live, without a restart.
+	firstBuild := true
 	embedderFactory := func(cfg config.Config) ports.EmbedderPort {
 		if cfg.Embedding.Disabled {
 			return nil
+		}
+		if firstBuild {
+			firstBuild = false
+			if decision.DisableEmbedding {
+				return nil
+			}
+			return embedder.New(cfg.Embedding)
+		}
+		if g, ok := crashguard.Read(paths.StateDir); ok {
+			suppressed, cleared, changed := crashguard.EmbeddingSuppressed(g, embeddingDigest(cfg))
+			if changed {
+				_ = crashguard.Write(paths.StateDir, cleared)
+			}
+			if suppressed {
+				return nil
+			}
 		}
 		return embedder.New(cfg.Embedding)
 	}
@@ -229,7 +294,30 @@ func runDaemon(ctx context.Context, paths config.Paths, args []string) error {
 // Herdr event hook so hooks return promptly). A daemon left over from a
 // different binary version is stopped and replaced, so binary upgrades
 // take effect without a manual kill.
+// embeddingDigest fingerprints the [embedding] config so the crash-loop
+// breaker can tell an operator config change (which lifts a latch) from a
+// plain restart. Any change to the section produces a different string.
+func embeddingDigest(cfg config.Config) string {
+	return fmt.Sprintf("%+v", cfg.Embedding)
+}
+
 func ensureDaemon(paths config.Paths) error {
+	// Crash-loop hard stop: after we've given up (still looping even with the
+	// embedder off), decline to respawn until the [embedding] config changes —
+	// this is what actually ends the storm herdr's per-event --ensure would
+	// otherwise sustain.
+	if g, ok := crashguard.Read(paths.StateDir); ok {
+		cfg, _ := config.Load(paths.File())
+		blocked, cleared, reason := crashguard.SpawnBlocked(g, embeddingDigest(cfg))
+		if blocked {
+			slog.Warn("daemon respawn suppressed by crash-loop breaker", "reason", reason)
+			return nil
+		}
+		if g.GaveUp && !cleared.GaveUp {
+			// Config changed since we gave up: lift the latch so this start retries.
+			_ = crashguard.Write(paths.StateDir, cleared)
+		}
+	}
 	return daemonlock.EnsureFresh(paths, buildinfo.Version, 3*time.Second, daemonlock.Stop, func() error {
 		self, err := os.Executable()
 		if err != nil {

--- a/cmd/hap/main_test.go
+++ b/cmd/hap/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+)
+
+// TestEmbeddingDigestStableAndChangeSensitive guards the crash-loop breaker's
+// core invariant: the [embedding] digest must be identical for the same config
+// loaded twice (so a plain restart keeps a latch), yet differ when the operator
+// edits the section (so the latch clears / semantic matching re-enables).
+func TestEmbeddingDigestStableAndChangeSensitive(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+
+	write := func(body string) config.Config {
+		t.Helper()
+		if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		c, err := config.Load(cfgPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+
+	c1 := write("[embedding]\nsimilarity_threshold = 0.9\n")
+	c2 := write("[embedding]\nsimilarity_threshold = 0.9\n")
+	if embeddingDigest(c1) != embeddingDigest(c2) {
+		t.Fatalf("digest must be stable across identical loads (both go through fillZeroes): %q vs %q",
+			embeddingDigest(c1), embeddingDigest(c2))
+	}
+
+	c3 := write("[embedding]\nsimilarity_threshold = 0.8\n")
+	if embeddingDigest(c3) == embeddingDigest(c1) {
+		t.Error("changing the [embedding] section must change the digest so a latch clears on operator edit")
+	}
+
+	// Disabling embedding is also a change (relevant since the operator may
+	// toggle it to escape a crash-loop).
+	c4 := write("[embedding]\ndisabled = true\n")
+	if embeddingDigest(c4) == embeddingDigest(c1) {
+		t.Error("toggling embedding.disabled must change the digest")
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/crashguard"
 	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
 	"github.com/0xGosu/herdr-auto-pilot/internal/daemonlock"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -359,7 +360,8 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 	// heartbeat support, or one not running); hung is a held lock with a stale
 	// beat — a live-but-wedged daemon, the case flock alone can't reveal.
 	var health daemonhealth.Health
-	var haveHealth, hung bool
+	var guard crashguard.State
+	var haveHealth, hung, gaveUp bool
 	if app.DaemonInfo != nil {
 		running, pid, ver := app.DaemonInfo()
 		if running && app.StateDir != "" {
@@ -376,8 +378,17 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 		}
 		now := time.Now()
 		hung = running && haveHealth && health.Stale(now)
+		// The crash-loop breaker may have latched a hard stop (daemon not
+		// starting) or an embedder auto-disable — surface both.
+		if app.StateDir != "" {
+			guard, _ = crashguard.Read(app.StateDir)
+		}
 		label := fmt.Sprintf("running %s (pid %d)", daemonlock.VersionLabel(ver), pid)
 		switch {
+		case !running && guard.GaveUp:
+			// Respawns are suppressed until the [embedding] config changes.
+			fmt.Fprintf(out, "daemon:              NOT STARTING — crash-loop breaker gave up: %s\n", guard.Reason)
+			gaveUp = true
 		case !running:
 			fmt.Fprintf(out, "daemon:              not running\n")
 		case hung:
@@ -401,12 +412,17 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 	}
 	fmt.Fprintf(out, "pending escalations: %d\n", st.PendingEscalations)
 	fmt.Fprintf(out, "monitored agents:    %d\n", len(st.MonitoredAgents))
-	if st.Embedding != "" {
+	// The crash-loop breaker's auto-disable is the authoritative state and
+	// replaces the config-derived line (which can't know matching was forced
+	// off); it latches until the [embedding] config changes.
+	switch {
+	case guard.EmbeddingOff:
+		fmt.Fprintf(out, "semantic matching:   AUTO-DISABLED by crash-loop breaker — %s\n", guard.Reason)
+	case st.Embedding != "":
 		fmt.Fprintf(out, "semantic matching:   %s\n", st.Embedding)
 	}
-	// The config-derived line above says what SHOULD be running; the daemon's
-	// live heartbeat can report the embedder soft-degraded (embed calls latched
-	// to text fallback), which that line would otherwise hide.
+	// A running embedder can still be soft-degraded (embed calls latched to
+	// text fallback) — the config-derived line above would otherwise hide it.
 	if haveHealth && health.Embedder == daemonhealth.EmbedderDegraded {
 		fmt.Fprintf(out, "embedder health:     DEGRADED at runtime — %s\n", health.EmbedderNote())
 	}
@@ -420,9 +436,10 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 		fmt.Fprintf(out, "last kill event:     %s by %s at %s\n",
 			st.LatestKill.State, st.LatestKill.Author, st.LatestKill.CreatedAt.Format(time.RFC3339))
 	}
-	// A hung daemon is a failure state: exit non-zero so scripted checks and
-	// the operator notice, even though the status body already explained it.
-	if hung {
+	// A hung daemon or a latched crash-loop give-up is a failure state: exit
+	// non-zero so scripted checks and the operator notice, even though the
+	// status body already explained it.
+	if hung || gaveUp {
 		return ErrUnhealthy
 	}
 	return nil

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
 	"github.com/0xGosu/herdr-auto-pilot/internal/cli"
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/crashguard"
 	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
@@ -121,6 +122,55 @@ func TestStatusIgnoresStaleHealthFromDeadInstance(t *testing.T) {
 	}
 	if !strings.Contains(out, "running "+buildinfo.Version+" (pid 4242)") {
 		t.Errorf("should fall back to a healthy running line, got:\n%s", out)
+	}
+}
+
+func TestStatusEmbeddingAutoDisabledByBreaker(t *testing.T) {
+	app, _ := testApp(t)
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	app.DaemonInfo = func() (bool, int, string) { return true, 4242, buildinfo.Version }
+	// A running daemon (fresh heartbeat) with the embedder auto-disabled.
+	if err := daemonhealth.Write(stateDir, daemonhealth.Health{
+		PID: 4242, Version: buildinfo.Version, HeartbeatAt: time.Now(),
+		Embedder: daemonhealth.EmbedderDisabled,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := crashguard.Write(stateDir, crashguard.State{
+		EmbeddingOff: true, ConfigDigest: "cfg", Reason: "auto-disabled after a crash-loop",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "status")
+	// Auto-disabled embedding is a working BM25 fallback, not an unhealthy exit.
+	if err != nil {
+		t.Fatalf("auto-disabled embedding is a working fallback, not unhealthy; got err=%v", err)
+	}
+	if !strings.Contains(out, "AUTO-DISABLED by crash-loop breaker") {
+		t.Errorf("must surface the embedder auto-disable, got:\n%s", out)
+	}
+}
+
+func TestStatusCrashLoopGaveUpUnhealthy(t *testing.T) {
+	app, _ := testApp(t)
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	// The breaker gave up → the daemon is NOT running (respawns suppressed).
+	app.DaemonInfo = func() (bool, int, string) { return false, 0, "" }
+	if err := crashguard.Write(stateDir, crashguard.State{
+		GaveUp: true, ConfigDigest: "cfg", Reason: "crash-looping even with the embedder disabled",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "status")
+	if !errors.Is(err, cli.ErrUnhealthy) {
+		t.Fatalf("a crash-loop give-up must exit non-zero, got err=%v", err)
+	}
+	if !strings.Contains(out, "NOT STARTING") || !strings.Contains(out, "gave up") {
+		t.Errorf("must explain the daemon is not starting due to the breaker, got:\n%s", out)
 	}
 }
 

--- a/internal/crashguard/crashguard.go
+++ b/internal/crashguard/crashguard.go
@@ -1,0 +1,224 @@
+// Package crashguard turns a daemon crash-loop into a graceful, self-limiting
+// degrade instead of an endless respawn storm.
+//
+// The motivating failure (#60): a native abort in the embedder (llama.cpp
+// GGML_ASSERT → SIGABRT) kills the daemon during startup, herdr's --ensure
+// hook respawns it, and it dies again — an accelerating loop that never
+// recovers and surfaces nothing. A native abort cannot be caught in Go, so the
+// only lever is out-of-process state: record each boot, and when boots cluster
+// too tightly, mitigate.
+//
+// The state machine (all decided in Evaluate, a pure function; the daemon does
+// the I/O around it):
+//
+//   - Each daemon boot appends a timestamp, pruned to a rolling Window.
+//   - Threshold boots within Window ⇒ crash-loop. First trip auto-disables the
+//     embedder (boot with BM25 fallback) — semantic matching is designed to
+//     degrade, and the embedder is the usual culprit. The disable LATCHES.
+//   - Still looping with the embedder already off ⇒ the crash is not the
+//     embedder; give up (stop starting) so the storm ends.
+//   - Latches clear only when the [embedding] config digest changes (operator
+//     intervention) — never automatically, so a restart can't silently
+//     re-enter the same loop. Surviving the Window clears the boot history
+//     (the loop is broken) but keeps the latch.
+package crashguard
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Window is the rolling span over which boots are counted, and Threshold is
+// how many boots within it constitute a crash-loop. Tuned to catch #60's
+// accelerating loop (measured gaps 49s→32s→20s→11s) before it fully dies,
+// without tripping on a couple of legitimate restarts.
+const (
+	Window    = 90 * time.Second
+	Threshold = 3
+)
+
+// FileName is the crashguard state file's basename inside the state dir.
+const FileName = "daemon.crashguard.json"
+
+// State is the persisted crash-loop record.
+type State struct {
+	// Starts are recent daemon boot timestamps, pruned to Window.
+	Starts []time.Time `json:"starts"`
+	// EmbeddingOff latches the auto-fallback: boot with the embedder disabled
+	// until the config digest changes.
+	EmbeddingOff bool `json:"embedding_off"`
+	// GaveUp latches the hard stop: still looping even with the embedder off,
+	// so stop starting entirely until the config digest changes.
+	GaveUp bool `json:"gave_up"`
+	// Reason is the human explanation for the current latch (for status).
+	Reason string `json:"reason,omitempty"`
+	// SetAt is when the current latch tripped.
+	SetAt time.Time `json:"set_at,omitempty"`
+	// ConfigDigest fingerprints the [embedding] config as of the last boot; a
+	// change clears the latches (the operator changed something).
+	ConfigDigest string `json:"config_digest,omitempty"`
+}
+
+// Decision is what a booting daemon should do, returned by Evaluate.
+type Decision struct {
+	// DisableEmbedding forces the embedder off for this run (auto-fallback).
+	DisableEmbedding bool
+	// GiveUp means do not run at all — the loop is unrecoverable by degrading.
+	GiveUp bool
+	// Reason explains a non-normal decision (for logs/status).
+	Reason string
+}
+
+// Evaluate records a boot at now for the given [embedding] config digest and
+// returns the updated state plus the boot decision. Pure: the caller reads the
+// prior state, calls this, and persists the result.
+func Evaluate(st State, now time.Time, digest string) (State, Decision) {
+	// An [embedding] config change since the last boot is operator
+	// intervention: clear every latch and the boot history, giving semantic
+	// matching a clean attempt.
+	if st.ConfigDigest != "" && digest != st.ConfigDigest {
+		st = State{ConfigDigest: digest}
+	}
+	st.ConfigDigest = digest
+
+	st.Starts = append(pruneStarts(st.Starts, now), now)
+	looping := len(st.Starts) >= Threshold
+
+	switch {
+	case st.GaveUp:
+		// Latched hard stop persists until the config digest changes (handled
+		// above); the daemon must not run.
+		return st, Decision{GiveUp: true, Reason: st.Reason}
+	case st.EmbeddingOff:
+		if looping {
+			// Disabling the embedder did not stop the loop — the crash is
+			// elsewhere; stop starting.
+			st.GaveUp = true
+			st.SetAt = now
+			st.Reason = fmt.Sprintf("crash-looping even with the embedder disabled (%d starts within %s); not restarting until the [embedding] config changes", len(st.Starts), Window)
+			return st, Decision{GiveUp: true, Reason: st.Reason}
+		}
+		return st, Decision{DisableEmbedding: true, Reason: st.Reason}
+	default:
+		if looping {
+			st.EmbeddingOff = true
+			st.SetAt = now
+			st.Reason = fmt.Sprintf("semantic matching auto-disabled after %d daemon starts within %s (suspected embedder crash-loop); change the [embedding] config to re-enable", len(st.Starts), Window)
+			// Reset the boot history to just this boot: escalating to give-up
+			// must require a FRESH cluster of boots AFTER the embedder is off
+			// (genuinely "still looping"), not the same cluster that tripped
+			// the auto-disable. Otherwise a single clean restart or upgrade
+			// landing in the window would jump straight to a full stop.
+			st.Starts = []time.Time{now}
+			return st, Decision{DisableEmbedding: true, Reason: st.Reason}
+		}
+		return st, Decision{}
+	}
+}
+
+// Survived clears the boot history once a daemon has stayed up past Window
+// (the loop is broken), keeping any latch. Returns the state to persist and
+// whether anything changed.
+func (st State) Survived() (State, bool) {
+	if len(st.Starts) == 0 {
+		return st, false
+	}
+	st.Starts = nil
+	return st, true
+}
+
+// EmbeddingSuppressed reports whether the auto-fallback latch disables the
+// embedder for the given [embedding] config digest. When the digest differs
+// from when the latch tripped, the operator changed the config: it returns
+// changed=true with the cleared state to persist (so a live reload, not just a
+// restart, re-enables semantic matching). Used by the daemon's embedder
+// factory on both first build and reload.
+func EmbeddingSuppressed(st State, digest string) (suppressed bool, cleared State, changed bool) {
+	if !st.EmbeddingOff {
+		return false, st, false
+	}
+	if st.ConfigDigest != "" && digest != st.ConfigDigest {
+		return false, State{ConfigDigest: digest}, true
+	}
+	return true, st, false
+}
+
+// SpawnBlocked reports whether an --ensure should decline to start a daemon: a
+// latched give-up that the current config digest has not cleared. When the
+// digest differs it returns the cleared state to persist (the operator changed
+// config; let the next start try again).
+func SpawnBlocked(st State, digest string) (blocked bool, cleared State, reason string) {
+	if !st.GaveUp {
+		return false, st, ""
+	}
+	if st.ConfigDigest != "" && digest != st.ConfigDigest {
+		return false, State{ConfigDigest: digest}, ""
+	}
+	return true, st, st.Reason
+}
+
+func pruneStarts(starts []time.Time, now time.Time) []time.Time {
+	cutoff := now.Add(-Window)
+	kept := starts[:0:0]
+	for _, t := range starts {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	return kept
+}
+
+// Path returns the crashguard state file path for a state directory.
+func Path(stateDir string) string { return filepath.Join(stateDir, FileName) }
+
+// Read returns the persisted state and whether one was found. Missing or
+// malformed yields ok=false with no error — a corrupt guard file must never
+// block the daemon; it just resets the loop tracking.
+func Read(stateDir string) (State, bool) {
+	data, err := os.ReadFile(Path(stateDir))
+	if err != nil {
+		return State{}, false
+	}
+	var st State
+	if err := json.Unmarshal(data, &st); err != nil {
+		return State{}, false
+	}
+	return st, true
+}
+
+// Write atomically persists st (temp + rename).
+func Write(stateDir string, st State) error {
+	data, err := json.Marshal(st)
+	if err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(stateDir, ".crashguard-*.json")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, Path(stateDir))
+}
+
+// Remove deletes the crashguard state (best-effort). A missing file is fine.
+func Remove(stateDir string) error {
+	err := os.Remove(Path(stateDir))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	return err
+}

--- a/internal/crashguard/crashguard_test.go
+++ b/internal/crashguard/crashguard_test.go
@@ -1,0 +1,235 @@
+package crashguard
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+var base = time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+
+// boot runs one Evaluate at base+offset and returns the decision, threading
+// state through a scenario.
+func boot(st State, offsetSec int, digest string) (State, Decision) {
+	return Evaluate(st, base.Add(time.Duration(offsetSec)*time.Second), digest)
+}
+
+func TestNormalBootsBelowThresholdDoNothing(t *testing.T) {
+	var st State
+	var d Decision
+	st, d = boot(st, 0, "cfg")
+	if d != (Decision{}) {
+		t.Fatalf("first boot decision = %+v, want zero", d)
+	}
+	st, d = boot(st, 10, "cfg")
+	if d != (Decision{}) {
+		t.Fatalf("second boot decision = %+v, want zero", d)
+	}
+	if st.EmbeddingOff || st.GaveUp {
+		t.Errorf("two boots must not latch anything: %+v", st)
+	}
+}
+
+func TestThirdBootWithinWindowAutoDisablesEmbedding(t *testing.T) {
+	var st State
+	st, _ = boot(st, 0, "cfg")
+	st, _ = boot(st, 10, "cfg")
+	st, d := boot(st, 20, "cfg")
+	if !d.DisableEmbedding || d.GiveUp {
+		t.Fatalf("third boot within window should auto-disable embedding, got %+v", d)
+	}
+	if !st.EmbeddingOff {
+		t.Error("EmbeddingOff must latch")
+	}
+	if d.Reason == "" {
+		t.Error("a mitigation decision should carry a reason")
+	}
+}
+
+func TestBootsSpreadBeyondWindowNeverTrip(t *testing.T) {
+	var st State
+	var d Decision
+	// One boot every 60s: never 3 within the 90s window.
+	for i := 0; i < 6; i++ {
+		st, d = boot(st, i*60, "cfg")
+		if d != (Decision{}) {
+			t.Fatalf("boot %d spread beyond window tripped: %+v", i, d)
+		}
+	}
+}
+
+func TestStillLoopingWithEmbeddingOffGivesUp(t *testing.T) {
+	var st State
+	st, _ = boot(st, 0, "cfg")
+	st, _ = boot(st, 10, "cfg")
+	st, _ = boot(st, 20, "cfg") // auto-disables embedding, resets history to [20]
+
+	// One more boot after the auto-disable is not yet a fresh cluster.
+	st, d := boot(st, 30, "cfg")
+	if d.GiveUp {
+		t.Fatalf("one boot after auto-disable must not give up yet, got %+v", d)
+	}
+	// A fresh 3-boot cluster WITH the embedder already off = still looping → give up.
+	st, d = boot(st, 40, "cfg")
+	if !d.GiveUp {
+		t.Fatalf("a fresh cluster with the embedder off should give up, got %+v", d)
+	}
+	if !st.GaveUp {
+		t.Error("GaveUp must latch")
+	}
+}
+
+func TestCleanRestartAfterAutoDisableDoesNotGiveUp(t *testing.T) {
+	// Regression: the auto-disable boot must reset the boot history so a single
+	// legitimate restart within the window does NOT escalate to a full stop.
+	var st State
+	st, _ = boot(st, 0, "cfg")
+	st, _ = boot(st, 10, "cfg")
+	st, _ = boot(st, 20, "cfg") // auto-disable, history reset to [20]
+	_, d := boot(st, 25, "cfg") // one clean restart soon after
+	if d.GiveUp {
+		t.Fatalf("a lone restart after auto-disable must not give up, got %+v", d)
+	}
+	if !d.DisableEmbedding {
+		t.Errorf("the embedder-off latch should still hold, got %+v", d)
+	}
+}
+
+func TestLatchesPersistAcrossBootsUntilConfigChange(t *testing.T) {
+	var st State
+	st, _ = boot(st, 0, "cfg")
+	st, _ = boot(st, 10, "cfg")
+	st, _ = boot(st, 20, "cfg") // EmbeddingOff latched
+
+	// Much later boot, loop history pruned, but the latch persists.
+	st, d := boot(st, 500, "cfg")
+	if !d.DisableEmbedding {
+		t.Fatalf("EmbeddingOff latch must persist after the loop clears, got %+v", d)
+	}
+	if len(st.Starts) != 1 {
+		t.Errorf("old starts should have pruned, got %d", len(st.Starts))
+	}
+
+	// A config change clears the latch → clean attempt.
+	st, d = boot(st, 510, "cfg-v2")
+	if d != (Decision{}) {
+		t.Fatalf("config change should clear the latch, got %+v", d)
+	}
+	if st.EmbeddingOff || st.GaveUp {
+		t.Errorf("config change must clear latches: %+v", st)
+	}
+}
+
+func TestGiveUpPersistsUntilConfigChange(t *testing.T) {
+	st := State{GaveUp: true, ConfigDigest: "cfg", Reason: "boom"}
+	_, d := boot(st, 0, "cfg")
+	if !d.GiveUp {
+		t.Fatalf("give-up must persist with unchanged config, got %+v", d)
+	}
+	st2, d := boot(st, 0, "cfg-v2")
+	if d.GiveUp {
+		t.Fatalf("config change must lift give-up, got %+v", d)
+	}
+	if st2.GaveUp {
+		t.Error("GaveUp must clear on config change")
+	}
+}
+
+func TestSurvivedClearsStartsKeepsLatch(t *testing.T) {
+	st := State{
+		Starts:       []time.Time{base, base.Add(time.Second)},
+		EmbeddingOff: true, ConfigDigest: "cfg", Reason: "disabled",
+	}
+	got, changed := st.Survived()
+	if !changed {
+		t.Fatal("Survived should report a change when starts are present")
+	}
+	if len(got.Starts) != 0 {
+		t.Errorf("Survived must clear starts, got %d", len(got.Starts))
+	}
+	if !got.EmbeddingOff {
+		t.Error("Survived must keep the EmbeddingOff latch")
+	}
+	// Idempotent when already empty.
+	if _, changed := got.Survived(); changed {
+		t.Error("Survived on empty starts should report no change")
+	}
+}
+
+func TestSpawnBlocked(t *testing.T) {
+	// Not gave-up → never blocked.
+	if blocked, _, _ := SpawnBlocked(State{}, "cfg"); blocked {
+		t.Error("no give-up must not block spawn")
+	}
+	// Gave-up, same digest → blocked.
+	gu := State{GaveUp: true, ConfigDigest: "cfg", Reason: "boom"}
+	blocked, _, reason := SpawnBlocked(gu, "cfg")
+	if !blocked || reason == "" {
+		t.Errorf("give-up with unchanged config must block with a reason, got blocked=%v reason=%q", blocked, reason)
+	}
+	// Gave-up, changed digest → not blocked, cleared state returned.
+	blocked, cleared, _ := SpawnBlocked(gu, "cfg-v2")
+	if blocked {
+		t.Error("config change must lift the spawn block")
+	}
+	if cleared.GaveUp || cleared.ConfigDigest != "cfg-v2" {
+		t.Errorf("cleared state should reset with the new digest, got %+v", cleared)
+	}
+}
+
+func TestEmbeddingSuppressed(t *testing.T) {
+	// No latch → never suppressed.
+	if supp, _, _ := EmbeddingSuppressed(State{}, "cfg"); supp {
+		t.Error("no latch must not suppress")
+	}
+	// Latched, same digest → suppressed.
+	latched := State{EmbeddingOff: true, ConfigDigest: "cfg"}
+	if supp, _, changed := EmbeddingSuppressed(latched, "cfg"); !supp || changed {
+		t.Errorf("latched + same digest: supp=%v changed=%v, want supp=true changed=false", supp, changed)
+	}
+	// Latched, changed digest → not suppressed, cleared state returned for live re-enable.
+	supp, cleared, changed := EmbeddingSuppressed(latched, "cfg-v2")
+	if supp || !changed {
+		t.Errorf("latched + changed digest: supp=%v changed=%v, want supp=false changed=true", supp, changed)
+	}
+	if cleared.EmbeddingOff || cleared.ConfigDigest != "cfg-v2" {
+		t.Errorf("cleared state should reset with the new digest, got %+v", cleared)
+	}
+}
+
+func TestReadWriteRemove(t *testing.T) {
+	dir := t.TempDir()
+	if _, ok := Read(dir); ok {
+		t.Error("missing file should read ok=false")
+	}
+	want := State{Starts: []time.Time{base}, EmbeddingOff: true, ConfigDigest: "cfg", Reason: "x"}
+	if err := Write(dir, want); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := Read(dir)
+	if !ok || !got.EmbeddingOff || got.ConfigDigest != "cfg" {
+		t.Errorf("round trip mismatch: %+v ok=%v", got, ok)
+	}
+	// Malformed → ok=false, never fatal.
+	os.WriteFile(Path(dir), []byte("{bad"), 0o600)
+	if _, ok := Read(dir); ok {
+		t.Error("malformed file should read ok=false")
+	}
+	if err := Remove(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := Remove(dir); err != nil {
+		t.Errorf("removing an absent file must not error: %v", err)
+	}
+}
+
+func TestWriteIsAtomicNoTempLeftover(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, State{}); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 || entries[0].Name() != FileName {
+		t.Errorf("expected only %s in dir, got %v", FileName, entries)
+	}
+}


### PR DESCRIPTION
Second daemon-resilience PR for #60 (follow-up to #63, now merged). Turns the #60 crash-loop into a graceful, self-limiting degrade. Does **not** fix the embedder abort itself (track-1 llama.cpp submodule bump).

## Problem
A native embedder abort (`GGML_ASSERT` → SIGABRT) kills the daemon during model load in `daemon.New`. herdr's per-agent-event `hap daemon --ensure` respawns it → it dies again — an accelerating storm (gaps 49s→32s→20s→11s) that never recovers.

## This PR
- **`internal/crashguard`** — a pure state machine (`Evaluate`) over a persisted `daemon.crashguard.json`. Each boot appends a timestamp (pruned to a **90s window**); **3 boots within it** auto-disable the embedder (BM25 fallback) and **reset the history**, so escalating further needs a *fresh* cluster with the embedder already off — that **gives up** (stops starting). Latches clear only when the **`[embedding]` config digest changes**; surviving the window clears history but keeps the latch.
- **`cmd/hap`** — `runDaemon` records + decides **before** `daemon.New` (the abort is in New's model load). GiveUp exits without running. The embedder factory honors the **authoritative boot decision** on first build (no digest re-derivation on the mitigation boot) and the persisted latch on reload (editing config re-enables matching **live**). A survive-timer clears history after the window. `ensureDaemon` consults `SpawnBlocked` to decline respawns after give-up.
- **`hap status`** — `AUTO-DISABLED by crash-loop breaker` replaces the config-derived matching line; `NOT STARTING — crash-loop breaker gave up` exits non-zero.

## Design (confirmed with maintainer)
- Re-enable = **persist until config change** (a restart can't silently re-enter the loop).
- Trip threshold = **3 starts in 90s**.

## Verification
- **End-to-end:** 3 rapid daemon boots trip the auto-disable; `hap status` surfaces it.
- **175 tests pass**, incl. a regression test that the auto-disable history-reset stops a lone clean restart from escalating to give-up, and digest stability/change-sensitivity across `config.Load`.

## Addressed in review
- `Evaluate` resets boot history on auto-disable (clean restart in-window no longer jumps to give-up).
- First build uses the boot decision directly (removes a latent two-site digest-divergence trap on the mitigation boot).
- Documented the self-healing in-process RMW race; boot-write failure logs loudly.

## Follow-up
PR 3: TUI banner distinguishing healthy / degraded / down-crash-looping.