### PR TITLE
#1 feat: record LLM self-reported confidence alongside computed score in audit

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -486,8 +486,9 @@ func escalations(ctx context.Context, app *frontend.App, out io.Writer, args []s
 		if row, ok := rules[e.Signature]; ok {
 			rule = frontend.RuleSummary(row, gradN)
 		}
-		fmt.Fprintf(out, "#%d\t%s\t%s\t%s\tagent=%s\tsuggestion=%q\trule=[%s]\n",
-			e.ID, e.CreatedAt.Format("15:04:05"), e.SituationType, e.Rationale, agent, e.Suggestion, rule)
+		fmt.Fprintf(out, "#%d\t%s\t%s\t%s\tagent=%s\tllm=%s\tsuggestion=%q\trule=[%s]\n",
+			e.ID, e.CreatedAt.Format("15:04:05"), e.SituationType, e.Rationale, agent,
+			llmConfCLI(e.LLMConfidence), e.Suggestion, rule)
 	}
 	fmt.Fprintf(out, "\n%d pending; respond with: confirm <id> | resolve <id> --action TEXT [--send] | dismiss <id>...\n", len(esc))
 	return nil
@@ -533,6 +534,15 @@ func dismiss(ctx context.Context, app *frontend.App, out io.Writer, args []strin
 	return nil
 }
 
+// llmConfCLI renders an audit/escalation row's LLM confidence: the 0-100
+// score, or "-" when the row carries no LLM score.
+func llmConfCLI(v *int) string {
+	if v == nil {
+		return "-"
+	}
+	return strconv.Itoa(*v)
+}
+
 // ruleIndex loads the learned signatures keyed by signature, plus the
 // graduation N, for annotating escalation/audit rows with their matched
 // rule. Degrades to an empty index on error — the listing must not fail
@@ -566,9 +576,9 @@ func audit(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 		if row, ok := rules[r.Signature]; ok {
 			rule = string(row.Mode)
 		}
-		fmt.Fprintf(out, "#%d\t%s\t%s\t%s\t%s\tconf=%.2f\trule=%s\t%s\n",
+		fmt.Fprintf(out, "#%d\t%s\t%s\t%s\t%s\tconf=%.2f\tllm=%s\trule=%s\t%s\n",
 			r.ID, r.CreatedAt.Format("01-02 15:04:05"), r.Status, r.SituationType,
-			r.Action, r.Confidence, rule, r.Rationale)
+			r.Action, r.Confidence, llmConfCLI(r.LLMConfidence), rule, r.Rationale)
 	}
 	return nil
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1223,8 +1223,9 @@ func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.Si
 	rec := domain.AuditRecord{
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
 		SituationType: s.Type, Action: "escalated", Confidence: dec.Confidence,
-		Rationale: rationale,
-		Status:    "escalated", Suggestion: dec.Suggestion,
+		LLMConfidence: dec.LLMConfidence,
+		Rationale:     rationale,
+		Status:        "escalated", Suggestion: dec.Suggestion,
 		// The content THIS escalation was classified from — per entry,
 		// unlike the signature's first-seen provenance snapshot.
 		PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes),
@@ -1971,9 +1972,17 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 				why += "proposed task: " + res.request.ProposedTask
 			}
 		}
+		// Carry the LLM's self-reported score onto the escalation's audit row
+		// (0-100); -1 means the agent reported none, so leave it nil.
+		var llmConf *int
+		if llmDec.ConfidentScore >= 0 {
+			score := llmDec.ConfidentScore
+			llmConf = &score
+		}
 		d.escalate(ctx, s, res.sig, domain.Decision{
 			Action: domain.ActionEscalate, Reason: reason, Rationale: why,
-			Suggestion: "LLM suggested: " + suggested,
+			LLMConfidence: llmConf,
+			Suggestion:    "LLM suggested: " + suggested,
 		}, tr, now)
 	}
 
@@ -2084,6 +2093,12 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		}
 	}
 
