### PR TITLE
#60 fix: isolate the embedder in a subprocess so a native abort degrades instead of killing the daemon

### DIFF
--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -108,6 +108,12 @@ func run(verb string, args []string) error {
 	switch verb {
 	case "daemon":
 		return runDaemon(ctx, paths, args)
+	case "embed-worker":
+		// Internal subcommand: the short-lived child that the embedder Client
+		// spawns to run llama.cpp out-of-process. It takes its config from the
+		// environment the parent sets and speaks the framed stdin/stdout embed
+		// protocol; not meant to be run by hand.
+		return embedder.RunWorker(ctx, os.Stdin, os.Stdout)
 	case "mcp":
 		return runMCP(ctx, paths)
 	case "tui":

--- a/internal/embedder/client.go
+++ b/internal/embedder/client.go
@@ -1,0 +1,305 @@
+package embedder
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+)
+
+// Client is the production EmbedderPort: it runs the CGO embedder engine
+// out-of-process in a `hap embed-worker` child and talks to it over a framed
+// pipe. This is the fix for #60 — a native abort in llama.cpp (GGML_ASSERT →
+// SIGABRT) is uncatchable from Go and, in-process, killed the whole daemon.
+// Isolated in a child, that abort instead closes the pipe, which the parent
+// reads as an ordinary Go error: it counts toward the same degrade-after-N
+// latch the in-process engine used and drops semantic matching to BM25, the
+// daemon staying up. This makes the architecture invariant "semantic matching
+// degrades, never blocks" actually achievable.
+//
+// The worker is persistent (kept warm across calls so the model loads once);
+// the Client supervises it — one live child at a time, respawned on the next
+// call after any transport failure, killed and restarted on a stall, and
+// abandoned once the latch trips.
+type Client struct {
+	modelPath string
+	gpuLayers int
+
+	// execPath/execArgs/extraEnv build the worker command. Production uses the
+	// running binary's `embed-worker` subcommand; tests inject a re-exec of the
+	// test binary via NewReexecClient. The model/gpu config always travels in
+	// the environment (see spawn), so execArgs need not carry it.
+	execPath string
+	execArgs []string
+	extraEnv []string
+
+	mu   sync.Mutex             // serializes request/response over the single pipe
+	proc atomic.Pointer[worker] // current live child, or nil
+
+	dims     atomic.Int32
+	failures atomic.Int32
+	degraded atomic.Bool
+	closed   atomic.Bool
+}
+
+// stderrTailBytes bounds the captured worker stderr kept for the degrade
+// reason; enough to hold a GGML_ASSERT backtrace line.
+const stderrTailBytes = 8 << 10
+
+// New builds the production embedder Client. An empty ModelPath resolves to the
+// bundled model under the plugin root. The worker is the running binary's
+// `hap embed-worker` subcommand; nothing spawns until the first EmbedText.
+func New(cfg config.Embedding) *Client {
+	return &Client{
+		modelPath: ResolveModelPath(cfg),
+		gpuLayers: cfg.GPULayers,
+		execArgs:  []string{"embed-worker"},
+	}
+}
+
+// worker is one live child process and its pipes.
+type worker struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.Reader
+	stderr *ringBuffer
+	once   sync.Once
+	warmed atomic.Bool // this child's first successful embed done (model loaded)
+}
+
+// shutdown closes stdin, kills the child, and reaps it — at most once, so the
+// EmbedText error path and Close can both call it without double-Wait.
+func (w *worker) shutdown() {
+	w.once.Do(func() {
+		_ = w.stdin.Close()
+		if w.cmd.Process != nil {
+			_ = w.cmd.Process.Kill()
+		}
+		_ = w.cmd.Wait() // reaps; also drains remaining stderr into the ring
+	})
+}
+
+func (c *Client) spawn() (*worker, error) {
+	exe := c.execPath
+	if exe == "" {
+		e, err := os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("resolve hap binary for embed worker: %w", err)
+		}
+		exe = e
+	}
+	cmd := exec.Command(exe, c.execArgs...)
+	cmd.Env = append(os.Environ(),
+		EnvWorkerModel+"="+c.modelPath,
+		EnvWorkerGPULayers+"="+strconv.Itoa(c.gpuLayers),
+	)
+	cmd.Env = append(cmd.Env, c.extraEnv...)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, err
+	}
+	ring := newRingBuffer(stderrTailBytes)
+	// Forward the worker's stderr to the ring (for the degrade reason) and to
+	// our own stderr. For the detached daemon our stderr is captured to
+	// daemon.stderr.log, so a native GGML_ASSERT line is recoverable post-mortem
+	// (the UX half of #60) rather than lost to /dev/null.
+	cmd.Stderr = io.MultiWriter(ring, os.Stderr)
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("start embed worker: %w", err)
+	}
+	return &worker{cmd: cmd, stdin: stdin, stdout: stdout, stderr: ring}, nil
+}
+
+// EmbedText returns the L2-normalized embedding of text, computed by the worker
+// child. The first call spawns the worker and loads the model (warm timeout);
+// later calls use the short stall timeout. A worker crash or stall becomes an
+// error here and, after maxConsecutiveFailures, latches degraded mode — the
+// exact contract the in-process engine offered, now crash-proof.
+func (c *Client) EmbedText(ctx context.Context, text string) ([]float32, error) {
+	if c.closed.Load() {
+		return nil, fmt.Errorf("embedder closed")
+	}
+	if c.degraded.Load() {
+		return nil, ErrDegraded
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed.Load() { // Close won the race while we queued on the mutex
+		return nil, fmt.Errorf("embedder closed")
+	}
+
+	w, err := c.ensureWorker()
+	if err != nil {
+		c.recordFailure()
+		return nil, err
+	}
+
+	// The warm budget is per-worker, not per-client: a freshly (re)spawned
+	// worker must reload the model, so its first embed gets warmTimeout even
+	// after an earlier worker warmed. Latching this at the client level would
+	// bill a post-crash cold reload at the short stall timeout and could turn a
+	// single transient worker death into a permanent BM25 latch. The daemon's
+	// Dims()>0 gate still keeps the select loop off the very first (cold) load.
+	timeout := embedTimeout
+	if !w.warmed.Load() {
+		timeout = warmTimeout
+	}
+
+	type result struct {
+		vec []float32
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		if werr := writeRequest(w.stdin, text); werr != nil {
+			ch <- result{nil, werr}
+			return
+		}
+		vec, rerr := readResponse(w.stdout)
+		ch <- result{vec, rerr}
+	}()
+
+	select {
+	case <-ctx.Done():
+		// Caller gave up (shutdown/deadline). Kill the worker to resync the pipe
+		// — the in-flight round-trip owns it — but do NOT count this as an
+		// embedder fault (matches the in-process engine).
+		c.stopWorker(w)
+		return nil, ctx.Err()
+	case <-time.After(timeout):
+		reason := c.stopWorker(w)
+		c.recordFailure()
+		return nil, fmt.Errorf("embed call exceeded %s stall guard%s", timeout, stderrSuffix(reason))
+	case r := <-ch:
+		if r.err != nil {
+			var embErr *EmbedError
+			if errors.As(r.err, &embErr) {
+				// The worker is alive and the pipe is in sync — a plain embed
+				// failure (missing model, bad input, worker-side degrade). Keep
+				// the warm worker; just count the failure.
+				c.recordFailure()
+				return nil, fmt.Errorf("embed: %s", embErr.Msg)
+			}
+			// Transport error: the worker died (native abort) or the pipe
+			// desynced. Tear it down; the next call respawns a fresh one.
+			reason := c.stopWorker(w)
+			c.recordFailure()
+			return nil, fmt.Errorf("embed worker crashed: %w%s", r.err, stderrSuffix(reason))
+		}
+		c.failures.Store(0)
+		// The worker's engine already L2-normalized the vector before framing it.
+		c.dims.Store(int32(len(r.vec)))
+		w.warmed.Store(true)
+		return r.vec, nil
+	}
+}
+
+// ensureWorker returns the live worker, spawning one if needed. Caller holds mu.
+func (c *Client) ensureWorker() (*worker, error) {
+	if w := c.proc.Load(); w != nil {
+		return w, nil
+	}
+	w, err := c.spawn()
+	if err != nil {
+		return nil, err
+	}
+	c.proc.Store(w)
+	return w, nil
+}
+
+// stopWorker detaches w from the client and shuts it down, returning its
+// captured stderr tail for the error message.
+func (c *Client) stopWorker(w *worker) string {
+	c.proc.CompareAndSwap(w, nil)
+	w.shutdown()
+	return w.stderr.String()
+}
+
+func (c *Client) recordFailure() {
+	if c.failures.Add(1) >= maxConsecutiveFailures && !c.degraded.Swap(true) {
+		slog.Warn("embedder degraded; semantic matching falls back to text search",
+			"model", c.modelPath, "consecutive_failures", maxConsecutiveFailures)
+	}
+}
+
+// ModelID identifies the loaded model for persistence scoping.
+func (c *Client) ModelID() string { return filepath.Base(c.modelPath) }
+
+// Dims is the embedding dimensionality (0 before the first successful embed).
+func (c *Client) Dims() int { return int(c.dims.Load()) }
+
+// Degraded reports whether the failure latch has tripped. Type-asserted by the
+// daemon's health heartbeat, mirroring the in-process engine.
+func (c *Client) Degraded() bool { return c.degraded.Load() }
+
+// Close stops the worker. It must never block the daemon select loop, so the
+// child is killed and reaped on a background goroutine.
+func (c *Client) Close() error {
+	if c.closed.Swap(true) {
+		return nil
+	}
+	if w := c.proc.Swap(nil); w != nil {
+		go w.shutdown()
+	}
+	return nil
+}
+
+// stderrSuffix formats a captured worker-stderr tail for an error message,
+// collapsing it to the trailing non-empty lines that carry the abort reason.
+func stderrSuffix(tail string) string {
+	tail = strings.TrimSpace(tail)
+	if tail == "" {
+		return ""
+	}
+	lines := strings.Split(tail, "\n")
+	if len(lines) > 4 {
+		lines = lines[len(lines)-4:]
+	}
+	return "; worker stderr: " + strings.Join(lines, " | ")
+}
+
+// ringBuffer is a bounded io.Writer that keeps only the last cap bytes written
+// — a fixed-size tail of the worker's stderr, safe for concurrent writes by the
+// exec stderr-copier and reads by the error path.
+type ringBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+	cap int
+}
+
+func newRingBuffer(capBytes int) *ringBuffer { return &ringBuffer{cap: capBytes} }
+
+func (r *ringBuffer) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.buf = append(r.buf, p...)
+	if len(r.buf) > r.cap {
+		r.buf = r.buf[len(r.buf)-r.cap:]
+	}
+	return len(p), nil
+}
+
+func (r *ringBuffer) String() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return string(r.buf)
+}

