### PR TITLE
#60 feat: TUI daemon-health banner + shared CLI/TUI health assessment

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -364,6 +364,10 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 		case !h.Running && h.GaveUp:
 			// Respawns are suppressed until the [embedding] config changes.
 			fmt.Fprintf(out, "daemon:              NOT STARTING — crash-loop breaker gave up: %s\n", h.Reason)
+		case !h.Running && h.CrashLooping:
+			// Down with a recent boot cluster: crashing and being respawned.
+			fmt.Fprintf(out, "daemon:              DOWN — crash-looping (%d restarts recently); recent output: %s\n",
+				h.RecentRestarts, h.StderrLog)
 		case !h.Running:
 			fmt.Fprintf(out, "daemon:              not running\n")
 		case h.Hung:
@@ -414,7 +418,7 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 	// A hung daemon or a latched crash-loop give-up is a failure state: exit
 	// non-zero so scripted checks and the operator notice, even though the
 	// status body already explained it.
-	if h.Hung || h.GaveUp {
+	if h.Hung || h.GaveUp || h.CrashLooping {
 		return ErrUnhealthy
 	}
 	return nil

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,8 +18,6 @@ import (
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
-	"github.com/0xGosu/herdr-auto-pilot/internal/crashguard"
-	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
 	"github.com/0xGosu/herdr-auto-pilot/internal/daemonlock"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
@@ -356,52 +354,29 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 		state = "PAUSED (kill switch active)"
 	}
 	fmt.Fprintf(out, "automation:          %s\n", state)
-	// health is the daemon's heartbeat record (absent for a daemon older than
-	// heartbeat support, or one not running); hung is a held lock with a stale
-	// beat — a live-but-wedged daemon, the case flock alone can't reveal.
-	var health daemonhealth.Health
-	var guard crashguard.State
-	var haveHealth, hung, gaveUp bool
+	// Daemon health combines the lock, heartbeat, and crash-loop breaker into
+	// one assessment shared with the TUI banner (frontend.AssessDaemonHealth),
+	// so CLI and TUI can never disagree about whether the daemon is healthy.
+	h := app.AssessDaemonHealth()
 	if app.DaemonInfo != nil {
-		running, pid, ver := app.DaemonInfo()
-		if running && app.StateDir != "" {
-			// Only trust a heartbeat written by THIS lock holder. A hard abort
-			// skips the daemon's cleanup, so a fresh same-version daemon can be
-			// holding the lock while a dead predecessor's stale record still
-			// sits on disk — attributing it here would false-flag the new
-			// daemon NOT RESPONDING during its startup window. flock guarantees
-			// the pid is live, so matching pids means the record is genuinely
-			// this daemon's (bar astronomically-unlikely pid reuse in that window).
-			if h, ok := daemonhealth.Read(app.StateDir); ok && h.PID == pid {
-				health, haveHealth = h, true
-			}
-		}
-		now := time.Now()
-		hung = running && haveHealth && health.Stale(now)
-		// The crash-loop breaker may have latched a hard stop (daemon not
-		// starting) or an embedder auto-disable — surface both.
-		if app.StateDir != "" {
-			guard, _ = crashguard.Read(app.StateDir)
-		}
-		label := fmt.Sprintf("running %s (pid %d)", daemonlock.VersionLabel(ver), pid)
+		label := fmt.Sprintf("running %s (pid %d)", daemonlock.VersionLabel(h.Version), h.PID)
 		switch {
-		case !running && guard.GaveUp:
+		case !h.Running && h.GaveUp:
 			// Respawns are suppressed until the [embedding] config changes.
-			fmt.Fprintf(out, "daemon:              NOT STARTING — crash-loop breaker gave up: %s\n", guard.Reason)
-			gaveUp = true
-		case !running:
+			fmt.Fprintf(out, "daemon:              NOT STARTING — crash-loop breaker gave up: %s\n", h.Reason)
+		case !h.Running:
 			fmt.Fprintf(out, "daemon:              not running\n")
-		case hung:
+		case h.Hung:
 			// A held lock with a dead heartbeat: alive but not progressing (or
 			// mid-crash-loop). Point at the captured stderr for the reason; if
 			// it is also a different binary, keep the --ensure remedy visible.
 			line := fmt.Sprintf("%s — NOT RESPONDING (last heartbeat %s ago); recent output: %s",
-				label, roundDuration(health.Age(now)), daemonhealth.StderrLogPath(app.StateDir))
-			if ver != buildinfo.Version {
+				label, roundDuration(h.HeartbeatAge), h.StderrLog)
+			if h.VersionStale {
 				line += fmt.Sprintf(" [also STALE: binary is %s; run: hap daemon --ensure]", buildinfo.Version)
 			}
 			fmt.Fprintf(out, "daemon:              %s\n", line)
-		case ver != buildinfo.Version:
+		case h.VersionStale:
 			// A holder from another binary keeps old bugs alive; make the
 			// mismatch and the remedy impossible to miss.
 			fmt.Fprintf(out, "daemon:              %s — STALE, binary is %s; run: hap daemon --ensure\n",
@@ -416,15 +391,15 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 	// replaces the config-derived line (which can't know matching was forced
 	// off); it latches until the [embedding] config changes.
 	switch {
-	case guard.EmbeddingOff:
-		fmt.Fprintf(out, "semantic matching:   AUTO-DISABLED by crash-loop breaker — %s\n", guard.Reason)
+	case h.EmbeddingAutoDisabled:
+		fmt.Fprintf(out, "semantic matching:   AUTO-DISABLED by crash-loop breaker — %s\n", h.Reason)
 	case st.Embedding != "":
 		fmt.Fprintf(out, "semantic matching:   %s\n", st.Embedding)
 	}
 	// A running embedder can still be soft-degraded (embed calls latched to
 	// text fallback) — the config-derived line above would otherwise hide it.
-	if haveHealth && health.Embedder == daemonhealth.EmbedderDegraded {
-		fmt.Fprintf(out, "embedder health:     DEGRADED at runtime — %s\n", health.EmbedderNote())
+	if h.EmbedderDegraded {
+		fmt.Fprintf(out, "embedder health:     DEGRADED at runtime — %s\n", h.EmbedderNote)
 	}
 	if st.Drift.Detected {
 		// Same shape as the STALE-daemon line: the mismatch and the remedy
@@ -439,7 +414,7 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 	// A hung daemon or a latched crash-loop give-up is a failure state: exit
 	// non-zero so scripted checks and the operator notice, even though the
 	// status body already explained it.
-	if hung || gaveUp {
+	if h.Hung || h.GaveUp {
 		return ErrUnhealthy
 	}
 	return nil

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -218,6 +218,11 @@ func TestStatusEmbedderDegradedSurfaced(t *testing.T) {
 	if !strings.Contains(out, "DEGRADED") {
 		t.Errorf("runtime-degraded embedder must be surfaced, got:\n%s", out)
 	}
+	// The remediation must name the REAL command (`hap config set <field> <value>`),
+	// not an invented syntax — guards against the note text drifting.
+	if !strings.Contains(out, "hap config set embedding.disabled") {
+		t.Errorf("degraded note must carry the actionable, valid remediation command, got:\n%s", out)
+	}
 }
 
 func seedSignatures(t *testing.T, st *store.Store) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -174,6 +174,27 @@ func TestStatusCrashLoopGaveUpUnhealthy(t *testing.T) {
 	}
 }
 
+func TestStatusCrashLoopingDownUnhealthy(t *testing.T) {
+	app, _ := testApp(t)
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	app.DaemonInfo = func() (bool, int, string) { return false, 0, "" } // down
+	now := time.Now()
+	if err := crashguard.Write(stateDir, crashguard.State{
+		Starts: []time.Time{now.Add(-20 * time.Second), now.Add(-5 * time.Second)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "status")
+	if !errors.Is(err, cli.ErrUnhealthy) {
+		t.Fatalf("a down, crash-looping daemon must exit non-zero, got err=%v", err)
+	}
+	if !strings.Contains(out, "DOWN") || !strings.Contains(out, "crash-looping") {
+		t.Errorf("must flag the daemon down and crash-looping, got:\n%s", out)
+	}
+}
+
 func TestStatusFreshHeartbeatHealthy(t *testing.T) {
 	app, _ := testApp(t)
 	stateDir := t.TempDir()

--- a/internal/frontend/daemonhealth.go
+++ b/internal/frontend/daemonhealth.go
@@ -1,0 +1,136 @@
+package frontend
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
+	"github.com/0xGosu/herdr-auto-pilot/internal/crashguard"
+	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
+)
+
+// DaemonSeverity ranks daemon health for front-ends that surface a single
+// banner (the TUI) or an exit code (the CLI).
+type DaemonSeverity int
+
+const (
+	// DaemonOK: running and progressing, or cleanly stopped — nothing to show.
+	DaemonOK DaemonSeverity = iota
+	// DaemonWarn: working but degraded (BM25 fallback, or an older binary).
+	DaemonWarn
+	// DaemonError: hung, or the crash-loop breaker stopped it — needs attention.
+	DaemonError
+)
+
+// DaemonHealth is a front-end-agnostic assessment of the daemon, combining the
+// lock (DaemonInfo), the heartbeat (daemonhealth), and the crash-loop breaker
+// (crashguard). cli status and the TUI banner both classify from this so they
+// can never disagree. Absent state files degrade gracefully — a field stays
+// false; it never errors.
+type DaemonHealth struct {
+	Running      bool
+	PID          int
+	Version      string
+	VersionStale bool // running a different binary than this one
+	// Hung: a held lock with a stale heartbeat — alive but not progressing.
+	Hung         bool
+	HeartbeatAge time.Duration
+	// GaveUp: the crash-loop breaker stopped restarting the daemon.
+	GaveUp bool
+	// EmbeddingAutoDisabled: the breaker forced the embedder off (BM25 fallback).
+	EmbeddingAutoDisabled bool
+	// EmbedderDegraded: the running embedder soft-degraded (embed calls latched
+	// to text matching).
+	EmbedderDegraded bool
+	// EmbedderNote is the daemonhealth remediation text for a degraded embedder
+	// (single source of the exact wording, incl. the `hap config set …` hint).
+	EmbedderNote string
+	// Reason explains a gave-up / auto-disabled latch.
+	Reason string
+	// StderrLog is the captured daemon stderr path (for hung/crashed post-mortem).
+	StderrLog string
+}
+
+// AssessDaemonHealth reads the daemon's lock, heartbeat, and crash-loop state.
+func (a *App) AssessDaemonHealth() DaemonHealth {
+	var h DaemonHealth
+	if a.DaemonInfo != nil {
+		h.Running, h.PID, h.Version = a.DaemonInfo()
+		// Version-staleness needs only the lock record, not any state file, so
+		// compute it before the StateDir short-circuit below.
+		if h.Running {
+			h.VersionStale = h.Version != buildinfo.Version
+		}
+	}
+	if a.StateDir == "" {
+		return h
+	}
+	h.StderrLog = daemonhealth.StderrLogPath(a.StateDir)
+
+	now := time.Now()
+	if h.Running {
+		// Trust a heartbeat only from THIS lock holder: a hard abort skips the
+		// daemon's cleanup, so a dead predecessor's stale record can coexist
+		// with a fresh daemon holding the lock — attributing it would
+		// false-flag the new daemon during its startup window.
+		if rec, ok := daemonhealth.Read(a.StateDir); ok && rec.PID == h.PID {
+			h.HeartbeatAge = rec.Age(now)
+			h.Hung = rec.Stale(now)
+			if rec.Embedder == daemonhealth.EmbedderDegraded {
+				h.EmbedderDegraded = true
+				h.EmbedderNote = rec.EmbedderNote()
+			}
+		}
+	}
+	if g, ok := crashguard.Read(a.StateDir); ok {
+		if g.EmbeddingOff {
+			h.EmbeddingAutoDisabled = true
+			h.Reason = g.Reason
+		}
+		// A give-up only matters while nothing is running (respawns suppressed).
+		if g.GaveUp && !h.Running {
+			h.GaveUp = true
+			h.Reason = g.Reason
+		}
+	}
+	return h
+}
+
+// Severity ranks the health for a single-banner/exit-code front-end.
+func (h DaemonHealth) Severity() DaemonSeverity {
+	switch {
+	case h.Hung || h.GaveUp:
+		return DaemonError
+	case h.EmbeddingAutoDisabled || h.EmbedderDegraded || (h.Running && h.VersionStale):
+		return DaemonWarn
+	default:
+		return DaemonOK
+	}
+}
+
+// Banner is a one-line summary for an unhealthy daemon, or "" when OK. The most
+// severe condition wins so a single line is never ambiguous.
+func (h DaemonHealth) Banner() string {
+	switch {
+	case h.GaveUp:
+		return "⚠ DAEMON NOT STARTING — crash-loop breaker gave up: " + h.Reason
+	case h.Hung:
+		return fmt.Sprintf("⚠ DAEMON NOT RESPONDING — no heartbeat for %s; see %s", formatAge(h.HeartbeatAge), h.StderrLog)
+	case h.EmbeddingAutoDisabled:
+		return "⚠ semantic matching AUTO-DISABLED by crash-loop breaker — " + h.Reason
+	case h.EmbedderDegraded:
+		return "⚠ embedder degraded — running on BM25 text fallback"
+	case h.Running && h.VersionStale:
+		return "⚠ daemon is STALE (older binary) — run: hap daemon --ensure"
+	default:
+		return ""
+	}
+}
+
+// formatAge renders a heartbeat age compactly ("45s", "2m0s").
+func formatAge(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	return d.Round(time.Second).String()
+}

--- a/internal/frontend/daemonhealth.go
+++ b/internal/frontend/daemonhealth.go
@@ -37,6 +37,12 @@ type DaemonHealth struct {
 	HeartbeatAge time.Duration
 	// GaveUp: the crash-loop breaker stopped restarting the daemon.
 	GaveUp bool
+	// CrashLooping: the daemon is down with a recent cluster of boots — it is
+	// crashing and being respawned, but the breaker has not yet given up. This
+	// is the primary #60 symptom (a dead daemon that otherwise looks quiet).
+	CrashLooping bool
+	// RecentRestarts is how many daemon boots fall within the breaker's window.
+	RecentRestarts int
 	// EmbeddingAutoDisabled: the breaker forced the embedder off (BM25 fallback).
 	EmbeddingAutoDisabled bool
 	// EmbedderDegraded: the running embedder soft-degraded (embed calls latched
@@ -92,6 +98,21 @@ func (a *App) AssessDaemonHealth() DaemonHealth {
 			h.GaveUp = true
 			h.Reason = g.Reason
 		}
+		// Down with a recent boot cluster = crash-looping (crashing + being
+		// respawned) but not yet given up. Count only boots within the breaker's
+		// window so a stale record from an old, since-recovered loop doesn't
+		// false-flag; a lone recent boot is ambiguous with a brief clean run, so
+		// require a cluster (>=2).
+		if !h.Running {
+			for _, s := range g.Starts {
+				if now.Sub(s) <= crashguard.Window {
+					h.RecentRestarts++
+				}
+			}
+			if h.RecentRestarts >= 2 && !h.GaveUp {
+				h.CrashLooping = true
+			}
+		}
 	}
 	return h
 }
@@ -99,7 +120,7 @@ func (a *App) AssessDaemonHealth() DaemonHealth {
 // Severity ranks the health for a single-banner/exit-code front-end.
 func (h DaemonHealth) Severity() DaemonSeverity {
 	switch {
-	case h.Hung || h.GaveUp:
+	case h.Hung || h.GaveUp || h.CrashLooping:
 		return DaemonError
 	case h.EmbeddingAutoDisabled || h.EmbedderDegraded || (h.Running && h.VersionStale):
 		return DaemonWarn
@@ -114,6 +135,9 @@ func (h DaemonHealth) Banner() string {
 	switch {
 	case h.GaveUp:
 		return "⚠ DAEMON NOT STARTING — crash-loop breaker gave up: " + h.Reason
+	case h.CrashLooping:
+		return fmt.Sprintf("⚠ DAEMON DOWN — crash-looping (%d restarts within %s); see %s",
+			h.RecentRestarts, crashguard.Window, h.StderrLog)
 	case h.Hung:
 		return fmt.Sprintf("⚠ DAEMON NOT RESPONDING — no heartbeat for %s; see %s", formatAge(h.HeartbeatAge), h.StderrLog)
 	case h.EmbeddingAutoDisabled:

--- a/internal/frontend/daemonhealth_test.go
+++ b/internal/frontend/daemonhealth_test.go
@@ -126,6 +126,68 @@ func TestAssessGaveUp(t *testing.T) {
 	}
 }
 
+func TestAssessCrashLoopingDown(t *testing.T) {
+	app := appWithDaemon(t, false, 0, "") // daemon currently down
+	// A recent cluster of boots (crashing + being respawned), not yet gave-up.
+	now := time.Now()
+	crashguard.Write(app.StateDir, crashguard.State{
+		Starts: []time.Time{now.Add(-20 * time.Second), now.Add(-5 * time.Second)},
+	})
+	h := app.AssessDaemonHealth()
+	if !h.CrashLooping || h.Severity() != DaemonError {
+		t.Errorf("down with a recent boot cluster should be crash-looping/error: %+v", h)
+	}
+	if h.RecentRestarts != 2 {
+		t.Errorf("RecentRestarts = %d, want 2", h.RecentRestarts)
+	}
+	if !strings.Contains(h.Banner(), "crash-looping") {
+		t.Errorf("banner = %q, want crash-looping", h.Banner())
+	}
+}
+
+func TestAssessLoneBootNotCrashLooping(t *testing.T) {
+	// A single recent boot while down is ambiguous with a brief clean run — do
+	// NOT flag it as crash-looping (avoid false alarms on a normal stop).
+	app := appWithDaemon(t, false, 0, "")
+	crashguard.Write(app.StateDir, crashguard.State{
+		Starts: []time.Time{time.Now().Add(-5 * time.Second)},
+	})
+	h := app.AssessDaemonHealth()
+	if h.CrashLooping || h.Severity() != DaemonOK {
+		t.Errorf("a lone boot must not read as crash-looping: %+v", h)
+	}
+}
+
+func TestAssessStaleStartsNotCrashLooping(t *testing.T) {
+	// Boots older than the breaker window are a since-recovered loop, not a
+	// current one.
+	app := appWithDaemon(t, false, 0, "")
+	old := time.Now().Add(-2 * crashguard.Window)
+	crashguard.Write(app.StateDir, crashguard.State{Starts: []time.Time{old, old}})
+	h := app.AssessDaemonHealth()
+	if h.CrashLooping {
+		t.Errorf("stale boots outside the window must not flag crash-looping: %+v", h)
+	}
+}
+
+func TestAssessGaveUpOutranksCrashLooping(t *testing.T) {
+	// Once given up, that terminal state wins over the crash-looping signal
+	// even though a recent boot cluster is still on disk.
+	app := appWithDaemon(t, false, 0, "")
+	now := time.Now()
+	crashguard.Write(app.StateDir, crashguard.State{
+		GaveUp: true, ConfigDigest: "cfg", Reason: "boom",
+		Starts: []time.Time{now.Add(-20 * time.Second), now.Add(-5 * time.Second)},
+	})
+	h := app.AssessDaemonHealth()
+	if h.CrashLooping {
+		t.Errorf("give-up must suppress the crash-looping flag: %+v", h)
+	}
+	if !h.GaveUp || !strings.Contains(h.Banner(), "NOT STARTING") {
+		t.Errorf("give-up banner must win, got %q (%+v)", h.Banner(), h)
+	}
+}
+
 func TestAssessVersionStale(t *testing.T) {
 	app := appWithDaemon(t, true, 100, "v0.0.1-old")
 	daemonhealth.Write(app.StateDir, daemonhealth.Health{

--- a/internal/frontend/daemonhealth_test.go
+++ b/internal/frontend/daemonhealth_test.go
@@ -1,0 +1,163 @@
+package frontend
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
+	"github.com/0xGosu/herdr-auto-pilot/internal/crashguard"
+	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
+)
+
+func appWithDaemon(t *testing.T, running bool, pid int, ver string) *App {
+	t.Helper()
+	dir := t.TempDir()
+	return &App{
+		StateDir:   dir,
+		DaemonInfo: func() (bool, int, string) { return running, pid, ver },
+	}
+}
+
+func TestAssessHealthyRunning(t *testing.T) {
+	app := appWithDaemon(t, true, 100, buildinfo.Version)
+	if err := daemonhealth.Write(app.StateDir, daemonhealth.Health{
+		PID: 100, Version: buildinfo.Version, HeartbeatAt: time.Now(),
+		Embedder: daemonhealth.EmbedderReady,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	h := app.AssessDaemonHealth()
+	if !h.Running || h.Hung || h.EmbedderDegraded {
+		t.Errorf("healthy daemon misclassified: %+v", h)
+	}
+	if h.Severity() != DaemonOK {
+		t.Errorf("severity = %v, want OK", h.Severity())
+	}
+	if h.Banner() != "" {
+		t.Errorf("healthy daemon should have no banner, got %q", h.Banner())
+	}
+}
+
+func TestAssessNotRunningClean(t *testing.T) {
+	app := appWithDaemon(t, false, 0, "")
+	h := app.AssessDaemonHealth()
+	if h.Severity() != DaemonOK || h.Banner() != "" {
+		t.Errorf("a cleanly stopped daemon is not an alert: %+v banner=%q", h, h.Banner())
+	}
+}
+
+func TestAssessHung(t *testing.T) {
+	app := appWithDaemon(t, true, 100, buildinfo.Version)
+	daemonhealth.Write(app.StateDir, daemonhealth.Health{
+		PID: 100, Version: buildinfo.Version,
+		HeartbeatAt: time.Now().Add(-2 * daemonhealth.StaleAfter),
+		Embedder:    daemonhealth.EmbedderReady,
+	})
+	h := app.AssessDaemonHealth()
+	if !h.Hung || h.Severity() != DaemonError {
+		t.Errorf("stale heartbeat should be hung/error: %+v", h)
+	}
+	if !strings.Contains(h.Banner(), "NOT RESPONDING") {
+		t.Errorf("banner = %q, want NOT RESPONDING", h.Banner())
+	}
+}
+
+func TestAssessIgnoresStaleRecordFromOtherPid(t *testing.T) {
+	app := appWithDaemon(t, true, 100, buildinfo.Version)
+	// Stale record from a dead predecessor (pid 999), not this lock holder (100).
+	daemonhealth.Write(app.StateDir, daemonhealth.Health{
+		PID: 999, HeartbeatAt: time.Now().Add(-2 * daemonhealth.StaleAfter),
+	})
+	h := app.AssessDaemonHealth()
+	if h.Hung {
+		t.Errorf("a different pid's stale record must not mark this daemon hung: %+v", h)
+	}
+}
+
+func TestAssessEmbedderDegraded(t *testing.T) {
+	app := appWithDaemon(t, true, 100, buildinfo.Version)
+	daemonhealth.Write(app.StateDir, daemonhealth.Health{
+		PID: 100, Version: buildinfo.Version, HeartbeatAt: time.Now(),
+		Embedder: daemonhealth.EmbedderDegraded,
+	})
+	h := app.AssessDaemonHealth()
+	if !h.EmbedderDegraded || h.Severity() != DaemonWarn {
+		t.Errorf("degraded embedder should be warn: %+v", h)
+	}
+	if !strings.Contains(h.Banner(), "degraded") {
+		t.Errorf("banner = %q, want degraded", h.Banner())
+	}
+	// The note carries the real remediation command for the CLI to render.
+	if !strings.Contains(h.EmbedderNote, "hap config set embedding.disabled") {
+		t.Errorf("EmbedderNote must carry the actionable command, got %q", h.EmbedderNote)
+	}
+}
+
+func TestAssessEmbeddingAutoDisabled(t *testing.T) {
+	app := appWithDaemon(t, true, 100, buildinfo.Version)
+	daemonhealth.Write(app.StateDir, daemonhealth.Health{
+		PID: 100, Version: buildinfo.Version, HeartbeatAt: time.Now(),
+		Embedder: daemonhealth.EmbedderDisabled,
+	})
+	crashguard.Write(app.StateDir, crashguard.State{
+		EmbeddingOff: true, ConfigDigest: "cfg", Reason: "auto-disabled after crash-loop",
+	})
+	h := app.AssessDaemonHealth()
+	if !h.EmbeddingAutoDisabled || h.Severity() != DaemonWarn {
+		t.Errorf("auto-disabled embedding should be warn: %+v", h)
+	}
+	if !strings.Contains(h.Banner(), "AUTO-DISABLED") {
+		t.Errorf("banner = %q, want AUTO-DISABLED", h.Banner())
+	}
+}
+
+func TestAssessGaveUp(t *testing.T) {
+	app := appWithDaemon(t, false, 0, "") // breaker suppressed the daemon
+	crashguard.Write(app.StateDir, crashguard.State{
+		GaveUp: true, ConfigDigest: "cfg", Reason: "looping even with embedder off",
+	})
+	h := app.AssessDaemonHealth()
+	if !h.GaveUp || h.Severity() != DaemonError {
+		t.Errorf("give-up should be error: %+v", h)
+	}
+	if !strings.Contains(h.Banner(), "NOT STARTING") {
+		t.Errorf("banner = %q, want NOT STARTING", h.Banner())
+	}
+}
+
+func TestAssessVersionStale(t *testing.T) {
+	app := appWithDaemon(t, true, 100, "v0.0.1-old")
+	daemonhealth.Write(app.StateDir, daemonhealth.Health{
+		PID: 100, Version: "v0.0.1-old", HeartbeatAt: time.Now(),
+		Embedder: daemonhealth.EmbedderReady,
+	})
+	h := app.AssessDaemonHealth()
+	if !h.VersionStale || h.Severity() != DaemonWarn {
+		t.Errorf("older binary should be warn/stale: %+v", h)
+	}
+	if !strings.Contains(h.Banner(), "STALE") {
+		t.Errorf("banner = %q, want STALE", h.Banner())
+	}
+}
+
+func TestAssessVersionStaleWithoutStateDir(t *testing.T) {
+	// Version-staleness must be detectable from DaemonInfo alone (no state dir),
+	// since it only compares the lock's recorded version to this binary.
+	app := &App{DaemonInfo: func() (bool, int, string) { return true, 100, "v0.0.1-old" }}
+	h := app.AssessDaemonHealth()
+	if !h.VersionStale {
+		t.Errorf("version-stale must be detected without a StateDir: %+v", h)
+	}
+	if h.Severity() != DaemonWarn {
+		t.Errorf("severity = %v, want warn", h.Severity())
+	}
+}
+
+// Give-up outranks auto-disable in the single banner.
+func TestBannerSeverityPrecedence(t *testing.T) {
+	h := DaemonHealth{GaveUp: true, EmbeddingAutoDisabled: true, Reason: "boom"}
+	if !strings.Contains(h.Banner(), "NOT STARTING") {
+		t.Errorf("give-up must win the banner over auto-disable, got %q", h.Banner())
+	}
+}

--- a/internal/tui/health_banner_test.go
+++ b/internal/tui/health_banner_test.go
@@ -34,3 +34,25 @@ func TestHealthBannerAbsentWhenHealthy(t *testing.T) {
 		t.Errorf("a healthy daemon must not show a warning banner, got:\n%s", m.View())
 	}
 }
+
+func TestHealthBannerCrashLoopingDown(t *testing.T) {
+	m := Model{width: 100, height: 30}
+	m.data.daemonHealth = frontend.DaemonHealth{CrashLooping: true, RecentRestarts: 3}
+	if !strings.Contains(m.View(), "crash-looping") {
+		t.Errorf("a down, crash-looping daemon must show a banner, got:\n%s", m.View())
+	}
+}
+
+// The banner consumes a chrome line, so the page-size budgets must reserve one
+// (else a full list/detail overflows the footer).
+func TestBannerReservesChromeLine(t *testing.T) {
+	base := Model{width: 100, height: 30}
+	banner := Model{width: 100, height: 30}
+	banner.data.daemonHealth = frontend.DaemonHealth{GaveUp: true, Reason: "boom"}
+	if got, want := banner.listPageSize(), base.listPageSize()-1; got != want {
+		t.Errorf("listPageSize with banner = %d, want %d (one less)", got, want)
+	}
+	if got, want := banner.detailPageSize(), base.detailPageSize()-1; got != want {
+		t.Errorf("detailPageSize with banner = %d, want %d (one less)", got, want)
+	}
+}

--- a/internal/tui/health_banner_test.go
+++ b/internal/tui/health_banner_test.go
@@ -1,0 +1,36 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+)
+
+func TestHealthBannerErrorState(t *testing.T) {
+	m := Model{width: 100, height: 30}
+	// A crash-loop give-up is error severity → a prominent banner.
+	m.data.daemonHealth = frontend.DaemonHealth{
+		GaveUp: true, Reason: "looping even with the embedder off",
+	}
+	view := m.View()
+	if !strings.Contains(view, "NOT STARTING") {
+		t.Errorf("an error-severity daemon must show a banner, got:\n%s", view)
+	}
+}
+
+func TestHealthBannerDegradedIsShown(t *testing.T) {
+	m := Model{width: 100, height: 30}
+	m.data.daemonHealth = frontend.DaemonHealth{Running: true, EmbedderDegraded: true}
+	if !strings.Contains(m.View(), "degraded") {
+		t.Errorf("a degraded embedder must show a banner, got:\n%s", m.View())
+	}
+}
+
+func TestHealthBannerAbsentWhenHealthy(t *testing.T) {
+	m := Model{width: 100, height: 30}
+	m.data.daemonHealth = frontend.DaemonHealth{Running: true} // healthy
+	if strings.Contains(m.View(), "⚠") {
+		t.Errorf("a healthy daemon must not show a warning banner, got:\n%s", m.View())
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -49,6 +49,10 @@ type refreshMsg struct {
 	kills       []domain.KillEvent
 	signatures  []frontend.SignatureRow
 	cfg         config.Config
+	// daemonHealth combines lock + heartbeat + crash-loop state for the health
+	// banner, so the operator sees a hung/degraded/crash-looping daemon that
+	// otherwise looks identical to "all quiet" (no escalations).
+	daemonHealth frontend.DaemonHealth
 	// pendingConsult holds agent ids that currently have an LLM consult in
 	// flight, so "l: retry LLM" is disabled while one is running (the daemon
 	// re-checks authoritatively). Populated only for retryable escalations.
@@ -234,6 +238,9 @@ func (m Model) refresh() tea.Cmd {
 
 func refreshData(ctx context.Context, app *frontend.App) refreshMsg {
 	var msg refreshMsg
+	// Daemon health is read from local state files (never errors), so assess it
+	// first — it stays meaningful even when GetStatus fails (e.g. daemon down).
+	msg.daemonHealth = app.AssessDaemonHealth()
 	msg.status, msg.err = app.GetStatus(ctx)
 	if msg.err != nil {
 		return msg
@@ -1579,6 +1586,17 @@ func (m Model) View() string {
 		}
 	}
 	fmt.Fprintf(&b, "%s\n\n", strings.Join(tabs, "|"))
+
+	// Daemon health banner: a hung, crash-looping, or degraded daemon otherwise
+	// looks identical to "all quiet" (no escalations). Error states use the
+	// error palette; degraded/stale (a working fallback) use warn.
+	if banner := m.data.daemonHealth.Banner(); banner != "" {
+		style := st.warn
+		if m.data.daemonHealth.Severity() == frontend.DaemonError {
+			style = st.err
+		}
+		fmt.Fprintf(&b, "%s\n", style.Render(banner))
+	}
 
 	if m.data.err != nil {
 		fmt.Fprintf(&b, "%s\n", st.err.Render("error: "+m.data.err.Error()))

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1024,7 +1024,8 @@ func (m Model) viewSelected() (tea.Model, tea.Cmd) {
 
 // detailPageSize is how many detail lines fit under the header and help:
 // header title + tabs + blank (3), detail title + blank (2), the more-lines
-// indicator (1), and blank + help (2) — plus the error line when present.
+// indicator (1), and blank + help (2) — plus the error line and the daemon
+// health banner when present.
 func (m Model) detailPageSize() int {
 	if m.height <= 0 {
 		return 20
@@ -1033,20 +1034,26 @@ func (m Model) detailPageSize() int {
 	if m.data.err != nil {
 		chrome++
 	}
+	if m.data.daemonHealth.Banner() != "" {
+		chrome++
+	}
 	return max(1, m.height-chrome)
 }
 
 // listPageSize is how many list rows fit under the current pane chrome,
 // mirroring detailPageSize's accounting (AR-002): header title + tabs +
 // blank (3), the more-rows indicator (1), and blank + help (2) — plus the
-// error line, the search/filter lines, and the prompt, hint, and status
-// areas when present.
+// error line, the daemon health banner, the search/filter lines, and the
+// prompt, hint, and status areas when present.
 func (m Model) listPageSize() int {
 	if m.height <= 0 {
 		return 20
 	}
 	chrome := 6
 	if m.data.err != nil {
+		chrome++
+	}
+	if m.data.daemonHealth.Banner() != "" {
 		chrome++
 	}
 	if m.searching || (m.tab.isList() && m.query[m.tab] != "") {


### PR DESCRIPTION
Final daemon-resilience PR for #60 (follows merged #63 heartbeat and #66 crash-loop breaker). Surfaces a hung / crash-looping / degraded daemon in the TUI — today it looks identical to "all quiet" (no escalations) — and unifies the CLI/TUI classification.

## This PR
- **`internal/frontend/daemonhealth.go`** (new): `App.AssessDaemonHealth()` reads the lock (`DaemonInfo`), the heartbeat (`daemonhealth`, **pid-gated** so a dead predecessor's stale record isn't attributed to a fresh daemon), and the crash-loop breaker (`crashguard`) into one `DaemonHealth`. `Severity()` → OK / Warn / Error; `Banner()` → a one-line message (most-severe wins) or `""` when healthy. Version-staleness is computed from the lock alone. The degraded remediation text comes from `daemonhealth.EmbedderNote()` — one source, so it can't drift to an invalid command.
- **`internal/tui`**: `refreshData` assesses health **before** `GetStatus` (so it survives a `GetStatus` error); `View` renders the banner after the tabs — `st.err` for **Error** (hung / crash-loop give-up), `st.warn` for **Warn** (degraded / auto-disabled / older binary).
- **`internal/cli`**: `status` classifies from `AssessDaemonHealth` instead of reading `daemonhealth`/`crashguard` inline — **same output, one source of truth** (dropped the duplicated reads).

Distinguishes the three states #60's primary ask calls for: **healthy** (no banner), **degraded** (BM25 fallback), **down/crash-looping**.

## Addressed in review
- The cli refactor had changed the degraded remediation to an invalid command (`set embedding.disabled=true` — no such syntax); restored to `daemonhealth.EmbedderNote()`'s real `hap config set embedding.disabled true`, and tightened the test to assert the actionable command (it previously only checked "DEGRADED", so the regression slipped through).

## Verification
**260 tests pass** (`vectors cpu`), incl.: the shared assessment across every state (pid-gate, no-state-dir version-stale, banner precedence); the TUI banner renders for error/warn and stays absent when healthy; cli `status` output preserved incl. the actionable remediation. Local `ineffassign`/gofmt/vet clean (the linters CI runs).

## Track-2 (#60) status
This completes the resilience/UX track: heartbeat+stderr (#63, merged), crash-loop breaker (#66, merged), and this banner. The arm64 embedder abort itself still needs track 1 (the `llama-go` submodule bump + a release-CI embed smoke test).