### PR TITLE
#95 fix: detect footer-less Submit tab in MultiTabForm

### DIFF
--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -23,8 +23,12 @@ var mcqFrames = []string{
 		"❯ 1. sqlite (Recommended)\n     single file, zero ops\n  2. postgres\n     needs a server\n  3. Type something.\n\n" + mcqFooter + "\n",
 	"scrollback narration up here\n──────\n" + mcqHeader + "\n\nHow should migrations run?\n\n" +
 		"❯ 1. auto on boot\n  2. manual command\n  3. Type something.\n\n" + mcqFooter + "\n",
-	"scrollback narration up here\n──────\n" + mcqHeader + "\n\nReady to submit your answers?\n\n" +
-		"❯ 1. Submit\n  2. Keep editing\n\n" + mcqFooter + "\n",
+	// The final Submit tab keeps the header but DROPS the footer, showing the
+	// confirmation body instead (issue #95). Without the footer-less-aware
+	// MultiTabForm, sweepFrames aborts here with "tab 3/3 no longer shows the
+	// 3-tab form" and the whole form escalates.
+	"scrollback narration up here\n──────\n" + mcqHeader + "\n\nReview your answers\n\n" +
+		"⚠ You have not answered all questions\n\nReady to submit your answers?\n\n❯ 1. Submit answers\n  2. Cancel\n",
 }
 
 // sweptSituation mirrors what the daemon builds after the sweep: the frame-1

--- a/internal/domain/mcqform.go
+++ b/internal/domain/mcqform.go
@@ -24,6 +24,15 @@ var (
 	digitTokenRE   = regexp.MustCompile(`^[1-9]$`)
 )
 
+// mcqSubmitScreenRE matches the final Submit tab's confirmation body. That
+// tab keeps the `←…✔ Submit…→` header but DROPS the tab-navigation footer
+// (issue #95), so the footer alone can not stand for "this is still the live
+// multi-tab form". The "Ready to submit your answers?" prompt is present
+// whether or not every question is answered (the "⚠ You have not answered all
+// questions" warning is conditional), and it is line-anchored so narration
+// can not trip it.
+var mcqSubmitScreenRE = regexp.MustCompile(`(?im)^\s*ready to submit your answers\?\s*$`)
+
 // mcqSingleFooterRE matches Claude's single-question selection footer — the
 // "Enter to select" line plus its navigation tail (a "·" separator or the
 // word "navigate"). The tail keeps an agent merely narrating "press enter to
@@ -46,14 +55,19 @@ func ClaudeMCQForm(pane string) bool {
 }
 
 // MultiTabForm reports whether pane content shows the multi-tab MCQ variant