--- a/internal/embedder/client_test.go
+++ b/internal/embedder/client_test.go
@@ -1,0 +1,192 @@
+package embedder
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+)
+
+// TestMain lets a Client under test spawn the embed worker by re-execing this
+// test binary (see NewReexecClient / RunWorkerHelperIfChild).
+func TestMain(m *testing.M) {
+	RunWorkerHelperIfChild() // returns immediately in a normal test run
+	os.Exit(m.Run())
+}
+
+// TestProtocolRoundTrip checks the wire framing survives text with newlines —
+// the reason it is length-prefixed rather than line-delimited.
+func TestProtocolRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	msg := "permission: edit\nthe config\r\nfile\n\n1. Yes\n2. No"
+	if err := writeRequest(&buf, msg); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readRequest(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != msg {
+		t.Errorf("round-trip = %q, want %q", got, msg)
+	}
+
+	var vbuf bytes.Buffer
+	vec := []float32{0.1, -0.2, 0.3, 0}
+	if err := writeVecResponse(&vbuf, vec); err != nil {
+		t.Fatal(err)
+	}
+	rvec, err := readResponse(&vbuf)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(rvec) != len(vec) {
+		t.Fatalf("dims = %d, want %d", len(rvec), len(vec))
+	}
+	for i := range vec {
+		if rvec[i] != vec[i] {
+			t.Errorf("vec[%d] = %v, want %v", i, rvec[i], vec[i])
+		}
+	}
+
+	var ebuf bytes.Buffer
+	if err := writeErrResponse(&ebuf, "boom"); err != nil {
+		t.Fatal(err)
+	}
+	_, err = readResponse(&ebuf)
+	var ee *EmbedError
+	if !errors.As(err, &ee) || ee.Msg != "boom" {
+		t.Errorf("err = %v, want *EmbedError{boom}", err)
+	}
+}
+
+// TestClientWorkerCrashDegrades is the core correctness assertion for #60: a
+// worker that aborts natively (mimicked by HAP_EMBED_WORKER_CRASH exiting the
+// child before it responds) surfaces as a Go ERROR on the parent — never a
+// panic or a parent death — and after maxConsecutiveFailures the Client latches
+// ErrDegraded, i.e. semantic matching degrades to BM25 while the daemon stays
+// up. Needs no model: the worker exits before loading one.
+func TestClientWorkerCrashDegrades(t *testing.T) {
+	c := NewReexecClient(
+		config.Embedding{ModelPath: filepath.Join(t.TempDir(), "unused.gguf")},
+		EnvWorkerCrash+"=1", // child exits on its first request, every spawn
+	)
+	defer c.Close()
+
+	ctx := context.Background()
+	for i := 0; i < maxConsecutiveFailures; i++ {
+		vec, err := c.EmbedText(ctx, "anything")
+		if err == nil {
+			t.Fatalf("call %d: a crashing worker must surface an error", i)
+		}
+		if vec != nil {
+			t.Fatalf("call %d: got a vector from a crashing worker", i)
+		}
+		if errors.Is(err, ErrDegraded) {
+			t.Fatalf("call %d: latched too early (before %d failures)", i, maxConsecutiveFailures)
+		}
+	}
+
+	// Latch tripped: further calls fail fast with ErrDegraded, no subprocess.
+	if _, err := c.EmbedText(ctx, "anything"); !errors.Is(err, ErrDegraded) {
+		t.Errorf("after %d worker crashes err = %v, want ErrDegraded", maxConsecutiveFailures, err)
+	}
+	if !c.Degraded() {
+		t.Error("Degraded() = false after the latch tripped")
+	}
+	if c.Dims() != 0 {
+		t.Errorf("Dims() = %d, want 0 (no successful embed)", c.Dims())
+	}
+	// The whole point: this test process reached here alive.
+}
+
+// TestClientContextCancelNotCounted confirms a caller giving up (ctx cancel)
+// does not push the Client toward the degrade latch, matching the engine.
+func TestClientContextCancelNotCounted(t *testing.T) {
+	c := NewReexecClient(config.Embedding{ModelPath: filepath.Join(t.TempDir(), "unused.gguf")})
+	defer c.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already done before the call
+	if _, err := c.EmbedText(ctx, "anything"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if c.Degraded() {
+		t.Error("a cancelled call must not count as an embedder fault")
+	}
+}
+
+// TestClientRealModel exercises the full subprocess path with the real gguf:
+// the framing, spawn, model load, and embed all work end to end, and the warm
+// worker is reused across calls. Skips when the model is absent.
+func TestClientRealModel(t *testing.T) {
+	c := NewReexecClient(config.Embedding{ModelPath: testModelPath(t)})
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	v1, err := c.EmbedText(ctx, "permission: edit the configuration file")
+	if err != nil {
+		t.Fatalf("embed via worker: %v", err)
+	}
+	if len(v1) != 384 {
+		t.Errorf("dims = %d, want 384 (MiniLM-L6)", len(v1))
+	}
+	if c.Dims() != len(v1) {
+		t.Errorf("Dims() = %d, want %d", c.Dims(), len(v1))
+	}
+	var norm float64
+	for _, x := range v1 {
+		norm += float64(x) * float64(x)
+	}
+	if math.Abs(norm-1.0) > 1e-3 {
+		t.Errorf("norm² = %v, want 1.0 (worker must return a normalized vector)", norm)
+	}
+
+	// Second call reuses the warm worker (no reload) and is deterministic.
+	v2, err := c.EmbedText(ctx, "permission: edit the configuration file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dot float64
+	for i := range v1 {
+		dot += float64(v1[i]) * float64(v2[i])
+	}
+	if dot < 0.999 {
+		t.Errorf("self-similarity across warm-worker calls = %v, want ≈1.0", dot)
+	}
+}
+
+// TestClientRecoversAfterWorkerCrash proves per-call recovery: with the worker
+// set to crash on its SECOND request, the first embed succeeds, the second
+// surfaces an error (not a process death), and the third succeeds again on a
+// freshly respawned worker — a single bad embed no longer latches the whole
+// process to BM25. Needs the real model (the first embed must load it).
+func TestClientRecoversAfterWorkerCrash(t *testing.T) {
+	c := NewReexecClient(config.Embedding{ModelPath: testModelPath(t)}, EnvWorkerCrash+"=2")
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	if _, err := c.EmbedText(ctx, "first"); err != nil {
+		t.Fatalf("first embed should succeed: %v", err)
+	}
+	if _, err := c.EmbedText(ctx, "second"); err == nil {
+		t.Fatal("second embed should error (worker crashes on its 2nd request)")
+	}
+	if c.Degraded() {
+		t.Fatal("one crash must not latch degraded")
+	}
+	// A fresh worker was spawned; it crashes only on ITS second request, so the
+	// next call succeeds.
+	if _, err := c.EmbedText(ctx, "third"); err != nil {
+		t.Fatalf("third embed should succeed on a respawned worker: %v", err)
+	}
+}

--- a/internal/embedder/embedder.go
+++ b/internal/embedder/embedder.go
@@ -58,9 +58,17 @@ type Llama struct {
 	closed   atomic.Bool
 }
 
-// New builds an embedder from config. An empty ModelPath resolves to the
-// bundled model under the plugin root (<root>/models/...).
-func New(cfg config.Embedding) *Llama {
+// NewEngine builds the in-process, CGO-backed embedder from config. An empty
+// ModelPath resolves to the bundled model under the plugin root
+// (<root>/models/...).
+//
+// This is the engine that actually links llama.cpp. In production it runs
+// inside the `hap embed-worker` child process (see RunWorker), never in the
+// daemon itself: a native abort in llama.cpp (GGML_ASSERT → SIGABRT) is
+// uncatchable from Go and would take the whole process down, so the daemon
+// drives it out-of-process through Client instead (see New). Direct callers
+// are the worker and the engine's own tests.
+func NewEngine(cfg config.Embedding) *Llama {
 	return &Llama{modelPath: ResolveModelPath(cfg), gpuLayers: cfg.GPULayers}
 }
 

--- a/internal/embedder/embedder_test.go
+++ b/internal/embedder/embedder_test.go
@@ -35,7 +35,7 @@ func cosine(a, b []float32) float64 {
 }
 
 func TestEmbedTextRealModel(t *testing.T) {
-	l := New(config.Embedding{ModelPath: testModelPath(t)})
+	l := NewEngine(config.Embedding{ModelPath: testModelPath(t)})
 	defer l.Close()
 	ctx := context.Background()
 
@@ -85,7 +85,7 @@ func TestEmbedTextRealModel(t *testing.T) {
 }
 
 func TestEmbedMissingModelDegrades(t *testing.T) {
-	l := New(config.Embedding{ModelPath: filepath.Join(t.TempDir(), "missing.gguf")})
+	l := NewEngine(config.Embedding{ModelPath: filepath.Join(t.TempDir(), "missing.gguf")})
 	defer l.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -102,11 +102,11 @@ func TestEmbedMissingModelDegrades(t *testing.T) {
 }
 
 func TestModelIDIsBasename(t *testing.T) {
-	l := New(config.Embedding{ModelPath: "/x/y/custom-model.gguf"})
+	l := NewEngine(config.Embedding{ModelPath: "/x/y/custom-model.gguf"})
 	if l.ModelID() != "custom-model.gguf" {
 		t.Errorf("ModelID = %q", l.ModelID())
 	}
-	def := New(config.Embedding{})
+	def := NewEngine(config.Embedding{})
 	if def.ModelID() != DefaultModelFile {
 		t.Errorf("default ModelID = %q, want %q", def.ModelID(), DefaultModelFile)
 	}

--- a/internal/embedder/protocol.go
+++ b/internal/embedder/protocol.go
@@ -1,0 +1,147 @@
+package embedder
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+)
+
+// The embed-worker wire protocol. A parent Client and a child worker exchange
+// one request/response per embed over the child's stdin/stdout. Framing is
+// length-prefixed binary, NOT newline-delimited: the masked salient text
+// carried in a request routinely contains newlines, so a line-oriented framing
+// would corrupt it.
+//
+// Request  (parent → worker):  uint32 len (big-endian) + len bytes of UTF-8 text.
+// Response (worker → parent):  1 status byte, then
+//   - respOK:  uint32 dim count (big-endian) + dim × float32 (little-endian), or
+//   - respErr: uint32 len (big-endian) + len bytes of UTF-8 error text.
+//
+// maxFrameBytes caps a single frame so a desynced pipe (e.g. a half-dead
+// worker) can't make the peer allocate unbounded memory; salient text and a
+// 384-dim vector are both far under it.
+const (
+	respOK  byte = 0
+	respErr byte = 1
+
+	maxFrameBytes = 8 << 20 // 8 MiB
+)
+
+// EmbedError is a well-formed error RESPONSE from a still-alive worker (a plain
+// embed failure: missing model, bad input, worker-side degrade). The Client
+// distinguishes it from a transport error — a dead worker / desynced pipe —
+// because the former leaves the warm worker reusable while the latter forces a
+// restart.
+type EmbedError struct{ Msg string }
+
+func (e *EmbedError) Error() string { return e.Msg }
+
+// writeRequest frames text and writes it to w.
+func writeRequest(w io.Writer, text string) error {
+	return writeLenBytes(w, []byte(text))
+}
+
+// readRequest reads one framed request from r.
+func readRequest(r io.Reader) (string, error) {
+	b, err := readLenBytes(r)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// writeVecResponse writes a successful embedding response.
+func writeVecResponse(w io.Writer, vec []float32) error {
+	buf := make([]byte, 1+4+4*len(vec))
+	buf[0] = respOK
+	binary.BigEndian.PutUint32(buf[1:5], uint32(len(vec)))
+	for i, f := range vec {
+		binary.LittleEndian.PutUint32(buf[5+4*i:9+4*i], math.Float32bits(f))
+	}
+	_, err := w.Write(buf)
+	return err
+}
+
+// writeErrResponse writes an error response carrying msg.
+func writeErrResponse(w io.Writer, msg string) error {
+	b := []byte(msg)
+	if len(b) > maxFrameBytes {
+		b = b[:maxFrameBytes]
+	}
+	buf := make([]byte, 1+4+len(b))
+	buf[0] = respErr
+	binary.BigEndian.PutUint32(buf[1:5], uint32(len(b)))
+	copy(buf[5:], b)
+	_, err := w.Write(buf)
+	return err
+}
+
+// readResponse reads one response frame. A respErr frame is returned as a
+// non-nil error whose text is the worker's message; a respOK frame yields the
+// vector. An unexpected EOF (the worker died mid-response — e.g. a native
+// SIGABRT) surfaces as an error here, which is exactly what turns an
+// uncatchable native abort into a catchable Go error on the parent.
+func readResponse(r io.Reader) ([]float32, error) {
+	var status [1]byte
+	if _, err := io.ReadFull(r, status[:]); err != nil {
+		return nil, err
+	}
+	switch status[0] {
+	case respErr:
+		b, err := readLenBytes(r)
+		if err != nil {
+			return nil, err
+		}
+		return nil, &EmbedError{Msg: string(b)}
+	case respOK:
+		var lenBuf [4]byte
+		if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+			return nil, err
+		}
+		n := binary.BigEndian.Uint32(lenBuf[:])
+		if int64(n)*4 > maxFrameBytes {
+			return nil, fmt.Errorf("embed response vector too large: %d dims", n)
+		}
+		raw := make([]byte, 4*n)
+		if _, err := io.ReadFull(r, raw); err != nil {
+			return nil, err
+		}
+		vec := make([]float32, n)
+		for i := range vec {
+			vec[i] = math.Float32frombits(binary.LittleEndian.Uint32(raw[4*i : 4*i+4]))
+		}
+		return vec, nil
+	default:
+		return nil, fmt.Errorf("embed worker sent unknown response status %d", status[0])
+	}
+}
+
+func writeLenBytes(w io.Writer, b []byte) error {
+	if len(b) > maxFrameBytes {
+		return fmt.Errorf("frame too large: %d bytes", len(b))
+	}
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(b)))
+	if _, err := w.Write(lenBuf[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(b)
+	return err
+}
+
+func readLenBytes(r io.Reader) ([]byte, error) {
+	var lenBuf [4]byte
+	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+		return nil, err
+	}
+	n := binary.BigEndian.Uint32(lenBuf[:])
+	if n > maxFrameBytes {
+		return nil, fmt.Errorf("frame too large: %d bytes", n)
+	}
+	b := make([]byte, n)
+	if _, err := io.ReadFull(r, b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}

--- a/internal/embedder/reexec.go
+++ b/internal/embedder/reexec.go
@@ -1,0 +1,41 @@
+package embedder
+
+import (
+	"context"
+	"os"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+)
+
+// envWorkerHelper, when set on a test binary, makes RunWorkerHelperIfChild run
+// the embed worker instead of the test suite. It lets a Client under test spawn
+// the embed worker by re-execing the current test binary — so the subprocess
+// isolation path is exercised without a real `hap` on PATH. Production main.go
+// never consults it (the real binary uses the `embed-worker` subcommand).
+const envWorkerHelper = "HAP_EMBED_WORKER_HELPER"
+
+// RunWorkerHelperIfChild runs the embed worker and exits when the current
+// process was spawned as an embed-worker re-exec (envWorkerHelper set);
+// otherwise it returns and the caller proceeds normally. Call it first thing in
+// a TestMain whose package constructs a Client via NewReexecClient.
+func RunWorkerHelperIfChild() {
+	if os.Getenv(envWorkerHelper) != "1" {
+		return
+	}
+	// Config (model/gpu) arrives via the same environment the real worker reads.
+	_ = RunWorker(context.Background(), os.Stdin, os.Stdout)
+	os.Exit(0)
+}
+
+// NewReexecClient builds a Client whose worker is a re-exec of the current test
+// binary (os.Args[0]) rather than the `hap` binary — the injectable worker seam
+// the tests use. extraEnv is appended to the child environment (e.g.
+// EnvWorkerCrash for fault injection). The package's TestMain must call
+// RunWorkerHelperIfChild so the re-exec becomes a worker.
+func NewReexecClient(cfg config.Embedding, extraEnv ...string) *Client {
+	c := New(cfg)
+	c.execPath = os.Args[0]
+	c.execArgs = nil
+	c.extraEnv = append([]string{envWorkerHelper + "=1"}, extraEnv...)
+	return c
+}

--- a/internal/embedder/worker.go
+++ b/internal/embedder/worker.go
@@ -1,0 +1,112 @@
+package embedder
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+)
+
+// Environment variables the parent Client sets on the `hap embed-worker`
+// child. The worker takes its whole configuration from the environment (not
+// argv) so the same spawn mechanism works for the real binary and for the
+// test-binary re-exec used by the Client tests.
+const (
+	// EnvWorkerModel is the gguf path the worker loads (required).
+	EnvWorkerModel = "HAP_EMBED_MODEL"
+	// EnvWorkerGPULayers is the GPU offload layer count (optional, default 0).
+	EnvWorkerGPULayers = "HAP_EMBED_GPU_LAYERS"
+	// EnvWorkerCrash is a TEST/FAULT-INJECTION seam: set to N and the worker
+	// os.Exit(134)s (mimicking a SIGABRT) when it receives its N-th embed
+	// request, before responding. It exists so the isolation contract — a
+	// native worker abort surfaces as a Go error on the parent, degrading
+	// instead of blocking — can be exercised on platforms where the real
+	// llama.cpp GGML_ASSERT (arm64 macOS, #60) cannot be triggered. Never set
+	// in production.
+	EnvWorkerCrash = "HAP_EMBED_WORKER_CRASH"
+)
+
+// crashExitCode mirrors the shell convention for a process killed by SIGABRT
+// (128 + SIGABRT(6)), so the injected fault looks like the real native abort.
+const crashExitCode = 134
+
+// workerConfigFromEnv reads the worker's embedding config from the environment
+// set by the parent Client.
+func workerConfigFromEnv() (config.Embedding, error) {
+	model := os.Getenv(EnvWorkerModel)
+	if model == "" {
+		return config.Embedding{}, fmt.Errorf("%s is not set", EnvWorkerModel)
+	}
+	cfg := config.Embedding{ModelPath: model}
+	if v := os.Getenv(EnvWorkerGPULayers); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return config.Embedding{}, fmt.Errorf("invalid %s=%q: %w", EnvWorkerGPULayers, v, err)
+		}
+		cfg.GPULayers = n
+	}
+	return cfg, nil
+}
+
+// RunWorker is the body of the `hap embed-worker` subcommand. It loads the
+// in-process CGO engine once and services length-prefixed embed requests from
+// in, writing framed responses to out, until in reaches EOF or ctx is done.
+//
+// It is deliberately dumb: it holds no failure latch and never retries. If a
+// request embeds cleanly it returns the vector; if the engine errors it returns
+// an error frame; if llama.cpp aborts natively the process simply dies and the
+// parent observes the closed pipe. All supervision — timeouts, the
+// degrade-after-N latch, restarts — lives in the parent Client.
+func RunWorker(ctx context.Context, in io.Reader, out io.Writer) error {
+	cfg, err := workerConfigFromEnv()
+	if err != nil {
+		return err
+	}
+	crashAt := 0
+	if v := os.Getenv(EnvWorkerCrash); v != "" {
+		crashAt, _ = strconv.Atoi(v)
+	}
+
+	eng := NewEngine(cfg)
+	defer eng.Close()
+
+	// bufio around stdout so each response is a single flushed write; requests
+	// are read straight from in (io.ReadFull needs no buffering).
+	bw := bufio.NewWriter(out)
+
+	requests := 0
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		text, err := readRequest(in)
+		if err != nil {
+			if err == io.EOF {
+				return nil // parent closed the pipe: clean shutdown
+			}
+			return err
+		}
+		requests++
+		if crashAt > 0 && requests >= crashAt {
+			// Fault-injection seam: die before responding so THIS request errors
+			// on the parent, mimicking a mid-embed native abort.
+			os.Exit(crashExitCode)
+		}
+
+		vec, embErr := eng.EmbedText(ctx, text)
+		if embErr != nil {
+			if werr := writeErrResponse(bw, embErr.Error()); werr != nil {
+				return werr
+			}
+		} else if werr := writeVecResponse(bw, vec); werr != nil {
+			return werr
+		}
+		if err := bw.Flush(); err != nil {
+			return err
+		}
+	}
+}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -1,0 +1,22 @@
+//go:build integration && vectors && cpu
+
+package integration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/embedder"
+)
+
+// TestMain lets the semantic test's subprocess-isolated embedder Client spawn
+// its worker by re-execing this test binary: when the child sets the worker
+// helper env, RunWorkerHelperIfChild runs the embed worker and exits instead of
+// running the suite. A normal run returns immediately and proceeds to the tests.
+//
+// Tagged the same as semantic_test.go (the only test needing the worker); the
+// lighter `-tags integration` build has no TestMain and is unaffected.
+func TestMain(m *testing.M) {
+	embedder.RunWorkerHelperIfChild()
+	os.Exit(m.Run())
+}

