### PR TITLE
#1 fix: refresh live herdr status/info on LLM retry instead of fabricating blocked

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1851,18 +1851,21 @@ func (d *Daemon) applyLLMRetry(ctx context.Context, r domain.LLMRetry) {
 		return
 	}
 
-	// Resolve the agent to its current pane — retry re-reads the LIVE screen,
-	// so the pane may differ from where the escalation first fired.
+	// Resolve the agent to its current pane AND its live herdr state — retry
+	// re-reads the LIVE screen, so the pane may differ from where the
+	// escalation first fired. ListAgents reports the real agent_status, type,
+	// and location; carry the WHOLE transition forward (like reconcileAttention)
+	// so the recapture reflects herdr's current snapshot, never a fabricated one.
 	agents, err := d.opt.Herdr.ListAgents(ctx)
 	if err != nil {
 		slog.Error("llm retry: listing agents failed", "agent", agentID, "error", err)
 		return
 	}
-	var paneID string
+	var live domain.AgentTransition
 	var found bool
 	for _, a := range agents {
 		if a.AgentID == agentID {
-			paneID, found = a.PaneID, true
+			live, found = a, true
 			break
 		}
 	}
@@ -1877,14 +1880,17 @@ func (d *Daemon) applyLLMRetry(ctx context.Context, r domain.LLMRetry) {
 		return
 	}
 
-	// Force an attention capture: "blocked" runs the delayed-capture path
-	// (handleAttention → classify → decideAndAct), which re-consults when the
-	// live pane still needs help. scheduleCapture coalesces per pane, so rapid
-	// double-retries collapse into one capture.
-	slog.Info("llm retry: re-driving consult", "agent", agentID, "pane", paneID)
-	d.scheduleCapture(ctx, domain.AgentTransition{
-		AgentID: agentID, PaneID: paneID, Status: "blocked",
-	})
+	// Re-drive the attention pipeline with the live transition. scheduleCapture
+	// fires unconditionally (it re-enters via delayedTr → handleAttention, not
+	// handleTransition, so the status does not gate the capture), re-reads the
+	// pane, and re-derives every gate at fire time — re-consulting when the live
+	// pane still needs help. Forwarding herdr's real status/type/location (vs a
+	// fabricated "blocked") keeps the trigger honest and lets the Claude
+	// structural detectors and signature lookup see the correct agent type.
+	// scheduleCapture coalesces per pane, so rapid double-retries collapse into
+	// one capture.
+	slog.Info("llm retry: re-driving consult", "agent", agentID, "pane", live.PaneID, "status", live.Status)
+	d.scheduleCapture(ctx, live)
 }
 
 func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domain.CorrectionRecord) error {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1661,6 +1661,68 @@ func TestRetryLLMAgentGoneNotifies(t *testing.T) {
 	}
 }
 
+// TestRetryLLMRefreshesLiveHerdrStatus proves the retry re-drives with herdr's
+// CURRENT status/type from `agent list`, not a fabricated "blocked". The
+// original escalation was recorded while herdr reported "blocked"; by retry
+// time the agent has moved on and herdr reports "done" with type "claude". The
+// re-driven escalation must render that live status (and carry the live agent
+// type), so a stale/fabricated status never leaks onto a retry.
+func TestRetryLLMRefreshesLiveHerdrStatus(t *testing.T) {
+	// No [llm] section → llm.configured is false, so the re-driven capture
+	// escalates deterministically (no consult branch) and we can assert the
+	// resulting trigger.
+	h := newHarness(t, "")
+	ctx := context.Background()
+
+	// Seed a retryable LLM escalation captured earlier at status "blocked".
+	seed, err := h.raw.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "agent-r", Signature: "sig", Trigger: "agent-status: blocked",
+		SituationType: domain.SituationApproval, Action: "escalated",
+		Rationale: "[llm_timeout] llm timeout", Status: "escalated", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Live herdr snapshot at retry time: the agent has moved on to "done" and
+	// its type is known. A pane is present for the re-classification read.
+	h.herdr.setPane(approvalPane)
+	h.herdr.setAgents([]domain.AgentTransition{
+		{AgentID: "agent-r", PaneID: "agent-r", AgentType: "claude", Status: "done"},
+	})
+
+	if _, err := h.raw.InsertLLMRetry(ctx, seed, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	h.daemon.processLLMRetries(ctx)
+
+	// The retry re-drives capture→classify→escalate on the live status. A new
+	// escalation appears whose trigger reflects herdr's REAL status ("done"),
+	// never the fabricated "blocked". Using "blocked" here (as the old code
+	// did) would have produced another "agent-status: blocked" row instead.
+	var redriven domain.AuditRecord
+	waitFor(t, 5*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(ctx)
+		for _, e := range esc {
+			if e.ID != seed && e.AgentID == "agent-r" {
+				redriven = e
+				return true
+			}
+		}
+		return false
+	})
+	if redriven.Trigger != "agent-status: done" {
+		t.Errorf("re-driven escalation trigger = %q, want %q (herdr's live status)",
+			redriven.Trigger, "agent-status: done")
+	}
+	// The live agent type must propagate too (empty type would fall back to
+	// "unknown" and break Claude's structural detectors / signature lookup).
+	if redriven.AgentType != "claude" {
+		t.Errorf("re-driven escalation agent type = %q, want \"claude\" (live from agent list)",
+			redriven.AgentType)
+	}
+}
+
 func contains(s, sub string) bool { return strings.Contains(s, sub) }
 
 func TestAgentNamedOnDiscoveryAndWorking(t *testing.T) {


### PR DESCRIPTION
applyLLMRetry resolved the agent's live pane via ListAgents but discarded
the live agent_status, agent type, and tab/workspace, then re-drove the
capture with a hardcoded Status: "blocked" and empty AgentType. A retried
escalation therefore rendered agent-status: blocked even when herdr now
reported idle/done, and lost location/type context.

Carry the whole live AgentTransition from ListAgents into scheduleCapture,
mirroring reconcileAttention. The recapture now reflects herdr's current
snapshot: real status (honest trigger), real agent type (re-enables the
Claude MCQ/error structural detectors and makes the retry's signature
match the original escalation), and real tab/workspace. The pane text is
still re-read fresh in handleAttention. scheduleCapture fires
unconditionally (delayedTr -> handleAttention), so status never gated the
capture — the fabricated "blocked" was unnecessary as well as wrong.

Add TestRetryLLMRefreshesLiveHerdrStatus: a retry on an agent herdr now
reports as done/claude escalates with agent-status: done and agent type
claude, not the fabricated blocked/unknown.