-// and how many tabs it has (checkbox entries plus the Submit entry). Both
-// the tab header and the tab-navigation footer are required, so a narrated
-// checkbox list can not false-positive. The LAST header occurrence is the
-// live render: a consuming "recent" read can carry earlier renders (or an
-// older form) above the current one.
+// and how many tabs it has (checkbox entries plus the Submit entry). The tab
+// header is always required; alongside it the pane must carry EITHER the
+// tab-navigation footer (the question tabs) OR the Submit confirmation body
+// (the final tab drops the footer — issue #95). Requiring one of the two
+// keeps a narrated checkbox list from false-positiving. The LAST header
+// occurrence is the live render: a consuming "recent" read can carry earlier
+// renders (or an older form) above the current one.
 func MultiTabForm(pane string) (tabs int, ok bool) {
 	headers := mcqTabHeaderRE.FindAllString(pane, -1)
-	if len(headers) == 0 || !mcqTabFooterRE.MatchString(pane) {
+	if len(headers) == 0 {
+		return 0, false
+	}
+	if !mcqTabFooterRE.MatchString(pane) && !mcqSubmitScreenRE.MatchString(pane) {
 		return 0, false
 	}
 	n := len(mcqTabEntryRE.FindAllString(headers[len(headers)-1], -1))

--- a/internal/domain/mcqform_test.go
+++ b/internal/domain/mcqform_test.go
@@ -67,6 +67,33 @@ func TestMultiTabFormRejectsSingleQuestionForm(t *testing.T) {
 	}
 }
 
+// mcqSubmitFrame is the FINAL tab of a live multi-tab form: the header is
+// intact but the tab-navigation footer is gone, replaced by the Submit
+// confirmation body (issue #95). MultiTabForm must still detect it so the
+// daemon's sweep does not abort on the last tab.
+const mcqSubmitFrame = `⏺ The advisor confirmed the approach.
+───────────────────────────────
+←  ☐ Agent identity  ☐ Stats to show  ✔ Submit  →
+
+Review your answers
+
+⚠ You have not answered all questions
+
+Ready to submit your answers?
+
+❯ 1. Submit answers
+  2. Cancel
+`
+
+func TestMultiTabFormDetectsFooterlessSubmitTab(t *testing.T) {
+	// Regression for #95: the Submit tab drops the footer but keeps the
+	// header; it must still resolve to the same 3-tab form.
+	tabs, ok := MultiTabForm(mcqSubmitFrame)
+	if !ok || tabs != 3 {
+		t.Fatalf("MultiTabForm(submit tab) = (%d,%v), want (3,true)", tabs, ok)
+	}
+}
+
 func TestMultiTabFormRejectsNarratedCheckboxes(t *testing.T) {
 	// A narrated checkbox list without the navigation footer must not
 	// trigger the sweep protocol.
@@ -85,8 +112,11 @@ func TestClaudeMCQForm(t *testing.T) {
 	}{
 		{"multi-tab v1 footer", mcqTabFrame, true},
 		{"multi-tab v2 footer", mcqTabFrameV2, true},
+		{"multi-tab submit tab no footer", mcqSubmitFrame, true},
 		{"single-question footer", singleQuestion, true},
 		{"narrated checkbox no footer", "Plan status:\n←  ☐ step one  ✔ done  →\nall good\n", false},
+		{"submit prompt without tab header", "All done.\nReady to submit your answers?\nyes I think so\n", false},
+		{"submit narration mid-line with header", "←  ☐ a  ☐ b  ✔ Submit  →\nSo, are you ready to submit your answers? Not yet.\n", false},
 		{"plain numbered list", "Summary:\n1. Refactored the consumer\n2. Updated the spec\n", false},
 		{"narrated enter to select without nav tail", "run help: press Enter to select an entry\n", false},
 	}


### PR DESCRIPTION
Fixes #95.

## Problem

Claude Code's multi-tab AskUserQuestion form renders its **final Submit tab** with the `←…✔ Submit…→` header intact but the tab-navigation footer **removed**, replaced by a confirmation body:

```
←  ☐ Agent identity  ☐ Stats to show  ✔ Submit  →

Review your answers

⚠ You have not answered all questions

Ready to submit your answers?

❯ 1. Submit answers
  2. Cancel
```

`domain.MultiTabForm` required the footer, so the daemon's Right-arrow sweep (`sweepFrames`) aborted on the last tab with `tab N/N no longer shows the N-tab form`, marked the sweep degraded, and escalated **every** multi-tab form as `[herdr_unreachable]`. Captured live from a running instance (`hap escalations` #74, pane `w3:p1`) — see #95 for the full evidence.

## Fix

`MultiTabForm` now requires the header **AND (footer OR the Submit confirmation body)**. The new `mcqSubmitScreenRE` is line-anchored to `^\s*ready to submit your answers\?\s*$` — the `⚠ You have not answered all questions` warning is conditional, so it keys on the always-present prompt, and the anchoring keeps narration from false-positiving.

The widening only ever adds detection; it cannot cause a mis-answer: the sweep sends only arrow keys, and `seriesStale` re-verifies the first question verbatim before any digit is delivered.

## Tests

- `internal/domain/mcqform_test.go`: `TestMultiTabFormDetectsFooterlessSubmitTab` + table rows for the Submit tab, a header-less submit prompt, and a mid-line submit narration (anchoring guard).
- `internal/daemon/sweep_test.go`: the `mcqFrames` Submit fixture now uses the real footer-less shape, so `TestMultiTabSweepAndSeriesDelivery` reproduces #95 — **verified it fails against `main` with the exact production error, passes with the fix**.
- Full `internal/domain`, `internal/daemon`, `internal/classify` suites pass with `-tags "vectors cpu"`.

## Notes

- The footer-less Submit shape is not just asserted — it was captured from a live Claude Code `2.1.207` session (the same evidence attached to #95).
- Not a duplicate of #50 (that was footer *wording* drift on the question tabs; this is the footer being *absent* on the Submit tab).