--- a/test/integration/semantic_test.go
+++ b/test/integration/semantic_test.go
@@ -179,7 +179,10 @@ func TestRealEmbeddingSemanticMatch(t *testing.T) {
 	}
 	defer st.Close()
 
-	emb := embedder.New(config.Embedding{ModelPath: modelPath})
+	// Route through the subprocess-isolated Client (the #60 fix), re-execing
+	// this test binary as the embed worker (see TestMain), so the real llama.cpp
+	// + FAISS pipeline is exercised end to end through the out-of-process path.
+	emb := embedder.NewReexecClient(config.Embedding{ModelPath: modelPath})
 	defer emb.Close()
 
 	fh := &semHerdr{}


### PR DESCRIPTION
On arm64 macOS the llama.cpp embedder aborts natively (GGML_ASSERT ->
ggml_abort -> SIGABRT). A native abort is uncatchable from Go, so the
in-process embedder took the whole daemon down: logging.Guard, the stall
guard, and the degrade-after-3 latch never ran. This violated the
architecture invariant "semantic matching degrades, never blocks" — the
crashguard/health work in v0.3.24-v0.3.27 mitigated the operational
crash-loop but the process still died on every embed.

Run the CGO engine out-of-process in a `hap embed-worker` child. A native
abort in the child now closes the pipe, which the parent reads as an
ordinary Go error and feeds into the same degrade-after-N latch the
in-process engine used, dropping semantic matching to BM25 while the daemon
stays up. Bonus: per-call recovery means one bad input fails a single embed
and moves on instead of latching the whole process to BM25.

