### PR TITLE
#83 feat: view captured daemon stderr from the TUI (completes #60 UX)

### DIFF
--- a/internal/frontend/daemonhealth.go
+++ b/internal/frontend/daemonhealth.go
@@ -2,12 +2,20 @@ package frontend
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
 	"github.com/0xGosu/herdr-auto-pilot/internal/crashguard"
 	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
 )
+
+// maxStderrTailBytes bounds how much of the captured daemon stderr a front-end
+// pulls into memory for the post-mortem detail view — a native abort dumps a
+// backtrace, but the reason line is near the end, so the tail is what matters.
+const maxStderrTailBytes = 16 << 10 // 16 KiB
 
 // DaemonSeverity ranks daemon health for front-ends that surface a single
 // banner (the TUI) or an exit code (the CLI).
@@ -149,6 +157,33 @@ func (h DaemonHealth) Banner() string {
 	default:
 		return ""
 	}
+}
+
+// DaemonStderrTail returns the tail of the daemon's captured stderr log (the
+// native-crash reason a hung/crash-looping daemon leaves behind, e.g. the #82
+// GGML_ASSERT) and the log's path. The banner names the path; this makes the
+// content reachable in-app (#83). It never errors — an empty StateDir, absent
+// file, or read failure degrades to empty tail, mirroring AssessDaemonHealth.
+func (a *App) DaemonStderrTail() (path, tail string) {
+	if a.StateDir == "" {
+		return "", ""
+	}
+	path = daemonhealth.StderrLogPath(a.StateDir)
+	f, err := os.Open(path)
+	if err != nil {
+		return path, ""
+	}
+	defer f.Close()
+	if fi, statErr := f.Stat(); statErr == nil && fi.Size() > maxStderrTailBytes {
+		// Seek to the last maxStderrTailBytes; a partial first line is
+		// acceptable for a post-mortem tail.
+		_, _ = f.Seek(-maxStderrTailBytes, io.SeekEnd)
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return path, ""
+	}
+	return path, strings.TrimRight(string(data), "\n \t")
 }
 
 // formatAge renders a heartbeat age compactly ("45s", "2m0s").