+	// Both scores land on the auto-acted audit row: the computed 0-1 agreement
+	// over this signature's history AND the LLM's self-reported 0-100 (>= 0
+	// here — a lower score would have escalated at the gate above).
+	computedConf := domain.Confidence(history).Score
+	llmConf := llmDec.ConfidentScore
+
 	if isNoop {
 		// NoOp promotion: record and stand down — nothing is sent. The
 		// staleness re-read is skipped on purpose: it exists solely to
@@ -2093,6 +2108,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		if _, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
 			AgentID: s.AgentID, AgentType: s.AgentType, Signature: res.sig.Signature, Trigger: "llm-fallback",
 			SituationType: s.Type, Action: "noop", Input: "",
+			Confidence: computedConf, LLMConfidence: &llmConf,
 			Rationale: "LLM: " + llmDec.Rationale, LLMOutput: llmDec.CapturedOutput,
 			Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
 		}); err != nil {
@@ -2182,6 +2198,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 	auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: res.sig.Signature, Trigger: "llm-fallback",
 		SituationType: s.Type, Action: "auto:" + llmDec.Action, Input: llmDec.Action,
+		Confidence: computedConf, LLMConfidence: &llmConf,
 		Rationale: "LLM: " + llmDec.Rationale, LLMOutput: llmDec.CapturedOutput,
 		Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
 	})

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1670,6 +1670,27 @@ func TestLLMFallbackStagingRegateAndPromotion(t *testing.T) {
 	if decs == nil || decs.Status != "accepted" {
 		t.Errorf("staged decision should be accepted, got %+v", decs)
 	}
+	// The auto-acted audit row captures BOTH scores: the LLM's self-reported
+	// 0-100 and the computed 0-1 agreement over this signature's history
+	// (4×"1" vs 1×"2" → 0.8-ish, always > 0), so the Audit view never shows an
+	// LLM=80 row alongside a misleading conf=0.00.
+	audits, _ := h.raw.AuditLog(ctx, 10)
+	var promoted *domain.AuditRecord
+	for i := range audits {
+		if audits[i].Action == "auto:1" && audits[i].Trigger == "llm-fallback" {
+			promoted = &audits[i]
+			break
+		}
+	}
+	if promoted == nil {
+		t.Fatalf("no promoted llm-fallback audit row found in %+v", audits)
+	}
+	if promoted.LLMConfidence == nil || *promoted.LLMConfidence != 80 {
+		t.Errorf("promoted row LLMConfidence = %v, want 80", promoted.LLMConfidence)
+	}
+	if promoted.Confidence <= 0 {
+		t.Errorf("promoted row computed Confidence = %v, want > 0", promoted.Confidence)
+	}
 }
 
 func TestLLMConfidentScoreShownOnEscalation(t *testing.T) {
@@ -1707,6 +1728,11 @@ func TestLLMConfidentScoreShownOnEscalation(t *testing.T) {
 	}
 	if !strings.Contains(esc[0].Rationale, "[llm_low_confidence]") {
 		t.Errorf("below-threshold reject expected, got %q", esc[0].Rationale)
+	}
+	// The score is also captured as a structured field on the audit row, not
+	// only embedded in the rationale prose.
+	if esc[0].LLMConfidence == nil || *esc[0].LLMConfidence != 62 {
+		t.Errorf("escalation LLMConfidence = %v, want 62", esc[0].LLMConfidence)
 	}
 }
 
@@ -1763,6 +1789,17 @@ func TestAutoActConfidenceThresholdGate(t *testing.T) {
 			esc, _ := h.raw.PendingEscalations(ctx)
 			if !strings.Contains(esc[0].Rationale, "[llm_low_confidence]") {
 				t.Errorf("expected llm_low_confidence escalation, got %q", esc[0].Rationale)
+			}
+			// The structured LLM score on the escalation row follows the
+			// not-reported convention: an unreported score (-1) must land as
+			// nil, NOT a stored -1; a reported-but-low score is kept verbatim.
+			got := esc[0].LLMConfidence
+			if tc.score < 0 {
+				if got != nil {
+					t.Errorf("unreported score must store nil LLMConfidence, got %v", *got)
+				}
+			} else if got == nil || *got != tc.score {
+				t.Errorf("escalation LLMConfidence = %v, want %d", got, tc.score)
 			}
 		})
 	}

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -136,9 +136,12 @@ type Decision struct {
 	OptionID   string // selected option (choice situations)
 	Source     Source
 	Confidence float64
-	Rationale  string
-	Reason     EscalateReason // set when Action == ActionEscalate
-	Suggestion string         // suggested input surfaced with shadow-mode escalations
+	// LLMConfidence carries a consulting LLM's self-reported confidence (0-100)
+	// through to the audit row escalate() writes; nil for non-LLM decisions.
+	LLMConfidence *int
+	Rationale     string
+	Reason        EscalateReason // set when Action == ActionEscalate
+	Suggestion    string         // suggested input surfaced with shadow-mode escalations
 }
 
 // Mode is the per-signature learning state.
