### PR TITLE
feat: add path-printing commands for diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ Herdr injects, and without them auto-detects Herdr's plugin directories
 exists — the plugin isn't installed — does it fall back to standalone
 dirs (`~/.config/herd-auto-prompter`, `~/.local/state/herd-auto-prompter`).
 
+To see exactly where those resolved — handy for tailing the daemon log,
+inspecting the DB, or hand-editing `config.toml` — ask `hap`. These are
+read-only, need no daemon, and print the bare path so they compose in
+scripts:
+
+```sh
+bin/hap state-dir            # state dir (DB, logs, socket, lock, match-index)
+bin/hap config path          # the config.toml path (printed even before it exists)
+bin/hap paths                # both, labeled
+cd "$(bin/hap state-dir)"    # e.g. jump into the state dir
+```
+
 ### Open the pane with a hotkey (optional)
 
 Herdr supports custom command keybindings, and the Auto Prompter pane can be

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -58,9 +58,11 @@ Operate:
                         embedding model change (via the daemon when running)
   pause | resume        global pause/kill switch
   kill-history          pause/kill event history
+  state-dir             print the state directory (DB, logs, socket, index)
+  paths                 print resolved config + state paths (labeled)
 
 Configure:
-  config [show|fields|set <field> <value>|set-threshold <situation> <value>]
+  config [show|fields|path|set <field> <value>|set-threshold <situation> <value>]
   rules [list|add <regex>|remove <index>]      never-auto patterns
   task-source [add] [--agent A] [--workspace W] [--template T] <checklist.md> | list | remove <index>
   clear-data --yes      reset learned history + audit data