--- a/internal/frontend/daemonhealth_test.go
+++ b/internal/frontend/daemonhealth_test.go
@@ -1,6 +1,7 @@
 package frontend
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,48 @@ func appWithDaemon(t *testing.T, running bool, pid int, ver string) *App {
 	return &App{
 		StateDir:   dir,
 		DaemonInfo: func() (bool, int, string) { return running, pid, ver },
+	}
+}
+
+func TestDaemonStderrTail(t *testing.T) {
+	app := appWithDaemon(t, false, 0, "")
+
+	// No file yet: the path is still returned, tail empty, no error (#83).
+	path, tail := app.DaemonStderrTail()
+	if path == "" {
+		t.Fatal("expected a stderr log path even before the file exists")
+	}
+	if tail != "" {
+		t.Errorf("absent file should yield empty tail, got %q", tail)
+	}
+
+	// Captured output: the tail is returned right-trimmed.
+	if err := os.WriteFile(path, []byte("GGML_ASSERT(i01 < ne01) failed\nggml_abort\n\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, tail = app.DaemonStderrTail(); !strings.Contains(tail, "GGML_ASSERT") {
+		t.Errorf("tail missing the crash reason: %q", tail)
+	}
+	if strings.HasSuffix(tail, "\n") {
+		t.Errorf("tail should be right-trimmed, got %q", tail)
+	}
+
+	// Oversized log: only the last maxStderrTailBytes are read, keeping the end.
+	big := strings.Repeat("x", maxStderrTailBytes) + "TAIL-MARKER"
+	if err := os.WriteFile(path, []byte(big), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, tail = app.DaemonStderrTail()
+	if !strings.HasSuffix(tail, "TAIL-MARKER") {
+		t.Errorf("oversized tail should keep the end marker")
+	}
+	if len(tail) > maxStderrTailBytes {
+		t.Errorf("tail = %d bytes, want <= %d", len(tail), maxStderrTailBytes)
+	}
+
+	// No StateDir configured: empty path and tail (no panic).
+	if p, tl := (&App{}).DaemonStderrTail(); p != "" || tl != "" {
+		t.Errorf("no StateDir should yield empty, got (%q, %q)", p, tl)
 	}
 }
 

--- a/internal/tui/daemon_stderr_test.go
+++ b/internal/tui/daemon_stderr_test.go
@@ -1,0 +1,82 @@
+package tui
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+)
+
+// `!` opens the captured daemon stderr as a detail when the daemon is in an
+// error state, surfacing the crash reason in-app (#83).
+func TestDaemonStderrKeyOpensDetailOnError(t *testing.T) {
+	dir := t.TempDir()
+	logPath := daemonhealth.StderrLogPath(dir)
+	if err := os.WriteFile(logPath, []byte("GGML_ASSERT(i01 < ne01) failed\nggml_abort\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := Model{width: 100, height: 30, app: &frontend.App{StateDir: dir}}
+	m.data.daemonHealth = frontend.DaemonHealth{
+		CrashLooping: true, RecentRestarts: 3, StderrLog: logPath,
+	}
+
+	upd, _ := m.Update(pressKeyMsg("!"))
+	got := upd.(Model)
+	if got.detail == nil {
+		t.Fatal("`!` in an error state must open the stderr detail")
+	}
+	if body := strings.Join(got.detail.lines, "\n"); !strings.Contains(body, "GGML_ASSERT") {
+		t.Errorf("detail missing the captured crash reason:\n%s", body)
+	}
+}
+
+// `!` is a guarded no-op when the daemon is healthy — there is no crash to show.
+func TestDaemonStderrKeyNoopWhenHealthy(t *testing.T) {
+	m := Model{width: 100, height: 30, app: &frontend.App{StateDir: t.TempDir()}}
+	m.data.daemonHealth = frontend.DaemonHealth{Running: true} // DaemonOK
+
+	upd, _ := m.Update(pressKeyMsg("!"))
+	got := upd.(Model)
+	if got.detail != nil {
+		t.Error("`!` must not open a detail when the daemon is healthy")
+	}
+	if !strings.Contains(got.message, "no captured output") {
+		t.Errorf("expected the guard message, got %q", got.message)
+	}
+}
+
+// An error state with no captured stderr shows the empty-tail notice, not a
+// blank overlay.
+func TestDaemonStderrKeyEmptyTail(t *testing.T) {
+	m := Model{width: 100, height: 30, app: &frontend.App{StateDir: t.TempDir()}}
+	m.data.daemonHealth = frontend.DaemonHealth{GaveUp: true, Reason: "boom"}
+
+	upd, _ := m.Update(pressKeyMsg("!"))
+	got := upd.(Model)
+	if got.detail == nil {
+		t.Fatal("`!` in an error state must open a detail even with no captured output")
+	}
+	if body := strings.Join(got.detail.lines, "\n"); !strings.Contains(body, "no captured stderr") {
+		t.Errorf("empty tail should show the notice, got:\n%s", body)
+	}
+}
+
+// The banner hint appears only for an error-severity daemon that has a captured
+// stderr log — never for a degraded (warn) daemon.
+func TestDaemonStderrHintOnlyOnError(t *testing.T) {
+	logPath := daemonhealth.StderrLogPath(t.TempDir())
+
+	e := Model{width: 100, height: 30}
+	e.data.daemonHealth = frontend.DaemonHealth{CrashLooping: true, RecentRestarts: 2, StderrLog: logPath}
+	if !strings.Contains(e.View(), "press ! for captured output") {
+		t.Errorf("error banner with a stderr log must show the hint, got:\n%s", e.View())
+	}
+
+	d := Model{width: 100, height: 30}
+	d.data.daemonHealth = frontend.DaemonHealth{Running: true, EmbedderDegraded: true, StderrLog: logPath}
+	if strings.Contains(d.View(), "press !") {
+		t.Errorf("a warn-severity banner must not show the stderr hint, got:\n%s", d.View())
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -640,6 +640,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m.viewSignatureDetail()
 		}
 		return m.viewSelected()
+	case "!":
+		// Global: open the daemon's captured stderr (the crash reason behind an
+		// error-severity banner) as a scrollable detail (#83).
+		return m.viewDaemonStderr()
 	case "f":
 		if m.tab == tabSignatures {
 			switch m.sigMode {
@@ -980,6 +984,41 @@ func (m Model) renameSelected() (tea.Model, tea.Cmd) {
 
 // viewSelected opens a full-record overlay for the selected row. The record
 // is snapshotted at open time; the build closure re-wraps it on resize.
+// viewDaemonStderr opens the daemon's captured stderr as a scrollable detail —
+// the last-crash reason behind a hung/crash-looping/gave-up banner (#83). Only
+// offered in an error state: a healthy daemon has no crash to explain.
+func (m Model) viewDaemonStderr() (tea.Model, tea.Cmd) {
+	if m.data.daemonHealth.Severity() != frontend.DaemonError {
+		m.message = "daemon is not crashed/hung — no captured output to show"
+		return m, nil
+	}
+	path, tail := m.app.DaemonStderrTail()
+	build := func(width int) []string {
+		var lines []string
+		if path != "" {
+			lines = append(lines, path, "")
+		}
+		if tail == "" {
+			return append(lines, "(no captured stderr — the daemon left no output)")
+		}
+		for _, ln := range strings.Split(tail, "\n") {
+			if ln == "" {
+				lines = append(lines, "")
+				continue
+			}
+			lines = append(lines, wrapText(ln, width)...)
+		}
+		return lines
+	}
+	m.message = ""
+	m.detail = &detailView{
+		title: "Daemon captured output (last crash)",
+		lines: build(m.wrapWidth()),
+		build: build,
+	}
+	return m, nil
+}
+
 func (m Model) viewSelected() (tea.Model, tea.Cmd) {
 	switch m.tab {
 	case tabAgents:
@@ -1601,6 +1640,11 @@ func (m Model) View() string {
 		style := st.warn
 		if m.data.daemonHealth.Severity() == frontend.DaemonError {
 			style = st.err
+			// The captured crash output explains the "why"; point the operator
+			// at the in-app viewer (same line, no extra layout row).
+			if m.data.daemonHealth.StderrLog != "" {
+				banner += "  ·  press ! for captured output"
+			}
 		}
 		fmt.Fprintf(&b, "%s\n", style.Render(banner))
 	}


### PR DESCRIPTION
## What (#83)

Sub-issue of #60 — the remaining UX half. The TUI daemon-health **banner** (shipped in #71) already:
- distinguishes **healthy / degraded / down·crash-looping** from the same `frontend.AssessDaemonHealth()` signal `hap status` uses (so CLI and TUI can't disagree), rendered in the `error`/`warn` palette;
- names the captured stderr log **path**.

The one open done-when item was: *the last captured stderr **reason** is reachable from the TUI* — not just the path. This PR adds that.

## Changes

- **`internal/frontend/daemonhealth.go`** — `DaemonStderrTail()` reads the tail (≤16 KiB) of the daemon's captured `daemon.stderr.log` (the native-abort reason a hung/crash-looping daemon leaves behind, e.g. the #82 `GGML_ASSERT`). Never errors — absent/unreadable degrades to empty, mirroring `AssessDaemonHealth`.
- **`internal/tui/tui.go`** — a global **`!`** key opens that tail as a scrollable detail overlay (reusing the existing `detailView{title,lines,build}` pattern, so it re-wraps on resize). Gated to `DaemonError` severity — a healthy daemon has no crash to explain; empty output shows a notice, not a blank pane. An inline banner hint **"press ! for captured output"** is appended on the **same line** for error-severity banners with a stderr log — no extra layout row, so `detailPageSize`/`listPageSize` accounting is unchanged.

## Tests

- `TestDaemonStderrTail` — tail content, oversized-file truncation (keeps the end), absent file, no-StateDir.
- `internal/tui/daemon_stderr_test.go` — `!` opens the detail on error (with the crash reason), no-ops when healthy (guard message), empty-tail notice, and the hint appears only for error severity (not warn).
- Full `internal/frontend` + `internal/tui` suites pass; `gofmt`/`go vet` clean (built with the real llama binding + `cpu` tag).

## Notes

- No divergence introduced: both `hap status` and the TUI still classify from `AssessDaemonHealth`/`Severity()`.
- Reviewed; the flagged Major (missing TUI test coverage) is addressed by `daemon_stderr_test.go`.

Closes #83; completes the remaining UX half of #60.