@@ -185,16 +188,22 @@ type DecisionRecord struct {
 
 // AuditRecord is one append-only audit trail entry (FR-020, DR-002).
 type AuditRecord struct {
-	ID              int64
-	DecisionID      int64
-	AgentID         string
-	AgentType       string // agent type at decision time (e.g. "claude"); "" on legacy rows
-	Signature       string
-	Trigger         string
-	SituationType   SituationType
-	Action          string // action taken, or "escalated"
-	Input           string
-	Confidence      float64
+	ID            int64
+	DecisionID    int64
+	AgentID       string
+	AgentType     string // agent type at decision time (e.g. "claude"); "" on legacy rows
+	Signature     string
+	Trigger       string
+	SituationType SituationType
+	Action        string // action taken, or "escalated"
+	Input         string
+	Confidence    float64
+	// LLMConfidence is the consulting LLM's self-reported confidence, 0-100
+	// (the same scale as LLMDecision.ConfidentScore). nil means the row did
+	// not come from an LLM decision (a learned rule, an operator action, or a
+	// pre-decision escalation) — distinct from a reported 0. Confidence above
+	// is the computed 0-1 agreement score; both coexist on LLM rows.
+	LLMConfidence   *int
 	Rationale       string
 	LLMOutput       string
 	CorrectsAuditID int64

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -95,6 +95,7 @@ CREATE TABLE IF NOT EXISTS audit_log (
 	action_or_escalation TEXT NOT NULL,
 	input TEXT NOT NULL DEFAULT '',
 	confidence REAL NOT NULL DEFAULT 0,
+	llm_confidence INTEGER,
 	rationale TEXT NOT NULL DEFAULT '',
 	llm_output TEXT NOT NULL DEFAULT '',
 	corrects_audit_id INTEGER NOT NULL DEFAULT 0,
@@ -203,6 +204,9 @@ func (s *Store) migrate() error {
 	for _, ddl := range []string{
 		`ALTER TABLE audit_log ADD COLUMN agent_type TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE audit_log ADD COLUMN pane_excerpt TEXT NOT NULL DEFAULT ''`,
+		// Nullable: NULL = no LLM score (learned/operator/pre-decision rows),
+		// distinct from a reported 0.
+		`ALTER TABLE audit_log ADD COLUMN llm_confidence INTEGER`,
 		`ALTER TABLE llm_decisions ADD COLUMN confident_score INTEGER NOT NULL DEFAULT -1`,
 		`ALTER TABLE llm_requests ADD COLUMN agent_id TEXT NOT NULL DEFAULT ''`,
 	} {
@@ -288,11 +292,11 @@ func (s *Store) AppendAudit(ctx context.Context, a domain.AuditRecord) (int64, e
 	err := s.tx(ctx, func(tx *sql.Tx) error {
 		res, err := tx.ExecContext(ctx, `
 			INSERT INTO audit_log (decision_id, agent_id, agent_type, signature, trigger, situation_type,
-				action_or_escalation, input, confidence, rationale, llm_output,
+				action_or_escalation, input, confidence, llm_confidence, rationale, llm_output,
 				corrects_audit_id, status, suggestion, pane_excerpt, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			a.DecisionID, a.AgentID, a.AgentType, a.Signature, a.Trigger, string(a.SituationType),
-			a.Action, a.Input, a.Confidence, a.Rationale, a.LLMOutput,
+			a.Action, a.Input, a.Confidence, llmConfArg(a.LLMConfidence), a.Rationale, a.LLMOutput,
 			a.CorrectsAuditID, a.Status, a.Suggestion, a.PaneExcerpt, unix(a.CreatedAt))
 		if err != nil {
 			return err
@@ -990,10 +994,15 @@ func (s *Store) scanAudits(rows *sql.Rows) ([]domain.AuditRecord, error) {
 		var a domain.AuditRecord
 		var situationType string
 		var created int64
+		var llmConf sql.NullInt64
 		if err := rows.Scan(&a.ID, &a.DecisionID, &a.AgentID, &a.AgentType, &a.Signature, &a.Trigger,
-			&situationType, &a.Action, &a.Input, &a.Confidence, &a.Rationale,
+			&situationType, &a.Action, &a.Input, &a.Confidence, &llmConf, &a.Rationale,
 			&a.LLMOutput, &a.CorrectsAuditID, &a.Status, &a.Suggestion, &a.PaneExcerpt, &created); err != nil {
 			return nil, err
+		}
+		if llmConf.Valid {
+			v := int(llmConf.Int64)
+			a.LLMConfidence = &v
 		}
 		a.SituationType = domain.SituationType(situationType)
 		a.CreatedAt = fromUnix(created)
@@ -1003,8 +1012,17 @@ func (s *Store) scanAudits(rows *sql.Rows) ([]domain.AuditRecord, error) {
 }
 
 const auditCols = `id, decision_id, agent_id, agent_type, signature, trigger, situation_type,
-	action_or_escalation, input, confidence, rationale, llm_output,
+	action_or_escalation, input, confidence, llm_confidence, rationale, llm_output,
 	corrects_audit_id, status, suggestion, pane_excerpt, created_at`
+
+// llmConfArg maps the optional LLM confidence to a SQL argument: nil stores
+// NULL (no LLM score), a value stores the 0-100 score.
+func llmConfArg(v *int) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
 
 // AuditLog returns recent audit records, newest first.
 func (s *Store) AuditLog(ctx context.Context, limit int) ([]domain.AuditRecord, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -186,6 +186,46 @@ func TestDismissEscalationsBefore(t *testing.T) {
 	}
 }
 
+func TestAuditLLMConfidenceRoundTrip(t *testing.T) {
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+
+	// An LLM-authored row carries both scores: computed agreement (0-1) and
+	// the LLM's self-reported confidence (0-100).
+	score := 85
+	llmID, err := s.AppendAudit(ctx, domain.AuditRecord{
+		Signature: "sig-llm", Trigger: "llm-fallback", SituationType: domain.SituationApproval,
+		Action: "auto:y", Confidence: 0.5, LLMConfidence: &score, Status: "auto", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetAudit(ctx, llmID)
+	if err != nil || got == nil {
+		t.Fatalf("get llm audit: %v", err)
+	}
+	if got.LLMConfidence == nil || *got.LLMConfidence != 85 {
+		t.Errorf("LLMConfidence round trip = %v, want 85", got.LLMConfidence)
+	}
+
+	// A learned/operator row has no LLM score: nil must survive as NULL, not
+	// collapse to a reported 0.
+	nonLLMID, err := s.AppendAudit(ctx, domain.AuditRecord{
+		Signature: "sig-rule", Trigger: "agent-status: blocked", SituationType: domain.SituationApproval,
+		Action: "auto:y", Confidence: 1.0, Status: "auto", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err = s.GetAudit(ctx, nonLLMID)
+	if err != nil || got == nil {
+		t.Fatalf("get non-llm audit: %v", err)
+	}
+	if got.LLMConfidence != nil {
+		t.Errorf("non-LLM row LLMConfidence = %v, want nil", *got.LLMConfidence)
+	}
+}
+
 func TestAuditAndCorrectionLineage(t *testing.T) {
 	s, _ := openTestStore(t)
 	ctx := context.Background()

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -51,6 +51,45 @@ func listModel(t *testing.T, n, height int) Model {
 	return upd.(Model)
 }
 
+func TestAuditAndEscalationRenderLLMConfidence(t *testing.T) {
+	score := 85
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	m := Model{width: 140, height: 40}
+	msg := refreshMsg{cfg: config.Default()}
+	msg.status.AgentNames = map[string]string{}
+	// An LLM-authored row (both scores) and a learned row (no LLM score).
+	msg.audit = []domain.AuditRecord{
+		{ID: 1, SituationType: domain.SituationApproval, Status: "auto", Action: "auto:1",
+			Confidence: 0.5, LLMConfidence: &score, CreatedAt: now},
+		{ID: 2, SituationType: domain.SituationApproval, Status: "auto", Action: "auto:y",
+			Confidence: 1.0, CreatedAt: now},
+	}
+	msg.escalations = []domain.AuditRecord{
+		{ID: 3, SituationType: domain.SituationApproval, Status: "escalated",
+			Rationale: "low", LLMConfidence: &score, CreatedAt: now},
+		{ID: 4, SituationType: domain.SituationApproval, Status: "escalated",
+			Rationale: "shadow", CreatedAt: now},
+	}
+	upd, _ := m.Update(msg)
+	m = upd.(Model)
+
+	m.tab = tabAudit
+	audit := m.View()
+	// LLM row shows the 0-100 score next to the 0-1 computed conf; the learned
+	// row shows a dash so the column stays aligned.
+	for _, want := range []string{"conf=0.50 llm=85", "conf=1.00 llm=-"} {
+		if !strings.Contains(audit, want) {
+			t.Errorf("audit view missing %q:\n%s", want, audit)
+		}
+	}
+
+	m.tab = tabEscalations
+	esc := m.View()
+	if !strings.Contains(esc, "llm=85") || !strings.Contains(esc, "llm=-") {
+		t.Errorf("escalations view should show llm=85 and llm=-:\n%s", esc)
+	}
+}
+
 // --- List viewport (AR-001..AR-010) ---
 
 func TestListTabsFitPaneWithManyRows(t *testing.T) {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1281,6 +1281,10 @@ func (m Model) auditDetailLines(r domain.AuditRecord, snapshot string, w int) []
 	lines = m.detailField(lines, w, "Agent", agent)
 	lines = m.detailField(lines, w, "Agent type", m.agentTypeFor(r))
 	lines = m.detailField(lines, w, "Confidence", fmt.Sprintf("%.2f", r.Confidence))
+	if r.LLMConfidence != nil {
+		lines = m.detailField(lines, w, "LLM confidence",
+			fmt.Sprintf("%d/100", *r.LLMConfidence))
+	}
 	lines = m.detailField(lines, w, "Trigger", r.Trigger)
 	lines = m.detailField(lines, w, "Suggestion", r.Suggestion)
 	lines = m.detailField(lines, w, "Action", r.Action)
@@ -1885,8 +1889,10 @@ func (m Model) renderEscalations(b *strings.Builder) {
 		}
 		return
 	}
-	// Prefix: "<mark> #%-5d %-8s %-10s %-8s agent=%-14s rule=%-6s " → 71 cells.
-	const escPrefix = 71
+	// Prefix: "<mark> #%-5d %-8s %-10s %-8s agent=%-14s llm=%-4s rule=%-6s "
+	// → 80 cells. llm is the consulting LLM's self-reported 0-100 ("-" when the
+	// escalation carries no LLM score, e.g. shadow-mode or a safety veto).
+	const escPrefix = 80
 	start, end := m.window(len(esc))
 	for i := start; i < end; i++ {
 		e := esc[i]
@@ -1899,10 +1905,11 @@ func (m Model) renderEscalations(b *strings.Builder) {
 			mark = "✓"
 		}
 		rWidth, sWidth := m.budget(escPrefix, e.Suggestion != "")
-		line := fmt.Sprintf("%s #%-5d %-8s %-10s %-8s agent=%-14s rule=%-6s %s",
+		line := fmt.Sprintf("%s #%-5d %-8s %-10s %-8s agent=%-14s llm=%-4s rule=%-6s %s",
 			mark, e.ID, e.CreatedAt.Format("15:04:05"), e.SituationType,
 			oneLine(orDash(m.agentTypeFor(e)), 8), agent,
-			m.ruleMarker(e.Signature), oneLine(e.Rationale, rWidth))
+			llmConfShort(e.LLMConfidence), m.ruleMarker(e.Signature),
+			oneLine(e.Rationale, rWidth))
 		if e.Suggestion != "" {
 			line += "  → " + oneLine(e.Suggestion, sWidth)
 		}
@@ -1924,14 +1931,17 @@ func (m Model) renderAudit(b *strings.Builder) {
 		}
 		return
 	}
-	// Prefix up to the action column is ~53 fixed cells + "rule=%-6s " (12).
-	actWidth, _ := m.budget(65, false)
+	// Prefix up to the action column is ~53 fixed cells + "rule=%-6s " (12) +
+	// "llm=%-4s " (9). conf is the computed 0-1 agreement; llm is the
+	// consulting LLM's self-reported 0-100 ("-" when the row has no LLM score).
+	actWidth, _ := m.budget(74, false)
 	start, end := m.window(len(rows))
 	for i := start; i < end; i++ {
 		r := rows[i]
-		line := fmt.Sprintf("#%-5d %-14s %-9s %-10s conf=%.2f rule=%-6s %s",
+		line := fmt.Sprintf("#%-5d %-14s %-9s %-10s conf=%.2f llm=%-4s rule=%-6s %s",
 			r.ID, r.CreatedAt.Format("01-02 15:04:05"), r.Status, r.SituationType,
-			r.Confidence, m.ruleMarker(r.Signature), oneLine(r.Action, actWidth))
+			r.Confidence, llmConfShort(r.LLMConfidence), m.ruleMarker(r.Signature),
+			oneLine(r.Action, actWidth))
 		if i == m.cursor {
 			line = m.styles().selected.Render(line)
 		}
@@ -2028,6 +2038,15 @@ func orDash(s string) string {
 		return "-"
 	}
 	return s
+}
+
+// llmConfShort renders an audit row's LLM confidence for a list column: the
+// 0-100 score, or "-" when the row has no LLM score (learned/operator rows).
+func llmConfShort(v *int) string {
+	if v == nil {
+		return "-"
+	}
+	return strconv.Itoa(*v)
 }
 
 // Run starts the TUI program.


### PR DESCRIPTION
## What & why

Answering an operator question — *why does the Audit view always show `conf=0.00` while Rules shows `conf=1.00`?* — surfaced that the two views read two different, unrelated numbers, and that the consulting LLM's own confidence was never captured as structured data (it only appeared as prose in the escalation rationale).

This PR makes every audit/escalation row carry **two** confidence scores and surfaces both in the views.

| Score | Field | Scale | When set |
|---|---|---|---|
| Computed agreement | `Confidence` | 0–1 | Always (existing) |
| LLM self-reported | `LLMConfidence` | 0–100, nullable | Only on LLM-derived rows |

`LLMConfidence` is a nullable `*int`: **nil = no LLM score** (learned rule, operator action, or a pre-decision escalation) — deliberately distinct from a reported `0`. The `-1` "not reported" sentinel from `LLMDecision` maps to nil, never a stored `-1` (the auto-act path only reaches score-bearing rows after the confidence gate, which escalates any negative score).

## Behaviour changes

- **LLM score is now structured, not just prose.** It was only embedded in the escalation rationale (`"llm confidence 62/100"`); it is now a real field.
- **LLM auto-act rows no longer show a misleading `conf=0.00`.** Those rows now also record the computed `Confidence` from signature history, so you won't see `llm=85` next to `conf=0.00` on the same row.

## Views

- **TUI Audit list:** `conf=0.50 llm=85` (dash when no LLM score)
- **TUI Escalations list:** new `llm=` column
- **Shared detail view:** `LLM confidence: 85/100` when present
- **CLI** `audit` and `escalations` output: `llm=` field

## Store

New nullable `llm_confidence` column with an idempotent `ALTER TABLE` migration (same pattern as `agent_type`/`pane_excerpt`); nil↔NULL round-trips via `sql.NullInt64`.

## Test coverage

- **578/578 unit tests passing** (`go test -tags "vectors cpu" ./...`), run via the test-runner subagent.
- New/extended tests: store round-trip (value + nil), daemon promotion (both scores on the row), daemon escalation (structured score), the `-1 → nil` boundary through the daemon path, and a TUI render test for the new `llm=` column.

## Code review sign-off

Reviewed by the code-review subagent — **correct across all four risk areas**: nil/`-1` sentinel boundary, pointer aliasing, SQL column/insert/scan alignment, and TUI width budgets. One Minor test-gap finding (no direct `-1`→nil daemon-path assertion) was raised and **has been fixed** in this branch.

## Related issue

No dedicated tracking issue — this was a direct request; the commit uses the repo's `#1` catch-all reference per convention.

## Notes

- Scoped to this feature only. Two pre-existing unrelated working-tree changes (`.claude/skills/hap/SKILL.md`, `sample/config.toml`) are intentionally left out.
- Merging to `main` triggers an automated **patch** release.