@@ -103,6 +105,16 @@ func run(verb string, args []string) error {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Path-printing verbs resolve from `paths` alone: no store, no daemon, no
+	// DB creation as a side effect. They must stay usable when the state dir is
+	// unwritable or the DB is corrupt — exactly the situations an operator runs
+	// them to diagnose ("paste your `hap paths`").
+	if verb == "state-dir" || verb == "paths" ||
+		(verb == "config" && len(args) > 0 && args[0] == "path") {
+		app := &frontend.App{ConfigPath: paths.File(), StateDir: paths.StateDir}
+		return cli.Run(ctx, app, os.Stdout, verb, args)
+	}
 
 	switch verb {
 	case "daemon":

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -98,22 +98,28 @@ func main() {
 }
 
 func run(verb string, args []string) error {
-	paths, err := config.ResolvePaths()
-	if err != nil {
-		return err
-	}
-
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Path-printing verbs resolve from `paths` alone: no store, no daemon, no
-	// DB creation as a side effect. They must stay usable when the state dir is
-	// unwritable or the DB is corrupt — exactly the situations an operator runs
-	// them to diagnose ("paste your `hap paths`").
+	// Path-printing verbs are pure diagnostics: they resolve paths WITHOUT
+	// creating directories, opening the store, or touching the daemon — so they
+	// stay usable, and side-effect-free, in exactly the degraded states an
+	// operator runs them to inspect (an unwritable parent dir, a corrupt DB:
+	// "paste your `hap paths`"). Resolve before the creating ResolvePaths below
+	// so none of that filesystem mutation happens on this path.
 	if verb == "state-dir" || verb == "paths" ||
 		(verb == "config" && len(args) > 0 && args[0] == "path") {
+		paths, err := config.ResolvePathsNoCreate()
+		if err != nil {
+			return err
+		}
 		app := &frontend.App{ConfigPath: paths.File(), StateDir: paths.StateDir}
 		return cli.Run(ctx, app, os.Stdout, verb, args)
+	}
+
+	paths, err := config.ResolvePaths()
+	if err != nil {
+		return err
 	}
 
 	switch verb {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -63,6 +63,11 @@ func Run(ctx context.Context, app *frontend.App, out io.Writer, verb string, arg
 		return killHistory(ctx, app, out)
 	case "config":
 		return configCmd(ctx, app, out, args)
+	case "state-dir":
+		fmt.Fprintln(out, app.StateDir)
+		return nil
+	case "paths":
+		return paths(out, app)
 	case "rules":
 		return rules(ctx, app, out, args)
 	case "task-source":
@@ -658,6 +663,9 @@ func configCmd(ctx context.Context, app *frontend.App, out io.Writer, args []str
 		return nil
 	}
 	switch args[0] {
+	case "path":
+		fmt.Fprintln(out, app.ConfigPath)
+		return nil
 	case "fields":
 		cfg, err := app.Config()
 		if err != nil {
@@ -691,7 +699,15 @@ func configCmd(ctx context.Context, app *frontend.App, out io.Writer, args []str
 		fmt.Fprintf(out, "threshold %s set to %.2f (daemon reloaded)\n", args[1], v)
 		return nil
 	}
-	return fmt.Errorf("usage: config [show|fields|set <field> <value>|set-threshold <situation> <value>]")
+	return fmt.Errorf("usage: config [show|fields|path|set <field> <value>|set-threshold <situation> <value>]")
+}
+
+// paths prints the resolved config and state paths, labeled, for human use.
+// The discrete `state-dir` and `config path` verbs stay bare for scripting.
+func paths(out io.Writer, app *frontend.App) error {
+	fmt.Fprintf(out, "config:    %s\n", app.ConfigPath)
+	fmt.Fprintf(out, "state:     %s\n", app.StateDir)
+	return nil
 }
 
 func printConfig(out io.Writer, cfg config.Config) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -581,3 +581,61 @@ func TestStatusShowsEmbeddingDrift(t *testing.T) {
 		t.Errorf("driftless status must not show the drift line, got:\n%s", out)
 	}
 }
+
+func TestStateDirCmd(t *testing.T) {
+	app, _ := testApp(t)
+	app.StateDir = t.TempDir()
+
+	out, err := run(t, app, "state-dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Bare absolute path, no decoration, so `cd "$(hap state-dir)"` works.
+	if got := strings.TrimSpace(out); got != app.StateDir {
+		t.Errorf("state-dir must print the bare state dir; got %q want %q", got, app.StateDir)
+	}
+}
+
+func TestConfigPathCmd(t *testing.T) {
+	app, _ := testApp(t)
+
+	out, err := run(t, app, "config", "path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(out); got != app.ConfigPath {
+		t.Errorf("config path must print the bare config.toml path; got %q want %q", got, app.ConfigPath)
+	}
+}
+
+func TestConfigPathWhenFileAbsent(t *testing.T) {
+	app, _ := testApp(t)
+	// testApp points ConfigPath at a file that is never written to disk.
+	if _, err := os.Stat(app.ConfigPath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: config.toml must not exist, stat err=%v", err)
+	}
+
+	out, err := run(t, app, "config", "path")
+	if err != nil {
+		t.Fatalf("config path must not error when the file is absent: %v", err)
+	}
+	if got := strings.TrimSpace(out); got != app.ConfigPath {
+		t.Errorf("config path must print the resolved location even when absent; got %q want %q", got, app.ConfigPath)
+	}
+}
+
+func TestPathsCmd(t *testing.T) {
+	app, _ := testApp(t)
+	app.StateDir = t.TempDir()
+
+	out, err := run(t, app, "paths")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "config:") || !strings.Contains(out, app.ConfigPath) {
+		t.Errorf("paths must show the labeled config path, got:\n%s", out)
+	}
+	if !strings.Contains(out, "state:") || !strings.Contains(out, app.StateDir) {
+		t.Errorf("paths must show the labeled state dir, got:\n%s", out)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -270,15 +270,43 @@ type Paths struct {
 	StateDir  string
 }
 
-// ResolvePaths determines the config/state dirs, in priority order:
+// ResolvePaths determines the config/state dirs (see resolvePaths for the
+// priority order) and creates them, so callers that go on to open the DB,
+// socket, or config file can rely on the directories existing.
+func ResolvePaths() (Paths, error) {
+	p, err := resolvePaths()
+	if err != nil {
+		return p, err
+	}
+	for _, dir := range []string{p.ConfigDir, p.StateDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return p, fmt.Errorf("create dir %s: %w", dir, err)
+		}
+	}
+	return p, nil
+}
+
+// ResolvePathsNoCreate resolves the config/state dirs with the same priority
+// order as ResolvePaths but creates nothing. Read-only callers that only need
+// to report a path (e.g. `hap state-dir` / `hap config path` / `hap paths`)
+// use this so they stay usable — and side-effect-free — even when a resolved
+// directory is missing under an unwritable parent, which is exactly the kind
+// of broken state an operator runs those diagnostics to inspect.
+func ResolvePathsNoCreate() (Paths, error) {
+	return resolvePaths()
+}
+
+// resolvePaths computes the config/state dirs, in priority order, without
+// creating any directory (the only filesystem access is the read-only
+// dirExists probe used to detect Herdr's layout):
 //
 //  1. HERDR_PLUGIN_CONFIG_DIR / HERDR_PLUGIN_STATE_DIR — set by Herdr for
 //     every command it launches (the plugin contract).
 //  2. Herdr's own plugin directories, when they exist — so running the
 //     binary from a plain shell operates on the same instance the daemon
 //     uses instead of a parallel standalone world.
-//  3. XDG-style standalone directories, created on demand.
-func ResolvePaths() (Paths, error) {
+//  3. XDG-style standalone directories.
+func resolvePaths() (Paths, error) {
 	p := Paths{
 		ConfigDir: os.Getenv("HERDR_PLUGIN_CONFIG_DIR"),
 		StateDir:  os.Getenv("HERDR_PLUGIN_STATE_DIR"),
@@ -301,7 +329,7 @@ func ResolvePaths() (Paths, error) {
 		// standalone state dir (or vice versa) would recreate the split
 		// world this detection exists to prevent. Detection never creates
 		// the layout — an uninstalled plugin stays standalone — but once
-		// either dir exists the missing sibling is created below.
+		// either dir exists the missing sibling is filled in.
 		herdrConfig := filepath.Join(configBase, "herdr", "plugins", "config", "herd-auto-prompter")
 		herdrState := filepath.Join(stateBase, "herdr", "plugins", "herd-auto-prompter")
 		if dirExists(herdrConfig) || dirExists(herdrState) {
@@ -318,11 +346,6 @@ func ResolvePaths() (Paths, error) {
 	}
 	if p.StateDir == "" {
 		p.StateDir = filepath.Join(stateBase, "herd-auto-prompter")
-	}
-	for _, dir := range []string{p.ConfigDir, p.StateDir} {
-		if err := os.MkdirAll(dir, 0o700); err != nil {
-			return p, fmt.Errorf("create dir %s: %w", dir, err)
-		}
 	}
 	return p, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -256,6 +256,29 @@ func TestResolvePathsHerdrDirsAdoptedAsAPair(t *testing.T) {
 	}
 }
 
+func TestResolvePathsNoCreateComputesButCreatesNothing(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+
+	p, err := ResolvePathsNoCreate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same standalone resolution as ResolvePaths...
+	wantCfg := filepath.Join(home, ".config", "herd-auto-prompter")
+	wantState := filepath.Join(home, ".local", "state", "herd-auto-prompter")
+	if p.ConfigDir != wantCfg || p.StateDir != wantState {
+		t.Fatalf("no-create resolution must match ResolvePaths, got %+v", p)
+	}
+	// ...but no directory is created — the diagnostics stay side-effect-free
+	// and usable even under an unwritable parent.
+	for _, dir := range []string{p.ConfigDir, p.StateDir} {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Errorf("ResolvePathsNoCreate must not create %s (stat err=%v)", dir, err)
+		}
+	}
+}
+
 func TestResolvePathsHonorsXDGBases(t *testing.T) {
 	home := t.TempDir()
 	setHome(t, home)


### PR DESCRIPTION
## 📌 Background

Operators need quick access to resolved configuration and state paths for diagnostics — tailing logs, inspecting the database, hand-editing `config.toml`, or reporting issues. These commands should work even when the state directory is unwritable or the database is corrupt, since they're often run to diagnose exactly those situations.

## 🔧 Reason for Changes

Added three new read-only commands that resolve and print paths without requiring daemon access, database initialization, or store setup:

- `hap state-dir` — prints the state directory (DB, logs, socket, index)
- `hap config path` — prints the config.toml path (even before it exists)
- `hap paths` — prints both paths labeled for human use

These commands are useful for:
- Composing in shell scripts: `cd "$(hap state-dir)"`
- Diagnosing configuration and state issues
- Reporting paths in bug reports
- Inspecting logs and database files directly

## ✅ Changes Implemented

- Added `state-dir` verb to print the state directory path (bare, no decoration)
- Added `config path` subcommand to print the config.toml path
- Added `paths` verb to print both paths with labels
- Fast-path these commands in `main.go` to skip daemon/store initialization
- Updated help text in `cmd/hap/main.go` to document the new commands
- Updated `README.md` with usage examples and explanation
- Added comprehensive unit tests covering all three commands, including the case where `config.toml` doesn't exist yet

## 🔍 Testing Results

- ✅ Unit tests added: `TestStateDirCmd`, `TestConfigPathCmd`, `TestConfigPathWhenFileAbsent`, `TestPathsCmd`
- ✅ Tests verify bare output format for scripting (`state-dir`, `config path`)
- ✅ Tests verify labeled output for human use (`paths`)
- ✅ Tests confirm commands work even when config file is absent
- ✅ Existing tests continue to pass

## 🚀 Deployment / Migration Details

No database migrations or environment changes required. These are purely additive, read-only commands that require no daemon or store setup.

---

### 📝 Additional Notes

The implementation uses a fast-path in `main.go` that detects these three commands and initializes only the minimal `frontend.App` with resolved paths, bypassing all daemon and store initialization. This ensures the commands remain usable for diagnostics even in degraded states.

https://claude.ai/code/session_01WUdo65HaiyeZftYiRBiovg