### PR TITLE
#0 feat: suggest a task for idle agents via local LLM

### DIFF
--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -253,6 +253,9 @@ func runDaemon(ctx context.Context, paths config.Paths, args []string) error {
 			RewriteTemplate:      cfg.LLM.RewriteCommand,
 			RewriteStartTemplate: cfg.LLM.RewriteCommandStart,
 			RewriteTimeout:       cfg.RewriteTimeout(),
+			TaskGenTemplate:      cfg.LLM.GenerateTaskCommand,
+			TaskGenStartTemplate: cfg.LLM.GenerateTaskCommandStart,
+			TaskGenTimeout:       cfg.GenerateTaskTimeout(),
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,6 +115,23 @@ type LLM struct {
 	// fails (placeholders {original_text}, {agent_name}). Empty uses the
 	// built-in default; a rewrite failure never blocks the send.
 	RewriteFallbackTemplate string `toml:"rewrite_fallback_template"`
+	// GenerateTaskCommand is the argv template for the one-shot task
+	// suggestion an idle agent gets when it has NO task source (no declared
+	// [[task_sources]] and nothing inferable from the pane). Placeholders:
+	// {self}, {agent_name}, {agent_type}, {pane_excerpt}, {cwd}. The suggested
+	// task is read from the CLI's stdout and surfaced as an escalation the
+	// operator confirms (writing a per-agent tasks.md) or dismisses. Empty
+	// keeps today's behavior: idle with no task source escalates as
+	// no_task_source and the plugin never synthesizes a prompt (FR-011).
+	GenerateTaskCommand []string `toml:"generate_task_command"`
+	// GenerateTaskCommandStart is the argv template used on the FIRST task
+	// generation per agent (same first-interaction boundary as CommandStart).
+	// Same placeholders as GenerateTaskCommand. Empty inherits
+	// GenerateTaskCommand; tracked independently of the consult "first".
+	GenerateTaskCommandStart []string `toml:"generate_task_command_start,omitempty"`
+	// GenerateTaskTimeoutSeconds bounds one task-generation run; zero or
+	// omitted inherits timeout_seconds.
+	GenerateTaskTimeoutSeconds int `toml:"generate_task_timeout_seconds,omitempty"`
 }
 
 // Embedding configures semantic signature matching: situations are matched
@@ -499,6 +516,16 @@ func (c Config) RewriteTimeout() time.Duration {
 		return c.LLMTimeout()
 	}
 	return time.Duration(c.LLM.RewriteTimeoutSeconds) * time.Second
+}
+
+// GenerateTaskTimeout returns the task-generation timeout:
+// generate_task_timeout_seconds, or — when zero/omitted — the consult
+// timeout_seconds.
+func (c Config) GenerateTaskTimeout() time.Duration {
+	if c.LLM.GenerateTaskTimeoutSeconds <= 0 {
+		return c.LLMTimeout()
+	}
+	return time.Duration(c.LLM.GenerateTaskTimeoutSeconds) * time.Second
 }
 
 // Built-in capture delays: the agent TUI can take several seconds to paint

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -491,6 +491,79 @@ rewrite_fallback_template = "Do this: {original_text}"
 	}
 }
 
+func TestGenerateTaskConfigKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+
+	// Omitted entirely: command disabled, timeout inherits the consult
+	// timeout (resolved at use time, never materialized into the file).
+	os.WriteFile(path, []byte("[llm]\ncommand = [\"claude\"]\n"), 0o600)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.LLM.GenerateTaskCommand) != 0 {
+		t.Errorf("generate_task_command should default empty, got %v", cfg.LLM.GenerateTaskCommand)
+	}
+	if cfg.LLM.GenerateTaskTimeoutSeconds != 0 {
+		t.Errorf("omitted generate-task timeout should stay 0 (inherit at use time), got %d", cfg.LLM.GenerateTaskTimeoutSeconds)
+	}
+	if cfg.GenerateTaskTimeout() != 60*time.Second {
+		t.Errorf("GenerateTaskTimeout() = %v, want inherited default 60s", cfg.GenerateTaskTimeout())
+	}
+
+	// Omitted timeout inherits a CUSTOM consult timeout, and Save must not
+	// freeze that inheritance into the file.
+	os.WriteFile(path, []byte("[llm]\ntimeout_seconds = 120\n"), 0o600)
+	if cfg, err = Load(path); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.GenerateTaskTimeout() != 120*time.Second {
+		t.Errorf("GenerateTaskTimeout() = %v, want inherited 120s", cfg.GenerateTaskTimeout())
+	}
+	if err := Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg, err = Load(path); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.LLM.GenerateTaskTimeoutSeconds != 0 || cfg.GenerateTaskTimeout() != 120*time.Second {
+		t.Errorf("Save must not freeze the inherited timeout: raw=%d effective=%v",
+			cfg.LLM.GenerateTaskTimeoutSeconds, cfg.GenerateTaskTimeout())
+	}
+
+	// Explicit values are honored verbatim and survive a round trip.
+	os.WriteFile(path, []byte(`[llm]
+timeout_seconds = 120
+generate_task_command = ["claude", "-p", "suggest a task for {agent_name}"]
+generate_task_command_start = ["claude", "-p", "first task for {agent_name}"]
+generate_task_timeout_seconds = 45
+`), 0o600)
+	if cfg, err = Load(path); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.LLM.GenerateTaskCommand) != 3 || cfg.LLM.GenerateTaskCommand[2] != "suggest a task for {agent_name}" {
+		t.Errorf("generate_task_command lost: %v", cfg.LLM.GenerateTaskCommand)
+	}
+	if len(cfg.LLM.GenerateTaskCommandStart) != 3 {
+		t.Errorf("generate_task_command_start lost: %v", cfg.LLM.GenerateTaskCommandStart)
+	}
+	if cfg.LLM.GenerateTaskTimeoutSeconds != 45 || cfg.GenerateTaskTimeout() != 45*time.Second {
+		t.Errorf("explicit generate-task timeout lost: raw=%d effective=%v",
+			cfg.LLM.GenerateTaskTimeoutSeconds, cfg.GenerateTaskTimeout())
+	}
+	if err := Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	rt, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rt.LLM.GenerateTaskCommand) != 3 || len(rt.LLM.GenerateTaskCommandStart) != 3 ||
+		rt.LLM.GenerateTaskTimeoutSeconds != 45 {
+		t.Errorf("round trip lost generate-task keys: %+v", rt.LLM)
+	}
+}
+
 func TestCommandStartConfigKeys(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -85,6 +85,7 @@ type Daemon struct {
 	nudges         chan control.Kind
 	llmResults     chan llmOutcome
 	rewriteResults chan rewriteOutcome
+	taskGenResults chan taskGenOutcome
 	sweepResults   chan sweepOutcome
 	// delayedTr re-enters attention transitions whose capture delay has
 	// elapsed; the pane read happens back on the main loop, like every
@@ -117,6 +118,10 @@ type Daemon struct {
 	// reconnect. Both guarded by mu.
 	firstConsult map[string]bool
 	firstRewrite map[string]bool
+	// firstTaskGen marks agents whose first idle task generation has fired, so
+	// the first one can use generate_task_command_start. Same keying/semantics
+	// as firstConsult/firstRewrite; guarded by mu.
+	firstTaskGen map[string]bool
 
 	// configured flips after the first successful reload so reloadEmbedder
 	// can tell first load from a config change.
@@ -183,6 +188,19 @@ type rewriteOutcome struct {
 	token     uint64
 }
 
+// taskGenOutcome carries a finished idle task generation back into the main
+// loop: the suggested task text, or an error the daemon surfaces as a
+// retryable escalation. The request rides along so the pending guard can be
+// cleared exactly like a consult.
+type taskGenOutcome struct {
+	situation domain.Situation
+	sig       domain.SignatureResult
+	tr        domain.AgentTransition
+	request   domain.LLMRequest
+	task      string
+	err       error
+}
+
 // sweepOutcome carries a finished multi-tab form sweep back into the main
 // loop: the situation with content/options aggregated across all tabs, or —
 // degraded — the original single-frame situation plus the failure reason
@@ -212,6 +230,7 @@ func New(opt Options) (*Daemon, error) {
 		nudges:          make(chan control.Kind, 16),
 		llmResults:      make(chan llmOutcome, 16),
 		rewriteResults:  make(chan rewriteOutcome, 16),
+		taskGenResults:  make(chan taskGenOutcome, 16),
 		sweepResults:    make(chan sweepOutcome, 16),
 		delayedTr:       make(chan domain.AgentTransition, 256),
 		pendingCapture:  map[string]*captureEntry{},
@@ -219,6 +238,7 @@ func New(opt Options) (*Daemon, error) {
 		episodeHandled:  map[string]bool{},
 		firstConsult:    map[string]bool{},
 		firstRewrite:    map[string]bool{},
+		firstTaskGen:    map[string]bool{},
 		lastAutoSend:    map[string]time.Time{},
 		lastAutoNoop:    map[string]time.Time{},
 		rewriteInFlight: map[string]rewriteFlight{},
@@ -465,6 +485,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 		case res := <-d.rewriteResults:
 			logging.Guard("rewrite-result", func() error {
 				d.handleRewriteOutcome(ctx, res)
+				return nil
+			})
+		case res := <-d.taskGenResults:
+			logging.Guard("task-gen-result", func() error {
+				d.handleTaskGenOutcome(ctx, res)
 				return nil
 			})
 		case res := <-d.sweepResults:
@@ -792,15 +817,16 @@ func (d *Daemon) decideAndAct(ctx context.Context, situation domain.Situation,
 			MaxConsecutive: cfg.Limits.MaxConsecutiveAutoPrompts,
 			MaxPerMinute:   cfg.Limits.MaxAutoPromptsPerMinute,
 		},
-		Now:                   now,
-		RetryCount:            retries,
-		MaxRetries:            cfg.Limits.MaxErrorRetries,
-		DeclaredTask:          declared,
-		LLMConfigured:         d.llmPort() != nil && d.llmPort().Configured(),
-		NeverAutoHit:          allowPattern,
-		NeverAutoMatched:      allowMatched,
-		SuspectedIrreversible: suspected,
-		IrreversibleHit:       irrevHit,
+		Now:                    now,
+		RetryCount:             retries,
+		MaxRetries:             cfg.Limits.MaxErrorRetries,
+		DeclaredTask:           declared,
+		LLMConfigured:          d.llmPort() != nil && d.llmPort().Configured(),
+		GenerateTaskConfigured: d.taskGenPort() != nil,
+		NeverAutoHit:           allowPattern,
+		NeverAutoMatched:       allowMatched,
+		SuspectedIrreversible:  suspected,
+		IrreversibleHit:        irrevHit,
 	}
 
 	decision := domain.Decide(in)
@@ -821,6 +847,8 @@ func (d *Daemon) decideAndAct(ctx context.Context, situation domain.Situation,
 		d.deliverNoop(ctx, situation, sig, decision, tr, now)
 	case domain.ActionConsult:
 		d.consultLLM(ctx, cfg, situation, sig, now)
+	case domain.ActionGenerateTask:
+		d.generateTask(ctx, cfg, situation, sig, tr, now)
 	default:
 		d.escalate(ctx, situation, sig, decision, tr, now)
 	}
@@ -1170,6 +1198,135 @@ func (d *Daemon) consultLLM(ctx context.Context, cfg config.Config, s domain.Sit
 		case <-ctx.Done():
 		}
 	}()
+}
+
+// taskGenPort returns the LLM adapter as a TaskGeneratorPort when a
+// generate-task CLI is configured, else nil (the capability is optional).
+func (d *Daemon) taskGenPort() ports.TaskGeneratorPort {
+	tg, ok := d.llmPort().(ports.TaskGeneratorPort)
+	if !ok || !tg.GenerateTaskConfigured() {
+		return nil
+	}
+	return tg
+}
+
+// generateTask asks the operator LLM to SUGGEST a task for an idle agent that
+// has no task source (FR-011 relaxation). Like consultLLM the subprocess runs
+// in a goroutine — it shells out to herdr for the pane excerpt and cwd — and
+// the suggestion funnels back through handleTaskGenOutcome as an escalation the
+// operator confirms or dismisses; it is never auto-acted. A pending
+// llm_requests row guards against concurrent generations from bursty idle
+// events and lets `l`-retry reuse the same in-flight check.
+func (d *Daemon) generateTask(ctx context.Context, cfg config.Config, s domain.Situation,
+	sig domain.SignatureResult, tr domain.AgentTransition, now time.Time) {
+
+	tg := d.taskGenPort()
+	if tg == nil {
+		return
+	}
+	// Don't stack a generation onto one already in flight for this agent.
+	if pending, err := d.opt.Store.HasPendingLLMConsult(ctx, s.AgentID); err != nil {
+		slog.Error("generate-task: pending check failed", "agent", s.AgentID, "error", err)
+		return
+	} else if pending {
+		slog.Info("generate-task skipped: request already in flight", "agent", s.AgentID)
+		return
+	}
+
+	// The first generation for this agent selects generate_task_command_start
+	// (when configured); mark it consumed on the main loop, before the goroutine.
+	d.mu.Lock()
+	first := !d.firstTaskGen[s.AgentID]
+	d.firstTaskGen[s.AgentID] = true
+	d.mu.Unlock()
+
+	req := domain.LLMRequest{
+		RequestID: fmt.Sprintf("gentask-%s-%d", s.AgentID, now.UnixNano()),
+		Signature: sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
+		AgentID: s.AgentID, Status: "pending", CreatedAt: now, First: first,
+	}
+	// Stage the pending row synchronously so a second idle event cannot race
+	// past the guard above before the goroutine registers the flight.
+	if _, err := d.opt.Store.StageLLMRequest(ctx, req); err != nil {
+		slog.Error("generate-task: staging request failed", "agent", s.AgentID, "error", err)
+		d.escalate(ctx, s, sig, domain.Decision{
+			Action: domain.ActionEscalate, Reason: domain.ReasonTaskGenFailed,
+			Rationale: "staging request failed: " + err.Error(),
+		}, tr, now)
+		return
+	}
+
+	go func() {
+		outcome := taskGenOutcome{situation: s, sig: sig, tr: tr, request: req}
+		err := logging.Guard("generate-task", func() error {
+			agentName, nerr := d.opt.Store.EnsureAgentName(ctx, s.AgentID)
+			if nerr != nil {
+				agentName = ""
+			}
+			// cwd comes from `pane get`; degrade to empty when the adapter
+			// cannot report it (ports.InspectorPort is optional).
+			var info domain.PaneInfo
+			if insp, ok := d.opt.Herdr.(ports.InspectorPort); ok {
+				if pi, perr := insp.PaneInfo(ctx, s.PaneID); perr == nil {
+					info = pi
+				}
+			}
+			cwd := info.ForegroundCwd
+			if cwd == "" {
+				cwd = info.Cwd
+			}
+			task, gerr := tg.GenerateTask(ctx, domain.TaskGenRequest{
+				AgentType:   s.AgentType,
+				AgentName:   agentName,
+				PaneExcerpt: d.paneExcerpt(ctx, cfg, s),
+				Cwd:         cwd,
+				First:       first,
+			})
+			outcome.task = task
+			return gerr
+		})
+		outcome.err = err
+		select {
+		case d.taskGenResults <- outcome:
+		case <-ctx.Done():
+		}
+	}()
+}
+
+// handleTaskGenOutcome surfaces a finished idle task generation as an
+// escalation: a suggestion the operator confirms (writing a per-agent tasks.md)
+// or dismisses on success, or a retryable failure rationale. It never acts on
+// the pane itself.
+func (d *Daemon) handleTaskGenOutcome(ctx context.Context, res taskGenOutcome) {
+	now := d.opt.Clock.Now()
+	s := res.situation
+
+	// Clear the pending guard for this agent; a failed write leaves it pending
+	// until expireStaleLLMWork reclaims it.
+	if err := d.opt.Store.UpdateLLMRequestStatus(ctx, res.request.RequestID, "done"); err != nil {
+		slog.Error("marking generate-task request done failed", "request", res.request.RequestID, "error", err)
+	}
+
+	if res.err != nil || res.task == "" {
+		rationale := "generate-task produced no task"
+		if res.err != nil {
+			rationale = res.err.Error()
+		}
+		d.escalate(ctx, s, res.sig, domain.Decision{
+			Action: domain.ActionEscalate, Reason: domain.ReasonTaskGenFailed,
+			Rationale: rationale,
+		}, res.tr, now)
+		return
+	}
+
+	// Success: surface the suggestion for confirmation. The reason stays
+	// no_task_source (the agent IS still without a source) so the escalation
+	// is NOT retryable — the operator confirms or dismisses it — while the
+	// suggestion carries the generated task for the confirm path.
+	d.escalate(ctx, s, res.sig, domain.Decision{
+		Action: domain.ActionEscalate, Reason: domain.ReasonNoTaskSource,
+		Suggestion: domain.SuggestTaskPrefix + res.task,
+	}, res.tr, now)
 }
 
 // consultContext builds the JSON context handed to the LLM CLI via the
@@ -1886,9 +2043,12 @@ func (d *Daemon) applyLLMRetry(ctx context.Context, r domain.LLMRetry) {
 	// pane, and re-derives every gate at fire time — re-consulting when the live
 	// pane still needs help. Forwarding herdr's real status/type/location (vs a
 	// fabricated "blocked") keeps the trigger honest and lets the Claude
-	// structural detectors and signature lookup see the correct agent type.
-	// scheduleCapture coalesces per pane, so rapid double-retries collapse into
-	// one capture.
+	// structural detectors and signature lookup see the correct agent type. This
+	// also carries an idle task-generation retry correctly: the live status is
+	// idle, so the pane re-classifies as idle and re-enters the generate-task
+	// path (and if the agent has since started working, it is no longer idle and
+	// no stale suggestion is regenerated). scheduleCapture coalesces per pane, so
+	// rapid double-retries collapse into one capture.
 	slog.Info("llm retry: re-driving consult", "agent", agentID, "pane", live.PaneID, "status", live.Status)
 	d.scheduleCapture(ctx, live)
 }
@@ -2002,7 +2162,17 @@ func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domai
 // blocks every future retry for that agent forever.
 func (d *Daemon) expireStaleLLMWork(ctx context.Context) {
 	cfg, _, _ := d.snapshot()
-	cutoff := d.opt.Clock.Now().Add(-2 * cfg.LLMTimeout())
+	// The reclaim window must exceed the LONGEST work a pending llm_requests
+	// row can represent: a consult (LLMTimeout) or an idle task generation
+	// (GenerateTaskTimeout, which can be configured longer). Using only the
+	// consult timeout would expire a still-running generation early, letting a
+	// second idle event launch a concurrent generation (defeats the in-flight
+	// guard in generateTask).
+	longest := cfg.LLMTimeout()
+	if gt := cfg.GenerateTaskTimeout(); gt > longest {
+		longest = gt
+	}
+	cutoff := d.opt.Clock.Now().Add(-2 * longest)
 
 	if _, err := d.opt.Store.ExpireStalePendingLLMRequests(ctx, cutoff); err != nil {
 		slog.Error("expiring stale LLM requests failed", "error", err)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1307,6 +1307,22 @@ func (d *Daemon) handleTaskGenOutcome(ctx context.Context, res taskGenOutcome) {
 		slog.Error("marking generate-task request done failed", "request", res.request.RequestID, "error", err)
 	}
 
+	// Staleness: generation took up to its timeout — never surface a suggestion
+	// for an agent that moved on. If the agent STARTED WORKING (its live herdr
+	// status is no longer idle/done), or it now has a matching task source, the
+	// suggestion is moot — drop it instead of leaving a stale, confirmable
+	// escalation. Unknown status (list error / agent absent) falls through and
+	// still surfaces the outcome (fail-safe). The confirm path re-checks too,
+	// since the operator may act minutes later.
+	if d.agentNotCleanlyIdle(ctx, s.AgentID) {
+		slog.Info("generate-task: agent no longer idle; dropping suggestion", "agent", s.AgentID)
+		return
+	}
+	if d.declaredTaskFor(ctx, s) != nil {
+		slog.Info("generate-task: agent now has a task source; dropping suggestion", "agent", s.AgentID)
+		return
+	}
+
 	if res.err != nil || res.task == "" {
 		rationale := "generate-task produced no task"
 		if res.err != nil {
@@ -1327,6 +1343,24 @@ func (d *Daemon) handleTaskGenOutcome(ctx context.Context, res taskGenOutcome) {
 		Action: domain.ActionEscalate, Reason: domain.ReasonNoTaskSource,
 		Suggestion: domain.SuggestTaskPrefix + res.task,
 	}, res.tr, now)
+}
+
+// agentNotCleanlyIdle reports whether the agent's LIVE herdr status means it is
+// no longer cleanly idle (see domain.AgentBusy: not idle/done/unknown). It
+// fails closed to false — an unreadable agent list or an absent agent is
+// inconclusive, so the caller does not drop on it. Used to invalidate an idle
+// task suggestion the agent has since moved past.
+func (d *Daemon) agentNotCleanlyIdle(ctx context.Context, agentID string) bool {
+	agents, err := d.opt.Herdr.ListAgents(ctx)
+	if err != nil {
+		return false
+	}
+	for _, a := range agents {
+		if a.AgentID == agentID {
+			return domain.AgentBusy(a.Status)
+		}
+	}
+	return false
 }
 
 // consultContext builds the JSON context handed to the LLM CLI via the

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1384,6 +1384,36 @@ func TestIdleTaskGenRetryReDrivesGeneration(t *testing.T) {
 	})
 }
 
+func TestIdleTaskGenDropsStaleSuggestion(t *testing.T) {
+	// If the agent starts work while the LLM runs (its live herdr status is no
+	// longer idle when the result returns), the suggestion is DROPPED — never
+	// surfaced, so it can't be confirmed and sent into a busy agent.
+	var h *harness
+	h, tg := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+		// Simulate the agent moving on mid-generation.
+		h.herdr.setAgents([]domain.AgentTransition{{AgentID: "agent-30", PaneID: "agent-30", Status: "working"}})
+		return "Some now-stale task", nil
+	})
+	h.herdr.setPane("Task is complete.\n")
+
+	ctx := context.Background()
+	h.push("agent-30", "idle")
+	// The drop path clears the pending row and writes NO audit, so once the
+	// outcome is processed (pending cleared, generator ran) the assertion is
+	// stable.
+	waitFor(t, 3*time.Second, func() bool {
+		pending, _ := h.raw.HasPendingLLMConsult(ctx, "agent-30")
+		return !pending && len(tg.genCalls()) == 1
+	})
+	esc, _ := h.raw.PendingEscalations(ctx)
+	if len(esc) != 0 {
+		t.Errorf("a stale suggestion must not be surfaced, got %d escalations", len(esc))
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Errorf("nothing may be sent for a dropped suggestion, got %v", h.herdr.sentInputs())
+	}
+}
+
 func TestErrorRetryCeilingEndToEnd(t *testing.T) {
 	// FR-014: up to 2 automated retries per error signature; 3rd escalates.
 	// A Claude error/retry situation (interrupt prompt) — generic build-log

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -253,6 +253,38 @@ func (f *fakeRewriter) rewriteCalls() []domain.RewriteRequest {
 	return append([]domain.RewriteRequest(nil), f.requests...)
 }
 
+// fakeTaskGen layers ports.TaskGeneratorPort on the LLM fake so the daemon's
+// type assertion finds the optional idle task-generation capability.
+type fakeTaskGen struct {
+	*fakeLLM
+	mu       sync.Mutex
+	generate func(ctx context.Context, req domain.TaskGenRequest) (string, error)
+	requests []domain.TaskGenRequest
+}
+
+func (f *fakeTaskGen) GenerateTaskConfigured() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.generate != nil
+}
+
+func (f *fakeTaskGen) GenerateTask(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+	f.mu.Lock()
+	f.requests = append(f.requests, req)
+	fn := f.generate
+	f.mu.Unlock()
+	if fn == nil {
+		return "", errors.New("no generate configured")
+	}
+	return fn(ctx, req)
+}
+
+func (f *fakeTaskGen) genCalls() []domain.TaskGenRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]domain.TaskGenRequest(nil), f.requests...)
+}
+
 // failingStore injects persistence failures on audit writes (FR-024).
 type failingStore struct {
 	ports.StorePort
@@ -308,7 +340,29 @@ func newHarnessRewriter(t *testing.T, cfgTOML string,
 	return newHarnessFull(t, cfgTOML, nil, fr), fr
 }
 
+// newHarnessTaskGen installs a task-generator-capable LLM port for idle
+// task-suggestion tests.
+func newHarnessTaskGen(t *testing.T, cfgTOML string,
+	generate func(ctx context.Context, req domain.TaskGenRequest) (string, error)) (*harness, *fakeTaskGen) {
+	tg := &fakeTaskGen{fakeLLM: &fakeLLM{}, generate: generate}
+	return newHarnessCore(t, cfgTOML, nil, tg, tg.fakeLLM), tg
+}
+
 func newHarnessFull(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.HerdrPort, rw *fakeRewriter) *harness {
+	fl := &fakeLLM{}
+	var llmPort ports.LLMPort = fl
+	if rw != nil {
+		fl = rw.fakeLLM
+		llmPort = rw
+	}
+	return newHarnessCore(t, cfgTOML, wrap, llmPort, fl)
+}
+
+// newHarnessCore wires the daemon with a caller-supplied LLM port (plus the
+// underlying *fakeLLM for assertions), so optional-capability variants
+// (rewriter, task generator) share one setup path.
+func newHarnessCore(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.HerdrPort,
+	llmPort ports.LLMPort, fl *fakeLLM) *harness {
 	t.Helper()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.toml")
@@ -329,12 +383,6 @@ func newHarnessFull(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.He
 	fs := &failingStore{StorePort: raw}
 	fh := &fakeHerdr{}
 	fe := &fakeEvents{ch: make(chan domain.AgentTransition, 64)}
-	fl := &fakeLLM{}
-	var llmPort ports.LLMPort = fl
-	if rw != nil {
-		fl = rw.fakeLLM
-		llmPort = rw
-	}
 	var herdrPort ports.HerdrPort = fh
 	if wrap != nil {
 		herdrPort = wrap(fh)
@@ -1226,6 +1274,114 @@ func TestIdleWithoutTaskSourceEscalates(t *testing.T) {
 	if len(h.herdr.sentInputs()) != 0 {
 		t.Fatal("no arbitrary prompt may be synthesized")
 	}
+}
+
+func TestIdleGeneratesTaskSuggestionEscalation(t *testing.T) {
+	// FR-011 relaxation: idle with no task source and generate_task_command
+	// configured surfaces an LLM-suggested task as a (non-retryable)
+	// escalation, and sends nothing to the pane.
+	idlePane := "Task is complete.\n"
+	h, tg := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+		return "Investigate the flaky auth test and add a retry guard", nil
+	})
+	h.herdr.setPane(idlePane)
+
+	ctx := context.Background()
+	h.push("agent-20", "idle")
+	var esc []domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	want := domain.SuggestTaskPrefix + "Investigate the flaky auth test and add a retry guard"
+	if esc[0].Suggestion != want {
+		t.Errorf("escalation suggestion = %q, want %q", esc[0].Suggestion, want)
+	}
+	if domain.IsRetryableLLMEscalation(&esc[0]) {
+		t.Error("a successful task suggestion must NOT be retryable (operator confirms/dismisses)")
+	}
+	if calls := tg.genCalls(); len(calls) != 1 {
+		t.Fatalf("generator should be called once, got %d", len(calls))
+	} else if calls[0].AgentType != "claude" && calls[0].AgentType != "unknown" {
+		t.Errorf("generator request should carry the agent type, got %q", calls[0].AgentType)
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Fatalf("nothing may be sent to the pane before the operator confirms, sent %v", h.herdr.sentInputs())
+	}
+	// The pending guard was cleared on the outcome path.
+	if pending, _ := h.raw.HasPendingLLMConsult(ctx, "agent-20"); pending {
+		t.Error("a resolved task generation must not leave a pending request")
+	}
+}
+
+func TestIdleTaskGenFailureIsRetryableEscalation(t *testing.T) {
+	// A failed generation surfaces the rationale and is retryable with `l`.
+	h, _ := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+		return "", errors.New("generate-task CLI failed: boom")
+	})
+	h.herdr.setPane("Task is complete.\n")
+
+	ctx := context.Background()
+	h.push("agent-21", "idle")
+	var esc []domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	if !domain.IsRetryableLLMEscalation(&esc[0]) {
+		t.Fatalf("a failed generation should be retryable, got rationale %q", esc[0].Rationale)
+	}
+	if !strings.Contains(esc[0].Rationale, string(domain.ReasonTaskGenFailed)) ||
+		!strings.Contains(esc[0].Rationale, "boom") {
+		t.Errorf("rationale should carry the failure tag and message, got %q", esc[0].Rationale)
+	}
+}
+
+func TestIdleTaskGenRetryReDrivesGeneration(t *testing.T) {
+	// A queued retry re-injects the idle status (not blocked) so the pane
+	// re-classifies as idle and re-enters the generate-task path.
+	var mu sync.Mutex
+	calls := 0
+	h, _ := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		if n == 1 {
+			return "", errors.New("generate-task timeout after 5s")
+		}
+		return "Write the missing unit tests for the parser", nil
+	})
+	h.herdr.setPane("Task is complete.\n")
+
+	ctx := context.Background()
+	h.push("agent-22", "idle")
+	var esc []domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1 && domain.IsRetryableLLMEscalation(&esc[0])
+	})
+
+	// Agent still live on its pane: queue a retry and nudge.
+	h.herdr.setAgents([]domain.AgentTransition{{AgentID: "agent-22", PaneID: "agent-22", Status: "idle"}})
+	if _, err := h.raw.InsertLLMRetry(ctx, esc[0].ID, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := control.Nudge(ctx, h.ctlPath, control.KindReload); err != nil {
+		t.Fatal(err)
+	}
+
+	// The retry re-drove generation, which this time yielded a suggestion.
+	want := domain.SuggestTaskPrefix + "Write the missing unit tests for the parser"
+	waitFor(t, 5*time.Second, func() bool {
+		all, _ := h.raw.PendingEscalations(ctx)
+		for _, e := range all {
+			if e.Suggestion == want {
+				return true
+			}
+		}
+		return false
+	})
 }
 
 func TestErrorRetryCeilingEndToEnd(t *testing.T) {

--- a/internal/domain/decide.go
+++ b/internal/domain/decide.go
@@ -14,6 +14,12 @@ const (
 	ActionNextInferredTask = "@next_task:inferred"
 )
 
+// SuggestGenerateTask is the confirmable action carried by an idle
+// task-suggestion escalation. Confirming it makes the front-end write a
+// per-agent tasks.md, register it as a task source, and send the suggested
+// task — it is never sent to a pane as literal text.
+const SuggestGenerateTask = "@generate_task"
+
 // ActionNoop is the learned "do nothing" action: the operator (or LLM)
 // decided the situation needs no reply at all. It flows through decision
 // history and graduation like any other action, but nothing is ever sent —
@@ -83,6 +89,10 @@ type DecideInput struct {
 	MaxRetries    int
 	DeclaredTask  *DeclaredTask // resolved declared source (nil = no source matched)
 	LLMConfigured bool
+	// GenerateTaskConfigured reports that llm.generate_task_command is set, so
+	// an idle agent with no task source generates a task suggestion instead of
+	// escalating no_task_source (FR-011 relaxation).
+	GenerateTaskConfigured bool
 	// NeverAutoHit and SuspectedIrreversible are precomputed by the caller
 	// from the compiled NeverAutoList so the core stays free of regex state.
 	// IrreversibleHit carries the matching indicator for the rationale.
@@ -167,6 +177,16 @@ func Decide(in DecideInput) Decision {
 			(resolveEsc == ReasonNoHistory || resolveEsc == ReasonUnfamiliarOptions) {
 			return Decision{Action: ActionConsult, Confidence: conf.Score,
 				Rationale: string(resolveEsc) + "; consulting LLM"}
+		}
+		// FR-011 relaxation: an idle agent with no task source normally
+		// escalates no_task_source (never synthesizing a prompt). When the
+		// operator has opted in with llm.generate_task_command, instead ask the
+		// LLM to SUGGEST a task — surfaced as an escalation for confirmation,
+		// never auto-acted, so the operator stays in control.
+		if in.Situation.Type == SituationIdle && resolveEsc == ReasonNoTaskSource &&
+			in.GenerateTaskConfigured {
+			return Decision{Action: ActionGenerateTask, Confidence: conf.Score,
+				Rationale: "idle with no task source; generating a task suggestion"}
 		}
 		return esc(resolveEsc, rationaleFor(resolveEsc), conf.Score, suggestion)
 	}

--- a/internal/domain/decide_test.go
+++ b/internal/domain/decide_test.go
@@ -315,6 +315,57 @@ func TestNoHistoryConsultsLLMWhenConfigured(t *testing.T) {
 	}
 }
 
+func TestIdleGeneratesTaskWhenConfigured(t *testing.T) {
+	// FR-011 relaxation: idle with no task source generates a suggestion when
+	// llm.generate_task_command is configured, instead of escalating.
+	in := baseInput(SituationIdle)
+	in.Situation.Content = "Task is complete."
+	in.GenerateTaskConfigured = true
+	d := Decide(in)
+	if d.Action != ActionGenerateTask {
+		t.Fatalf("idle with no task source and generate_task_command should generate a task, got %+v", d)
+	}
+}
+
+func TestIdleNoTaskSourceStillEscalatesWithoutGenerateConfig(t *testing.T) {
+	// Without the opt-in command, today's safe behavior is preserved.
+	in := baseInput(SituationIdle)
+	in.Situation.Content = "Task is complete."
+	in.LLMConfigured = true // consult being configured must not relax idle
+	d := Decide(in)
+	if d.Action != ActionEscalate || d.Reason != ReasonNoTaskSource {
+		t.Fatalf("idle with no task source and no generate_task_command must escalate, got %+v", d)
+	}
+}
+
+func TestIdleDeclaredTaskBeatsGeneration(t *testing.T) {
+	// A matched declared source wins even when generation is configured — the
+	// operator's own list is authoritative.
+	in := autonomous(baseInput(SituationIdle),
+		ActionNextDeclaredTask, ActionNextDeclaredTask, ActionNextDeclaredTask,
+		ActionNextDeclaredTask, ActionNextDeclaredTask, ActionNextDeclaredTask,
+		ActionNextDeclaredTask, ActionNextDeclaredTask)
+	in.DeclaredTask = &DeclaredTask{Task: "write the parser", Path: "/tmp/tasks.md"}
+	in.GenerateTaskConfigured = true
+	d := Decide(in)
+	if d.Action != ActionSend {
+		t.Fatalf("declared task must win over generation, got %+v", d)
+	}
+}
+
+func TestTaskGenFailureIsRetryable(t *testing.T) {
+	// A task_gen_failed escalation is retryable (like a failed consult); a
+	// gated escalation is not.
+	retryable := &AuditRecord{Status: "escalated", Rationale: "[task_gen_failed] llm CLI failed"}
+	if !IsRetryableLLMEscalation(retryable) {
+		t.Errorf("task_gen_failed escalation should be retryable")
+	}
+	notRetryable := &AuditRecord{Status: "escalated", Rationale: "[no_task_source]"}
+	if IsRetryableLLMEscalation(notRetryable) {
+		t.Errorf("no_task_source escalation must not be retryable")
+	}
+}
+
 func TestUnfamiliarOptionsConsultLLMWhenConfigured(t *testing.T) {
 	in := autonomous(baseInput(SituationChoice),
 		"use pnpm", "use pnpm", "use pnpm", "use pnpm", "use pnpm", "use pnpm", "use pnpm", "use pnpm")

--- a/internal/domain/taskgen.go
+++ b/internal/domain/taskgen.go
@@ -1,5 +1,11 @@
 package domain
 
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
 // Task generation for idle agents with no task source (FR-011 relaxation):
 // when llm.generate_task_command is configured, an idle agent that has no
 // declared [[task_sources]] and nothing inferable from its pane triggers a
@@ -28,4 +34,84 @@ type TaskGenRequest struct {
 	// lifetime, selecting llm.generate_task_command_start when configured.
 	// Tracked independently of the consult "first".
 	First bool
+}
+
+// AgentBusy reports whether a herdr agent status means the agent is NOT
+// cleanly idle — anything other than idle, done, or unknown (""). Used to
+// invalidate an idle task suggestion the agent has since moved past. Note that
+// blocked/detected count as busy: a generated task is never pushed into an
+// agent that is not cleanly idle (the safe direction).
+func AgentBusy(status string) bool {
+	return status != "" && status != "idle" && status != "done"
+}
+
+// generatedTaskLineRE strips whatever list/checkbox markup the LLM may have
+// prepended to a task line — a bullet ("-", "*", "+"), an ordered marker
+// ("1.", "2)"), and/or a checkbox ("[ ]", "[x]", "[-]", "[]") — leaving the
+// bare task text. This lets NormalizeGeneratedTasks re-render a well-formed
+// checklist regardless of whether the model already used Markdown.
+var generatedTaskLineRE = regexp.MustCompile(`^\s*(?:[-*+]\s+|\d+[.)]\s+)?(?:\[\s*[xX+\-*]?\s*\]\s*)?(.*)$`)
+
+// NormalizeGeneratedTasks parses a generate-task CLI's raw stdout into a clean
+// list of task strings. The model may return one task or several, plain or as
+// a Markdown list; each non-empty line is reduced to its bare task text (any
+// leading bullet/number/checkbox stripped) so the caller can render a
+// well-formed checklist without ever writing a malformed or unintended item.
+// Returns nil when nothing usable remains.
+func NormalizeGeneratedTasks(raw string) []string {
+	var tasks []string
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Skip Markdown code-fence lines ("```", "~~~") so a fenced list does
+		// not turn its fence into a task.
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			continue
+		}
+		m := generatedTaskLineRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		t := strings.TrimSpace(m[1])
+		// A real task has at least one letter or digit — drop bullet-only,
+		// punctuation-only, or stray-backtick lines that would otherwise be
+		// written (and possibly sent) as an "item".
+		if t != "" && hasAlphanumeric(t) {
+			tasks = append(tasks, t)
+		}
+	}
+	return tasks
+}
+
+// hasAlphanumeric reports whether s contains any letter or digit.
+func hasAlphanumeric(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// RenderGeneratedTaskList renders the normalized tasks as a checklist file:
+// the first task is in-progress ("[-]", the one sent to the agent now) and the
+// rest are pending ("[ ]", picked up by the normal declared-task flow on later
+// idles). Callers pass the result of NormalizeGeneratedTasks; an empty list
+// yields just the header.
+func RenderGeneratedTaskList(agentName string, tasks []string) string {
+	var b strings.Builder
+	b.WriteString("# Tasks for ")
+	b.WriteString(agentName)
+	b.WriteString("\n\n")
+	for i, t := range tasks {
+		marker := "[ ]"
+		if i == 0 {
+			marker = "[-]"
+		}
+		b.WriteString("- ")
+		b.WriteString(marker)
+		b.WriteString(" ")
+		b.WriteString(t)
+		b.WriteString("\n")
+	}
+	return b.String()
 }

--- a/internal/domain/taskgen.go
+++ b/internal/domain/taskgen.go
@@ -1,0 +1,31 @@
+package domain
+
+// Task generation for idle agents with no task source (FR-011 relaxation):
+// when llm.generate_task_command is configured, an idle agent that has no
+// declared [[task_sources]] and nothing inferable from its pane triggers a
+// one-shot LLM call that SUGGESTS a task. The suggestion is surfaced as an
+// escalation the operator confirms or dismisses; it is never auto-acted. These
+// are the pure pieces — the subprocess lives in internal/llm.
+
+// SuggestTaskPrefix prefixes the generated-task suggestion carried on an idle
+// task-suggestion escalation. The daemon writes it; the front-end's
+// SuggestedAction strips it to recover the task text and maps the escalation to
+// SuggestGenerateTask. Kept here so both sides stay in sync.
+const SuggestTaskPrefix = "LLM suggested task: "
+
+// TaskGenRequest is everything the generate-task CLI template can reference.
+type TaskGenRequest struct {
+	// AgentType is the agent's type ("claude", "codex", …), for {agent_type}.
+	AgentType string
+	// AgentName is the agent's short name, for {agent_name}.
+	AgentName string
+	// PaneExcerpt is the tail of the live pane, for {pane_excerpt}.
+	PaneExcerpt string
+	// Cwd is the agent's working directory, for {cwd} — the project the
+	// suggested task should be about.
+	Cwd string
+	// First marks this as the agent's first task generation this daemon
+	// lifetime, selecting llm.generate_task_command_start when configured.
+	// Tracked independently of the consult "first".
+	First bool
+}

--- a/internal/domain/taskgen_test.go
+++ b/internal/domain/taskgen_test.go
@@ -1,0 +1,84 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeGeneratedTasks(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"single plain line", "Investigate the flaky auth test", []string{"Investigate the flaky auth test"}},
+		{"trims surrounding whitespace", "  \n Do the thing \n\n", []string{"Do the thing"}},
+		{
+			"multiple plain lines",
+			"First task\nSecond task\nThird task",
+			[]string{"First task", "Second task", "Third task"},
+		},
+		{
+			"markdown checkbox list is stripped",
+			"- [ ] Write parser\n- [ ] Add validation\n- [ ] Wire logging",
+			[]string{"Write parser", "Add validation", "Wire logging"},
+		},
+		{
+			"mixed markers and blank lines",
+			"* [x] done item\n\n1. numbered task\n2) other numbered\n- dash bullet\n[ ] bare checkbox",
+			[]string{"done item", "numbered task", "other numbered", "dash bullet", "bare checkbox"},
+		},
+		{"empty input", "", nil},
+		{"only whitespace and empty markers", "   \n- \n[ ] \n", nil},
+		{
+			"markdown code fence is dropped",
+			"```\n- [ ] Real task\n```",
+			[]string{"Real task"},
+		},
+		{
+			"fenced with language tag",
+			"```markdown\nDo the work\n```",
+			[]string{"Do the work"},
+		},
+		{"punctuation-only lines dropped", "---\nDo it\n***\n`", []string{"Do it"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NormalizeGeneratedTasks(tc.raw)
+			if len(got) != len(tc.want) {
+				t.Fatalf("NormalizeGeneratedTasks(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("task[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRenderGeneratedTaskList(t *testing.T) {
+	// First task is in-progress "[-]"; the rest are pending "[ ]".
+	got := RenderGeneratedTaskList("brave-otter", []string{"first", "second", "third"})
+	want := "# Tasks for brave-otter\n\n- [-] first\n- [ ] second\n- [ ] third\n"
+	if got != want {
+		t.Errorf("RenderGeneratedTaskList =\n%q\nwant\n%q", got, want)
+	}
+
+	// The first (only) item of a single-task list is in-progress, and the
+	// declared-task parser treats it as not-actionable (no next "[ ]").
+	single := RenderGeneratedTaskList("a", []string{"only task"})
+	if !strings.Contains(single, "- [-] only task") {
+		t.Errorf("single task must be in-progress, got %q", single)
+	}
+	if NextDeclaredTask(single) != "" {
+		t.Errorf("an all-in-progress list must have no next declared task, got %q", NextDeclaredTask(single))
+	}
+
+	// A multi-task list's NEXT declared task is the first pending "[ ]" item,
+	// so the normal flow drives the queue after the in-progress one.
+	multi := RenderGeneratedTaskList("a", []string{"doing now", "up next", "later"})
+	if next := NextDeclaredTask(multi); next != "up next" {
+		t.Errorf("next declared task = %q, want the first pending item %q", next, "up next")
+	}
+}

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -79,6 +79,10 @@ const (
 	ActionEscalate ActionKind = "escalate" // hand to the human, take no action
 	ActionConsult  ActionKind = "consult_llm"
 	ActionKindNoop ActionKind = "noop" // deliberately do nothing (learned no-op)
+	// ActionGenerateTask: an idle agent with no task source triggers a
+	// one-shot LLM task suggestion (llm.generate_task_command). The result is
+	// surfaced as an escalation, never auto-acted (FR-011 relaxation).
+	ActionGenerateTask ActionKind = "generate_task"
 )
 
 // Source identifies who authored a decision.
@@ -119,6 +123,10 @@ const (
 	ReasonUnfamiliarOptions    EscalateReason = "unfamiliar_options"
 	ReasonNoHistory            EscalateReason = "no_history"
 	ReasonNotConsecutiveEnough EscalateReason = "graduation_pending"
+	// ReasonTaskGenFailed: the idle task-generation CLI failed, timed out, or
+	// produced no usable task. The failure rationale is surfaced and the
+	// escalation is retryable (like a failed consult).
+	ReasonTaskGenFailed EscalateReason = "task_gen_failed"
 )
 
 // Decision is the outcome of the pure decision core for one situation.
@@ -201,7 +209,8 @@ type AuditRecord struct {
 
 // IsRetryableLLMEscalation reports whether an escalation is a candidate for
 // re-invoking the LLM: a still-pending escalation whose consult never produced
-// a decision (it timed out or the CLI exited without submitting). A
+// a decision (it timed out or the CLI exited without submitting), or whose
+// idle task-generation CLI failed (task_gen_failed). A
 // gated-but-answered escalation (shadow_mode, variance_guard, …) is NOT
 // retryable — re-invoking would hit the same gate. The reason is carried as a
 // "[reason]" prefix on Rationale (see the daemon's escalate()).
@@ -210,7 +219,8 @@ func IsRetryableLLMEscalation(a *AuditRecord) bool {
 		return false
 	}
 	return strings.HasPrefix(a.Rationale, "["+string(ReasonLLMTimeout)+"]") ||
-		strings.HasPrefix(a.Rationale, "["+string(ReasonLLMNoSubmit)+"]")
+		strings.HasPrefix(a.Rationale, "["+string(ReasonLLMNoSubmit)+"]") ||
+		strings.HasPrefix(a.Rationale, "["+string(ReasonTaskGenFailed)+"]")
 }
 
 // CorrectionRecord is a front-end-written correction amending an audit entry.

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -452,12 +453,39 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 // failure never leaves the agent without the task source that was just
 // established.
 func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord, send bool) error {
-	task := strings.TrimSpace(strings.TrimPrefix(audit.Suggestion, domain.SuggestTaskPrefix))
-	if task == "" {
+	// The suggestion may carry one task or several (plain or as a Markdown
+	// list); normalize into clean bare task strings so the file is always a
+	// well-formed checklist, never raw multiline text written after "- [-] ".
+	raw := strings.TrimPrefix(audit.Suggestion, domain.SuggestTaskPrefix)
+	tasks := domain.NormalizeGeneratedTasks(raw)
+	if len(tasks) == 0 {
 		return fmt.Errorf("audit record %d carries no generated task to confirm", audit.ID)
 	}
 	if audit.AgentID == "" {
 		return fmt.Errorf("audit record %d has no agent to attach a task source to", audit.ID)
+	}
+	// Cheap early-out for a stale re-confirm (already resolved/dismissed): the
+	// atomic claim below is the authoritative guard against the concurrent race.
+	if audit.Status != "escalated" {
+		return fmt.Errorf("audit record %d is no longer a pending escalation", audit.ID)
+	}
+
+	// Staleness: the operator may confirm minutes after the suggestion was
+	// raised. If the agent has since started working, sending an outdated task
+	// would interrupt it — refuse rather than create a source and send. Fail
+	// open when the status is unknown (list error / agent absent): the operator
+	// explicitly asked to confirm.
+	if a.Herdr != nil {
+		if agents, lerr := a.Herdr.ListAgents(ctx); lerr == nil {
+			for _, ag := range agents {
+				if ag.AgentID == audit.AgentID {
+					if domain.AgentBusy(ag.Status) {
+						return fmt.Errorf("agent is no longer idle (%s); the suggested task is stale — dismiss it or wait until the agent is idle", ag.Status)
+					}
+					break
+				}
+			}
+		}
 	}
 
 	// A short name reads well in the file name and matches the task source
@@ -467,8 +495,12 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 		name = audit.AgentID
 	}
 
-	// Keep the file inside the daemon's state dir (no repo pollution); the
-	// config dir is a safe fallback when the state dir is unknown.
+	// Idempotent side effects FIRST (before the claim): writing the file and
+	// registering the source can be safely repeated — the file is rewritten
+	// with identical content and addTaskSourceIfAbsent de-dupes under
+	// UpdateConfig's advisory lock. Running them before the claim means a
+	// failure here leaves the escalation still pending, so the operator can
+	// retry; only the non-idempotent send is gated by the claim below.
 	base := a.StateDir
 	if base == "" {
 		base = filepath.Dir(a.ConfigPath)
@@ -478,36 +510,68 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 		return fmt.Errorf("create tasks dir: %w", err)
 	}
 	path := filepath.Join(dir, sanitizeTaskFileName(name)+".md")
-	// A single in-progress "[-]" item: the plugin parses "[-]" as not an
-	// actionable next task, so it is not re-sent; once the operator marks it
-	// done and adds a "[ ]" item, the normal declared-task flow resumes.
-	content := fmt.Sprintf("# Tasks for %s\n\n- [-] %s\n", name, task)
+	// First task is in-progress ("[-]", sent to the agent now); any remaining
+	// tasks are pending ("[ ]") and the normal declared-task flow picks them up
+	// on later idles.
+	content := domain.RenderGeneratedTaskList(name, tasks)
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		return fmt.Errorf("write tasks file: %w", err)
 	}
-
 	// Register the file as this agent's task source (writes config.toml and
-	// nudges the daemon to reload). Scope by the agent selector; workspace ""
-	// = any so the source follows the agent across workspaces.
-	if err := a.AddTaskSource(ctx, name, "", path, ""); err != nil {
+	// nudges the daemon to reload). Idempotent: a re-confirm for the same
+	// agent+path never stacks duplicate entries. Scope by the agent selector;
+	// workspace "" = any so the source follows the agent across workspaces.
+	if err := a.addTaskSourceIfAbsent(ctx, name, path); err != nil {
 		return fmt.Errorf("register task source: %w", err)
 	}
 
-	// Record the correction so the escalation resolves and the idle signature
-	// learns to drive from its declared task list.
+	// Atomically CLAIM the escalation. Only the writer that flips
+	// escalated→resolved proceeds to the non-idempotent send, so a
+	// double-submit can never send the task twice.
+	claimed, err := a.Store.ResolveEscalation(ctx, audit.ID)
+	if err != nil {
+		return err
+	}
+	if !claimed {
+		return fmt.Errorf("audit record %d is no longer a pending escalation", audit.ID)
+	}
+
+	// Record the correction so the idle signature learns to drive from its
+	// declared task list. Best-effort: the escalation is already resolved and
+	// the source established, so a failed learning write must not fail the
+	// confirm — it only skips a learning event.
 	if _, err := a.Store.InsertCorrection(ctx, domain.CorrectionRecord{
 		AuditID: audit.ID, CorrectedAction: domain.ActionNextDeclaredTask,
 		Author: a.Author, CreatedAt: time.Now(),
 	}); err != nil {
-		return fmt.Errorf("task source created, but recording the confirmation failed: %w", err)
+		slog.Warn("recording generated-task confirmation correction failed", "audit", audit.ID, "error", err)
 	}
 
 	if send && a.Herdr != nil {
-		if err := a.Herdr.Send(ctx, audit.AgentID, task); err != nil {
+		// Only the first task is sent — the operator's "start now" task.
+		if err := a.Herdr.Send(ctx, audit.AgentID, tasks[0]); err != nil {
 			return fmt.Errorf("task source created, but sending the task to the agent failed: %w", err)
 		}
 	}
 	return a.nudge(ctx, control.KindReload)
+}
+
+// addTaskSourceIfAbsent registers a task list for an agent, skipping the append
+// when an identical agent+path entry already exists — so confirming the same
+// generated-task escalation twice never accumulates duplicate sources.
+func (a *App) addTaskSourceIfAbsent(ctx context.Context, agent, path string) error {
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return a.UpdateConfig(ctx, func(cfg *config.Config) error {
+		for _, ts := range cfg.TaskSources {
+			if ts.Agent == agent && ts.Path == path {
+				return nil
+			}
+		}
+		cfg.TaskSources = append(cfg.TaskSources, config.TaskSource{Agent: agent, Path: path})
+		return nil
+	})
 }
 
 // sanitizeTaskFileName makes an agent name safe as a file name: path

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -379,6 +379,12 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 	// means the sentinel, and the literal spelling must never be learned
 	// as pane text (free text like "do nothing" stays literal).
 	action = domain.NormalizeNoopAction(action)
+	// Confirming an idle task suggestion is not a pane send: it writes a
+	// per-agent tasks.md, registers it as a task source, and (when send) hands
+	// the task to the agent. Handle it before the send-oriented flow below.
+	if action == domain.SuggestGenerateTask {
+		return a.acceptGeneratedTask(ctx, audit, send)
+	}
 	if _, err := a.Store.InsertCorrection(ctx, domain.CorrectionRecord{
 		AuditID: auditID, CorrectedAction: action, Author: a.Author, CreatedAt: time.Now(),
 	}); err != nil {
@@ -437,6 +443,89 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 		}
 	}
 	return a.nudge(ctx, control.KindReload)
+}
+
+// acceptGeneratedTask confirms an idle task suggestion: it writes a per-agent
+// tasks.md (a single in-progress "[-]" item), registers it as a task source in
+// config.toml, records the correction that resolves the escalation, and — when
+// send — hands the task to the agent. Side effects run source-first so a send
+// failure never leaves the agent without the task source that was just
+// established.
+func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord, send bool) error {
+	task := strings.TrimSpace(strings.TrimPrefix(audit.Suggestion, domain.SuggestTaskPrefix))
+	if task == "" {
+		return fmt.Errorf("audit record %d carries no generated task to confirm", audit.ID)
+	}
+	if audit.AgentID == "" {
+		return fmt.Errorf("audit record %d has no agent to attach a task source to", audit.ID)
+	}
+
+	// A short name reads well in the file name and matches the task source
+	// selector; fall back to the agent id when unresolvable.
+	name, err := a.Store.EnsureAgentName(ctx, audit.AgentID)
+	if err != nil || name == "" {
+		name = audit.AgentID
+	}
+
+	// Keep the file inside the daemon's state dir (no repo pollution); the
+	// config dir is a safe fallback when the state dir is unknown.
+	base := a.StateDir
+	if base == "" {
+		base = filepath.Dir(a.ConfigPath)
+	}
+	dir := filepath.Join(base, "tasks")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create tasks dir: %w", err)
+	}
+	path := filepath.Join(dir, sanitizeTaskFileName(name)+".md")
+	// A single in-progress "[-]" item: the plugin parses "[-]" as not an
+	// actionable next task, so it is not re-sent; once the operator marks it
+	// done and adds a "[ ]" item, the normal declared-task flow resumes.
+	content := fmt.Sprintf("# Tasks for %s\n\n- [-] %s\n", name, task)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return fmt.Errorf("write tasks file: %w", err)
+	}
+
+	// Register the file as this agent's task source (writes config.toml and
+	// nudges the daemon to reload). Scope by the agent selector; workspace ""
+	// = any so the source follows the agent across workspaces.
+	if err := a.AddTaskSource(ctx, name, "", path, ""); err != nil {
+		return fmt.Errorf("register task source: %w", err)
+	}
+
+	// Record the correction so the escalation resolves and the idle signature
+	// learns to drive from its declared task list.
+	if _, err := a.Store.InsertCorrection(ctx, domain.CorrectionRecord{
+		AuditID: audit.ID, CorrectedAction: domain.ActionNextDeclaredTask,
+		Author: a.Author, CreatedAt: time.Now(),
+	}); err != nil {
+		return fmt.Errorf("task source created, but recording the confirmation failed: %w", err)
+	}
+
+	if send && a.Herdr != nil {
+		if err := a.Herdr.Send(ctx, audit.AgentID, task); err != nil {
+			return fmt.Errorf("task source created, but sending the task to the agent failed: %w", err)
+		}
+	}
+	return a.nudge(ctx, control.KindReload)
+}
+
+// sanitizeTaskFileName makes an agent name safe as a file name: path
+// separators and whitespace collapse to hyphens, so a colorful short name (or
+// a raw agent id) never escapes the tasks dir.
+func sanitizeTaskFileName(name string) string {
+	repl := func(r rune) rune {
+		if strings.ContainsRune("/\\ \t\n", r) || r == os.PathSeparator {
+			return '-'
+		}
+		return r
+	}
+	out := strings.Map(repl, name)
+	out = strings.Trim(out, "-.")
+	if out == "" {
+		return "agent"
+	}
+	return out
 }
 
 // Confirm records agreement with an escalation's suggested action.
@@ -532,6 +621,12 @@ func (a *App) PruneEscalations(ctx context.Context, olderThan time.Duration) (in
 // Keep in sync with the daemon's suggestionAction.
 func SuggestedAction(audit *domain.AuditRecord) string {
 	sug := audit.Suggestion
+	// An idle task suggestion is confirmed into a tasks.md + task source, not
+	// sent to the pane as literal text — recognize it before the send-oriented
+	// prefixes below.
+	if strings.HasPrefix(sug, domain.SuggestTaskPrefix) {
+		return domain.SuggestGenerateTask
+	}
 	for _, p := range []string{"respond: ", "choose: ", "answer series: ", "on error: ", "LLM suggested: "} {
 		if len(sug) > len(p) && sug[:len(p)] == p {
 			sug = sug[len(p):]

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -308,6 +308,7 @@ type fakeHerdr struct {
 	inputs  []string
 	pane    string // returned by ReadPane (live menu content)
 	readErr error
+	agents  []domain.AgentTransition // returned by ListAgents (live statuses)
 }
 
 func (f *fakeHerdr) Send(_ context.Context, paneID, input string) error {
@@ -320,7 +321,9 @@ func (f *fakeHerdr) ReadPane(context.Context, string, int) (string, error) {
 	return f.pane, f.readErr
 }
 
-func (f *fakeHerdr) ListAgents(context.Context) ([]domain.AgentTransition, error) { return nil, nil }
+func (f *fakeHerdr) ListAgents(context.Context) ([]domain.AgentTransition, error) {
+	return f.agents, nil
+}
 
 func TestConfirmSendsRenderedDeclaredTaskPrompt(t *testing.T) {
 	// The confirm path must deliver the exact rendered prompt carried in the
@@ -443,6 +446,116 @@ func TestConfirmGeneratedTaskWithoutSendStillWritesSource(t *testing.T) {
 	cfg, _ := config.Load(app.ConfigPath)
 	if len(cfg.TaskSources) != 1 {
 		t.Errorf("source must still be registered on a non-send confirm, got %d", len(cfg.TaskSources))
+	}
+}
+
+func TestConfirmGeneratedMultipleTasksWritesChecklist(t *testing.T) {
+	// A multiline suggestion (a Markdown checklist from the LLM) is normalized:
+	// the file lists the first task in-progress "[-]" and the rest pending
+	// "[ ]", and ONLY the first task is sent to the agent.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w1:p1")
+	// The model already used Markdown checkboxes — markers must be stripped,
+	// not double-inserted.
+	suggestion := domain.SuggestTaskPrefix + "- [ ] Investigate the flaky auth test\n- [ ] Add a retry guard\n- [ ] Backfill unit tests"
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:p1", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: suggestion, CreatedAt: time.Now(),
+	})
+
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(stateDir, "tasks", name+".md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("tasks file not written: %v", err)
+	}
+	want := "- [-] Investigate the flaky auth test\n- [ ] Add a retry guard\n- [ ] Backfill unit tests\n"
+	if !strings.Contains(string(body), want) {
+		t.Errorf("tasks file = %q, want a checklist %q", body, want)
+	}
+	// Only the first task is sent to the agent.
+	if len(fake.inputs) != 1 || fake.inputs[0] != "Investigate the flaky auth test" {
+		t.Errorf("delivered %v, want only the first task", fake.inputs)
+	}
+	// The next declared task is the first pending item, so the queue drives on
+	// later idles.
+	if next := domain.NextDeclaredTask(string(body)); next != "Add a retry guard" {
+		t.Errorf("next declared task = %q, want the first pending item", next)
+	}
+}
+
+func TestConfirmGeneratedTaskIsIdempotent(t *testing.T) {
+	// A double-submit (or re-confirm after resolution) must not re-send the
+	// task or accumulate duplicate task sources: the atomic claim lets only the
+	// first confirm apply side effects.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	app.StateDir = t.TempDir()
+	ctx := context.Background()
+
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w3:p3", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Do the thing", CreatedAt: time.Now(),
+	})
+
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+	// Second confirm must fail (already claimed) and change nothing.
+	if err := app.Confirm(ctx, id, true); err == nil {
+		t.Error("second confirm on a resolved escalation must fail")
+	}
+
+	if len(fake.inputs) != 1 {
+		t.Errorf("task must be sent exactly once, got %d sends", len(fake.inputs))
+	}
+	cfg, _ := config.Load(app.ConfigPath)
+	if len(cfg.TaskSources) != 1 {
+		t.Errorf("want exactly 1 task source after a double confirm, got %d", len(cfg.TaskSources))
+	}
+}
+
+func TestConfirmGeneratedTaskRefusesWhenAgentWorking(t *testing.T) {
+	// If the agent has started working by the time the operator confirms, the
+	// suggestion is stale: no source is created, nothing is sent, and the
+	// escalation stays pending so the operator can dismiss it.
+	app, st := testApp(t)
+	fake := &fakeHerdr{agents: []domain.AgentTransition{{AgentID: "w4:p4", Status: "working"}}}
+	app.Herdr = fake
+	app.StateDir = t.TempDir()
+	ctx := context.Background()
+
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w4:p4", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Do the thing", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, id, true); err == nil {
+		t.Fatal("confirming a stale suggestion for a working agent must fail")
+	}
+	if len(fake.inputs) != 0 {
+		t.Errorf("nothing may be sent to a working agent, got %v", fake.inputs)
+	}
+	cfg, _ := config.Load(app.ConfigPath)
+	if len(cfg.TaskSources) != 0 {
+		t.Errorf("no task source may be created for a stale suggestion, got %d", len(cfg.TaskSources))
+	}
+	// The escalation is untouched (still pending), so it can be dismissed.
+	audit, _ := st.GetAudit(ctx, id)
+	if audit.Status != "escalated" {
+		t.Errorf("escalation must remain pending after a refused confirm, got %q", audit.Status)
 	}
 }
 

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -352,6 +352,100 @@ func TestConfirmSendsRenderedDeclaredTaskPrompt(t *testing.T) {
 	}
 }
 
+func TestConfirmGeneratedTaskWritesSourceAndSends(t *testing.T) {
+	// Confirming an idle task suggestion writes a per-agent tasks.md (single
+	// in-progress "[-]" item), registers a matching [[task_sources]] entry,
+	// records the correction, and sends the task to the agent.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	// Route the tasks file into a known state dir.
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w1:p1")
+	taskText := "Investigate the flaky auth test and add a retry guard"
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:p1", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + taskText, CreatedAt: time.Now(),
+	})
+
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// tasks.md written with a single in-progress item.
+	path := filepath.Join(stateDir, "tasks", name+".md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("tasks file not written: %v", err)
+	}
+	if !strings.Contains(string(body), "- [-] "+taskText) {
+		t.Errorf("tasks file = %q, want a single in-progress %q item", body, taskText)
+	}
+
+	// The item is parsed as not-actionable, so the declared-task resolver
+	// treats the list as complete (no next "[ ]" item to re-send).
+	if next := domain.NextDeclaredTask(string(body)); next != "" {
+		t.Errorf("in-progress item must not resolve as a next declared task, got %q", next)
+	}
+
+	// A matching task source was appended, scoped to the agent, pointing at
+	// the absolute file path.
+	cfg, err := config.Load(app.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 1 {
+		t.Fatalf("want 1 task source, got %d", len(cfg.TaskSources))
+	}
+	if cfg.TaskSources[0].Agent != name || cfg.TaskSources[0].Path != path {
+		t.Errorf("task source = %+v, want agent %q path %q", cfg.TaskSources[0], name, path)
+	}
+
+	// The correction resolves the escalation and learns the declared-task
+	// action.
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 1 || corr[0].CorrectedAction != domain.ActionNextDeclaredTask || corr[0].AuditID != id {
+		t.Errorf("confirm should record a declared-task correction: %+v", corr)
+	}
+
+	// The task text was sent to the agent's pane.
+	if len(fake.inputs) != 1 || fake.inputs[0] != taskText {
+		t.Errorf("delivered %v, want the task text %q", fake.inputs, taskText)
+	}
+	if len(fake.panes) != 1 || fake.panes[0] != "w1:p1" {
+		t.Errorf("delivered to %v, want the audit's agent pane", fake.panes)
+	}
+}
+
+func TestConfirmGeneratedTaskWithoutSendStillWritesSource(t *testing.T) {
+	// send=false establishes the source and file but delivers nothing.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	app.StateDir = t.TempDir()
+	ctx := context.Background()
+
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w2:p2", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Write missing tests", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, id, false); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.inputs) != 0 {
+		t.Errorf("send=false must deliver nothing, got %v", fake.inputs)
+	}
+	cfg, _ := config.Load(app.ConfigPath)
+	if len(cfg.TaskSources) != 1 {
+		t.Errorf("source must still be registered on a non-send confirm, got %d", len(cfg.TaskSources))
+	}
+}
+
 func TestConfirmDeliversMenuDigitNotLabel(t *testing.T) {
 	// Regression: an LLM/learned approval carries the option LABEL ("Yes"),
 	// but Claude's numbered menu only accepts the digit. Confirm must

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -52,6 +52,15 @@ type Adapter struct {
 	RewriteStartTemplate []string
 	// RewriteTimeout bounds one rewrite run (<=0 falls back to Timeout).
 	RewriteTimeout time.Duration
+	// TaskGenTemplate is the argv template for the one-shot idle task
+	// suggestion (llm.generate_task_command); placeholders {self},
+	// {agent_name}, {agent_type}, {pane_excerpt}, {cwd}. Empty disables it.
+	TaskGenTemplate []string
+	// TaskGenStartTemplate is used instead of TaskGenTemplate on an agent's
+	// first task generation (req.First); empty falls back to TaskGenTemplate.
+	TaskGenStartTemplate []string
+	// TaskGenTimeout bounds one task-generation run (<=0 falls back to Timeout).
+	TaskGenTimeout time.Duration
 }
 
 // Configured reports whether an LLM CLI is configured (IR-005).

--- a/internal/llm/taskgen.go
+++ b/internal/llm/taskgen.go
@@ -1,0 +1,113 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// GenerateTask implements ports.TaskGeneratorPort: a one-shot subprocess that
+// suggests a task for an idle agent with no task source. Like Rewrite (and
+// unlike Consult's MCP-staged flow), the suggested task IS the CLI's stdout
+// (trimmed); stderr is kept separate for diagnostics. Every failure mode
+// returns an error — the daemon surfaces it as a retryable escalation, so a
+// broken generate-task CLI never acts on its own.
+
+// maxTaskGenOutput caps the accepted task text (matches the rewrite/consult
+// 16KB capture cap). A suggested task should be one short line; anything huge
+// is a misbehaving CLI, not a task.
+const maxTaskGenOutput = 16 * 1024
+
+// GenerateTaskConfigured reports whether a generate-task CLI is configured.
+func (a *Adapter) GenerateTaskConfigured() bool {
+	return a != nil && len(a.TaskGenTemplate) > 0
+}
+
+// GenerateTask launches the generate-task CLI and returns its trimmed stdout.
+func (a *Adapter) GenerateTask(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+	if !a.GenerateTaskConfigured() {
+		return "", fmt.Errorf("no generate-task CLI configured")
+	}
+	self := a.SelfPath
+	if self == "" {
+		var err error
+		if self, err = os.Executable(); err != nil {
+			return "", fmt.Errorf("resolve self path: %w", err)
+		}
+	}
+	// The first generation for an agent uses generate_task_command_start when
+	// configured; an empty start template falls back to the base command.
+	// Auto-repair BEFORE substitution: the normalizer pattern-matches argv
+	// shapes, and substituted pane text is untrusted — it must not be able to
+	// perturb the repair (same fixes as Consult/Rewrite).
+	base := a.TaskGenTemplate
+	if req.First && len(a.TaskGenStartTemplate) > 0 {
+		base = a.TaskGenStartTemplate
+	}
+	template := NormalizeLLMCommand(base)
+	argv := make([]string, len(template))
+	for i, arg := range template {
+		arg = strings.ReplaceAll(arg, "{self}", self)
+		arg = strings.ReplaceAll(arg, "{agent_name}", req.AgentName)
+		arg = strings.ReplaceAll(arg, "{agent_type}", req.AgentType)
+		arg = strings.ReplaceAll(arg, "{pane_excerpt}", req.PaneExcerpt)
+		arg = strings.ReplaceAll(arg, "{cwd}", req.Cwd)
+		argv[i] = arg
+	}
+
+	if err := preflight(argv[0]); err != nil {
+		return "", err
+	}
+
+	timeout := a.TaskGenTimeout
+	if timeout <= 0 {
+		timeout = a.Timeout
+	}
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, argv[0], argv[1:]...)
+	cmd.Dir = a.WorkDir()
+	// After the timeout kills the CLI, don't wait on lingering grandchildren
+	// holding the output pipes open — fail safe promptly.
+	cmd.WaitDelay = 2 * time.Second
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = append(os.Environ(),
+		"HAP_AGENT_NAME="+req.AgentName,
+		"HAP_AGENT_TYPE="+req.AgentType,
+		"HAP_CWD="+req.Cwd,
+	)
+	runErr := cmd.Run()
+
+	if runErr != nil {
+		// Classify as timeout only when the run actually failed: a CLI
+		// finishing right at the deadline must keep its valid output.
+		if runCtx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("generate-task timeout after %s (stderr: %s)",
+				timeout, tailOf(stderr.String(), 500))
+		}
+		return "", fmt.Errorf("generate-task CLI failed: %w (stderr: %s)",
+			runErr, tailOf(stderr.String(), 500))
+	}
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", fmt.Errorf("generate-task CLI produced empty output (stderr: %s)",
+			tailOf(stderr.String(), 500))
+	}
+	if len(result) > maxTaskGenOutput {
+		return "", fmt.Errorf("generate-task CLI produced oversized output (%d bytes > %d cap)",
+			len(result), maxTaskGenOutput)
+	}
+	return result, nil
+}