- embedder.go: rename the in-process constructor New -> NewEngine (the
  worker-side engine; unchanged behavior).
- protocol.go: length-prefixed binary framing (salient text contains
  newlines, so line framing is wrong); an EOF mid-response — a worker crash —
  surfaces as a Go error.
- worker.go: RunWorker services framed embed requests over stdin/stdout;
  config travels in the environment. HAP_EMBED_WORKER_CRASH is a
  fault-injection seam that exits the child mid-run so the isolation contract
  is testable where the real GGML_ASSERT cannot be triggered.
- client.go: Client (now embedder.New) supervises a persistent warm worker —
  respawn on transport failure, kill+restart on stall, latch degraded after
  maxConsecutiveFailures, ctx-cancel not counted, worker stderr captured for
  the degrade reason and forwarded so a native abort still lands in
  daemon.stderr.log. Implements EmbedderPort + Degraded(), so the daemon and
  frontend are unchanged.
- cmd/hap: wire the internal embed-worker subcommand.
- tests: fault-injection proves crash -> error -> degrade with the parent
  alive; real-model tests prove the framing/spawn/warm-worker path and
  per-call crash recovery end to end. The integration test routes through the
  subprocess Client (also spares its test binary the SIGABRT on affected
  machines).

crashguard stays as the outer breaker; with isolation it should no longer
trip on embedder faults.