### PR TITLE
#82 fix: truncate embedder input to model context window (fixes native SIGABRT)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,19 @@ jobs:
           CGO_ENABLED=1 go build -tags "${GO_BUILD_TAGS}" -trimpath \
             -ldflags "-s -w -X github.com/0xGosu/herdr-auto-pilot/internal/buildinfo.Version=${VERSION} -extldflags '${RPATH}'" \
             -o "dist/hap-${{ matrix.target }}" ./cmd/hap
+      - name: Embed smoke test (>512 tokens, guards #82)
+        # A real embed on EACH native runner: catches a native GGML abort in
+        # the embedder before it ships. The input MUST exceed the model's 512
+        # position embeddings — a short string never trips the overflow (#82).
+        # TestEmbedLongInputNoCrash embeds a ~700-token string; the process
+        # SIGABRTs here if truncation regresses. shasum works on macOS + Linux.
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 5 --retry-delay 10 -o "${MODEL_FILE}" "${MODEL_URL}"
+          echo "${MODEL_SHA256}  ${MODEL_FILE}" | shasum -a 256 -c -
+          HAP_TEST_EMBED_MODEL="${PWD}/${MODEL_FILE}" \
+            go test -tags "${GO_BUILD_TAGS}" -count=1 \
+            -run 'TestEmbedLongInputNoCrash|TestEmbedTextRealModel' ./internal/embedder/
       - name: Bundle native runtime libraries
         run: |
           # llama.cpp is statically linked into the binary; only the FAISS

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,8 +146,11 @@ type Embedding struct {
 	// tokens before embedding, so it MUST NOT exceed what the model supports:
 	// feeding a BERT/MiniLM model more than its 512 positions hard-aborts the
 	// native library (#82). 0 → the built-in default
-	// (embedder.DefaultContextWindow, 512 for the bundled MiniLM). Raise it
-	// only when pointing model_path at a model with a larger window.
+	// (embedder.DefaultContextWindow, 512 for the bundled MiniLM). A positive
+	// value below embedder.minContextWindow (256) is clamped up to it — no
+	// real embedding model has a smaller window, and a tiny one can't hold the
+	// special tokens. Raise it only when pointing model_path at a model with a
+	// larger window.
 	ModelContextWindow int `toml:"model_context_window"`
 	// PaneSalientChars bounds the fallback salient window: for situations
 	// with no structured salient field (idle, and any unclassified content),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,6 +141,14 @@ type Embedding struct {
 	BM25MinScore float64 `toml:"bm25_min_score"`
 	// GPULayers offloads model layers to the GPU (0 = CPU only).
 	GPULayers int `toml:"gpu_layers"`
+	// ModelContextWindow overrides the embedding model's maximum sequence
+	// length (position-embedding limit). Input is truncated to this many
+	// tokens before embedding, so it MUST NOT exceed what the model supports:
+	// feeding a BERT/MiniLM model more than its 512 positions hard-aborts the
+	// native library (#82). 0 → the built-in default
+	// (embedder.DefaultContextWindow, 512 for the bundled MiniLM). Raise it
+	// only when pointing model_path at a model with a larger window.
+	ModelContextWindow int `toml:"model_context_window"`
 	// PaneSalientChars bounds the fallback salient window: for situations
 	// with no structured salient field (idle, and any unclassified content),
 	// the signature and its embedding are minted from the trailing this-many

--- a/internal/domain/signature.go
+++ b/internal/domain/signature.go
@@ -61,7 +61,12 @@ const overMaskMaxRatio = 0.6
 // structured salient field (idle, and any unclassified content), the
 // signature is minted from the last this-many characters of pane content.
 // Operators can widen or narrow it via embedding.pane_salient_chars.
-const DefaultPaneSalientChars = 800
+//
+// Kept comfortably below the embedding model's 512-token limit as a first
+// line of defense against the position-embedding overflow (#82): token-dense
+// content (CJK, box-drawing, code) can approach ~1 token/char, so 500 chars
+// stays clear of 512 even before the embedder's own truncation guard.
+const DefaultPaneSalientChars = 500
 
 // SignatureResult is the output of signature generation.
 type SignatureResult struct {

--- a/internal/domain/signature_test.go
+++ b/internal/domain/signature_test.go
@@ -183,7 +183,7 @@ func TestComputeSignatureNWindow(t *testing.T) {
 	if got, want := ComputeSignatureN(a, 0).Raw, ComputeSignature(a).Raw; got != want {
 		t.Errorf("salientChars<=0 should match the default: %q vs %q", got, want)
 	}
-	if DefaultPaneSalientChars != 800 {
-		t.Errorf("DefaultPaneSalientChars = %d, want 800", DefaultPaneSalientChars)
+	if DefaultPaneSalientChars != 500 {
+		t.Errorf("DefaultPaneSalientChars = %d, want 500", DefaultPaneSalientChars)
 	}
 }

--- a/internal/embedder/client.go
+++ b/internal/embedder/client.go
@@ -35,6 +35,7 @@ import (
 type Client struct {
 	modelPath string
 	gpuLayers int
+	ctxWindow int // model context window forwarded to the worker (0 = worker default)
 
 	// execPath/execArgs/extraEnv build the worker command. Production uses the
 	// running binary's `embed-worker` subcommand; tests inject a re-exec of the
@@ -64,6 +65,7 @@ func New(cfg config.Embedding) *Client {
 	return &Client{
 		modelPath: ResolveModelPath(cfg),
 		gpuLayers: cfg.GPULayers,
+		ctxWindow: cfg.ModelContextWindow, // 0 → worker uses DefaultContextWindow
 		execArgs:  []string{"embed-worker"},
 	}
 }
@@ -103,6 +105,7 @@ func (c *Client) spawn() (*worker, error) {
 	cmd.Env = append(os.Environ(),
 		EnvWorkerModel+"="+c.modelPath,
 		EnvWorkerGPULayers+"="+strconv.Itoa(c.gpuLayers),
+		EnvWorkerContextWindow+"="+strconv.Itoa(c.ctxWindow),
 	)
 	cmd.Env = append(cmd.Env, c.extraEnv...)
 

--- a/internal/embedder/embedder.go
+++ b/internal/embedder/embedder.go
@@ -37,6 +37,25 @@ const warmTimeout = 30 * time.Second
 // stays on its fallback path for the process lifetime.
 const maxConsecutiveFailures = 3
 
+// DefaultContextWindow is the BERT/MiniLM position-embedding limit (n_ctx) of
+// the bundled all-MiniLM-L6-v2: 512 position rows. Feeding GetEmbeddings a
+// sequence longer than the model's window overflows the position-embedding
+// get_rows and hard-aborts the native library (GGML_ASSERT(i01 < ne01) →
+// SIGABRT, #82) — uncatchable in Go, so the ONLY defense is to not exceed it.
+// Overridable per model via config Embedding.ModelContextWindow.
+const DefaultContextWindow = 512
+
+// specialTokenHeadroom is reserved out of the context window for the special
+// tokens the model adds ([CLS]/[SEP], plus a small margin) so the assembled
+// sequence stays strictly under the limit even if Tokenize and the internal
+// GetEmbeddings tokenizer disagree by a token or two.
+const specialTokenHeadroom = 8
+
+// truncateIters bounds the proportional-cut retry loop so a pathological
+// text→token ratio can never spin; each pass overshoots the cut, so it
+// converges in one or two iterations in practice.
+const truncateIters = 8
+
 // ErrDegraded is returned once the failure latch has tripped.
 var ErrDegraded = fmt.Errorf("embedder degraded after %d consecutive failures", maxConsecutiveFailures)
 
@@ -44,6 +63,7 @@ var ErrDegraded = fmt.Errorf("embedder degraded after %d consecutive failures", 
 type Llama struct {
 	modelPath string
 	gpuLayers int
+	ctxWindow int // model position-embedding limit (n_ctx); see DefaultContextWindow
 
 	initOnce sync.Once
 	initErr  error
@@ -69,7 +89,20 @@ type Llama struct {
 // drives it out-of-process through Client instead (see New). Direct callers
 // are the worker and the engine's own tests.
 func NewEngine(cfg config.Embedding) *Llama {
-	return &Llama{modelPath: ResolveModelPath(cfg), gpuLayers: cfg.GPULayers}
+	return &Llama{
+		modelPath: ResolveModelPath(cfg),
+		gpuLayers: cfg.GPULayers,
+		ctxWindow: ResolveContextWindow(cfg),
+	}
+}
+
+// ResolveContextWindow returns the configured embedding context window, or the
+// bundled model's default when unset/non-positive.
+func ResolveContextWindow(cfg config.Embedding) int {
+	if cfg.ModelContextWindow > 0 {
+		return cfg.ModelContextWindow
+	}
+	return DefaultContextWindow
 }
 
 // ResolveModelPath expands the configured model path, defaulting to the
@@ -106,7 +139,10 @@ func (l *Llama) init() {
 		l.initErr = fmt.Errorf("load embedding model %s: %w", l.modelPath, err)
 		return
 	}
-	lctx, err := model.NewContext(llama.WithEmbeddings())
+	// WithContext caps the KV/positional window at the model's limit — defense
+	// in depth alongside truncateToBudget; the truncation is what actually
+	// prevents the >n_ctx position-embedding overflow (#82).
+	lctx, err := model.NewContext(llama.WithEmbeddings(), llama.WithContext(l.ctxWindow))
 	if err != nil {
 		model.Close()
 		l.initErr = fmt.Errorf("create embedding context: %w", err)
@@ -148,7 +184,7 @@ func (l *Llama) EmbedText(ctx context.Context, text string) ([]float32, error) {
 			ch <- result{nil, l.initErr}
 			return
 		}
-		vec, err := l.lctx.GetEmbeddings(text)
+		vec, err := l.lctx.GetEmbeddings(l.truncateToBudget(text))
 		ch <- result{vec, err}
 	}()
 
@@ -171,6 +207,60 @@ func (l *Llama) EmbedText(ctx context.Context, text string) ([]float32, error) {
 		l.warmed.Store(true)
 		return r.vec, nil
 	}
+}
+
+// truncateToBudget shortens text so its tokenization stays within tokenBudget,
+// guaranteeing the sequence GetEmbeddings assembles never exceeds the model's
+// position-embedding limit (which would SIGABRT the native library, #82). It
+// must be called with l.mu held and after init (l.lctx valid).
+//
+// GetEmbeddings tokenizes internally and takes text, not tokens, so the cut is
+// made on the text: tokenize to measure, and if over budget, keep a prefix
+// sized by the current token→rune ratio (overshooting downward), then re-check.
+// The salient content is front-loaded, so a prefix is the right thing to keep.
+// A Tokenize error is non-fatal — fall through to GetEmbeddings, which will
+// surface its own error (degrading, never aborting the daemon).
+func (l *Llama) truncateToBudget(text string) string {
+	budget := l.ctxWindow - specialTokenHeadroom
+	if budget < 1 {
+		budget = 1
+	}
+	toks, err := l.lctx.Tokenize(text)
+	if err != nil || len(toks) <= budget {
+		return text
+	}
+	runes := []rune(text)
+	for i := 0; i < truncateIters && len(toks) > budget; i++ {
+		if len(runes) <= 1 {
+			break // nothing left to trim
+		}
+		// Overshoot by 5% under the proportional target so a sub-linear
+		// token→rune relationship still converges downward each pass.
+		keep := int(float64(len(runes)) * float64(budget) / float64(len(toks)) * 0.95)
+		if keep < 1 {
+			keep = 1
+		}
+		if keep >= len(runes) { // ratio made no progress: force a real cut
+			keep = len(runes) / 2
+		}
+		runes = runes[:keep]
+		toks, err = l.lctx.Tokenize(string(runes))
+		if err != nil {
+			break
+		}
+	}
+	// Guarantee the invariant the whole function exists for: the returned text
+	// must tokenize within budget, or GetEmbeddings SIGABRTs the worker (#82).
+	// The proportional loop can exit still-over-budget — bounded iterations, a
+	// Tokenize error, or an override window set above the model's real limit —
+	// so hard-halve the prefix until it fits. Halving reaches 1 rune, so this
+	// always terminates; a Tokenize error leaves toks stale and stops the loop
+	// (the embed then surfaces its own error and degrades, never aborts).
+	for err == nil && len(toks) > budget && len(runes) > 1 {
+		runes = runes[:len(runes)/2]
+		toks, err = l.lctx.Tokenize(string(runes))
+	}
+	return string(runes)
 }
 
 func (l *Llama) recordFailure() {

--- a/internal/embedder/embedder.go
+++ b/internal/embedder/embedder.go
@@ -51,6 +51,14 @@ const DefaultContextWindow = 512
 // GetEmbeddings tokenizer disagree by a token or two.
 const specialTokenHeadroom = 8
 
+// minContextWindow floors any positive ModelContextWindow override. A window
+// small enough that the budget can't even hold the special tokens (e.g. 1 or
+// 2) makes every input — including the empty string, which still tokenizes to
+// [CLS]/[SEP] — exceed n_ctx and SIGABRT the worker (#82, PR review). No real
+// embedding model has a window below this, so a lower value is always a
+// misconfiguration; clamp up to it rather than trust it.
+const minContextWindow = 256
+
 // truncateIters bounds the proportional-cut retry loop so a pathological
 // text→token ratio can never spin; each pass overshoots the cut, so it
 // converges in one or two iterations in practice.
@@ -96,13 +104,21 @@ func NewEngine(cfg config.Embedding) *Llama {
 	}
 }
 
-// ResolveContextWindow returns the configured embedding context window, or the
-// bundled model's default when unset/non-positive.
+// ResolveContextWindow returns the effective embedding context window: the
+// bundled model's default when unset/non-positive, otherwise the override
+// floored to minContextWindow. This is the single chokepoint for every
+// construction path (config and the HAP_EMBED_CONTEXT_WINDOW worker env both
+// reach the engine through NewEngine), so no sub-minimum window can ever reach
+// GetEmbeddings and abort the worker.
 func ResolveContextWindow(cfg config.Embedding) int {
-	if cfg.ModelContextWindow > 0 {
-		return cfg.ModelContextWindow
+	w := cfg.ModelContextWindow
+	if w <= 0 {
+		return DefaultContextWindow
 	}
-	return DefaultContextWindow
+	if w < minContextWindow {
+		return minContextWindow
+	}
+	return w
 }
 
 // ResolveModelPath expands the configured model path, defaulting to the

--- a/internal/embedder/embedder_test.go
+++ b/internal/embedder/embedder_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -82,6 +83,63 @@ func TestEmbedTextRealModel(t *testing.T) {
 			cosine(v1, para), cosine(v1, other))
 	}
 	t.Logf("paraphrase cos=%.3f unrelated cos=%.3f", cosine(v1, para), cosine(v1, other))
+}
+
+// TestEmbedLongInputNoCrash guards #82: a sequence longer than the model's
+// 512 position embeddings must be truncated, not fed whole — an untruncated
+// long input overflows the position-embedding get_rows and hard-aborts the
+// native library (SIGABRT), which would take the whole process down. The
+// embed must instead succeed on the truncated prefix and return a valid
+// vector. 700 space-delimited words tokenize well past 512.
+func TestEmbedLongInputNoCrash(t *testing.T) {
+	l := NewEngine(config.Embedding{ModelPath: testModelPath(t)})
+	defer l.Close()
+	ctx := context.Background()
+
+	long := strings.Repeat("word ", 700)
+	// Pre-truncation this aborts the process; post-fix it returns a vector.
+	v, err := l.EmbedText(ctx, long)
+	if err != nil {
+		t.Fatalf("long input should embed after truncation, got error: %v", err)
+	}
+	if len(v) != 384 {
+		t.Errorf("dims = %d, want 384", len(v))
+	}
+
+	// The truncated text alone must tokenize within budget — proves the guard
+	// actually bounded the sequence rather than the embed getting lucky.
+	l.initOnce.Do(l.init)
+	if l.initErr != nil {
+		t.Fatalf("init: %v", l.initErr)
+	}
+	safe := l.truncateToBudget(long)
+	toks, err := l.lctx.Tokenize(safe)
+	if err != nil {
+		t.Fatalf("tokenize truncated: %v", err)
+	}
+	budget := DefaultContextWindow - specialTokenHeadroom
+	if len(toks) > budget {
+		t.Errorf("truncated to %d tokens, want <= %d", len(toks), budget)
+	}
+
+	// A short input is returned unchanged (no needless truncation).
+	short := "permission: edit the config file"
+	if got := l.truncateToBudget(short); got != short {
+		t.Errorf("short input was altered: %q", got)
+	}
+
+	// A pathologically small context window must not panic (the proportional
+	// cut walking runes toward 0) and must still embed on the hard-clamped
+	// prefix.
+	tiny := NewEngine(config.Embedding{ModelPath: testModelPath(t), ModelContextWindow: 12})
+	defer tiny.Close()
+	tv, err := tiny.EmbedText(ctx, long)
+	if err != nil {
+		t.Fatalf("tiny-window embed should succeed on the clamped prefix, got: %v", err)
+	}
+	if len(tv) != 384 {
+		t.Errorf("tiny-window dims = %d, want 384", len(tv))
+	}
 }
 
 func TestEmbedMissingModelDegrades(t *testing.T) {

--- a/internal/embedder/embedder_test.go
+++ b/internal/embedder/embedder_test.go
@@ -128,17 +128,43 @@ func TestEmbedLongInputNoCrash(t *testing.T) {
 		t.Errorf("short input was altered: %q", got)
 	}
 
-	// A pathologically small context window must not panic (the proportional
-	// cut walking runes toward 0) and must still embed on the hard-clamped
-	// prefix.
-	tiny := NewEngine(config.Embedding{ModelPath: testModelPath(t), ModelContextWindow: 12})
+	// A pathologically small context window override is floored to
+	// minContextWindow (a window below it can't hold the special tokens and
+	// would SIGABRT). The engine must use the floor, not the raw value, and
+	// still embed the long input on the truncated prefix.
+	tiny := NewEngine(config.Embedding{ModelPath: testModelPath(t), ModelContextWindow: 1})
 	defer tiny.Close()
+	if tiny.ctxWindow != minContextWindow {
+		t.Errorf("ctxWindow = %d, want floored to %d", tiny.ctxWindow, minContextWindow)
+	}
 	tv, err := tiny.EmbedText(ctx, long)
 	if err != nil {
-		t.Fatalf("tiny-window embed should succeed on the clamped prefix, got: %v", err)
+		t.Fatalf("floored-window embed should succeed on the truncated prefix, got: %v", err)
 	}
 	if len(tv) != 384 {
-		t.Errorf("tiny-window dims = %d, want 384", len(tv))
+		t.Errorf("floored-window dims = %d, want 384", len(tv))
+	}
+}
+
+// TestResolveContextWindowFloor covers the override boundaries — 0/negative
+// fall to the default, and any positive value below the safe minimum (at or
+// below the special-token headroom included) is clamped up so the budget can
+// never go sub-headroom (#82, PR review).
+func TestResolveContextWindowFloor(t *testing.T) {
+	cases := []struct{ in, want int }{
+		{0, DefaultContextWindow},
+		{-5, DefaultContextWindow},
+		{1, minContextWindow},
+		{specialTokenHeadroom, minContextWindow},
+		{255, minContextWindow},
+		{minContextWindow, minContextWindow},
+		{512, 512},
+		{2048, 2048},
+	}
+	for _, c := range cases {
+		if got := ResolveContextWindow(config.Embedding{ModelContextWindow: c.in}); got != c.want {
+			t.Errorf("ResolveContextWindow(%d) = %d, want %d", c.in, got, c.want)
+		}
 	}
 }
 

--- a/internal/embedder/worker.go
+++ b/internal/embedder/worker.go
@@ -20,6 +20,9 @@ const (
 	EnvWorkerModel = "HAP_EMBED_MODEL"
 	// EnvWorkerGPULayers is the GPU offload layer count (optional, default 0).
 	EnvWorkerGPULayers = "HAP_EMBED_GPU_LAYERS"
+	// EnvWorkerContextWindow overrides the model's context window / token cap
+	// (optional; empty or "0" → DefaultContextWindow).
+	EnvWorkerContextWindow = "HAP_EMBED_CONTEXT_WINDOW"
 	// EnvWorkerCrash is a TEST/FAULT-INJECTION seam: set to N and the worker
 	// os.Exit(134)s (mimicking a SIGABRT) when it receives its N-th embed
 	// request, before responding. It exists so the isolation contract — a
@@ -48,6 +51,13 @@ func workerConfigFromEnv() (config.Embedding, error) {
 			return config.Embedding{}, fmt.Errorf("invalid %s=%q: %w", EnvWorkerGPULayers, v, err)
 		}
 		cfg.GPULayers = n
+	}
+	if v := os.Getenv(EnvWorkerContextWindow); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return config.Embedding{}, fmt.Errorf("invalid %s=%q: %w", EnvWorkerContextWindow, v, err)
+		}
+		cfg.ModelContextWindow = n
 	}
 	return cfg, nil
 }

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -638,6 +638,7 @@ var ConfigFields = []ConfigFieldDef{
 	{Key: "embedding.bm25_min_score", TUIEditable: true},
 	{Key: "embedding.gpu_layers", TUIEditable: true},
 	{Key: "embedding.pane_salient_chars", TUIEditable: true},
+	{Key: "embedding.model_context_window", TUIEditable: true},
 	{Key: "tui.max_content_width", TUIEditable: true},
 	{Key: "tui.theme", TUIEditable: true},
 }
@@ -739,6 +740,11 @@ func FieldValue(cfg config.Config, key string) string {
 		return fmt.Sprintf("%.2f", cfg.Embedding.BM25MinScore)
 	case "embedding.gpu_layers":
 		return strconv.Itoa(cfg.Embedding.GPULayers)
+	case "embedding.model_context_window":
+		if cfg.Embedding.ModelContextWindow <= 0 {
+			return fmt.Sprintf("%d (default)", embedder.DefaultContextWindow)
+		}
+		return strconv.Itoa(cfg.Embedding.ModelContextWindow)
 	case "safety.disable_seed":
 		return strconv.FormatBool(cfg.Safety.DisableSeed)
 	case "tui.max_content_width":
@@ -871,6 +877,15 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 				return fmt.Errorf("embedding.gpu_layers must be a non-negative integer, got %q", value)
 			}
 			cfg.Embedding.GPULayers = v
+			return nil
+		case "embedding.model_context_window":
+			// 0 restores the built-in default (embedder.DefaultContextWindow);
+			// a positive value tunes the token cap for a larger custom model.
+			v, err := strconv.Atoi(value)
+			if err != nil || v < 0 {
+				return fmt.Errorf("embedding.model_context_window must be a non-negative integer (0 = default), got %q", value)
+			}
+			cfg.Embedding.ModelContextWindow = v
 			return nil
 		case "llm.pane_excerpt_chars":
 			// 0 is the config's "restore the 5000-char default" sentinel

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -701,6 +701,7 @@ func TestConfigFieldRegistryParity(t *testing.T) {
 		"embedding.similarity_threshold":      "0.90",
 		"embedding.bm25_min_score":            "0.35",
 		"embedding.gpu_layers":                "0",
+		"embedding.model_context_window":      "512",
 		"tui.max_content_width":               "140",
 		"tui.theme":                           "dark",
 	}
@@ -771,7 +772,7 @@ func TestPaneSalientCharsFieldDisplay(t *testing.T) {
 	// Unset (0) renders the effective built-in default, not a bare "0".
 	def := config.Default()
 	got := frontend.FieldValue(def, "embedding.pane_salient_chars")
-	if !strings.Contains(got, "default") || !strings.Contains(got, "800") {
+	if !strings.Contains(got, "default") || !strings.Contains(got, "500") {
 		t.Errorf("unset pane_salient_chars should show the default, got %q", got)
 	}
 	// An explicit value renders plainly.


### PR DESCRIPTION
## Problem (#82)

The embedder passed untruncated text to llama `GetEmbeddings`. Any input tokenizing past the model's **512-position limit** (bundled all-MiniLM-L6-v2) overflowed the position-embedding `get_rows` and hard-aborted the native library:

```
ggml/src/ggml-cpu/ops.cpp:4747: GGML_ASSERT(i01 >= 0 && i01 < ne01) failed → ggml_abort → SIGABRT
```

Bisected directly against the shipped `hap embed-worker` on Apple M3: **≤510 words OK, ≥511 crash** (510 + `[CLS]`/`[SEP]` = exactly 512). So this is **not arm64-specific and not a llama.cpp version bug** — it crashes on any platform once input exceeds the window. The original #82 plan (repin the llama.cpp submodule) is therefore **unnecessary and dropped**.

Subprocess isolation (#60-A) already keeps the daemon alive when the worker aborts, but every long embed still failed → semantic matching silently missed on long/token-dense pane content.

## Fix

- **`internal/embedder`** — `truncateToBudget` tokenizes and shortens text to `ctxWindow − specialTokenHeadroom` before `GetEmbeddings`. A post-loop halving fallback **guarantees** the returned text is within budget (never returns over-budget, never panics on tiny/empty input). `WithContext(window)` added as defense-in-depth.
- **Config override** — new `embedding.model_context_window` (0 = default 512), plumbed `config → frontend get/set/registry → Client → HAP_EMBED_CONTEXT_WINDOW worker env → NewEngine → Llama`. Lets a larger custom model tune the cap. Documented that it **must not exceed** the model's real limit (no `n_ctx_train` accessor in the binding to auto-clamp — residual risk noted).
- **`internal/domain`** — lower `DefaultPaneSalientChars` 800 → 500 as a first-line margin (token-dense content — CJK/box-drawing/code — can approach ~1 token/char).
- **Tests** — `TestEmbedLongInputNoCrash` embeds a ~700-token string plus a tiny-window (12) case and asserts a vector, not an abort.
- **`release.yml`** — gating **>512-token** embed smoke test on each native runner (the deterministic trip a short embed never catches).

## Testing

Built the llama binding locally (Metal-off) and ran with the real model on M3:
- `internal/embedder` — all pass incl. `TestEmbedLongInputNoCrash` (no SIGABRT; paraphrase cos 0.912) and the tiny-window case.
- `internal/domain`, `internal/config`, `internal/frontend` — all pass (registry parity + salient-chars default updated).
- `gofmt`/`go vet` clean.

Code-reviewed; the 3 flagged edge cases in `truncateToBudget` (non-convergence, over-large override, tiny-window slice panic) are all addressed by the guard + halving fallback.

Root-cause half of #60; supersedes the repin approach in #82.

Closes #82.