--- a/internal/llm/taskgen_test.go
+++ b/internal/llm/taskgen_test.go
@@ -1,0 +1,152 @@
+package llm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+func TestGenerateTaskConfigured(t *testing.T) {
+	var nilAdapter *Adapter
+	if nilAdapter.GenerateTaskConfigured() {
+		t.Error("nil adapter must report not configured")
+	}
+	if (&Adapter{}).GenerateTaskConfigured() {
+		t.Error("empty template must report not configured")
+	}
+	if !(&Adapter{TaskGenTemplate: []string{"cat"}}).GenerateTaskConfigured() {
+		t.Error("non-empty template must report configured")
+	}
+}
+
+func TestGenerateTaskSubstitutesPlaceholders(t *testing.T) {
+	dir := t.TempDir()
+	argvFile := filepath.Join(dir, "argv")
+	script := writeScript(t,
+		`printf '%s\n' "$@" > `+argvFile+`
+printf 'name=%s\n' "$HAP_AGENT_NAME" >> `+argvFile+`
+printf 'cwd=%s\n' "$HAP_CWD" >> `+argvFile+"\necho 'Investigate the flaky auth test'\n")
+	a := &Adapter{
+		TaskGenTemplate: []string{script,
+			"name={agent_name}", "type={agent_type}", "pane={pane_excerpt}", "cwd={cwd}"},
+		TaskGenTimeout: 5 * time.Second,
+	}
+	got, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{
+		AgentType:   "claude",
+		AgentName:   "brave-otter",
+		PaneExcerpt: "idle at prompt",
+		Cwd:         "/workspaces/proj",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "Investigate the flaky auth test" {
+		t.Errorf("result = %q, want trimmed stdout", got)
+	}
+	argv, err := os.ReadFile(argvFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "name=brave-otter\ntype=claude\npane=idle at prompt\ncwd=/workspaces/proj\nname=brave-otter\ncwd=/workspaces/proj\n"
+	if string(argv) != want {
+		t.Errorf("argv/env = %q, want %q", argv, want)
+	}
+}
+
+func TestGenerateTaskUsesStartTemplateOnFirst(t *testing.T) {
+	script := writeScript(t, `printf '%s' "$1"`+"\n")
+	a := &Adapter{
+		TaskGenTemplate:      []string{script, "base"},
+		TaskGenStartTemplate: []string{script, "start"},
+		TaskGenTimeout:       5 * time.Second,
+	}
+	first, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{First: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != "start" {
+		t.Errorf("first generation marker = %q, want start", first)
+	}
+	later, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{First: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if later != "base" {
+		t.Errorf("later generation marker = %q, want base", later)
+	}
+
+	// No start template → First=true falls back to the base template.
+	b := &Adapter{TaskGenTemplate: []string{script, "base"}, TaskGenTimeout: 5 * time.Second}
+	got, err := b.GenerateTask(context.Background(), domain.TaskGenRequest{First: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "base" {
+		t.Errorf("empty start template must fall back to base, got %q", got)
+	}
+}
+
+func TestGenerateTaskEmptyOutputErrors(t *testing.T) {
+	script := writeScript(t, "echo 'why it failed' >&2\nexit 0\n")
+	a := &Adapter{TaskGenTemplate: []string{script}, TaskGenTimeout: 5 * time.Second}
+	_, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{})
+	if err == nil || !strings.Contains(err.Error(), "empty output") {
+		t.Fatalf("empty stdout must error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "why it failed") {
+		t.Errorf("error should carry the stderr tail: %v", err)
+	}
+}
+
+func TestGenerateTaskNonZeroExitErrors(t *testing.T) {
+	script := writeScript(t, "echo 'boom' >&2\nexit 3\n")
+	a := &Adapter{TaskGenTemplate: []string{script}, TaskGenTimeout: 5 * time.Second}
+	_, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("non-zero exit must error with stderr tail, got %v", err)
+	}
+}
+
+func TestGenerateTaskTimeout(t *testing.T) {
+	script := writeScript(t, "sleep 30\n")
+	a := &Adapter{TaskGenTemplate: []string{script}, TaskGenTimeout: 300 * time.Millisecond}
+	start := time.Now()
+	_, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{})
+	if err == nil || !strings.Contains(err.Error(), "timeout") {
+		t.Fatalf("timeout must error, got %v", err)
+	}
+	if time.Since(start) > 5*time.Second {
+		t.Error("generate-task did not honor the timeout bound")
+	}
+}
+
+func TestGenerateTaskTimeoutFallsBackToConsultTimeout(t *testing.T) {
+	script := writeScript(t, "sleep 30\n")
+	a := &Adapter{
+		TaskGenTemplate: []string{script},
+		Timeout:         300 * time.Millisecond, // TaskGenTimeout unset
+	}
+	start := time.Now()
+	if _, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{}); err == nil {
+		t.Fatal("timeout must error")
+	}
+	if time.Since(start) > 5*time.Second {
+		t.Error("generate-task did not inherit the consult timeout")
+	}
+}
+
+func TestGenerateTaskPreflightsMissingCommand(t *testing.T) {
+	a := &Adapter{
+		TaskGenTemplate: []string{"hap-generate-task-command-that-does-not-exist"},
+		TaskGenTimeout:  time.Second,
+	}
+	_, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{})
+	if err == nil || !strings.Contains(err.Error(), "not found in PATH") {
+		t.Fatalf("missing command must produce a PATH-aware error, got %v", err)
+	}
+}

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -190,6 +190,10 @@ type FrontendStore interface {
 	// recording a correction; the audit row is kept (append-only, FR-020).
 	// Errors when the record is not a pending escalation.
 	DismissEscalation(ctx context.Context, auditID int64) error
+	// ResolveEscalation atomically flips one pending escalation to "resolved",
+	// returning whether it claimed the row (false when already resolved/
+	// dismissed). Callers apply one-time side effects only on a true claim.
+	ResolveEscalation(ctx context.Context, auditID int64) (bool, error)
 	// DismissEscalationsBefore dismisses every pending escalation created
 	// before cutoff, returning how many were dismissed.
 	DismissEscalationsBefore(ctx context.Context, cutoff time.Time) (int64, error)

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -105,6 +105,18 @@ type RewriterPort interface {
 	RewriteConfigured() bool
 }
 
+// TaskGeneratorPort is an optional capability of the LLM adapter: a one-shot
+// task suggestion for an idle agent with no task source
+// (llm.generate_task_command). Like Rewrite, the suggested task is the
+// subprocess's stdout. Callers type-assert and degrade gracefully when absent.
+type TaskGeneratorPort interface {
+	// GenerateTask runs the configured generate-task CLI and returns the
+	// suggested task text, or an error on timeout / failure / empty output.
+	GenerateTask(ctx context.Context, req domain.TaskGenRequest) (string, error)
+	// GenerateTaskConfigured reports whether a generate-task CLI is configured.
+	GenerateTaskConfigured() bool
+}
+
 // StorePort is the persistence boundary. Write-ownership is partitioned:
 // daemon-exclusive writers for signatures/agent_rate/error_retries/decisions,
 // daemon-emitted audit rows, and signature_embeddings (with one maintenance

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -842,6 +842,31 @@ func (s *Store) DismissEscalation(ctx context.Context, auditID int64) error {
 	})
 }
 
+// ResolveEscalation atomically flips one pending escalation to "resolved",
+// returning whether it CLAIMED the row (false when it was already resolved/
+// dismissed, or another writer won the race). The status guard in the WHERE
+// clause makes the claim safe against a double-confirm, so a caller can apply
+// one-time side effects (writing a file, appending config, sending) only when
+// it actually claimed the escalation.
+func (s *Store) ResolveEscalation(ctx context.Context, auditID int64) (bool, error) {
+	var claimed bool
+	err := s.tx(ctx, func(tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx,
+			`UPDATE audit_log SET status = 'resolved' WHERE id = ? AND status = 'escalated'`,
+			auditID)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		claimed = n > 0
+		return nil
+	})
+	return claimed, err
+}
+
 // DismissEscalationsBefore dismisses every pending escalation created before
 // cutoff, returning how many were dismissed (the front-end prune).
 func (s *Store) DismissEscalationsBefore(ctx context.Context, cutoff time.Time) (int64, error) {

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -120,6 +120,25 @@ rewrite_command = [
 rewrite_timeout_seconds = 60       # omitted: inherits timeout_seconds
 rewrite_fallback_template = "You must act based on the following: {original_text}"
 
+# ── Idle task suggestion (optional) ──
+# When an agent goes idle with NO task source (no [[task_sources]] matches it
+# and nothing is inferable from the pane), a one-shot CLI can SUGGEST a task.
+# Its stdout is the suggested task; hap surfaces it as an escalation. Confirm
+# it (enter/y) and hap writes a per-agent tasks.md (a single in-progress `[-]`
+# item), registers it as a [[task_sources]] entry, and sends the task to the
+# agent; dismiss (x) to ignore; if the CLI fails, retry with `l`. Placeholders:
+# {self}, {agent_name}, {agent_type}, {pane_excerpt}, {cwd}. Omit to keep the
+# safe default: idle with no task source escalates and hap synthesizes nothing.
+# generate_task_command = [
+#   "claude", "-p",
+#   "Suggest ONE concrete next task for the coding agent in this project. Reply with ONLY the task, one line.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
+#   "--model", "haiku",
+# ]
+# generate_task_command_start runs INSTEAD on the agent's first generation
+# (tracked independently); omit to reuse generate_task_command.
+# generate_task_command_start = [ ... ]
+# generate_task_timeout_seconds = 60   # omitted: inherits timeout_seconds
+
 
 # ── Semantic rule matching (vector embeddings) ──────────────────────
 # Situations are matched to learned rules by embedding their masked salient

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -122,16 +122,20 @@ rewrite_fallback_template = "You must act based on the following: {original_text
 
 # ── Idle task suggestion (optional) ──
 # When an agent goes idle with NO task source (no [[task_sources]] matches it
-# and nothing is inferable from the pane), a one-shot CLI can SUGGEST a task.
-# Its stdout is the suggested task; hap surfaces it as an escalation. Confirm
-# it (enter/y) and hap writes a per-agent tasks.md (a single in-progress `[-]`
-# item), registers it as a [[task_sources]] entry, and sends the task to the
-# agent; dismiss (x) to ignore; if the CLI fails, retry with `l`. Placeholders:
+# and nothing is inferable from the pane), a one-shot CLI can SUGGEST tasks.
+# Its stdout is the suggestion (one task per line — plain text or a Markdown
+# checklist; hap normalizes the format), surfaced as an escalation. Confirm it
+# (enter/y) and hap writes a per-agent tasks.md whose FIRST task is in-progress
+# ("[-]") and the rest pending ("[ ]"), registers it as a [[task_sources]]
+# entry, and sends ONLY the first task to the agent (the remaining tasks are
+# picked up by the normal declared-task flow on later idles). Dismiss (x) to
+# ignore; if the CLI fails, retry with `l`. A suggestion is dropped/refused if
+# the agent starts working before it is surfaced/confirmed. Placeholders:
 # {self}, {agent_name}, {agent_type}, {pane_excerpt}, {cwd}. Omit to keep the
 # safe default: idle with no task source escalates and hap synthesizes nothing.
 # generate_task_command = [
 #   "claude", "-p",
-#   "Suggest ONE concrete next task for the coding agent in this project. Reply with ONLY the task, one line.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
+#   "Suggest concrete next tasks for the coding agent in this project, most important first. Reply with ONLY the tasks, one per line.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
 #   "--model", "haiku",
 # ]
 # generate_task_command_start runs INSTEAD on the agent's first generation


### PR DESCRIPTION
## Summary

When an agent goes **idle** with **no task source** (no declared `[[task_sources]]` matches it and nothing is inferable from the pane) and the operator has configured the new `llm.generate_task_command`, hap invokes a **one-shot local LLM** that **suggests a task**. The suggestion surfaces as a normal **escalation**:

- **confirm+send** (`enter`/`y`) → hap writes a per-agent `tasks.md` (single in-progress `[-]` item) under the state dir, registers it as a `[[task_sources]]` entry, and sends the task to the agent;
- **dismiss** (`x`) → nothing happens;
- if generation **failed**, the escalation shows the failure rationale and the operator **retries with `l`** (same key as the existing LLM-consult retry).

This relaxes the FR-011 *"never synthesize a prompt without a task source"* invariant **only behind the new opt-in command** — unconfigured idle still escalates `no_task_source` and synthesizes nothing.

Once `tasks.md` exists, the **normal declared-task flow** takes over on later idles (the completed-list template steers the agent), so hap never re-generates for that agent.

## Design notes

- The generate-task CLI is a **one-shot whose stdout is the task text** — mirrors `llm.rewrite_command`, not the `submit_decision` MCP flow (this path always escalates, never auto-acts, so no safety re-gate is needed).
- **No tasklist parser change:** `[-]` already parses as done/checked, so a single-`[-]` file resolves via the existing "completed sentinel" path.
- Safety gates (kill switch, never-auto, variance guard, rate limit, irreversible heuristic) all precede the generation branch in `Decide`.
- The async generation runs off the main loop; a pending `llm_requests` row guards against concurrent generations from bursty idle events and lets `l`-retry reuse the in-flight check.

## Config

```toml
[llm]
generate_task_command = ["claude", "-p", "Suggest ONE concrete next task ...\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}", "--model", "haiku"]
# generate_task_command_start = [ ... ]   # optional first-generation variant
# generate_task_timeout_seconds = 60      # omitted: inherits timeout_seconds
```

Placeholders: `{self}`, `{agent_name}`, `{agent_type}`, `{pane_excerpt}`, `{cwd}`.

## Files

| Area | Change |
|---|---|
| `internal/config` | new `[llm]` keys + `GenerateTaskTimeout()` |
| `internal/domain` | `ActionGenerateTask`, `ReasonTaskGenFailed`, `SuggestGenerateTask`/`SuggestTaskPrefix`, `TaskGenRequest`, idle relaxation, retryability |
| `internal/ports` | `TaskGeneratorPort` |
| `internal/llm` | `taskgen.go` one-shot subprocess (mirrors `rewrite.go`) |
| `cmd/hap` | wire adapter fields |
| `internal/daemon` | dispatch, `generateTask`, `handleTaskGenOutcome`, idle retry re-drive, stale-cutoff = max(consult, gentask) timeout |
| `internal/frontend` | `SuggestedAction` prefix, `Resolve` branch, `acceptGeneratedTask` |
| `sample/config.toml` | documented the new keys |

## Testing

- Full unit suite: **675 tests, 0 failures** (`go test -tags "vectors cpu" ./...`); build + `go vet` + `gofmt` clean.
- New coverage: config parse/timeout, decide idle relaxation + retryability, one-shot adapter (success/empty/timeout/preflight/start-template), daemon end-to-end (generate→escalation, failure→retryable, retry re-drive), frontend confirm (writes file + task source + correction + send).
- Code review (subagent): rated Excellent; the one minor finding (stale-cutoff ignoring a long `generate_task_timeout_seconds`) is fixed in `expireStaleLLMWork`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)