### PR TITLE
#95 feat: multi-select questions in Claude multi-tab MCQ forms (+ bundled concurrent work)

### DIFF
--- a/.claude/skills/hap-development-local/SKILL.md
+++ b/.claude/skills/hap-development-local/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: hap-development-local
+description: "Develop and debug the Herd Auto Prompter (hap) plugin against a live herdr — link the working tree, rebuild the binary, and hot-swap the daemon so code changes take effect. Use when iterating on hap source inside a running herdr (HERDR_ENV=1) and you want the local build (not the installed release) to run."
+---
+
+# hap-development-local — local dev loop for the hap plugin
+
+use this skill when you are **editing hap's Go source** and want the running
+herdr to exercise your **working-tree build** instead of the installed release.
+it is the developer counterpart to the `hap` skill (which *operates* an
+already-installed plugin) and the `herdr` skill (which drives herdr itself).
+
+before using this skill, confirm you are inside herdr (`HERDR_ENV=1`) and in the
+repo (`/workspaces/herdr-auto-pilot`, or wherever the working tree lives). if
+`HERDR_ENV` is not `1`, there is no live herdr to link against — say so and stop.
+
+## the mental model (read this first)
+
+herdr can run a plugin from a **local path** instead of a GitHub install. once
+linked, herdr invokes the plugin's binary as **`./bin/hap` relative to the
+plugin root** for every manifest command (daemon, tui, event hooks). so the
+single source of truth for what herdr runs is the file at
+`<plugin_root>/bin/hap`. rebuild that file, restart the daemon, done.
+
+three moving parts, keep them straight:
+
+- **`<plugin_root>/bin/hap`** — what herdr actually executes. Rebuild this.
+- **the running daemon** — a long-lived process spawned from whatever binary
+  last ran `hap daemon --ensure`. It does *not* pick up a new binary on its
+  own; you must re-run `--ensure` to make it self-replace.
+- **`/usr/local/bin/hap` (PATH symlink)** — a convenience symlink for *your*
+  shell. **`herdr plugin link` does NOT repoint it** — see the gotcha below.
+
+a local build reports version **`dev`** (`internal/buildinfo.Version`, stamped
+only by release ldflags). that string is how you tell local-vs-release apart.
+
+## one-time setup: link the working tree
+
+```bash
+herdr plugin link /workspaces/herdr-auto-pilot
+```
+
+- switches the plugin from `github:…@<sha>` to `local:/workspaces/herdr-auto-pilot`
+  (`source.kind=local`, `plugin_root=/workspaces/herdr-auto-pilot`).
+- **does NOT run the manifest `build`/`install.sh` step**, so it will not
+  download a release binary over your `bin/hap`. Your build is safe.
+- verify: `herdr plugin list` → `herd-auto-prompter … [local:/workspaces/herdr-auto-pilot]`.
+
+### GOTCHA: fix the PATH symlink once
+
+`herdr plugin link` leaves `/usr/local/bin/hap` pointing at the **old GitHub
+install copy** (`~/.config/herdr/plugins/github/herd-auto-prompter-*/bin/hap`,
+an *old* release version). So typing `hap …` in a shell still runs the stale
+binary even though herdr's own invocations use your local build. Repoint it once:
+
+```bash
+ln -sf /workspaces/herdr-auto-pilot/bin/hap /usr/local/bin/hap
+hap version   # → "hap (herd-auto-prompter) dev"  (confirms PATH = local build)
+```
+
+Alternatively, skip the symlink entirely and always call `./bin/hap` from the
+repo root. But repointing it means `hap status` / `hap daemon --ensure` in any
+shell hit your dev build, which is what you usually want.
+
+To go back to the released plugin later: `herdr plugin unlink herd-auto-prompter`
+then `herdr plugin install 0xGosu/herdr-auto-pilot` (and repoint or remove the
+symlink).
+
+## the iteration loop (every code change)
+
+```bash
+# 1. rebuild the local binary — CGO, ~5 min. Native deps must be present (below).
+go build -tags "vectors cpu" -o bin/hap ./cmd/hap
+
+# 2. hot-swap the daemon: the old daemon is flagged STALE (pid+version lock
+#    mismatch) and self-replaces; the old pid exits cleanly.
+hap daemon --ensure
+
+# 3. confirm the swap took
+hap status        # → "daemon: running dev (pid …)"  (no "STALE")
+```
+
+that's the whole loop. `bin/hap` → `daemon --ensure` → `status`. the daemon
+does **not** hot-reload on its own — you must re-run `--ensure` after each
+rebuild or herdr keeps running the previous process.
+
+### the `--tags "vectors cpu"` is mandatory
+
+the semantic matcher links native code (llama.cpp via CGO, FAISS behind bleve's
+`vectors` tag). a build without **both** tags fails to link or compile:
+- `vectors` — turns on bleve's FAISS-backed KNN vector search.
+- `cpu` — disables llama-go's default GPU (Vulkan/Metal) linkage.
+
+### native deps (only if the build fails to link)
+
+CGO needs the native libraries once per environment. In the standard devcontainer
+they are **already set up** (verified 2026-07): `libfaiss.so`/`libfaiss_c.so` in
+`/usr/local/lib`, and `libllama.a` (a *static* archive, linked in — not a `.so`)
+under `submodule/github.com/seed-hypermedia/llama-go/`. If a fresh environment
+fails to link, run the one-time setup, then rebuild:
+
+```bash
+bash scripts/setup-native.sh   # submodules + llama-go libs + FAISS → /usr/local/lib
+```
+
+## reading the daemon state
+
+`hap status` self-diagnoses a stale daemon — this is your signal that a rebuild
+hasn't been swapped in yet:
+
+```
+daemon: running v0.3.42 (pid 925453) — STALE, binary is dev; run: hap daemon --ensure
+```
+
+means: the *running process* is an old release build, but the *binary on disk*
+is now your local `dev` build. Run `hap daemon --ensure` to reconcile. After the
+swap it reads plainly:
+
+```
+daemon: running dev (pid 1062410)
+```
+
+useful checks:
+
+```bash
+pgrep -af 'hap daemon'         # which binary path the live daemon runs
+./bin/hap status               # bypass the PATH symlink, use the local build directly
+```
+
+the daemon's self-replace / health mechanics (heartbeat, crash-loop breaker,
+pid+version flock) are issue #60's work — the version-mismatch detection that
+powers this hot-swap lives there.
+
+## live-testing a rebuild against real agents
+
+once your `dev` daemon is running (above), drive a **real agent** to the state
+you changed and watch how the daemon classifies it — this is the end-to-end
+check the unit suite can't give you (it fakes herdr). the flow below is the one
+used to verify the multi-tab MCQ (`choice`) parsing; adapt the prompt/assertion
+for other situation types. it composes the `herdr` skill (spawn/drive panes) and
+the `hap` skill (inspect what the daemon parsed).
+
+**1 — isolate the test in its own workspace** so real work isn't disturbed:
+
+```bash
+herdr workspace create --cwd /tmp --label "hap-testing" --no-focus   # → note workspace_id (e.g. w4) + root_pane (w4:p1)
+```
+
+**2 — spawn a real agent** and wait for it to be ready. `pane run` sends the
+launch command; use a cheap model to save tokens:
+
+```bash
+herdr pane run w4:p1 "claude --model haiku"
+herdr pane read w4:p1 --source visible --lines 5   # confirm the ❯ prompt is up
+```
+
+**3 — prompt the agent to produce the situation you want to test.** GOTCHA:
+`pane run` types the text but the agent TUI often does **not** submit on the
+trailing Enter — the prompt sits in the input box. Send an explicit `Enter`:
+
+```bash
+herdr pane run w4:p1 "Do not write any code. Call your AskUserQuestion tool once with 3 multiple-choice questions in a single call: (1) language (Go, Python, Rust, TypeScript); (2) test framework (built-in, pytest, jest); (3) indentation (tabs, 2 spaces, 4 spaces). Ask all 3 together and wait."
+herdr pane send-keys w4:p1 Enter                                    # actually submit it
+herdr wait output w4:p1 --match "Language|programming language" --regex --timeout 45000
+herdr pane read w4:p1 --source visible --lines 45                   # confirm the multi-tab form rendered
+```
+
+**4 — wait past the capture delay, then inspect what the daemon parsed.** The
+first attention event for a fresh agent waits **10s** (`[[capture_delay]]`
+`start_ms`) before the classification read, so give it ~12s:
+
+```bash
+sleep 12
+hap agents          # your agent shows up (hap auto-names it, e.g. "deft-wren") with its status
+hap escalations     # the parsed situation — type + suggestion
+```
+
+expected for the MCQ case — the situation classified as **`choice`** with a
+multi-tab answer, e.g.:
+
+```
+#125  05:27:47  choice  [llm_low_confidence] llm confidence 96/100  agent=deft-wren  suggestion="LLM suggested: 1 1 1 2"
+```
+
+**5 — read the parse.** `hap escalations` / `hap audit --limit N` / the daemon
+log (`grep w4:p1 "$(hap state-dir)/herd-auto-prompter.log"`) all show the
+classification. cross-check the shape:
+
+- the **situation type** is what you expect (`choice`, not `idle`/`approval`).
+- a multi-tab MCQ answer has **one entry per tab in tab order, Submit included** —
+  so a 3-question form yields a **4-token** answer (`1 1 1 2` = 3 answers +
+  Submit). A well-formed N+1-entry answer that the daemon accepted is itself
+  proof the form parsed into N question tabs + Submit, each with its options.
+- two escalations for one form are normal — event bursts coalesce into a couple
+  of capture bursts, each re-consulted.
+
+### live-testing gotchas learned the hard way
+
+- **`pane run` doesn't submit in an agent TUI** — always follow with
+  `herdr pane send-keys <pane> Enter`. (Plain shells submit fine; agent input
+  boxes hold the line.)
+- **respect the 10s first-event capture delay** — check `hap escalations`
+  *after* ~12s, or you'll see nothing and think the parse failed.
+- **`get_context` is NOT replayable after the fact** — a `choice` consult's
+  `llm_requests` row is consumed once the consult finishes, so
+  `hap mcp` get_context returns "no pending decision request" post-hoc. To
+  capture the exact parsed `context_json`, read it *while the consult is live*,
+  or rely on `hap escalations` + the daemon log (which persist).
+- **choice options aren't stored in `audit_log.input`** — the parsed MCQ
+  structure lives in the pending-escalation memory, not the DB; don't expect to
+  recover it from `audit_log` after resolving.
+- **no `sqlite3` CLI in the devcontainer** — query the state DB read-only with
+  Python: `sqlite3.connect("file:$DB?mode=ro&immutable=1", uri=True)` (the
+  daemon holds it open in WAL mode).
+- **closing a test agent without deleting its workspace** — an agent in a
+  workspace's only tab: `herdr tab create --workspace w4` (add a scratch tab so
+  the workspace survives) **then** `herdr tab close w4:t1` (the agent's tab).
+  Closing the last tab directly can take the workspace with it.
+
+## quick reference
+
+| goal | command |
+|---|---|
+| link working tree | `herdr plugin link /workspaces/herdr-auto-pilot` |
+| fix PATH symlink (once) | `ln -sf /workspaces/herdr-auto-pilot/bin/hap /usr/local/bin/hap` |
+| rebuild | `go build -tags "vectors cpu" -o bin/hap ./cmd/hap` |
+| hot-swap daemon | `hap daemon --ensure` |
+| confirm swap | `hap status` → `running dev` |
+| confirm PATH build | `hap version` → `dev` |
+| revert to release | `herdr plugin unlink herd-auto-prompter` |
+
+## gotchas recap
+
+- **link does not repoint `/usr/local/bin/hap`** — fix it manually or use `./bin/hap`.
+- **link does not overwrite `bin/hap`** — the build/install step doesn't run on link.
+- **the daemon does not hot-reload** — always `hap daemon --ensure` after a rebuild.
+- **omitting `vectors cpu` breaks the build** — both tags always.
+- **`dev` is the tell** — a `dev` version = your local build; a `vX.Y.Z` version = a release.

--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -234,6 +234,12 @@ list all configurable fields:
 hap config fields
 ```
 
+print the config file path (even before the file exists):
+
+```bash
+hap config path
+```
+
 set a specific config field:
 
 ```bash
@@ -254,6 +260,7 @@ hap config set safety.disable_seed true
 hap config set embedding.disabled true
 hap config set embedding.similarity_threshold 0.85
 hap config set embedding.gpu_layers 4
+hap config set embedding.model_context_window 512
 hap config set embedding.pane_salient_chars 1000
 hap config set tui.max_content_width 120
 hap config set tui.theme high-contrast
@@ -300,11 +307,15 @@ edits made through `hap config set` / `set-threshold` apply live — the command
 | `llm.command_start` | (unset) | argv template for the FIRST consult per agent; empty inherits `llm.command` (opt-in) |
 | `llm.rewrite_command` | (unset) | argv template for the one-shot rewrite CLI (see llm rewrite) |
 | `llm.rewrite_command_start` | (unset) | argv template for the FIRST rewrite per agent; empty inherits `llm.rewrite_command` (opt-in) |
+| `llm.task_generate_command` | (unset) | argv template for the one-shot task suggestion given to an idle agent with NO task source (see task sources); empty keeps today's escalate-only behavior |
+| `llm.task_generate_command_start` | (unset) | argv template for the FIRST task generation per agent; empty inherits `llm.task_generate_command` (opt-in) |
+| `llm.task_generate_timeout_seconds` | 0 (inherits `timeout_seconds`) | timeout for one task-generation run |
 | `embedding.disabled` | false | disable semantic matching entirely |
 | `embedding.model_path` | (bundled all-minilm-l6-v2-q8_0.gguf) | path to a .gguf embedding model |
 | `embedding.similarity_threshold` | 0.90 | min cosine similarity to reuse a learned signature |
 | `embedding.bm25_min_score` | 0.35 | min normalized BM25 similarity for text fallback |
 | `embedding.gpu_layers` | 0 | model layers offloaded to GPU (inert in official builds) |
+| `embedding.model_context_window` | 0 (built-in default: 512 for MiniLM) | max tokens fed to the embedder before truncation; MUST NOT exceed what the model supports (over 512 hard-aborts a BERT/MiniLM native lib). raise only when `model_path` points at a larger-window model; values below 256 clamp up |
 | `embedding.pane_salient_chars` | 800 | fallback signature window for idle/unclassified situations (trailing N chars) |
 | `tui.max_content_width` | 0 (full width) | cap variable-width list columns; 0 = full width |
 | `tui.theme` | default | TUI color theme: default, dark, light, high-contrast |
@@ -418,6 +429,8 @@ when every item is checked off, the prompt is still sent with `{next_task_conten
 when an `[llm].command` is configured, each determined task is first reviewed by the llm before it is sent: via the `get_context`/`submit_decision` mcp tools it sees the live pane plus the queued task (`proposed_task`/`current_task`), the checklist path (`task_list_path`), and every remaining item (`pending_tasks`), then either sends the task as-is (`recommend_action` `@next_task:declared`, which sends the queued task verbatim), sends an edited task or a different pending item (literal `recommend_action` text), or declines (`@noop`). the outcome follows `auto_act_confidence_threshold` symmetrically — a confident review is applied automatically (the task is sent, or silently skipped on a decline), a low-confidence one is surfaced for confirmation (the suggestion is the llm's exact recommendation; the original task and reasoning show in the escalation detail). since the default threshold is 999, every review is surfaced until you lower it. this review is on by default; set `llm_review = false` on a `[[task_sources]]` entry (in `config.toml`) to opt that source out.
 
 without a declared task source, the plugin falls back to inferring the next task from the agent's own native todo rendering (currently only `claude` agent type is supported for inference). other agent types skip inference and escalate.
+
+if inference finds nothing (no task source and nothing inferable from the pane) and `llm.task_generate_command` is configured, the plugin runs that CLI once to synthesize a next task for the idle agent (placeholders: `{self}`, `{agent_name}`, `{agent_type}`, `{pane_excerpt}`, `{cwd}`). the CLI's stdout is surfaced as an escalation the operator confirms (writing a per-agent `tasks.md`) or dismisses — the plugin never sends a synthesized task unattended. leave `task_generate_command` unset to keep the default: an idle agent with no task source escalates as `no_task_source` and nothing is synthesized. `task_generate_command_start` is the first-interaction variant (empty inherits `task_generate_command`); `task_generate_timeout_seconds` bounds one run (0 inherits `llm.timeout_seconds`).
 
 ## reset data
 
@@ -562,6 +575,18 @@ also available as env vars: `HAP_REWRITE_TEXT`, `HAP_SITUATION_TYPE`, `HAP_AGENT
 - safety controls still apply to the rewritten text: output matching the never-auto patterns or the irreversible heuristic is discarded in favor of the wrapped original.
 - learning is unaffected: decision history records the original learned action, never the rewritten text.
 
+## resolved paths (diagnostics)
+
+print where hap keeps its config and state — useful when reporting an issue or jumping into the state dir. these resolve paths without creating anything, and work even before the files exist:
+
+```bash
+hap state-dir       # the state directory (DB, logs, socket, lock, match-index)
+hap config path     # the config.toml path
+hap paths           # both, labeled
+```
+
+example: `cd "$(hap state-dir)"` jumps into the state directory.
+
 ## version
 
 ```bash
@@ -660,7 +685,7 @@ hap signatures reembed
 
 ## notes
 
-- `hap status`, `hap agents`, `hap escalations`, `hap audit`, `hap signatures list`, `hap signatures show`, `hap config show`, `hap config fields`, `hap rules list`, `hap task-source list`, `hap kill-history`, and `hap version` are read-only and safe to run anytime.
+- `hap status`, `hap agents`, `hap escalations`, `hap audit`, `hap signatures list`, `hap signatures show`, `hap config show`, `hap config fields`, `hap config path`, `hap rules list`, `hap task-source list`, `hap kill-history`, `hap state-dir`, `hap paths`, and `hap version` are read-only and safe to run anytime.
 - `hap confirm` and `hap resolve` with `--send` will deliver text to an agent pane — be mindful of what you send.
 - `hap dismiss` drops escalations without responding — safe, nothing is sent or learned, audit rows kept as `dismissed`.
 - `hap escalations prune [minutes]` bulk-dismisses old escalations (default 360 minutes).

--- a/.claude/skills/herdr/SKILL.md
+++ b/.claude/skills/herdr/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: herdr
+description: "Control herdr from inside it. Manage workspaces and tabs, split panes, spawn agents, read output, and wait for state changes — all via CLI commands that talk to the running herdr instance over a local unix socket. Use when running inside herdr (HERDR_ENV=1)."
+---
+
+# herdr — agent skill
+
+before using this skill, check that `HERDR_ENV=1`. if it is not set to `1`, say you are not running inside a herdr-managed pane and stop. do not inspect or control the focused herdr pane from outside herdr.
+
+you are running inside herdr, a terminal-native agent multiplexer. herdr gives you workspaces, tabs, and panes — each pane is a real terminal with its own shell, agent, server, or log stream — and you can control all of it from the cli.
+
+this means you can:
+
+- see what other panes and agents are doing
+- create tabs for separate subcontexts inside one workspace
+- split panes and run commands in them
+- start servers, watch logs, and run tests in sibling panes
+- wait for specific output before continuing
+- wait for another agent to finish
+- spawn more agent instances
+
+the `herdr` binary is available in your PATH. its workspace, tab, pane, and wait commands talk to the running herdr instance over a local unix socket.
+
+if you need the raw protocol or full api reference, read the [socket api docs](https://herdr.dev/docs/socket-api/).
+if you need to teach the user how to use herdr, including setup, example usages, troubleshooting, read the [herdr agent guide](https://herdr.dev/agent-guide.md).
+
+## concepts
+
+**workspaces** are project contexts. each workspace has one or more tabs. unless manually renamed, a workspace's label follows the first tab's root pane — usually the repo name, otherwise the root pane's current folder name.
+
+**tabs** are subcontexts inside a workspace. each tab has one or more panes.
+
+**panes** are terminal splits inside a tab. each pane runs its own process — a shell, an agent, a server, anything.
+
+**agent status** is detected automatically by herdr. the api exposes one public field for it:
+
+- `agent_status` — `idle`, `working`, `blocked`, `done`, `unknown`
+
+`done` means the agent finished, but you have not looked at that finished pane yet.
+
+plain shells still exist as panes, but herdr's sidebar agent section intentionally focuses on detected agents rather than listing every shell.
+
+**ids** — workspace ids look like `1`, `2`. tab ids look like `1:1`, `1:2`, `2:1`. pane ids look like `1-1`, `1-2`, `2-1`. these are compact public ids for the current live session.
+
+important: ids can compact when tabs, panes, or workspaces are closed. do not treat them as durable ids. re-read ids from `workspace list`, `tab list`, `pane list`, or create/split responses when you need a current id. do not guess that an older `1-3` is still the same pane later.
+
+## discover yourself
+
+see what panes exist and which one is focused:
+
+```bash
+herdr pane list
+```
+
+the focused pane is yours. other panes are your neighbors.
+
+list workspaces:
+
+```bash
+herdr workspace list
+```
+
+## tab management
+
+list tabs in the current workspace:
+
+```bash
+herdr tab list --workspace 1
+```
+
+create a new tab:
+
+```bash
+herdr tab create --workspace 1
+```
+
+without `--label`, the new tab keeps the default numbered tab name.
+
+create and name it in one step:
+
+```bash
+herdr tab create --workspace 1 --label "logs"
+```
+
+rename it:
+
+```bash
+herdr tab rename 1:2 "logs"
+```
+
+focus it:
+
+```bash
+herdr tab focus 1:2
+```
+
+close it:
+
+```bash
+herdr tab close 1:2
+```
+
+## read another pane
+
+see what is on another pane's screen:
+
+```bash
+herdr pane read 1-1 --source recent --lines 50
+```
+
+- `--source visible` = current viewport
+- `--source recent` = recent scrollback as rendered in the pane
+- `--source recent-unwrapped` = recent terminal text with soft wraps joined back together
+
+## split a pane and run a command
+
+split your pane to the right and keep focus on your current pane:
+
+```bash
+herdr pane split 1-2 --direction right --no-focus
+```
+
+that prints json with the new pane nested at `result.pane.pane_id`. parse that value, then run a command in that pane:
+
+```bash
+NEW_PANE=$(herdr pane split 1-2 --direction right --no-focus | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"]["pane_id"])')
+herdr pane run "$NEW_PANE" "npm run dev"
+```
+
+split downward instead:
+
+```bash
+herdr pane split 1-2 --direction down --no-focus
+```
+
+## wait for output
+
+block until specific text appears in a pane. useful for waiting on servers, builds, and tests.
+
+for `--source recent`, matching uses unwrapped recent terminal text, so pane width and soft wrapping do not break matches. `pane read --source recent` still shows the pane as rendered. if you want to inspect the same transcript that the waiter matches, use `pane read --source recent-unwrapped`.
+
+```bash
+herdr wait output 1-3 --match "ready on port 3000" --timeout 30000
+```
+
+with regex:
+
+```bash
+herdr wait output 1-3 --match "server.*ready" --regex --timeout 30000
+```
+
+if it times out, exit code is `1`.
+
+## wait for an agent status
+
+block until another agent reaches a specific status:
+
+```bash
+herdr wait agent-status 1-1 --status done --timeout 60000
+```
+
+use this when you want the same `done` / `idle` distinction the UI shows.
+
+## send text or keys to a pane
+
+send text without pressing Enter:
+
+```bash
+herdr pane send-text 1-1 "hello from claude"
+```
+
+press Enter or other keys:
+
+```bash
+herdr pane send-keys 1-1 Enter
+```
+
+`pane run` sends the text and then a real `Enter` key in one request:
+
+```bash
+herdr pane run 1-1 "echo hello"
+```
+
+## workspace management
+
+create a new workspace:
+
+```bash
+herdr workspace create --cwd /path/to/project
+```
+
+without `--label`, the new workspace keeps the default cwd-based name.
+
+create and name one in one step:
+
+```bash
+herdr workspace create --cwd /path/to/project --label "api server"
+```
+
+create one without focusing it:
+
+```bash
+herdr workspace create --no-focus
+```
+
+focus a workspace:
+
+```bash
+herdr workspace focus 2
+```
+
+rename:
+
+```bash
+herdr workspace rename 1 "api server"
+```
+
+close:
+
+```bash
+herdr workspace close 2
+```
+
+## close a pane
+
+```bash
+herdr pane close 1-3
+```
+
+## recipes
+
+### run a server and wait until it is ready
+
+```bash
+NEW_PANE=$(herdr pane split 1-2 --direction right --no-focus | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"]["pane_id"])')
+herdr pane run "$NEW_PANE" "npm run dev"
+herdr wait output "$NEW_PANE" --match "ready" --timeout 30000
+herdr pane read "$NEW_PANE" --source recent --lines 20
+```
+
+### run tests in a separate pane and inspect the result
+
+```bash
+herdr pane split 1-2 --direction down --no-focus
+herdr pane run 1-3 "cargo test"
+herdr wait output 1-3 --match "test result" --timeout 60000
+herdr pane read 1-3 --source recent --lines 30
+```
+
+### check what another agent is working on
+
+```bash
+herdr pane list
+herdr pane read 1-1 --source recent --lines 80
+```
+
+### watch another pane robustly
+
+use this pattern when you need to coordinate with a sibling pane:
+
+```bash
+# inspect what is already there
+herdr pane read 1-3 --source recent --lines 40
+
+# wait only for the next output you expect
+herdr wait output 1-3 --match "ready" --timeout 30000
+
+# if you need to inspect the same transcript the waiter matched,
+# read the unwrapped recent text directly
+herdr pane read 1-3 --source recent-unwrapped --lines 40
+```
+
+### spawn a new agent and give it a task
+
+```bash
+herdr pane split 1-2 --direction right --no-focus
+herdr pane run 1-3 "claude"
+herdr wait output 1-3 --match ">" --timeout 15000
+herdr pane run 1-3 "review the test coverage in src/api/"
+```
+
+### coordinate with another agent
+
+```bash
+herdr wait agent-status 1-1 --status done --timeout 120000
+herdr pane read 1-1 --source recent --lines 100
+```
+
+## notes
+
+- `workspace list`, `workspace create`, `tab list`, `tab create`, `tab get`, `tab focus`, `tab rename`, `tab close`, `pane list`, `pane get`, `pane split`, `wait output`, and `wait agent-status` print json on success.
+- `pane read` prints text, not json.
+- `pane read --format ansi` or `pane read --ansi` returns a rendered ANSI snapshot for TUI feedback loops.
+- `pane read --source recent-unwrapped` is useful when you want to inspect the same unwrapped transcript that `wait output --source recent` matches against.
+- `pane send-text`, `pane send-keys`, and `pane run` print nothing on success.
+- parse ids from `workspace create`, `tab create`, and `pane split` responses when you need new ids. `workspace create` returns `result.workspace`, `result.tab`, and `result.root_pane`. `tab create` returns `result.tab` and `result.root_pane`. for `pane split`, the new pane id is at `result.pane.pane_id`.
+- use `pane read` for current output that already exists. use `wait output` for future output you expect next.
+- `--no-focus` on split, tab create, and workspace create keeps your current terminal context focused.
+- without `--label`, workspace create keeps cwd-based naming and tab create keeps numbered naming.
+- `--label` on tab create and workspace create applies the custom name immediately.
+- if you are running inside herdr, the `HERDR_ENV` environment variable is set to `1`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ Verify after any release: `gh release view vX.Y.Z` — expect 3 binaries,
   belongs in a goroutine that funnels results back through a channel
   (see `consultLLM` / `llmResults`).
 - **Attention events are delay-captured** — the classification pane read
-  waits `[[capture_delay]]` (default 10s on an agent's first event, 500ms
+  waits `[[capture_delay]]` (default 10s on an agent's first event, 2000ms
   after) via a per-pane `time.AfterFunc` → `delayedTr`, so the agent TUI
   has painted and event bursts coalesce (latest wins, one capture per
   burst). Daemon tests inherit a 1ms wildcard rule from the harness.

--- a/README.md
+++ b/README.md
@@ -243,7 +243,10 @@ The plugin never acts on a situation it hasn't learned from you.
    printable key goes into the query — action keys like `q`, `y`, and `x`
    can't fire mid-search. Action outcomes (confirm, resolve, delete, …)
    stay pinned in a status area (`✓`/`✗` plus timestamp) until the next
-   action, so the result of a multi-step operation isn't missed.
+   action, so the result of a multi-step operation isn't missed. Detail
+   views with captured pane content open at the bottom, where coding-agent
+   prompts and results appear; `tui.max_content_height` can cap each preview
+   while retaining its newest trailing lines (`0` keeps the full capture).
 3. **Graduate.** After **5 consecutive consistent confirmations** (configurable)
    *and* confidence above the per-situation threshold, that signature becomes
    autonomous: next time, the plugin acts on its own and logs it.
@@ -322,6 +325,7 @@ model_context_window = 0    # 0 = bundled-model default (512 tokens); input is
 # original look — so existing setups see no change.
 [tui]
 max_content_width = 0       # cap variable-width list columns; 0 = full width
+max_content_height = 0      # cap captured-pane preview lines; 0 = unlimited (keeps the tail)
 theme = "high-contrast"
 
 # Optional per-role color overrides, layered on top of the theme; unset
@@ -477,7 +481,7 @@ adds/removes task sources (`t`/`x`), and clears learned data (`X`).
 Simple fields — numbers, booleans, and the `tui.theme` enum, including
 `llm.pane_excerpt_chars`, `llm.task_generate_timeout_seconds`,
 `embedding.model_context_window`, `safety.disable_seed`, and
-`tui.max_content_width` — edit inline (`enter`) or via
+`tui.max_content_width` / `tui.max_content_height` — edit inline (`enter`) or via
 `hap config set <key> <value>`. Free-text fields (`llm.command`,
 `llm.command_start`, `llm.rewrite_command`, `llm.rewrite_command_start`,
 `llm.rewrite_fallback_template`, `llm.task_generate_command`,
@@ -487,7 +491,7 @@ prompt mangles quoted argv values — edit them in `config.toml` or with
 `config set`, which accepts every listed scalar key. The safety indicator
 patterns and `[[capture_delay]]` rules also display read-only on the tab. The
 `[tui.palette]` overrides are edited directly in `config.toml`. Capture delays show the built-in defaults (10000
-ms first event / 500 ms after) when none are configured, and long values are
+ms first event / 2000 ms after) when none are configured, and long values are
 truncated to one line — the full value lives in `config.toml`. Prompts that
 *look* destructive
 but match no pattern are escalated by a suspected-irreversible heuristic

--- a/README.md
+++ b/README.md
@@ -244,9 +244,12 @@ The plugin never acts on a situation it hasn't learned from you.
    can't fire mid-search. Action outcomes (confirm, resolve, delete, …)
    stay pinned in a status area (`✓`/`✗` plus timestamp) until the next
    action, so the result of a multi-step operation isn't missed. Detail
-   views with captured pane content open at the bottom, where coding-agent
-   prompts and results appear; `tui.max_content_height` can cap each preview
-   while retaining its newest trailing lines (`0` keeps the full capture).
+   views always open at the top. Captured situations are collapsed to their
+   title plus a trailing preview (three lines normally; ten for Escalations'
+   Current Situation), and Audit's LLM output uses the same three-line
+   preview. Press `v` again to expand or collapse all previews. Expanded
+   content still retains its newest trailing lines when
+   `tui.max_content_height` caps it (`0` keeps the full content).
 3. **Graduate.** After **5 consecutive consistent confirmations** (configurable)
    *and* confidence above the per-situation threshold, that signature becomes
    autonomous: next time, the plugin acts on its own and logs it.
@@ -325,7 +328,7 @@ model_context_window = 0    # 0 = bundled-model default (512 tokens); input is
 # original look — so existing setups see no change.
 [tui]
 max_content_width = 0       # cap variable-width list columns; 0 = full width
-max_content_height = 0      # cap captured-pane preview lines; 0 = unlimited (keeps the tail)
+max_content_height = 0      # expanded long-field lines; 0 = unlimited (collapsed previews use short tails)
 theme = "high-contrast"
 
 # Optional per-role color overrides, layered on top of the theme; unset

--- a/docs/plans/enhance-tui-ux/requirements.md
+++ b/docs/plans/enhance-tui-ux/requirements.md
@@ -268,7 +268,7 @@ Terminology: a **list tab** is one of Agents, Escalations, Audit, or Rules — t
 **User Role:** Operator
 **Acceptance Criteria:**
 - WHEN rendering the Config tab, the system SHALL display each `[[capture_delay]]` rule (agent type, start_ms, event_ms; config.go 151–155) as a read-only row.
-- WHEN no `[[capture_delay]]` rules are configured, the system SHALL show the effective built-in defaults (start 10000 ms / event 500 ms) so the operator can see what timing applies.
+- WHEN no `[[capture_delay]]` rules are configured, the system SHALL show the effective built-in defaults (start 10000 ms / event 2000 ms) so the operator can see what timing applies.
 - Classifier manifests (`[[classifier]]`, config.go 141–146) SHALL remain file-only and out of scope for this change.
 
 ### CR-036 — TUI field editability classification

--- a/docs/plans/enhance-tui-ux/tasks.md
+++ b/docs/plans/enhance-tui-ux/tasks.md
@@ -285,7 +285,7 @@ Critical path: **D → C** (config fields before theme resolution) and **A → B
   - _Complexity: Medium_
 
 - [ ] 32\. Render read-only Safety-indicator and capture-delay sections
-  - Extend `buildRuleItems` (tui.go 184–217) with read-only rows: a "Safety indicators" section for `safety.irreversible_indicators` and each `[[safety.indicator_rules]]` entry (pattern + agent scope, config.go 48–59), and a capture-delay section showing each `[[capture_delay]]` rule (config.go 151–155) or the built-in defaults (10000/500 ms) when none are configured. Edit/remove keys on these rows show an informational "edited in config.toml" message (mirroring tui.go 1140) and never mutate config. Classifier manifests stay file-only.
+  - Extend `buildRuleItems` (tui.go 184–217) with read-only rows: a "Safety indicators" section for `safety.irreversible_indicators` and each `[[safety.indicator_rules]]` entry (pattern + agent scope, config.go 48–59), and a capture-delay section showing each `[[capture_delay]]` rule (config.go 151–155) or the built-in defaults (10000/2000 ms) when none are configured. Edit/remove keys on these rows show an informational "edited in config.toml" message (mirroring tui.go 1140) and never mutate config. Classifier manifests stay file-only.
   - Acceptance Criteria:
     - Configured indicator patterns, indicator rules, and capture-delay rules are visible on the Config tab; the defaults row appears when no capture-delay rule exists.
     - `enter`/`e`/`x` on the read-only rows produce the informational message and change nothing.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,10 +226,11 @@ type TUI struct {
 	// (rationale, suggestion, action) in the list views. 0 (the default)
 	// means use the full terminal width, so rows fill a wide monitor.
 	MaxContentWidth int `toml:"max_content_width"`
-	// MaxContentHeight caps the number of wrapped lines shown for captured
-	// pane previews in detail views. When a preview exceeds the cap, its
-	// trailing lines are retained because coding-agent prompts and results
-	// are normally at the bottom. 0 (the default) shows the full capture.
+	// MaxContentHeight caps the number of wrapped lines shown when captured
+	// pane previews are expanded in detail views. Collapsed previews use a
+	// short field-specific tail (normally 3 lines; Escalation Current Situation
+	// uses 10). When expanded content exceeds the cap, its trailing lines are
+	// retained. 0 (the default) shows the full capture.
 	MaxContentHeight int `toml:"max_content_height"`
 	// Theme selects a named TUI palette (see ValidThemes). Empty and
 	// unknown names resolve to "default" — the exact pre-theming look.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,6 +226,11 @@ type TUI struct {
 	// (rationale, suggestion, action) in the list views. 0 (the default)
 	// means use the full terminal width, so rows fill a wide monitor.
 	MaxContentWidth int `toml:"max_content_width"`
+	// MaxContentHeight caps the number of wrapped lines shown for captured
+	// pane previews in detail views. When a preview exceeds the cap, its
+	// trailing lines are retained because coding-agent prompts and results
+	// are normally at the bottom. 0 (the default) shows the full capture.
+	MaxContentHeight int `toml:"max_content_height"`
 	// Theme selects a named TUI palette (see ValidThemes). Empty and
 	// unknown names resolve to "default" — the exact pre-theming look.
 	Theme string `toml:"theme,omitempty"`
@@ -550,7 +555,7 @@ func (c Config) GenerateTaskTimeout() time.Duration {
 // after launch; later events only need a short settle.
 const (
 	defaultCaptureStartDelay = 10000 * time.Millisecond
-	defaultCaptureEventDelay = 500 * time.Millisecond
+	defaultCaptureEventDelay = 2000 * time.Millisecond
 )
 
 // CaptureDelay returns how long to wait before reading the pane after a

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -362,9 +362,9 @@ func TestPaneExcerptCharsDefaultsAndOverride(t *testing.T) {
 	}
 }
 
-func TestTUIMaxContentWidthParsed(t *testing.T) {
+func TestTUIContentLimitsParsed(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
-	os.WriteFile(path, []byte("[tui]\nmax_content_width = 140\n"), 0o600)
+	os.WriteFile(path, []byte("[tui]\nmax_content_width = 140\nmax_content_height = 12\n"), 0o600)
 	cfg, err := Load(path)
 	if err != nil {
 		t.Fatal(err)
@@ -372,10 +372,13 @@ func TestTUIMaxContentWidthParsed(t *testing.T) {
 	if cfg.TUI.MaxContentWidth != 140 {
 		t.Errorf("max_content_width = %d, want 140", cfg.TUI.MaxContentWidth)
 	}
-	// Omitted → 0 (meaning full terminal width).
+	if cfg.TUI.MaxContentHeight != 12 {
+		t.Errorf("max_content_height = %d, want 12", cfg.TUI.MaxContentHeight)
+	}
+	// Omitted → 0 (meaning full width and unlimited preview height).
 	os.WriteFile(path, []byte("[learning]\ngraduation_n = 5\n"), 0o600)
-	if cfg, _ = Load(path); cfg.TUI.MaxContentWidth != 0 {
-		t.Errorf("omitted max_content_width should default to 0, got %d", cfg.TUI.MaxContentWidth)
+	if cfg, _ = Load(path); cfg.TUI.MaxContentWidth != 0 || cfg.TUI.MaxContentHeight != 0 {
+		t.Errorf("omitted content limits should default to 0, got %+v", cfg.TUI)
 	}
 }
 
@@ -435,7 +438,7 @@ func TestTUIThemeBackwardCompat(t *testing.T) {
 	if cfg, err = Load(path); err != nil {
 		t.Fatalf("file without [tui] must load: %v", err)
 	}
-	if cfg.TUI.MaxContentWidth != 0 || cfg.TUI.Theme != "" ||
+	if cfg.TUI.MaxContentWidth != 0 || cfg.TUI.MaxContentHeight != 0 || cfg.TUI.Theme != "" ||
 		cfg.TUI.Palette != (PaletteOverrides{}) {
 		t.Errorf("missing [tui] must default to zero TUI config, got %+v", cfg.TUI)
 	}
@@ -894,7 +897,7 @@ func TestCaptureDelayRuleMatching(t *testing.T) {
 		want  time.Duration
 	}{
 		{"no rules start default", rules(), "claude", true, 10000 * time.Millisecond},
-		{"no rules event default", rules(), "claude", false, 500 * time.Millisecond},
+		{"no rules event default", rules(), "claude", false, 2000 * time.Millisecond},
 		{"exact match start", rules(CaptureDelayRule{AgentType: "claude", StartMs: 1500, EventMs: 50}), "claude", true, 1500 * time.Millisecond},
 		{"exact match event", rules(CaptureDelayRule{AgentType: "claude", StartMs: 1500, EventMs: 50}), "claude", false, 50 * time.Millisecond},
 		{"first match wins", rules(

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1622,9 +1622,14 @@ func (d *Daemon) consultContext(ctx context.Context, cfg config.Config, s domain
 	}
 	if s.TabCount > 1 {
 		fields["tab_count"] = s.TabCount
-		fields["answer_format"] = fmt.Sprintf(
-			"this is a multi-tab question form with %d tabs (the final tab is Submit); the pane excerpt lists every question in order. submit_decision select_options MUST be a list of exactly %d integers, one chosen option number per tab including Submit, e.g. [1, 2, 3, 2, 1]",
+		answer := fmt.Sprintf(
+			"this is a multi-tab question form with %d tabs (the final tab is Submit); the pane excerpt lists every question in order. submit_decision select_options is a list of exactly %d entries, one per tab in order including Submit, e.g. [1, 2, 3, 2, 1]",
 			s.TabCount, s.TabCount)
+		if kinds, anyMulti := tabSelectKinds(s.TabMultiSelect); anyMulti {
+			fields["tab_select_kinds"] = kinds
+			answer += ". Some tabs are MULTI-SELECT (tab_select_kinds marks each tab \"single\" or \"multi\"; a multi-select question shows `[ ]` checkboxes on its options): for a multi-select tab pass an ARRAY of the option numbers to toggle instead of a single integer, e.g. [1, [1, 3], 2] chooses option 1 on tab 1, toggles options 1 and 3 on tab 2, and option 2 on tab 3"
+		}
+		fields["answer_format"] = answer
 	} else if len(s.Options) > 0 {
 		fields["answer_format"] = "answer with submit_decision select_options: a one-element list with the 1-based number of the chosen option, e.g. [2]"
 	} else if s.Type == domain.SituationApproval || s.Type == domain.SituationChoice {
@@ -1643,6 +1648,27 @@ func (d *Daemon) consultContext(ctx context.Context, cfg config.Config, s domain
 	}
 	contextJSON, _ := json.Marshal(fields)
 	return contextJSON
+}
+
+// tabSelectKinds renders per-tab select kinds ("single"/"multi") for the LLM
+// consult context and reports whether any tab is multi-select. Returns
+// (nil, false) when no per-tab metadata is present (e.g. a form that was not
+// swept), so the consult falls back to the single-select-only phrasing.
+func tabSelectKinds(multi []bool) ([]string, bool) {
+	if len(multi) == 0 {
+		return nil, false
+	}
+	kinds := make([]string, len(multi))
+	any := false
+	for i, m := range multi {
+		if m {
+			kinds[i] = "multi"
+			any = true
+		} else {
+			kinds[i] = "single"
+		}
+	}
+	return kinds, any
 }
 
 // paneExcerpt reads a deep pane excerpt (last llm.pane_excerpt_chars) for
@@ -2241,8 +2267,8 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 				"another pane interaction is in flight for this agent; not delivering concurrently")
 			return
 		}
-		seq, _ := domain.ParseDigitSeries(llmDec.Action)
-		d.deliverSeriesLLM(ctx, ks, s, res.sig.Signature, llmDec, seq, auditID, now)
+		groups, _ := domain.ParseTabSelections(llmDec.Action)
+		d.deliverSeriesLLM(ctx, ks, s, res.sig.Signature, llmDec, groups, auditID, now)
 		return
 	}
 	if err := d.opt.Herdr.Send(ctx, s.PaneID, domain.DeliverKeystroke(s.Type, pane, llmDec.Action)); err != nil {

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -29,6 +29,13 @@ const sweepKeyDelay = 250 * time.Millisecond
 // may have left the form focused elsewhere.
 const sweepResetKeys = 10
 
+// sweepAdvanceKey advances to the next tab after a MULTI-SELECT question's
+// toggles. A multi-select tab does not auto-advance on a digit press, so we
+// send this explicitly. Right-arrow matches the capture sweep's proven tab
+// navigation; const-ized so the integration test can switch to "tab" if a
+// real form needs it.
+const sweepAdvanceKey = "right"
+
 // sweepAllowed re-reads the gates that must veto pane interaction BEFORE
 // any sweep keystroke: kill switch (FR-017), rate pause (FR-019), and the
 // never-auto patterns on the visible content (FR-015). Failing any gate —
@@ -121,6 +128,7 @@ func (d *Daemon) sweepFrames(ctx context.Context, ks ports.KeystrokeSender,
 	s domain.Situation) (domain.Situation, error) {
 
 	frames := make([]string, 0, s.TabCount)
+	multiSelect := make([]bool, 0, s.TabCount)
 	moved := false
 	var sweepErr error
 	for tab := 0; tab < s.TabCount; tab++ {
@@ -144,7 +152,20 @@ func (d *Daemon) sweepFrames(ctx context.Context, ks ports.KeystrokeSender,
 			sweepErr = fmt.Errorf("tab %d/%d no longer shows the %d-tab form", tab+1, s.TabCount, s.TabCount)
 			break
 		}
+		// A multi-select tab is answered by toggling checkboxes, which is a
+		// RELATIVE flip. We can only reason about the keystrokes if the tab
+		// starts all-unchecked (the observed default); any pre-selected option
+		// means an operator (or a default) already touched it, so escalate the
+		// whole form rather than blind-toggle into the wrong set.
+		multi := domain.MultiSelectTab(frame)
+		if multi {
+			if n := countChecked(frame); n > 0 {
+				sweepErr = fmt.Errorf("tab %d/%d already has %d option(s) selected; cannot auto-toggle safely", tab+1, s.TabCount, n)
+				break
+			}
+		}
 		frames = append(frames, frame)
+		multiSelect = append(multiSelect, multi)
 	}
 
 	if moved {
@@ -162,7 +183,21 @@ func (d *Daemon) sweepFrames(ctx context.Context, ks ports.KeystrokeSender,
 	swept := s
 	swept.Content = domain.AggregateMCQFrames(frames)
 	swept.Options = domain.OptionLabels(swept.Content)
+	swept.TabMultiSelect = multiSelect
 	return swept, nil
+}
+
+// countChecked reports how many of a frame's checkbox options are already
+// checked (`[x]`). Used to enforce the all-unchecked baseline before an
+// autonomous multi-select toggle.
+func countChecked(frame string) int {
+	n := 0
+	for _, checked := range domain.OptionCheckStates(frame) {
+		if checked {
+			n++
+		}
+	}
+	return n
 }
 
 // handleSweepOutcome resumes the decision pipeline with the aggregated
@@ -223,8 +258,8 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 		escalateWith(domain.ReasonHerdrUnreachable, "keystrokes unavailable")
 		return
 	}
-	seq, ok := domain.ParseDigitSeries(dec.Input)
-	if !ok || len(seq) != s.TabCount {
+	groups, ok := domain.ParseTabSelections(dec.Input)
+	if !ok || len(groups) != s.TabCount {
 		escalateWith(domain.ReasonUnfamiliarOptions,
 			fmt.Sprintf("answer series %q does not fit the %d-tab form", dec.Input, s.TabCount))
 		return
@@ -255,7 +290,7 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 	go func() {
 		defer d.releasePane(s.AgentID)
 		logging.Guard("series-delivery", func() error {
-			if err := d.sendDigitSeries(ctx, ks, s.PaneID, seq); err != nil {
+			if err := d.sendTabSelections(ctx, ks, s.PaneID, groups, s.TabMultiSelect); err != nil {
 				slog.Error("answer series delivery failed", "pane", s.PaneID, "error", err)
 				d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
 				d.notify(ctx, "Herd Auto Prompter: action delivery failed",
@@ -289,13 +324,13 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 // row is already committed by the caller (FR-024); the keystrokes and the
 // accept/learn/rate writes run off the main loop.
 func (d *Daemon) deliverSeriesLLM(ctx context.Context, ks ports.KeystrokeSender,
-	s domain.Situation, sigKey string, llmDec *domain.LLMDecision, seq []string,
+	s domain.Situation, sigKey string, llmDec *domain.LLMDecision, groups [][]string,
 	auditID int64, now time.Time) {
 
 	go func() {
 		defer d.releasePane(s.AgentID)
 		logging.Guard("series-delivery-llm", func() error {
-			if err := d.sendDigitSeries(ctx, ks, s.PaneID, seq); err != nil {
+			if err := d.sendTabSelections(ctx, ks, s.PaneID, groups, s.TabMultiSelect); err != nil {
 				slog.Error("LLM answer series delivery failed", "pane", s.PaneID, "error", err)
 				d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
 				d.notify(ctx, "Herd Auto Prompter: action delivery failed", err.Error())
@@ -326,23 +361,28 @@ func (d *Daemon) deliverSeriesLLM(ctx context.Context, ks ports.KeystrokeSender,
 	}()
 }
 
-// sendDigitSeries resets the form to its first question (fixed Left-arrow
-// burst — a human may have tabbed around since capture), then presses one
-// digit per tab in order, pausing between keystrokes so the form can
-// advance and re-render.
-func (d *Daemon) sendDigitSeries(ctx context.Context, ks ports.KeystrokeSender, paneID string, seq []string) error {
+// sendTabSelections resets the form to its first question (fixed Left-arrow
+// burst — a human may have tabbed around since capture), then presses the
+// per-tab answer keystrokes from domain.MultiTabKeys: the toggle digit(s) for
+// each tab, plus an explicit advance after a MULTI-SELECT tab (which does not
+// auto-advance on a digit press). Keystrokes are paced by sweepKeyDelay so the
+// form advances and re-renders between presses.
+func (d *Daemon) sendTabSelections(ctx context.Context, ks ports.KeystrokeSender, paneID string,
+	groups [][]string, tabMultiSelect []bool) error {
+
 	for i := 0; i < sweepResetKeys; i++ {
 		if err := ks.SendKey(ctx, paneID, "left"); err != nil {
 			return fmt.Errorf("reset left-arrow %d/%d: %w", i+1, sweepResetKeys, err)
 		}
 	}
 	time.Sleep(sweepKeyDelay)
-	for i, digit := range seq {
+	keys := domain.MultiTabKeys(groups, tabMultiSelect, sweepAdvanceKey)
+	for i, key := range keys {
 		if i > 0 {
 			time.Sleep(sweepKeyDelay)
 		}
-		if err := ks.SendKey(ctx, paneID, digit); err != nil {
-			return fmt.Errorf("digit %d/%d: %w", i+1, len(seq), err)
+		if err := ks.SendKey(ctx, paneID, key); err != nil {
+			return fmt.Errorf("keystroke %d/%d (%q): %w", i+1, len(keys), key, err)
 		}
 	}
 	return nil

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -23,18 +23,11 @@ import (
 // following read (or the next keystroke).
 const sweepKeyDelay = 250 * time.Millisecond
 
-// sweepResetKeys is a fixed Left-arrow count larger than any real form's
-// tab count, so a reset burst lands on the first question regardless of
-// size — before answer delivery too, since the operator (or a failed reset)
-// may have left the form focused elsewhere.
-const sweepResetKeys = 10
-
-// sweepAdvanceKey advances to the next tab after a MULTI-SELECT question's
-// toggles. A multi-select tab does not auto-advance on a digit press, so we
-// send this explicitly. Right-arrow matches the capture sweep's proven tab
-// navigation; const-ized so the integration test can switch to "tab" if a
-// real form needs it.
-const sweepAdvanceKey = "right"
+// sweepResetKeys / sweepAdvanceKey alias the shared domain protocol constants
+// so the capture sweep, autonomous delivery, and the operator-confirm frontend
+// all navigate a form identically (a single source of truth — domain.MCQ*).
+const sweepResetKeys = domain.MCQResetKeys
+const sweepAdvanceKey = domain.MCQAdvanceKey
 
 // sweepAllowed re-reads the gates that must veto pane interaction BEFORE
 // any sweep keystroke: kill switch (FR-017), rate pause (FR-019), and the
@@ -187,6 +180,31 @@ func (d *Daemon) sweepFrames(ctx context.Context, ks ports.KeystrokeSender,
 	return swept, nil
 }
 
+// anyMultiSelect reports whether any tab in the swept form is multi-select.
+func anyMultiSelect(flags []bool) bool {
+	for _, m := range flags {
+		if m {
+			return true
+		}
+	}
+	return false
+}
+
+// reverifyMultiSelect re-checks, immediately before autonomous delivery, that
+// every multi-select tab is STILL all-unchecked and the form is unchanged. The
+// tab-1 staleness re-read (seriesStale) can not see middle tabs, so without
+// this an operator toggling a middle-tab checkbox during a long consult would
+// be blind-toggled into the wrong set (toggling is relative). It re-runs the
+// capture sweep purely as a guard — a non-nil error means the baseline moved,
+// so delivery must be refused. A no-op for forms with no multi-select tab.
+func (d *Daemon) reverifyMultiSelect(ctx context.Context, ks ports.KeystrokeSender, s domain.Situation) error {
+	if !anyMultiSelect(s.TabMultiSelect) {
+		return nil
+	}
+	_, err := d.sweepFrames(ctx, ks, s)
+	return err
+}
+
 // countChecked reports how many of a frame's checkbox options are already
 // checked (`[x]`). Used to enforce the all-unchecked baseline before an
 // autonomous multi-select toggle.
@@ -290,6 +308,13 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 	go func() {
 		defer d.releasePane(s.AgentID)
 		logging.Guard("series-delivery", func() error {
+			if err := d.reverifyMultiSelect(ctx, ks, s); err != nil {
+				slog.Warn("multi-select baseline moved before delivery; refusing", "pane", s.PaneID, "error", err)
+				d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
+				d.notify(ctx, "Herd Auto Prompter: action delivery skipped",
+					fmt.Sprintf("Agent %s: the multi-select form changed before the answer could be delivered (%v); please review it.", s.AgentID, err))
+				return nil
+			}
 			if err := d.sendTabSelections(ctx, ks, s.PaneID, groups, s.TabMultiSelect); err != nil {
 				slog.Error("answer series delivery failed", "pane", s.PaneID, "error", err)
 				d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
@@ -330,6 +355,13 @@ func (d *Daemon) deliverSeriesLLM(ctx context.Context, ks ports.KeystrokeSender,
 	go func() {
 		defer d.releasePane(s.AgentID)
 		logging.Guard("series-delivery-llm", func() error {
+			if err := d.reverifyMultiSelect(ctx, ks, s); err != nil {
+				slog.Warn("multi-select baseline moved before LLM delivery; refusing", "pane", s.PaneID, "error", err)
+				d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
+				d.notify(ctx, "Herd Auto Prompter: action delivery skipped",
+					fmt.Sprintf("Agent %s: the multi-select form changed before the answer could be delivered (%v); please review it.", s.AgentID, err))
+				return nil
+			}
 			if err := d.sendTabSelections(ctx, ks, s.PaneID, groups, s.TabMultiSelect); err != nil {
 				slog.Error("LLM answer series delivery failed", "pane", s.PaneID, "error", err)
 				d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -191,18 +192,30 @@ func anyMultiSelect(flags []bool) bool {
 }
 
 // reverifyMultiSelect re-checks, immediately before autonomous delivery, that
-// every multi-select tab is STILL all-unchecked and the form is unchanged. The
-// tab-1 staleness re-read (seriesStale) can not see middle tabs, so without
-// this an operator toggling a middle-tab checkbox during a long consult would
-// be blind-toggled into the wrong set (toggling is relative). It re-runs the
-// capture sweep purely as a guard — a non-nil error means the baseline moved,
-// so delivery must be refused. A no-op for forms with no multi-select tab.
+// the multi-select form is UNCHANGED since capture. The tab-1 staleness re-read
+// (seriesStale) can not see middle tabs, so without this an operator toggling a
+// middle-tab checkbox — or a same-tab-count form replacing this one — during a
+// long consult would receive stale answer groups and stale explicit-advance
+// decisions (toggling is relative). It re-runs the capture sweep and then fails
+// CLOSED unless the re-swept aggregate content AND per-tab select kinds match
+// the situation being delivered — sweepFrames alone only guarantees the same
+// tab count and an unchecked baseline. A no-op for forms with no multi-select
+// tab.
 func (d *Daemon) reverifyMultiSelect(ctx context.Context, ks ports.KeystrokeSender, s domain.Situation) error {
 	if !anyMultiSelect(s.TabMultiSelect) {
 		return nil
 	}
-	_, err := d.sweepFrames(ctx, ks, s)
-	return err
+	reswept, err := d.sweepFrames(ctx, ks, s)
+	if err != nil {
+		return err
+	}
+	if reswept.Content != s.Content {
+		return fmt.Errorf("form content changed since capture")
+	}
+	if !slices.Equal(reswept.TabMultiSelect, s.TabMultiSelect) {
+		return fmt.Errorf("per-tab select kinds changed since capture")
+	}
+	return nil
 }
 
 // countChecked reports how many of a frame's checkbox options are already

--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -163,10 +163,11 @@ func TestMultiTabSweepMultiSelectDelivery(t *testing.T) {
 	}
 	joined := strings.Join(h.herdr.keysSent(), " ")
 	reset := strings.TrimSpace(strings.Repeat("left ", 10))
-	// Sweep: 2 rights + 10-left reset; delivery: 10-left reset, then tab1 "1"
-	// (auto-advances), tab2 "1" "3" then explicit "right" (multi-select does
-	// not auto-advance), submit "1".
-	want := "right right " + reset + " " + reset + " 1 1 3 right 1"
+	// Capture sweep: 2 rights + reset. Delivery re-verifies the multi-select
+	// baseline (a second capture sweep: 2 rights + reset), then delivers:
+	// reset, tab1 "1" (auto-advances), tab2 "1" "3" then explicit "right"
+	// (multi-select does not auto-advance), submit "1".
+	want := "right right " + reset + " right right " + reset + " " + reset + " 1 1 3 right 1"
 	if joined != want {
 		t.Errorf("multi-select keystroke protocol mismatch:\n got %s\nwant %s", joined, want)
 	}

--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -31,15 +31,37 @@ var mcqFrames = []string{
 		"⚠ You have not answered all questions\n\nReady to submit your answers?\n\n❯ 1. Submit answers\n  2. Cancel\n",
 }
 
+// mcqMultiFrames is a 3-tab form whose SECOND tab is multi-select (its options
+// carry `[ ]` checkboxes, all unchecked). Tab 1 is single-select and tab 3 is
+// the footer-less Submit tab.
+var mcqMultiFrames = []string{
+	"──────\n" + mcqHeader + "\n\nWhich backend?\n\n❯ 1. sqlite\n  2. postgres\n\n" + mcqFooter + "\n",
+	"──────\n" + mcqHeader + "\n\nWhich stats to show?\n\n❯ 1. [ ] Auto-sends\n  2. [ ] Escalations\n  3. [ ] Confirmed\n\n" + mcqFooter + "\n",
+	"──────\n" + mcqHeader + "\n\nReview your answers\n\nReady to submit your answers?\n\n❯ 1. Submit answers\n  2. Cancel\n",
+}
+
+// mcqMultiPrecheckedFrames is mcqMultiFrames with the multi-select tab already
+// carrying a selection (`[x]`) — the baseline the sweep must refuse to toggle.
+var mcqMultiPrecheckedFrames = []string{
+	mcqMultiFrames[0],
+	"──────\n" + mcqHeader + "\n\nWhich stats to show?\n\n❯ 1. [ ] Auto-sends\n  2. [x] Escalations\n  3. [ ] Confirmed\n\n" + mcqFooter + "\n",
+	mcqMultiFrames[2],
+}
+
 // sweptSituation mirrors what the daemon builds after the sweep: the frame-1
 // classification with content/options aggregated across every tab.
 func sweptSituation(t *testing.T) domain.Situation {
 	t.Helper()
-	s := classifierForTest().Classify("claude", "blocked", mcqFrames[0])
-	if s.Type != domain.SituationChoice || s.TabCount != 3 {
-		t.Fatalf("fixture must classify as a 3-tab choice, got type=%v tabs=%d", s.Type, s.TabCount)
+	return sweptSituationFrom(t, mcqFrames)
+}
+
+func sweptSituationFrom(t *testing.T, frames []string) domain.Situation {
+	t.Helper()
+	s := classifierForTest().Classify("claude", "blocked", frames[0])
+	if s.Type != domain.SituationChoice || s.TabCount != len(frames) {
+		t.Fatalf("fixture must classify as a %d-tab choice, got type=%v tabs=%d", len(frames), s.Type, s.TabCount)
 	}
-	s.Content = domain.AggregateMCQFrames(mcqFrames)
+	s.Content = domain.AggregateMCQFrames(frames)
 	s.Options = domain.OptionLabels(s.Content)
 	return s
 }
@@ -47,9 +69,13 @@ func sweptSituation(t *testing.T) domain.Situation {
 // seedSeriesRule trains the aggregated signature to autonomous with a
 // digit-series action, mirroring graduated learning.
 func (h *harness) seedSeriesRule(t *testing.T, series string) string {
+	return h.seedSeriesRuleFrom(t, mcqFrames, series)
+}
+
+func (h *harness) seedSeriesRuleFrom(t *testing.T, frames []string, series string) string {
 	t.Helper()
 	ctx := context.Background()
-	s := sweptSituation(t)
+	s := sweptSituationFrom(t, frames)
 	sig := domain.ComputeSignature(s)
 	if sig.Verdict != domain.GuardOK {
 		t.Fatalf("aggregate over-masked: %q", sig.Salient)
@@ -113,6 +139,62 @@ func TestMultiTabSweepAndSeriesDelivery(t *testing.T) {
 	decs, _ := h.raw.DecisionsForSignature(ctx, sig, 10)
 	if len(decs) != 9 || decs[0].ChosenAction != "1 2 1" || decs[0].Source != domain.SourceRule {
 		t.Errorf("series decision not learned: %+v", decs[0])
+	}
+}
+
+// A form with a MULTI-SELECT tab (tab 2) delivers the toggle digits for that
+// tab followed by an explicit advance keystroke — a multi-select tab does not
+// auto-advance — while the single-select tabs still advance on their one digit.
+func TestMultiTabSweepMultiSelectDelivery(t *testing.T) {
+	h := newHarness(t, "")
+	h.herdr.setFrames(mcqMultiFrames)
+	// tab1=option1, tab2 toggles options 1 and 3, submit=option1.
+	sig := h.seedSeriesRuleFrom(t, mcqMultiFrames, "1 1,3 1")
+
+	h.push("agent-mcqmulti", "blocked")
+
+	ctx := context.Background()
+	waitFor(t, 10*time.Second, func() bool {
+		decs, _ := h.raw.DecisionsForSignature(ctx, sig, 10)
+		return len(decs) == 9
+	})
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Errorf("series must go out as keystrokes, text sent: %v", h.herdr.sentInputs())
+	}
+	joined := strings.Join(h.herdr.keysSent(), " ")
+	reset := strings.TrimSpace(strings.Repeat("left ", 10))
+	// Sweep: 2 rights + 10-left reset; delivery: 10-left reset, then tab1 "1"
+	// (auto-advances), tab2 "1" "3" then explicit "right" (multi-select does
+	// not auto-advance), submit "1".
+	want := "right right " + reset + " " + reset + " 1 1 3 right 1"
+	if joined != want {
+		t.Errorf("multi-select keystroke protocol mismatch:\n got %s\nwant %s", joined, want)
+	}
+}
+
+// A multi-select tab that ALREADY has a selection can not be toggled safely
+// (toggling is relative): the sweep refuses, the form escalates, and no digit
+// is ever pressed.
+func TestMultiTabSweepMultiSelectPrecheckedEscalates(t *testing.T) {
+	h := newHarness(t, "")
+	h.herdr.setFrames(mcqMultiPrecheckedFrames)
+	h.seedSeriesRuleFrom(t, mcqMultiFrames, "1 1,3 1") // even a graduated rule must not fire
+
+	h.push("agent-mcqprechecked", "blocked")
+
+	ctx := context.Background()
+	waitFor(t, 10*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	esc, _ := h.raw.PendingEscalations(ctx)
+	if !strings.Contains(esc[0].Rationale, "already has") {
+		t.Errorf("escalation must name the pre-selected baseline: %+v", esc[0])
+	}
+	for _, k := range h.herdr.keysSent() {
+		if k != "right" && k != "left" {
+			t.Errorf("no digit may be pressed when the toggle baseline is unsafe, keys: %v", h.herdr.keysSent())
+		}
 	}
 }
 
@@ -290,7 +372,7 @@ func TestLLMMultiTabConsultAndSeriesPromotion(t *testing.T) {
 		t.Errorf("series audit must carry the swept aggregate, got %q", audits[0].PaneExcerpt)
 	}
 	<-mu
-	for _, want := range []string{`"tab_count":3`, "select_options MUST be a list of exactly 3 integers", "[question 1/3]", "[question 3/3]"} {
+	for _, want := range []string{`"tab_count":3`, "select_options is a list of exactly 3 entries", "[question 1/3]", "[question 3/3]"} {
 		if !strings.Contains(contextJSON, want) {
 			t.Errorf("consult context missing %q: %s", want, contextJSON)
 		}

--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -48,13 +48,8 @@ var mcqMultiPrecheckedFrames = []string{
 	mcqMultiFrames[2],
 }
 
-// sweptSituation mirrors what the daemon builds after the sweep: the frame-1
-// classification with content/options aggregated across every tab.
-func sweptSituation(t *testing.T) domain.Situation {
-	t.Helper()
-	return sweptSituationFrom(t, mcqFrames)
-}
-
+// sweptSituationFrom mirrors what the daemon builds after the sweep: the
+// frame-1 classification with content/options aggregated across every tab.
 func sweptSituationFrom(t *testing.T, frames []string) domain.Situation {
 	t.Helper()
 	s := classifierForTest().Classify("claude", "blocked", frames[0])
@@ -170,6 +165,35 @@ func TestMultiTabSweepMultiSelectDelivery(t *testing.T) {
 	want := "right right " + reset + " right right " + reset + " " + reset + " 1 1 3 right 1"
 	if joined != want {
 		t.Errorf("multi-select keystroke protocol mismatch:\n got %s\nwant %s", joined, want)
+	}
+}
+
+// reverifyMultiSelect fails CLOSED when the live form changed since capture
+// even though the tab count is unchanged and every tab is still unchecked — a
+// same-count replacement or a changed middle tab (which the tab-1 staleness
+// check can not see) must not receive the stale answer groups.
+func TestReverifyMultiSelectRejectsChangedForm(t *testing.T) {
+	h := newHarness(t, "")
+	s := sweptSituationFrom(t, mcqMultiFrames)
+	s.TabMultiSelect = []bool{false, true, false}
+	s.PaneID = "w1:p1"
+	ctx := context.Background()
+
+	// Unchanged form re-verifies clean.
+	h.herdr.setFrames(mcqMultiFrames)
+	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s); err != nil {
+		t.Fatalf("an unchanged multi-select form must re-verify clean, got %v", err)
+	}
+
+	// The middle tab now shows a DIFFERENT (still-unchecked, same-count) form.
+	changed := []string{
+		mcqMultiFrames[0],
+		"──────\n" + mcqHeader + "\n\nWhich stats to show?\n\n❯ 1. [ ] Latency\n  2. [ ] Errors\n\n" + mcqFooter + "\n",
+		mcqMultiFrames[2],
+	}
+	h.herdr.setFrames(changed)
+	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s); err == nil {
+		t.Fatal("reverify must reject a form whose content changed since capture")
 	}
 }
 

--- a/internal/domain/keys.go
+++ b/internal/domain/keys.go
@@ -1,5 +1,19 @@
 package domain
 
+// MCQ multi-tab answer protocol constants, shared by the daemon (sweep +
+// autonomous delivery) and the operator-confirm frontend so the two delivery
+// paths can never diverge on how they navigate a form.
+const (
+	// MCQAdvanceKey advances past a MULTI-SELECT tab after its toggles. A
+	// multi-select tab does not auto-advance on a digit press; a single-select
+	// tab does, so it needs no explicit advance. Right-arrow matches the
+	// capture sweep's proven tab navigation.
+	MCQAdvanceKey = "right"
+	// MCQResetKeys is a fixed Left-arrow count larger than any real form's tab
+	// count, so a reset burst lands on the first question regardless of size.
+	MCQResetKeys = 10
+)
+
 // MultiTabKeys builds the ordered keystrokes that answer a multi-tab MCQ form,
 // EXCLUDING the leading reset burst (the caller owns resetting focus to the
 // first tab). For each tab it presses the chosen option digits in order; then,

--- a/internal/domain/keys.go
+++ b/internal/domain/keys.go
@@ -1,0 +1,24 @@
+package domain
+
+// MultiTabKeys builds the ordered keystrokes that answer a multi-tab MCQ form,
+// EXCLUDING the leading reset burst (the caller owns resetting focus to the
+// first tab). For each tab it presses the chosen option digits in order; then,
+// for a MULTI-SELECT tab, it presses an explicit advanceKey to move on —
+// toggling a checkbox does NOT auto-advance the form. A single-select tab
+// emits only its one digit, which both selects and auto-advances.
+//
+// CRITICAL: the advance decision keys off tabMultiSelect[i], NOT the number of
+// digits chosen. A multi-select tab where the answer picks a single option is
+// still multi-select and still will not auto-advance, so it still needs the
+// explicit advanceKey. The final Submit tab is single-select (its digit
+// submits), so it must not be marked multi-select.
+func MultiTabKeys(groups [][]string, tabMultiSelect []bool, advanceKey string) []string {
+	keys := make([]string, 0, len(groups))
+	for i, g := range groups {
+		keys = append(keys, g...)
+		if i < len(tabMultiSelect) && tabMultiSelect[i] {
+			keys = append(keys, advanceKey)
+		}
+	}
+	return keys
+}

--- a/internal/domain/keys_test.go
+++ b/internal/domain/keys_test.go
@@ -1,0 +1,54 @@
+package domain
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMultiTabKeys(t *testing.T) {
+	cases := []struct {
+		name   string
+		groups [][]string
+		multi  []bool
+		want   []string
+	}{
+		{
+			name:   "all single-select: one digit per tab, no advance (auto-advances)",
+			groups: [][]string{{"1"}, {"2"}, {"1"}},
+			multi:  []bool{false, false, false},
+			want:   []string{"1", "2", "1"},
+		},
+		{
+			name:   "middle tab multi-select: toggles then explicit advance",
+			groups: [][]string{{"1"}, {"1", "3"}, {"1"}},
+			multi:  []bool{false, true, false},
+			want:   []string{"1", "1", "3", "right", "1"},
+		},
+		{
+			name:   "multi-select tab with a single chosen option STILL advances",
+			groups: [][]string{{"1"}, {"2"}, {"1"}},
+			multi:  []bool{false, true, false},
+			want:   []string{"1", "2", "right", "1"},
+		},
+		{
+			name:   "Submit tab (last) never advances even though earlier multi",
+			groups: [][]string{{"1", "2"}, {"1"}},
+			multi:  []bool{true, false},
+			want:   []string{"1", "2", "right", "1"},
+		},
+		{
+			name:   "nil multiSelect metadata degrades to single-select delivery",
+			groups: [][]string{{"1"}, {"2"}},
+			multi:  nil,
+			want:   []string{"1", "2"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MultiTabKeys(tc.groups, tc.multi, "right")
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("MultiTabKeys = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/domain/mcqform.go
+++ b/internal/domain/mcqform.go
@@ -17,8 +17,12 @@ import (
 // pane shows ONE question at a time; the header is the only signal that more
 // tabs exist.
 var (
-	mcqTabHeaderRE = regexp.MustCompile(`(?m)^\s*←.*[☐✔].*→\s*$`)
-	mcqTabEntryRE  = regexp.MustCompile(`[☐✔]`)
+	// The tab header marks each question ☐ (unanswered) or ☒ (answered) plus a
+	// final ✔ Submit. ☒ must be counted too — an operator (or the daemon) may
+	// answer a tab before the form is (re)captured, and missing ☒ undercounts
+	// the tabs (verified live: a partially-answered 3-tab form read as 2).
+	mcqTabHeaderRE = regexp.MustCompile(`(?m)^\s*←.*[☐☒✔].*→\s*$`)
+	mcqTabEntryRE  = regexp.MustCompile(`[☐☒✔]`)
 	mcqTabFooterRE = regexp.MustCompile(`(?i)(tab/arrow keys to navigate|tab to switch questions)`)
 	mcqFooterRE    = regexp.MustCompile(`(?im)^.*enter to select.*$`)
 	// digitTokenRE matches one per-tab answer token: a single menu digit, or —

--- a/internal/domain/mcqform.go
+++ b/internal/domain/mcqform.go
@@ -21,7 +21,11 @@ var (
 	mcqTabEntryRE  = regexp.MustCompile(`[☐✔]`)
 	mcqTabFooterRE = regexp.MustCompile(`(?i)(tab/arrow keys to navigate|tab to switch questions)`)
 	mcqFooterRE    = regexp.MustCompile(`(?im)^.*enter to select.*$`)
-	digitTokenRE   = regexp.MustCompile(`^[1-9]$`)
+	// digitTokenRE matches one per-tab answer token: a single menu digit, or —
+	// for a multi-select tab that toggles several options — a comma-separated
+	// set of digits ("1,3"). There is still exactly ONE token per tab, so the
+	// len(tokens)==TabCount guards hold whether or not a tab is multi-select.
+	digitTokenRE = regexp.MustCompile(`^[1-9](,[1-9])*$`)
 )
 
 // mcqSubmitScreenRE matches the final Submit tab's confirmation body. That
@@ -77,10 +81,13 @@ func MultiTabForm(pane string) (tabs int, ok bool) {
 	return n, true
 }
 
-// ParseDigitSeries parses a space-separated series of menu digits — the
-// answer format for multi-tab forms ("1 2 3 2 1", one digit per tab
-// including the final Submit tab). A single digit is NOT a series: that is
-// an ordinary single-menu answer.
+// ParseDigitSeries parses the space-separated per-tab answer tokens for a
+// multi-tab form ("1 2 3 2 1", one token per tab including the final Submit
+// tab). A token is a menu digit or — for a multi-select tab — a comma-
+// separated set of digits to toggle ("1,3"). There is exactly one token per
+// tab, so callers that gate on len(tokens)==TabCount stay correct. A single
+// token is NOT a series: that is an ordinary single-menu answer. Delivery
+// uses ParseTabSelections to expand each token into its individual digits.
 func ParseDigitSeries(s string) ([]string, bool) {
 	fields := strings.Fields(s)
 	if len(fields) < 2 {
@@ -92,6 +99,30 @@ func ParseDigitSeries(s string) ([]string, bool) {
 		}
 	}
 	return fields, true
+}
+
+// ParseTabSelections expands ParseDigitSeries into per-tab digit lists: each
+// tab's token is comma-split into the option digits to press, with duplicates
+// removed in first-seen order ("1 1,3 2" -> [["1"],["1","3"],["2"]]). The
+// number of groups equals the tab count, so len==TabCount guards still hold.
+func ParseTabSelections(s string) ([][]string, bool) {
+	fields, ok := ParseDigitSeries(s)
+	if !ok {
+		return nil, false
+	}
+	groups := make([][]string, len(fields))
+	for i, f := range fields {
+		seen := make(map[string]bool)
+		var digs []string
+		for _, d := range strings.Split(f, ",") {
+			if !seen[d] {
+				seen[d] = true
+				digs = append(digs, d)
+			}
+		}
+		groups[i] = digs
+	}
+	return groups, true
 }
 
 // ExtractMCQForm returns just the form region of one pane frame: from the

--- a/internal/domain/mcqform_test.go
+++ b/internal/domain/mcqform_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -137,9 +138,13 @@ func TestParseDigitSeries(t *testing.T) {
 	}{
 		{"1 2 3 2 1", 5, true},
 		{" 1  2 ", 2, true},
-		{"1", 0, false},     // single digit = ordinary single-menu answer
-		{"1 2 x", 0, false}, // non-digit token
-		{"12 3", 0, false},  // multi-digit token is not a menu digit
+		{"1 1,3 2", 3, true}, // a multi-select tab toggles several options
+		{"1,2 3", 2, true},   // comma group in the first tab
+		{"1", 0, false},      // single digit = ordinary single-menu answer
+		{"1 2 x", 0, false},  // non-digit token
+		{"12 3", 0, false},   // multi-digit token is not a menu digit
+		{"1, 3", 0, false},   // trailing comma is not a valid group
+		{"1,0 3", 0, false},  // 0 is not a 1-based menu digit
 		{"", 0, false},
 		{"yes no", 0, false},
 	}
@@ -147,6 +152,31 @@ func TestParseDigitSeries(t *testing.T) {
 		seq, ok := ParseDigitSeries(c.in)
 		if ok != c.ok || len(seq) != c.want {
 			t.Errorf("ParseDigitSeries(%q) = (%v,%v), want len %d ok %v", c.in, seq, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestParseTabSelections(t *testing.T) {
+	cases := []struct {
+		in   string
+		want [][]string
+		ok   bool
+	}{
+		{"1 2 1", [][]string{{"1"}, {"2"}, {"1"}}, true},
+		{"1 1,3 2", [][]string{{"1"}, {"1", "3"}, {"2"}}, true},
+		{"1,3,3 2", [][]string{{"1", "3"}, {"2"}}, true}, // duplicate toggle deduped
+		{"1", nil, false},    // single token is not a series
+		{"1 x", nil, false},  // invalid token
+		{"1, 2", nil, false}, // trailing comma
+	}
+	for _, c := range cases {
+		got, ok := ParseTabSelections(c.in)
+		if ok != c.ok {
+			t.Errorf("ParseTabSelections(%q) ok = %v, want %v", c.in, ok, c.ok)
+			continue
+		}
+		if ok && !reflect.DeepEqual(got, c.want) {
+			t.Errorf("ParseTabSelections(%q) = %v, want %v", c.in, got, c.want)
 		}
 	}
 }

--- a/internal/domain/mcqform_test.go
+++ b/internal/domain/mcqform_test.go
@@ -59,6 +59,17 @@ func TestMultiTabFormDetectsV2Footer(t *testing.T) {
 	}
 }
 
+func TestMultiTabFormCountsAnsweredTabs(t *testing.T) {
+	// A partially-answered form marks answered tabs ☒ (not ☐). All three tabs
+	// must still be counted (verified live: this read as 2 before the fix).
+	frame := "←  ☒ Agent identity  ☐ Stats to show  ✔ Submit  →\n\n" +
+		"Which stats?\n❯ 1. [ ] Auto-sends\n  2. [ ] Escalations\n\nEnter to select · Tab/Arrow keys to navigate · Esc to cancel\n"
+	tabs, ok := MultiTabForm(frame)
+	if !ok || tabs != 3 {
+		t.Fatalf("MultiTabForm(answered tab) = (%d,%v), want (3,true)", tabs, ok)
+	}
+}
+
 func TestMultiTabFormRejectsSingleQuestionForm(t *testing.T) {
 	// The single-question AskUserQuestion form has the "Enter to select"
 	// footer but no tab header and an ↑/↓ (not Tab/Arrow) footer.

--- a/internal/domain/menu.go
+++ b/internal/domain/menu.go
@@ -11,10 +11,43 @@ import (
 // menu that starts at 0 or skips a number is honored, not re-indexed).
 var numberedOptionRE = regexp.MustCompile(`(?m)^[ \t]*(?:[❯>][ \t]*)?(?:(\d+)[.)]|\[(\d+)\])[ \t]+(\S.*?)[ \t]*$`)
 
+// checkboxLabelRE matches the leading `[ ]` / `[x]` checkbox marker that a
+// Claude multi-SELECT question renders in front of each toggleable option
+// (e.g. "1. [ ] Auto-sends" parses to label "[ ] Auto-sends"). The capture
+// group is the box contents: a space (unchecked) or x/X (checked).
+var checkboxLabelRE = regexp.MustCompile(`^\[([ xX])\]`)
+
 // NumberedOption pairs a menu option's displayed number with its label.
 type NumberedOption struct {
 	Number string
 	Label  string
+}
+
+// MultiSelectTab reports whether a captured MCQ frame shows a multi-SELECT
+// question: one whose options carry per-option `[ ]`/`[x]` checkboxes (toggle
+// several with digit keys, then advance). A single-select question renders
+// plain numbered options with no checkbox and returns false.
+func MultiSelectTab(frame string) bool {
+	for _, o := range ParseNumberedOptions(frame) {
+		if checkboxLabelRE.MatchString(o.Label) {
+			return true
+		}
+	}
+	return false
+}
+
+// OptionCheckStates returns, for a multi-select frame, each option digit's
+// current checkbox state (true = checked). Options without a checkbox marker
+// are omitted, so an all-unchecked multi-select tab yields every digit mapped
+// to false. Delivery uses this to verify the toggle baseline before typing.
+func OptionCheckStates(frame string) map[string]bool {
+	states := make(map[string]bool)
+	for _, o := range ParseNumberedOptions(frame) {
+		if m := checkboxLabelRE.FindStringSubmatch(o.Label); m != nil {
+			states[o.Number] = m[1] == "x" || m[1] == "X"
+		}
+	}
+	return states
 }
 
 // ParseNumberedOptions extracts the numbered options from pane content in

--- a/internal/domain/menu_test.go
+++ b/internal/domain/menu_test.go
@@ -4,6 +4,33 @@ import "testing"
 
 const claudeApproval = "Bash(go test ./...)\n\nDo you want to proceed?\n❯ 1. Yes\n  2. No, and tell the agent what to do differently\n"
 
+// A multi-SELECT question renders per-option checkboxes; a single-select one
+// renders plain numbered options.
+const multiSelectFrame = "Which stats should show?\n❯ 1. [ ] Auto-sends\n  2. [x] Escalations\n  3. [ ] Confirmed\n\nEnter to select · Tab to switch questions\n"
+
+func TestMultiSelectTab(t *testing.T) {
+	if !MultiSelectTab(multiSelectFrame) {
+		t.Error("checkbox options must classify as multi-select")
+	}
+	if MultiSelectTab(claudeApproval) {
+		t.Error("plain numbered options must NOT classify as multi-select")
+	}
+}
+
+func TestOptionCheckStates(t *testing.T) {
+	states := OptionCheckStates(multiSelectFrame)
+	if len(states) != 3 {
+		t.Fatalf("want 3 checkbox states, got %d: %+v", len(states), states)
+	}
+	if states["1"] || !states["2"] || states["3"] {
+		t.Errorf("check states wrong: %+v (want only option 2 checked)", states)
+	}
+	// A frame without checkboxes yields no states.
+	if got := OptionCheckStates(claudeApproval); len(got) != 0 {
+		t.Errorf("non-checkbox options must yield no check states, got %+v", got)
+	}
+}
+
 func TestParseNumberedOptions(t *testing.T) {
 	opts := ParseNumberedOptions(claudeApproval)
 	if len(opts) != 2 {

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -69,6 +69,7 @@ type Situation struct {
 	PermissionVerb string   // salient permission verb/action (approval situations)
 	ErrorSummary   string   // salient error text (error situations)
 	TabCount       int      // multi-tab MCQ form: number of tabs incl. Submit (0/1 = single question)
+	TabMultiSelect []bool   // per-tab: true where a question is multi-select (toggle several, then advance); len==TabCount, Submit tab false. Set during the sweep; nil on the non-swept path.
 }
 
 // ActionKind is what the plugin decided to do.

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -871,6 +871,7 @@ var ConfigFields = []ConfigFieldDef{
 	{Key: "embedding.pane_salient_chars", TUIEditable: true},
 	{Key: "embedding.model_context_window", TUIEditable: true},
 	{Key: "tui.max_content_width", TUIEditable: true},
+	{Key: "tui.max_content_height", TUIEditable: true},
 	{Key: "tui.theme", TUIEditable: true},
 }
 
@@ -998,6 +999,11 @@ func FieldValue(cfg config.Config, key string) string {
 			return "0 (full width)"
 		}
 		return strconv.Itoa(cfg.TUI.MaxContentWidth)
+	case "tui.max_content_height":
+		if cfg.TUI.MaxContentHeight == 0 {
+			return "0 (unlimited)"
+		}
+		return strconv.Itoa(cfg.TUI.MaxContentHeight)
 	case "tui.theme":
 		if cfg.TUI.Theme == "" {
 			return "default"
@@ -1178,6 +1184,13 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 				return fmt.Errorf("tui.max_content_width must be a non-negative integer (0 = full width), got %q", value)
 			}
 			cfg.TUI.MaxContentWidth = v
+			return nil
+		case "tui.max_content_height":
+			v, err := strconv.Atoi(value)
+			if err != nil || v < 0 {
+				return fmt.Errorf("tui.max_content_height must be a non-negative integer (0 = unlimited), got %q", value)
+			}
+			cfg.TUI.MaxContentHeight = v
 			return nil
 		case "tui.theme":
 			// `config set` rejects unknown names with the valid list (the

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -38,6 +38,58 @@ const menuReadLines = 40
 const seriesResetKeys = 10
 const seriesKeyDelay = 250 * time.Millisecond
 
+// seriesAdvanceKey advances past a MULTI-SELECT tab after its toggles (mirrors
+// the daemon's sweepAdvanceKey); a single-select tab auto-advances on its digit.
+const seriesAdvanceKey = "right"
+
+// deliverTabSeries answers a multi-tab question form for the operator-confirm
+// path. Unlike the daemon it never swept the form, so it reads each tab as it
+// goes: reset to the first question, then per tab verify the form is still up,
+// detect whether the tab is multi-select (its options show `[ ]` checkboxes),
+// press the chosen digit(s), and — for a multi-select tab — press an explicit
+// advance (a single-select tab auto-advances on its one digit). A multi-select
+// tab that already has a selection is refused: toggling is relative, so a
+// non-empty baseline would produce the wrong set. groups has one entry per tab
+// (validated by the caller against the tab count).
+func (a *App) deliverTabSeries(ctx context.Context, ks ports.KeystrokeSender, agentID string, groups [][]string) error {
+	for i := 0; i < seriesResetKeys; i++ {
+		if err := ks.SendKey(ctx, agentID, "left"); err != nil {
+			return fmt.Errorf("resetting the form failed: %w", err)
+		}
+	}
+	time.Sleep(seriesKeyDelay)
+	for tab, group := range groups {
+		frame, err := a.readVisiblePane(ctx, agentID, menuReadLines)
+		if err != nil {
+			return fmt.Errorf("re-reading tab %d/%d failed: %w", tab+1, len(groups), err)
+		}
+		if tabs, ok := domain.MultiTabForm(frame); !ok || tabs != len(groups) {
+			return fmt.Errorf("the pane no longer shows the %d-tab form at tab %d; answer in the pane", len(groups), tab+1)
+		}
+		multi := domain.MultiSelectTab(frame)
+		if multi {
+			for digit, checked := range domain.OptionCheckStates(frame) {
+				if checked {
+					return fmt.Errorf("tab %d already has option %s selected; answer in the pane", tab+1, digit)
+				}
+			}
+		}
+		for _, digit := range group {
+			if err := ks.SendKey(ctx, agentID, digit); err != nil {
+				return fmt.Errorf("sending option %s on tab %d failed: %w", digit, tab+1, err)
+			}
+			time.Sleep(seriesKeyDelay)
+		}
+		if multi {
+			if err := ks.SendKey(ctx, agentID, seriesAdvanceKey); err != nil {
+				return fmt.Errorf("advancing past tab %d failed: %w", tab+1, err)
+			}
+			time.Sleep(seriesKeyDelay)
+		}
+	}
+	return nil
+}
+
 // readVisiblePane returns the pane's current on-screen content, preferring a
 // visible-source read (which reflects a standing menu) and falling back to
 // the plain recent read when the adapter cannot do visible reads.
@@ -402,37 +454,24 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 		// free-text prompt, or a non-menu situation, deliver the literal
 		// reply unchanged.
 		pane, rerr := a.readVisiblePane(ctx, audit.AgentID, menuReadLines)
-		// A digit series ("1 2 3 2 1") answers a multi-tab question form:
-		// one digit keystroke per tab, Submit included — sent as literal
-		// text it would land in the first question's input instead.
-		if seq, isSeries := domain.ParseDigitSeries(outbound); isSeries &&
+		// A per-tab answer series ("1 2 1", or "1 1,3 2" when a tab is multi-
+		// select) answers a multi-tab question form: one keystroke group per
+		// tab, Submit included — sent as literal text it would land in the
+		// first question's input instead.
+		if groups, isSeries := domain.ParseTabSelections(outbound); isSeries &&
 			audit.SituationType == domain.SituationChoice {
 			if rerr != nil {
 				return fmt.Errorf("correction recorded, but the pane could not be read to deliver the answer series: %w", rerr)
 			}
-			if tabs, ok := domain.MultiTabForm(pane); !ok || tabs != len(seq) {
-				return fmt.Errorf("correction recorded, but the pane no longer shows a %d-tab form; answer series not delivered", len(seq))
+			if tabs, ok := domain.MultiTabForm(pane); !ok || tabs != len(groups) {
+				return fmt.Errorf("correction recorded, but the pane no longer shows a %d-tab form; answer series not delivered", len(groups))
 			}
 			ks, ok := a.Herdr.(ports.KeystrokeSender)
 			if !ok {
 				return fmt.Errorf("correction recorded, but this herdr adapter cannot send keystrokes for the answer series")
 			}
-			// Reset to the first question with a fixed Left-arrow burst —
-			// the operator may have tabbed around the form since the
-			// escalation was raised — then answer one digit per tab.
-			for i := 0; i < seriesResetKeys; i++ {
-				if err := ks.SendKey(ctx, audit.AgentID, "left"); err != nil {
-					return fmt.Errorf("correction recorded, but resetting the form failed: %w", err)
-				}
-			}
-			time.Sleep(seriesKeyDelay)
-			for i, digit := range seq {
-				if i > 0 {
-					time.Sleep(seriesKeyDelay)
-				}
-				if err := ks.SendKey(ctx, audit.AgentID, digit); err != nil {
-					return fmt.Errorf("correction recorded, but the answer series failed at digit %d/%d: %w", i+1, len(seq), err)
-				}
+			if err := a.deliverTabSeries(ctx, ks, audit.AgentID, groups); err != nil {
+				return fmt.Errorf("correction recorded, but %w", err)
 			}
 			return a.nudge(ctx, control.KindReload)
 		}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -31,62 +31,87 @@ import (
 // recover the live numbered menu before delivering the operator's reply.
 const menuReadLines = 40
 
-// seriesResetKeys / seriesKeyDelay mirror the daemon's multi-tab answer
-// protocol (sweepResetKeys / sweepKeyDelay): a fixed Left-arrow burst lands
-// on the first question regardless of form size, and the delay lets the
-// form advance and re-render between keystrokes.
-const seriesResetKeys = 10
+// seriesResetKeys / seriesAdvanceKey alias the shared domain protocol
+// constants so the operator-confirm path navigates a form identically to the
+// daemon's sweep and delivery (single source of truth — domain.MCQ*).
+// seriesKeyDelay mirrors the daemon's sweepKeyDelay pacing.
+const seriesResetKeys = domain.MCQResetKeys
+const seriesAdvanceKey = domain.MCQAdvanceKey
 const seriesKeyDelay = 250 * time.Millisecond
 
-// seriesAdvanceKey advances past a MULTI-SELECT tab after its toggles (mirrors
-// the daemon's sweepAdvanceKey); a single-select tab auto-advances on its digit.
-const seriesAdvanceKey = "right"
-
 // deliverTabSeries answers a multi-tab question form for the operator-confirm
-// path. Unlike the daemon it never swept the form, so it reads each tab as it
-// goes: reset to the first question, then per tab verify the form is still up,
-// detect whether the tab is multi-select (its options show `[ ]` checkboxes),
-// press the chosen digit(s), and — for a multi-select tab — press an explicit
-// advance (a single-select tab auto-advances on its one digit). A multi-select
-// tab that already has a selection is refused: toggling is relative, so a
-// non-empty baseline would produce the wrong set. groups has one entry per tab
-// (validated by the caller against the tab count).
+// path. Unlike the daemon it never swept the form, so it verifies in two
+// passes to stay all-or-nothing (matching the daemon's refuse-before-any-
+// keystroke behavior): first a read-only walk of every tab confirming the form
+// is stable and no multi-select tab already has a selection, then — only if
+// that passes — a delivery pass that toggles. This way a refusal never leaves
+// the form half-answered. groups has one entry per tab (validated by the
+// caller against the tab count).
 func (a *App) deliverTabSeries(ctx context.Context, ks ports.KeystrokeSender, agentID string, groups [][]string) error {
+	multi, err := a.verifyTabBaseline(ctx, ks, agentID, len(groups))
+	if err != nil {
+		return err
+	}
+	if err := a.resetForm(ctx, ks, agentID); err != nil {
+		return err
+	}
+	keys := domain.MultiTabKeys(groups, multi, seriesAdvanceKey)
+	for i, key := range keys {
+		if i > 0 {
+			time.Sleep(seriesKeyDelay)
+		}
+		if err := ks.SendKey(ctx, agentID, key); err != nil {
+			return fmt.Errorf("delivering keystroke %d/%d (%q) failed: %w", i+1, len(keys), key, err)
+		}
+	}
+	return nil
+}
+
+// verifyTabBaseline walks the form read-only (reset, then one Right per tab)
+// and returns each tab's multi-select flag, erroring if the form drifted or a
+// multi-select tab already carries a selection. It toggles nothing, so the
+// caller can refuse before any answer keystroke — an all-or-nothing baseline
+// check that mirrors the daemon's capture-time refusal.
+func (a *App) verifyTabBaseline(ctx context.Context, ks ports.KeystrokeSender, agentID string, tabCount int) ([]bool, error) {
+	if err := a.resetForm(ctx, ks, agentID); err != nil {
+		return nil, err
+	}
+	multi := make([]bool, tabCount)
+	for tab := 0; tab < tabCount; tab++ {
+		if tab > 0 {
+			if err := ks.SendKey(ctx, agentID, seriesAdvanceKey); err != nil {
+				return nil, fmt.Errorf("walking to tab %d failed: %w", tab+1, err)
+			}
+			time.Sleep(seriesKeyDelay)
+		}
+		frame, err := a.readVisiblePane(ctx, agentID, menuReadLines)
+		if err != nil {
+			return nil, fmt.Errorf("re-reading tab %d/%d failed: %w", tab+1, tabCount, err)
+		}
+		if tabs, ok := domain.MultiTabForm(frame); !ok || tabs != tabCount {
+			return nil, fmt.Errorf("the pane no longer shows the %d-tab form at tab %d; answer in the pane", tabCount, tab+1)
+		}
+		if domain.MultiSelectTab(frame) {
+			multi[tab] = true
+			for digit, checked := range domain.OptionCheckStates(frame) {
+				if checked {
+					return nil, fmt.Errorf("tab %d already has option %s selected; answer in the pane", tab+1, digit)
+				}
+			}
+		}
+	}
+	return multi, nil
+}
+
+// resetForm sends the fixed Left-arrow burst that lands focus on the first
+// question, then pauses for the form to re-render.
+func (a *App) resetForm(ctx context.Context, ks ports.KeystrokeSender, agentID string) error {
 	for i := 0; i < seriesResetKeys; i++ {
 		if err := ks.SendKey(ctx, agentID, "left"); err != nil {
 			return fmt.Errorf("resetting the form failed: %w", err)
 		}
 	}
 	time.Sleep(seriesKeyDelay)
-	for tab, group := range groups {
-		frame, err := a.readVisiblePane(ctx, agentID, menuReadLines)
-		if err != nil {
-			return fmt.Errorf("re-reading tab %d/%d failed: %w", tab+1, len(groups), err)
-		}
-		if tabs, ok := domain.MultiTabForm(frame); !ok || tabs != len(groups) {
-			return fmt.Errorf("the pane no longer shows the %d-tab form at tab %d; answer in the pane", len(groups), tab+1)
-		}
-		multi := domain.MultiSelectTab(frame)
-		if multi {
-			for digit, checked := range domain.OptionCheckStates(frame) {
-				if checked {
-					return fmt.Errorf("tab %d already has option %s selected; answer in the pane", tab+1, digit)
-				}
-			}
-		}
-		for _, digit := range group {
-			if err := ks.SendKey(ctx, agentID, digit); err != nil {
-				return fmt.Errorf("sending option %s on tab %d failed: %w", digit, tab+1, err)
-			}
-			time.Sleep(seriesKeyDelay)
-		}
-		if multi {
-			if err := ks.SendKey(ctx, agentID, seriesAdvanceKey); err != nil {
-				return fmt.Errorf("advancing past tab %d failed: %w", tab+1, err)
-			}
-			time.Sleep(seriesKeyDelay)
-		}
-	}
 	return nil
 }
 

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -587,8 +587,13 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	}
 
 	if send && a.Herdr != nil {
-		// Only the first task is sent — the operator's "start now" task.
-		if err := a.Herdr.Send(ctx, audit.AgentID, tasks[0]); err != nil {
+		// Only the first task is sent — the operator's "start now" task. Render
+		// it through the same default next-task template used by a declared task
+		// source, so every idle-task handoff includes both the task and its list.
+		prompt := domain.DeclaredTask{
+			Task: tasks[0], Path: path, AgentName: name,
+		}.Prompt()
+		if err := a.Herdr.Send(ctx, audit.AgentID, prompt); err != nil {
 			return fmt.Errorf("task source created, but sending the task to the agent failed: %w", err)
 		}
 	}

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -415,9 +415,11 @@ func TestConfirmGeneratedTaskWritesSourceAndSends(t *testing.T) {
 		t.Errorf("confirm should record a declared-task correction: %+v", corr)
 	}
 
-	// The task text was sent to the agent's pane.
-	if len(fake.inputs) != 1 || fake.inputs[0] != taskText {
-		t.Errorf("delivered %v, want the task text %q", fake.inputs, taskText)
+	// The generated task uses the same default prompt as every declared task,
+	// including the newly created task-list path.
+	wantPrompt := domain.DeclaredTask{Task: taskText, Path: path, AgentName: name}.Prompt()
+	if len(fake.inputs) != 1 || fake.inputs[0] != wantPrompt {
+		t.Errorf("delivered %v, want the rendered prompt %q", fake.inputs, wantPrompt)
 	}
 	if len(fake.panes) != 1 || fake.panes[0] != "w1:p1" {
 		t.Errorf("delivered to %v, want the audit's agent pane", fake.panes)
@@ -483,9 +485,13 @@ func TestConfirmGeneratedMultipleTasksWritesChecklist(t *testing.T) {
 	if !strings.Contains(string(body), want) {
 		t.Errorf("tasks file = %q, want a checklist %q", body, want)
 	}
-	// Only the first task is sent to the agent.
-	if len(fake.inputs) != 1 || fake.inputs[0] != "Investigate the flaky auth test" {
-		t.Errorf("delivered %v, want only the first task", fake.inputs)
+	// Only the first task is sent to the agent, rendered through the same
+	// default prompt used for later items from the registered source.
+	wantPrompt := domain.DeclaredTask{
+		Task: "Investigate the flaky auth test", Path: path, AgentName: name,
+	}.Prompt()
+	if len(fake.inputs) != 1 || fake.inputs[0] != wantPrompt {
+		t.Errorf("delivered %v, want only the first task as %q", fake.inputs, wantPrompt)
 	}
 	// The next declared task is the first pending item, so the queue drives on
 	// later idles.

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -933,6 +933,7 @@ func TestConfigFieldRegistryParity(t *testing.T) {
 		"embedding.gpu_layers":                "0",
 		"embedding.model_context_window":      "512",
 		"tui.max_content_width":               "140",
+		"tui.max_content_height":              "12",
 		"tui.theme":                           "dark",
 	}
 
@@ -1075,6 +1076,10 @@ func TestSetFieldNewKeysValidation(t *testing.T) {
 		{"tui.max_content_width", "0", false},
 		{"tui.max_content_width", "-1", true},
 		{"tui.max_content_width", "abc", true},
+		{"tui.max_content_height", "12", false},
+		{"tui.max_content_height", "0", false},
+		{"tui.max_content_height", "-1", true},
+		{"tui.max_content_height", "abc", true},
 		{"safety.disable_seed", "true", false},
 		{"safety.disable_seed", "false", false},
 		{"safety.disable_seed", "yes", true},
@@ -1133,6 +1138,9 @@ func TestSetFieldNewKeysValidation(t *testing.T) {
 	if err := app.SetField(ctx, "tui.max_content_width", "140"); err != nil {
 		t.Fatal(err)
 	}
+	if err := app.SetField(ctx, "tui.max_content_height", "12"); err != nil {
+		t.Fatal(err)
+	}
 	if err := app.SetField(ctx, "safety.disable_seed", "true"); err != nil {
 		t.Fatal(err)
 	}
@@ -1144,6 +1152,9 @@ func TestSetFieldNewKeysValidation(t *testing.T) {
 	}
 	if cfg.TUI.MaxContentWidth != 140 {
 		t.Errorf("tui.max_content_width = %d, want 140", cfg.TUI.MaxContentWidth)
+	}
+	if cfg.TUI.MaxContentHeight != 12 {
+		t.Errorf("tui.max_content_height = %d, want 12", cfg.TUI.MaxContentHeight)
 	}
 	if !cfg.Safety.DisableSeed {
 		t.Error("safety.disable_seed = false, want true (assignment not persisted)")

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -1700,9 +1700,12 @@ func TestResolveDigitSeriesDeliversKeystrokes(t *testing.T) {
 	if len(fake.inputs) != 0 {
 		t.Errorf("series must not be sent as text, sent %v", fake.inputs)
 	}
-	// A fixed Left-arrow burst resets the form to question 1 first — the
-	// operator may have tabbed around since the escalation was raised.
-	want := strings.TrimSpace(strings.Repeat("left ", 10)) + " 1 2 1"
+	// All-or-nothing delivery: a read-only baseline pre-pass first (reset, then
+	// a Right-arrow walk of tabs 2 and 3) confirms the form is stable and no
+	// multi-select tab is pre-selected, then the delivery pass resets again and
+	// types one digit per (single-select) tab.
+	reset := strings.TrimSpace(strings.Repeat("left ", 10))
+	want := reset + " right right " + reset + " 1 2 1"
 	if got := strings.Join(fake.keys, " "); got != want {
 		t.Errorf("keystrokes = %q, want %q", got, want)
 	}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -114,15 +114,19 @@ func toolDefinitions() []map[string]any {
 		},
 		{
 			"name":        "submit_decision",
-			"description": "Submit your decision for the pending request. Which field to use depends on the situation_type in get_context: \"approval\" and \"choice\" listing options (or a multi-tab form) MUST be answered with select_options — the 1-based option number(s) shown in the context (single menu: exactly one integer, e.g. [2]; multi-tab question form: one integer per tab in tab order, Submit included, e.g. [1, 2, 3, 2, 1]) — while an approval/choice with NO options listed (e.g. a bare y/n prompt) takes recommend_action with the literal text the prompt expects; \"idle\" and \"error\" MUST be answered with recommend_action — the literal reply text (next prompt/task for idle, recovery command/reply for error), and select_options is rejected. In ANY situation, if the agent needs NO reply at all — it finished, it is only reporting status, or any prompt would just nudge it pointlessly — submit recommend_action \"@noop\" to explicitly do nothing. When get_context carries a proposed_task (a pre-send task review of an idle agent), decide from the pane whether to send that queued task now: to send it unchanged submit recommend_action \"@next_task:declared\" (the daemon sends proposed_task verbatim — no need to copy it); put literal text in recommend_action only to edit the task or, if current_task is already done, to send the next unfinished item from pending_tasks; or submit \"@noop\" with a rationale to decline (e.g. every task is done). Your confident_score gates this exactly like any other decision — a confident review is applied automatically (the task is sent, or skipped on a decline) and a low-confidence one is surfaced to the operator. ALWAYS include confident_score: the daemon auto-acts only when your confidence meets the operator's threshold, otherwise it asks the operator to confirm — so a missing or low score means your decision is surfaced for human review, not acted on. The daemon re-gates every submission through this confidence gate and the never-auto patterns before acting.",
+			"description": "Submit your decision for the pending request. Which field to use depends on the situation_type in get_context: \"approval\" and \"choice\" listing options (or a multi-tab form) MUST be answered with select_options — the 1-based option number(s) shown in the context (single menu: exactly one integer, e.g. [2]; multi-tab question form: one entry per tab in tab order, Submit included, e.g. [1, 2, 3, 2, 1] — and for a MULTI-SELECT tab, whose options show `[ ]` checkboxes, pass an array of the numbers to toggle, e.g. [1, [1, 3], 2]) — while an approval/choice with NO options listed (e.g. a bare y/n prompt) takes recommend_action with the literal text the prompt expects; \"idle\" and \"error\" MUST be answered with recommend_action — the literal reply text (next prompt/task for idle, recovery command/reply for error), and select_options is rejected. In ANY situation, if the agent needs NO reply at all — it finished, it is only reporting status, or any prompt would just nudge it pointlessly — submit recommend_action \"@noop\" to explicitly do nothing. When get_context carries a proposed_task (a pre-send task review of an idle agent), decide from the pane whether to send that queued task now: to send it unchanged submit recommend_action \"@next_task:declared\" (the daemon sends proposed_task verbatim — no need to copy it); put literal text in recommend_action only to edit the task or, if current_task is already done, to send the next unfinished item from pending_tasks; or submit \"@noop\" with a rationale to decline (e.g. every task is done). Your confident_score gates this exactly like any other decision — a confident review is applied automatically (the task is sent, or skipped on a decline) and a low-confidence one is surfaced to the operator. ALWAYS include confident_score: the daemon auto-acts only when your confidence meets the operator's threshold, otherwise it asks the operator to confirm — so a missing or low score means your decision is surfaced for human review, not acted on. The daemon re-gates every submission through this confidence gate and the never-auto patterns before acting.",
 			"inputSchema": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"request_id": map[string]any{"type": "string", "description": "Decision request id (optional; defaults to the current request)"},
 					"recommend_action": map[string]any{"type": "string",
 						"description": "Literal reply text to send to the agent — REQUIRED for idle and error situations, and for approval/choice prompts with no options listed — or \"@noop\" in any situation to explicitly send nothing. Not accepted as the answer to an approval/choice that lists options (use select_options)."},
-					"select_options": map[string]any{"type": "array", "items": map[string]any{"type": "integer", "minimum": 1, "maximum": 9},
-						"description": "REQUIRED answer for approval and choice situations that list options: the chosen option number(s), 1-based. A single menu takes exactly one integer, e.g. [2]. A multi-tab question form takes exactly one integer per tab in tab order, Submit included, e.g. [1, 2, 3, 2, 1]. Rejected for idle/error situations."},
+					"select_options": map[string]any{"type": "array",
+						"items": map[string]any{"oneOf": []any{
+							map[string]any{"type": "integer", "minimum": 1, "maximum": 9},
+							map[string]any{"type": "array", "items": map[string]any{"type": "integer", "minimum": 1, "maximum": 9}},
+						}},
+						"description": "REQUIRED answer for approval and choice situations that list options: the chosen option number(s), 1-based. A single menu takes exactly one integer, e.g. [2]. A multi-tab question form takes one entry per tab in tab order, Submit included: an integer for a single-select tab, or an ARRAY of integers to toggle several options on a MULTI-SELECT tab (its options show `[ ]` checkboxes), e.g. [1, [1, 3], 2] toggles options 1 and 3 on tab 2. Rejected for idle/error situations."},
 					"confident_score": map[string]any{"type": "integer", "minimum": 0, "maximum": 100,
 						"description": "REQUIRED. How confident you are in this decision, 0 (a guess) to 100 (certain). This gates auto-action: the daemon only acts automatically when this meets the operator's auto_act_confidence_threshold; below it (or if omitted) the decision is shown to the operator to confirm."},
 					"rationale": map[string]any{"type": "string", "description": "Why this action matches the operator's likely intent"},
@@ -133,14 +137,35 @@ func toolDefinitions() []map[string]any {
 	}
 }
 
+// selectOption is one tab's answer inside submit_decision.select_options: a
+// single option number (single-select tab / single menu) or an array of
+// numbers to TOGGLE (a multi-select tab). It unmarshals from either a JSON
+// integer (2) or a JSON array of integers ([1,3]), so the two answer shapes
+// coexist in one array — e.g. [1, [1,3], 2].
+type selectOption []int
+
+func (so *selectOption) UnmarshalJSON(b []byte) error {
+	var n int
+	if err := json.Unmarshal(b, &n); err == nil {
+		*so = []int{n}
+		return nil
+	}
+	var arr []int
+	if err := json.Unmarshal(b, &arr); err != nil {
+		return fmt.Errorf("select_options entry must be an option number (e.g. 2) or an array of numbers (e.g. [1,3]): %w", err)
+	}
+	*so = arr
+	return nil
+}
+
 type toolCallParams struct {
 	Name      string `json:"name"`
 	Arguments struct {
-		RequestID       string `json:"request_id"`
-		RecommendAction string `json:"recommend_action"`
-		SelectOptions   []int  `json:"select_options"`
-		ConfidentScore  *int   `json:"confident_score"`
-		Rationale       string `json:"rationale"`
+		RequestID       string         `json:"request_id"`
+		RecommendAction string         `json:"recommend_action"`
+		SelectOptions   []selectOption `json:"select_options"`
+		ConfidentScore  *int           `json:"confident_score"`
+		Rationale       string         `json:"rationale"`
 		// Legacy aliases from the pre-rename tool surface; accepted so a
 		// consult started under an older prompt still lands.
 		Action   string `json:"action"`
@@ -158,36 +183,52 @@ type consultContextFields struct {
 	TabCount int      `json:"tab_count"`
 }
 
-// resolveSelectOptions turns 1-based option numbers into the outbound reply
-// the daemon's gates expect: the option's text for a single menu (falling
-// back to the bare digit when the context lists no options — numbered menus
-// accept an already-numeric selection), or the space-joined digit series for
-// a multi-tab form (one digit per tab, Submit included).
-func resolveSelectOptions(contextJSON string, selects []int) (action, optionID string, err error) {
+// resolveSelectOptions turns per-tab 1-based option numbers into the outbound
+// reply the daemon's gates expect: the option's text for a single menu
+// (falling back to the bare digit when the context lists no options — numbered
+// menus accept an already-numeric selection), or the per-tab answer series for
+// a multi-tab form. Each tab contributes one space-separated token; a multi-
+// SELECT tab's several toggles are comma-joined within that token
+// (e.g. [1, [1,3], 2] -> "1 1,3 2"). Delivery decides where to press an
+// explicit advance from the captured per-tab select kind, not from this shape.
+func resolveSelectOptions(contextJSON string, selects []selectOption) (action, optionID string, err error) {
 	var cc consultContextFields
 	// The blob is daemon-authored JSON; if it doesn't parse, degrade to no
 	// options/tabs rather than refusing the submission.
 	_ = json.Unmarshal([]byte(contextJSON), &cc)
 	if cc.TabCount > 1 && len(selects) != cc.TabCount {
-		return "", "", fmt.Errorf("this multi-tab form has %d tabs (Submit included): select_options needs exactly %d integers in tab order, got %d",
+		return "", "", fmt.Errorf("this multi-tab form has %d tabs (Submit included): select_options needs exactly %d entries in tab order, got %d",
 			cc.TabCount, cc.TabCount, len(selects))
 	}
 	if cc.TabCount <= 1 && len(selects) != 1 {
-		return "", "", fmt.Errorf("this situation takes a single choice: select_options needs exactly one integer, got %d", len(selects))
+		return "", "", fmt.Errorf("this situation takes a single choice: select_options needs exactly one option number, got %d", len(selects))
 	}
-	for i, n := range selects {
-		if n < 1 || n > 9 {
-			return "", "", fmt.Errorf("select_options[%d] = %d: option numbers are 1-based menu digits (1-9)", i, n)
+	for i, g := range selects {
+		if len(g) == 0 {
+			return "", "", fmt.Errorf("select_options[%d] is empty: choose at least one option number", i)
+		}
+		for _, n := range g {
+			if n < 1 || n > 9 {
+				return "", "", fmt.Errorf("select_options[%d] = %d: option numbers are 1-based menu digits (1-9)", i, n)
+			}
 		}
 	}
 	if cc.TabCount > 1 {
-		digits := make([]string, len(selects))
-		for i, n := range selects {
-			digits[i] = strconv.Itoa(n)
+		tokens := make([]string, len(selects))
+		for i, g := range selects {
+			digits := make([]string, len(g))
+			for j, n := range g {
+				digits[j] = strconv.Itoa(n)
+			}
+			tokens[i] = strings.Join(digits, ",")
 		}
-		return strings.Join(digits, " "), "", nil
+		return strings.Join(tokens, " "), "", nil
 	}
-	n := selects[0]
+	// Single menu: exactly one option number (a toggle array makes no sense).
+	if len(selects[0]) != 1 {
+		return "", "", fmt.Errorf("this single menu takes exactly one option number, got %d", len(selects[0]))
+	}
+	n := selects[0][0]
 	if len(cc.Options) > 0 {
 		if n > len(cc.Options) {
 			return "", "", fmt.Errorf("select_options[0] = %d but only %d options are offered", n, len(cc.Options))

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -181,6 +181,18 @@ type toolCallParams struct {
 type consultContextFields struct {
 	Options  []string `json:"options"`
 	TabCount int      `json:"tab_count"`
+	// TabSelectKinds is per-tab "single"/"multi" (present only when a form has
+	// a multi-select tab). Only a "multi" tab may receive several option
+	// numbers (an array); a scalar/single-select tab or the Submit tab takes
+	// exactly one, so a multi-value entry there is rejected — otherwise the
+	// extra digits would deliver with no advance and shift onto later tabs.
+	TabSelectKinds []string `json:"tab_select_kinds"`
+}
+
+// tabIsMulti reports whether tab i is a multi-select tab per the context's
+// per-tab kinds (absent/short kinds → single-select, the safe default).
+func tabIsMulti(kinds []string, i int) bool {
+	return i < len(kinds) && kinds[i] == "multi"
 }
 
 // resolveSelectOptions turns per-tab 1-based option numbers into the outbound
@@ -206,6 +218,9 @@ func resolveSelectOptions(contextJSON string, selects []selectOption) (action, o
 	for i, g := range selects {
 		if len(g) == 0 {
 			return "", "", fmt.Errorf("select_options[%d] is empty: choose at least one option number", i)
+		}
+		if len(g) > 1 && !tabIsMulti(cc.TabSelectKinds, i) {
+			return "", "", fmt.Errorf("select_options[%d] lists %d numbers but that tab is single-select (only a MULTI-select tab with `[ ]` checkboxes takes several); the Submit tab and single-choice tabs take exactly one", i, len(g))
 		}
 		for _, n := range g {
 			if n < 1 || n > 9 {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -145,7 +145,7 @@ func TestMCPSelectOptionsValidation(t *testing.T) {
 	resp := c.call(t, "tools/call", map[string]any{
 		"name": "submit_decision", "arguments": map[string]any{"select_options": []int{1, 2}},
 	})
-	if text, _ := json.Marshal(resp); !strings.Contains(string(text), "exactly 3 integers") {
+	if text, _ := json.Marshal(resp); !strings.Contains(string(text), "exactly 3 entries") {
 		t.Fatalf("wrong series length must error with the expected count: %s", text)
 	}
 	resp = c.call(t, "tools/call", map[string]any{
@@ -157,6 +157,24 @@ func TestMCPSelectOptionsValidation(t *testing.T) {
 	pending, _ := st.PendingLLMDecisions(ctx)
 	if len(pending) != 1 || pending[0].Action != "1 2 1" {
 		t.Fatalf("multi-tab selects should join to a digit series, got %+v", pending)
+	}
+	if err := st.UpdateLLMDecisionStatus(ctx, pending[0].ID, "expired"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A MULTI-SELECT tab is answered with an array of option numbers; the mixed
+	// int-or-array shape joins to the comma-grouped per-tab series delivery.
+	stage("req-ms", `{"options":[],"tab_count":3}`)
+	c = startServer(t, st, "req-ms")
+	resp = c.call(t, "tools/call", map[string]any{
+		"name": "submit_decision", "arguments": map[string]any{"select_options": []any{1, []int{1, 3}, 2}},
+	})
+	if text, _ := json.Marshal(resp); !strings.Contains(string(text), "staged") {
+		t.Fatalf("mixed int-or-array series should stage: %s", text)
+	}
+	pending, _ = st.PendingLLMDecisions(ctx)
+	if len(pending) != 1 || pending[0].Action != "1 1,3 2" {
+		t.Fatalf("mixed selects should join to a grouped series, got %+v", pending)
 	}
 	if err := st.UpdateLLMDecisionStatus(ctx, pending[0].ID, "expired"); err != nil {
 		t.Fatal(err)

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -162,9 +162,10 @@ func TestMCPSelectOptionsValidation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// A MULTI-SELECT tab is answered with an array of option numbers; the mixed
-	// int-or-array shape joins to the comma-grouped per-tab series delivery.
-	stage("req-ms", `{"options":[],"tab_count":3}`)
+	// A MULTI-SELECT tab (per tab_select_kinds) is answered with an array of
+	// option numbers; the mixed int-or-array shape joins to the comma-grouped
+	// per-tab series delivery.
+	stage("req-ms", `{"options":[],"tab_count":3,"tab_select_kinds":["single","multi","single"]}`)
 	c = startServer(t, st, "req-ms")
 	resp = c.call(t, "tools/call", map[string]any{
 		"name": "submit_decision", "arguments": map[string]any{"select_options": []any{1, []int{1, 3}, 2}},
@@ -178,6 +179,17 @@ func TestMCPSelectOptionsValidation(t *testing.T) {
 	}
 	if err := st.UpdateLLMDecisionStatus(ctx, pending[0].ID, "expired"); err != nil {
 		t.Fatal(err)
+	}
+
+	// An array on a SINGLE-select tab (tab 1 here) is rejected: its extra
+	// digits would deliver with no advance and shift onto later tabs.
+	stage("req-ms2", `{"options":[],"tab_count":3,"tab_select_kinds":["single","multi","single"]}`)
+	c = startServer(t, st, "req-ms2")
+	resp = c.call(t, "tools/call", map[string]any{
+		"name": "submit_decision", "arguments": map[string]any{"select_options": []any{[]int{1, 2}, 1, 2}},
+	})
+	if text, _ := json.Marshal(resp); !strings.Contains(string(text), "single-select") {
+		t.Fatalf("array on a single-select tab must be rejected: %s", text)
 	}
 
 	// A single menu takes exactly one integer, bounded by the offered set.

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -668,7 +668,7 @@ func TestConfigShowsIndicatorAndCaptureRows(t *testing.T) {
 		"indicator #0  drop table",
 		"indicator-rule #0  agents=claude  rm -rf /",
 		"Capture delays (read-only — edit config.toml)",
-		"defaults  start=10000ms event=500ms (built-in)", // no [[capture_delay]] configured
+		"defaults  start=10000ms event=2000ms (built-in)", // no [[capture_delay]] configured
 	} {
 		if !strings.Contains(view, want) {
 			t.Errorf("config tab missing %q:\n%s", want, view)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -94,11 +94,12 @@ type prompt struct {
 // Escalations, Audit, and Rules tabs. Scalar fields stay untruncated; captured
 // pane previews may use the operator-configured tail height.
 type detailView struct {
-	title        string
-	lines        []string                 // wrapped to the pane width at open/resize
-	offset       int                      // first visible line (↑/↓ scroll)
-	build        func(width int) []string // rebuilds lines from the snapshot on resize
-	anchorBottom bool                     // captured-pane details open/follow the terminal tail
+	title                string
+	lines                []string                                // wrapped to the pane width at open/resize
+	offset               int                                     // first visible line (↑/↓ scroll)
+	build                func(width int, expanded bool) []string // rebuilds lines from the snapshot on resize/toggle
+	hasExpandablePreview bool                                    // v toggles long-field previews instead of closing
+	previewExpanded      bool                                    // false = title + compact field-specific tail
 	// confirmID is the escalation's audit id captured at open time, so
 	// enter confirms the record ON SCREEN even if a background refresh
 	// clamped the list cursor. 0 = not a confirmable escalation detail.
@@ -361,19 +362,11 @@ func buildRuleItems(cfg config.Config) []ruleItem {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		wasDetailBottom := false
-		if m.detail != nil {
-			wasDetailBottom = m.detail.offset >= max(0, len(m.detail.lines)-m.detailPageSize())
-		}
 		m.width, m.height = msg.Width, msg.Height
 		if m.detail != nil && m.detail.build != nil {
-			m.detail.lines = m.detail.build(m.wrapWidth())
+			m.detail.lines = m.detail.build(m.wrapWidth(), m.detail.previewExpanded)
 			bottom := max(0, len(m.detail.lines)-m.detailPageSize())
-			if m.detail.anchorBottom && wasDetailBottom {
-				m.detail.offset = bottom
-			} else {
-				m.detail.offset = min(m.detail.offset, bottom)
-			}
+			m.detail.offset = min(m.detail.offset, bottom)
 		}
 		m.clampListViewport()
 		return m, nil
@@ -418,17 +411,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		gradN := m.data.cfg.Learning.GraduationN
-		build := func(width int) []string {
-			return m.signatureDetailLines(msg.row, msg.history, gradN, width)
+		build := func(width int, expanded bool) []string {
+			return m.signatureDetailLines(msg.row, msg.history, gradN, width, expanded)
 		}
 		d := &detailView{
-			title: fmt.Sprintf("Signature %s", shortSig(msg.row.Signature)),
-			lines: build(m.wrapWidth()),
-			build: build,
-		}
-		if msg.row.PaneExcerpt != "" {
-			d.anchorBottom = true
-			d.offset = max(0, len(d.lines)-m.detailPageSize())
+			title:                fmt.Sprintf("Signature %s", shortSig(msg.row.Signature)),
+			lines:                build(m.wrapWidth(), false),
+			build:                build,
+			hasExpandablePreview: msg.row.PaneExcerpt != "",
 		}
 		m.detail = d
 		return m, nil
@@ -507,7 +497,15 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.offsets[m.tab] = 0
 			m.searching = false
 			m.message = ""
-		case "esc", "q", "v":
+		case "v":
+			if m.detail.hasExpandablePreview && m.detail.build != nil {
+				m.detail.previewExpanded = !m.detail.previewExpanded
+				m.detail.lines = m.detail.build(m.wrapWidth(), m.detail.previewExpanded)
+				m.detail.offset = 0
+				return m, nil
+			}
+			m.detail = nil
+		case "esc", "q":
 			m.detail = nil
 		}
 		return m, nil
@@ -1009,7 +1007,7 @@ func (m Model) viewDaemonStderr() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	path, tail := m.app.DaemonStderrTail()
-	build := func(width int) []string {
+	build := func(width int, _ bool) []string {
 		var lines []string
 		if path != "" {
 			lines = append(lines, path, "")
@@ -1029,7 +1027,7 @@ func (m Model) viewDaemonStderr() (tea.Model, tea.Cmd) {
 	m.message = ""
 	m.detail = &detailView{
 		title: "Daemon captured output (last crash)",
-		lines: build(m.wrapWidth()),
+		lines: build(m.wrapWidth(), false),
 		build: build,
 	}
 	return m, nil
@@ -1040,11 +1038,11 @@ func (m Model) viewSelected() (tea.Model, tea.Cmd) {
 	case tabAgents:
 		if agents := m.visibleAgents(); m.cursor < len(agents) {
 			a := agents[m.cursor]
-			build := func(width int) []string { return m.agentDetailLines(a, width) }
+			build := func(width int, _ bool) []string { return m.agentDetailLines(a, width) }
 			m.message = ""
 			m.detail = &detailView{
 				title: fmt.Sprintf("Agent %s", a.AgentID),
-				lines: build(m.wrapWidth()),
+				lines: build(m.wrapWidth(), false),
 				build: build,
 			}
 		}
@@ -1055,14 +1053,26 @@ func (m Model) viewSelected() (tea.Model, tea.Cmd) {
 				kind = "Escalation"
 			}
 			r := *rec
+			isAudit := m.tab == tabAudit
+			currentPreviewLines := 10
+			if isAudit {
+				currentPreviewLines = 3
+			}
 			// Fetched once at open time (not on every resize rebuild).
 			snapshot := m.app.SignatureSnapshot(m.ctx, r.Signature)
-			build := func(width int) []string { return m.auditDetailLines(r, snapshot, width) }
+			build := func(width int, expanded bool) []string {
+				return m.auditDetailLines(r, snapshot, width, auditDetailOptions{
+					expanded:              expanded,
+					collapseLLMOutput:     isAudit,
+					currentSituationLines: currentPreviewLines,
+				})
+			}
 			m.message = ""
 			d := &detailView{
-				title: fmt.Sprintf("%s #%d", kind, r.ID),
-				lines: build(m.wrapWidth()),
-				build: build,
+				title:                fmt.Sprintf("%s #%d", kind, r.ID),
+				lines:                build(m.wrapWidth(), false),
+				build:                build,
+				hasExpandablePreview: r.PaneExcerpt != "" || snapshot != "" || (isAudit && r.LLMOutput != ""),
 			}
 			// Only the Escalations detail is confirmable via enter and
 			// carries the per-entry actions (c/x/l), which act on this
@@ -1070,13 +1080,6 @@ func (m Model) viewSelected() (tea.Model, tea.Cmd) {
 			if m.tab == tabEscalations {
 				d.confirmID = r.ID
 				d.escRetryable = m.canRetry(r)
-			}
-			// Captured panes are terminal tails: open at the bottom so the
-			// newest prompt/result is visible first. Earlier metadata remains
-			// available with Up.
-			if r.PaneExcerpt != "" || snapshot != "" {
-				d.anchorBottom = true
-				d.offset = max(0, len(d.lines)-m.detailPageSize())
 			}
 			m.detail = d
 		}
@@ -1253,20 +1256,28 @@ func (m Model) detailField(lines []string, width int, label, value string) []str
 	return lines
 }
 
-// detailPreviewField appends captured pane content. A configured height is a
-// line cap after wrapping, so it stays stable at the actual display width.
-// Captures are tailed rather than headed: the actionable prompt and latest
-// coding-agent output live at the bottom of the terminal pane.
-func (m Model) detailPreviewField(lines []string, width int, label, value string) []string {
+// detailPreviewField appends long detail content. Collapsed details show the
+// requested number of trailing wrapped lines. Expanded details use the
+// configured height cap (0 = unlimited). Both modes tail rather than head the
+// content because actionable agent output normally lives at the bottom.
+func (m Model) detailPreviewField(lines []string, width int, label, value string, expanded bool, collapsedLimit int) []string {
 	if strings.TrimSpace(value) == "" {
 		return lines
 	}
 	wrapped := wrapText(value, width)
-	if limit := m.data.cfg.TUI.MaxContentHeight; limit > 0 && len(wrapped) > limit {
+	limit := max(1, collapsedLimit)
+	mode := "preview"
+	if expanded {
+		limit = m.data.cfg.TUI.MaxContentHeight
+		mode = "expanded"
+	}
+	if limit > 0 && len(wrapped) > limit {
 		omitted := len(wrapped) - limit
-		label = fmt.Sprintf("%s (last %d of %d lines; %d earlier omitted)",
-			label, limit, len(wrapped), omitted)
+		label = fmt.Sprintf("%s (%s: last %d of %d lines; %d earlier omitted)",
+			label, mode, limit, len(wrapped), omitted)
 		wrapped = wrapped[len(wrapped)-limit:]
+	} else if !expanded {
+		label += " (preview)"
 	}
 	lines = append(lines, m.styles().section.Render(label))
 	for _, ln := range wrapped {
@@ -1314,7 +1325,13 @@ func locationLabel(id string, lookup func() (label string, number int, ok bool))
 	return id
 }
 
-func (m Model) auditDetailLines(r domain.AuditRecord, snapshot string, w int) []string {
+type auditDetailOptions struct {
+	expanded              bool
+	collapseLLMOutput     bool
+	currentSituationLines int
+}
+
+func (m Model) auditDetailLines(r domain.AuditRecord, snapshot string, w int, opts auditDetailOptions) []string {
 	var lines []string
 	agent := r.AgentID
 	if n := m.data.status.AgentName(r.AgentID); n != "" {
@@ -1335,7 +1352,11 @@ func (m Model) auditDetailLines(r domain.AuditRecord, snapshot string, w int) []
 	lines = m.detailField(lines, w, "Action", r.Action)
 	lines = m.detailField(lines, w, "Input", r.Input)
 	lines = m.detailField(lines, w, "Rationale", r.Rationale)
-	lines = m.detailField(lines, w, "LLM output", r.LLMOutput)
+	if opts.collapseLLMOutput {
+		lines = m.detailPreviewField(lines, w, "LLM output", r.LLMOutput, opts.expanded, 3)
+	} else {
+		lines = m.detailField(lines, w, "LLM output", r.LLMOutput)
+	}
 	lines = m.detailField(lines, w, "Signature", r.Signature)
 	if r.Signature != "" {
 		if row, ok := m.ruleFor(r.Signature); ok {
@@ -1359,11 +1380,12 @@ func (m Model) auditDetailLines(r domain.AuditRecord, snapshot string, w int) []
 	// detail. Legacy rows predate the per-entry column and show only the
 	// provenance block.
 	if r.PaneExcerpt != "" {
-		lines = m.detailPreviewField(lines, w, "Current situation", r.PaneExcerpt)
+		lines = m.detailPreviewField(lines, w, "Current situation", r.PaneExcerpt,
+			opts.expanded, opts.currentSituationLines)
 	}
 	if r.Signature != "" {
 		if snapshot != "" {
-			lines = m.detailPreviewField(lines, w, "Original situation", snapshot)
+			lines = m.detailPreviewField(lines, w, "Original situation", snapshot, opts.expanded, 3)
 		} else {
 			lines = m.detailField(lines, w, "Original situation", "(not captured yet — recorded on the rule's next sighting)")
 		}
@@ -1466,7 +1488,7 @@ func (m Model) deleteSignaturePrompt() (tea.Model, tea.Cmd) {
 }
 
 // signatureDetailLines renders the full-record overlay for one signature.
-func (m Model) signatureDetailLines(row frontend.SignatureRow, history []domain.DecisionRecord, graduationN, w int) []string {
+func (m Model) signatureDetailLines(row frontend.SignatureRow, history []domain.DecisionRecord, graduationN, w int, expanded bool) []string {
 	var lines []string
 	lines = m.detailField(lines, w, "Signature", row.Signature)
 	lines = m.detailField(lines, w, "Situation", string(row.SituationType))
@@ -1483,6 +1505,13 @@ func (m Model) signatureDetailLines(row frontend.SignatureRow, history []domain.
 	if !row.UpdatedAt.IsZero() {
 		lines = m.detailField(lines, w, "Updated", row.UpdatedAt.Format(time.RFC3339))
 	}
+	// Rule provenance appears with the other record fields. It is collapsed
+	// by default and expands in place when the operator presses v again.
+	if row.PaneExcerpt != "" {
+		lines = m.detailPreviewField(lines, w, "Original situation", row.PaneExcerpt, expanded, 3)
+	} else {
+		lines = m.detailField(lines, w, "Original situation", "(not captured yet — recorded on the rule's next sighting)")
+	}
 	if len(history) > 0 {
 		var b strings.Builder
 		for _, d := range history {
@@ -1498,14 +1527,6 @@ func (m Model) signatureDetailLines(row frontend.SignatureRow, history []domain.
 	if a := row.LastAudit; a != nil {
 		lines = m.detailField(lines, w, "Last audit",
 			fmt.Sprintf("#%d (%s) %s — %s", a.ID, a.Status, a.Action, a.Rationale))
-	}
-	// Keep rule provenance last so a bottom-anchored detail opens on the pane
-	// tail rather than the decision metadata that follows it. This is what the
-	// learned action answers and therefore the most useful first view.
-	if row.PaneExcerpt != "" {
-		lines = m.detailPreviewField(lines, w, "Original situation", row.PaneExcerpt)
-	} else {
-		lines = m.detailField(lines, w, "Original situation", "(not captured yet — recorded on the rule's next sighting)")
 	}
 	return lines
 }
@@ -1768,15 +1789,25 @@ func (m Model) View() string {
 
 func (m Model) helpLine() string {
 	if m.detail != nil {
+		preview := ""
+		closeKeys := "esc/q/v: close"
+		if m.detail.hasExpandablePreview {
+			closeKeys = "esc/q: close"
+			if m.detail.previewExpanded {
+				preview = "  v: collapse previews"
+			} else {
+				preview = "  v: expand previews"
+			}
+		}
 		if m.detail.confirmID != 0 {
 			retry := ""
 			if m.detail.escRetryable {
 				retry = "  l: retry LLM"
 			}
 			return "enter: confirm+send  c: correct  x: delete" + retry +
-				"  ↑/↓: scroll  tab: switch tab  esc/q/v: close"
+				preview + "  ↑/↓: scroll  tab: switch tab  " + closeKeys
 		}
-		return "↑/↓: scroll  tab: switch tab  esc/q/v: close"
+		return "↑/↓: scroll  tab: switch tab" + preview + "  " + closeKeys
 	}
 	if m.searching {
 		return "type to filter  backspace: erase  esc/enter: apply & close"

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -91,12 +91,14 @@ type prompt struct {
 }
 
 // detailView is a full-record overlay opened with `v` on the Agents,
-// Escalations, Audit, and Rules tabs, showing the selected row untruncated.
+// Escalations, Audit, and Rules tabs. Scalar fields stay untruncated; captured
+// pane previews may use the operator-configured tail height.
 type detailView struct {
-	title  string
-	lines  []string                 // wrapped to the pane width at open/resize
-	offset int                      // first visible line (↑/↓ scroll)
-	build  func(width int) []string // rebuilds lines from the snapshot on resize
+	title        string
+	lines        []string                 // wrapped to the pane width at open/resize
+	offset       int                      // first visible line (↑/↓ scroll)
+	build        func(width int) []string // rebuilds lines from the snapshot on resize
+	anchorBottom bool                     // captured-pane details open/follow the terminal tail
 	// confirmID is the escalation's audit id captured at open time, so
 	// enter confirms the record ON SCREEN even if a background refresh
 	// clamped the list cursor. 0 = not a confirmable escalation detail.
@@ -359,10 +361,19 @@ func buildRuleItems(cfg config.Config) []ruleItem {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		wasDetailBottom := false
+		if m.detail != nil {
+			wasDetailBottom = m.detail.offset >= max(0, len(m.detail.lines)-m.detailPageSize())
+		}
 		m.width, m.height = msg.Width, msg.Height
 		if m.detail != nil && m.detail.build != nil {
 			m.detail.lines = m.detail.build(m.wrapWidth())
-			m.detail.offset = min(m.detail.offset, max(0, len(m.detail.lines)-m.detailPageSize()))
+			bottom := max(0, len(m.detail.lines)-m.detailPageSize())
+			if m.detail.anchorBottom && wasDetailBottom {
+				m.detail.offset = bottom
+			} else {
+				m.detail.offset = min(m.detail.offset, bottom)
+			}
 		}
 		m.clampListViewport()
 		return m, nil
@@ -410,11 +421,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		build := func(width int) []string {
 			return m.signatureDetailLines(msg.row, msg.history, gradN, width)
 		}
-		m.detail = &detailView{
+		d := &detailView{
 			title: fmt.Sprintf("Signature %s", shortSig(msg.row.Signature)),
 			lines: build(m.wrapWidth()),
 			build: build,
 		}
+		if msg.row.PaneExcerpt != "" {
+			d.anchorBottom = true
+			d.offset = max(0, len(d.lines)-m.detailPageSize())
+		}
+		m.detail = d
 		return m, nil
 	case tea.KeyMsg:
 		return m.handleKey(msg)
@@ -1055,6 +1071,13 @@ func (m Model) viewSelected() (tea.Model, tea.Cmd) {
 				d.confirmID = r.ID
 				d.escRetryable = m.canRetry(r)
 			}
+			// Captured panes are terminal tails: open at the bottom so the
+			// newest prompt/result is visible first. Earlier metadata remains
+			// available with Up.
+			if r.PaneExcerpt != "" || snapshot != "" {
+				d.anchorBottom = true
+				d.offset = max(0, len(d.lines)-m.detailPageSize())
+			}
 			m.detail = d
 		}
 	}
@@ -1230,6 +1253,28 @@ func (m Model) detailField(lines []string, width int, label, value string) []str
 	return lines
 }
 
+// detailPreviewField appends captured pane content. A configured height is a
+// line cap after wrapping, so it stays stable at the actual display width.
+// Captures are tailed rather than headed: the actionable prompt and latest
+// coding-agent output live at the bottom of the terminal pane.
+func (m Model) detailPreviewField(lines []string, width int, label, value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return lines
+	}
+	wrapped := wrapText(value, width)
+	if limit := m.data.cfg.TUI.MaxContentHeight; limit > 0 && len(wrapped) > limit {
+		omitted := len(wrapped) - limit
+		label = fmt.Sprintf("%s (last %d of %d lines; %d earlier omitted)",
+			label, limit, len(wrapped), omitted)
+		wrapped = wrapped[len(wrapped)-limit:]
+	}
+	lines = append(lines, m.styles().section.Render(label))
+	for _, ln := range wrapped {
+		lines = append(lines, "  "+ln)
+	}
+	return lines
+}
+
 func (m Model) agentDetailLines(a domain.AgentTransition, w int) []string {
 	var lines []string
 	lines = m.detailField(lines, w, "Short name", orDash(m.data.status.AgentName(a.AgentID)))
@@ -1314,11 +1359,11 @@ func (m Model) auditDetailLines(r domain.AuditRecord, snapshot string, w int) []
 	// detail. Legacy rows predate the per-entry column and show only the
 	// provenance block.
 	if r.PaneExcerpt != "" {
-		lines = m.detailField(lines, w, "Current situation", r.PaneExcerpt)
+		lines = m.detailPreviewField(lines, w, "Current situation", r.PaneExcerpt)
 	}
 	if r.Signature != "" {
 		if snapshot != "" {
-			lines = m.detailField(lines, w, "Original situation", snapshot)
+			lines = m.detailPreviewField(lines, w, "Original situation", snapshot)
 		} else {
 			lines = m.detailField(lines, w, "Original situation", "(not captured yet — recorded on the rule's next sighting)")
 		}
@@ -1438,13 +1483,6 @@ func (m Model) signatureDetailLines(row frontend.SignatureRow, history []domain.
 	if !row.UpdatedAt.IsZero() {
 		lines = m.detailField(lines, w, "Updated", row.UpdatedAt.Format(time.RFC3339))
 	}
-	// Rule provenance: what the pane showed when this signature was first
-	// seen — the situation the learned action answers.
-	if row.PaneExcerpt != "" {
-		lines = m.detailField(lines, w, "Original situation", row.PaneExcerpt)
-	} else {
-		lines = m.detailField(lines, w, "Original situation", "(not captured yet — recorded on the rule's next sighting)")
-	}
 	if len(history) > 0 {
 		var b strings.Builder
 		for _, d := range history {
@@ -1460,6 +1498,14 @@ func (m Model) signatureDetailLines(row frontend.SignatureRow, history []domain.
 	if a := row.LastAudit; a != nil {
 		lines = m.detailField(lines, w, "Last audit",
 			fmt.Sprintf("#%d (%s) %s — %s", a.ID, a.Status, a.Action, a.Rationale))
+	}
+	// Keep rule provenance last so a bottom-anchored detail opens on the pane
+	// tail rather than the decision metadata that follows it. This is what the
+	// learned action answers and therefore the most useful first view.
+	if row.PaneExcerpt != "" {
+		lines = m.detailPreviewField(lines, w, "Original situation", row.PaneExcerpt)
+	} else {
+		lines = m.detailField(lines, w, "Original situation", "(not captured yet — recorded on the rule's next sighting)")
 	}
 	return lines
 }
@@ -1809,7 +1855,13 @@ func (m Model) renderDetail(b *strings.Builder) {
 	for _, ln := range lines[start:end] {
 		fmt.Fprintln(b, ln)
 	}
-	if end < len(lines) {
+	switch {
+	case start > 0 && end < len(lines):
+		fmt.Fprintf(b, "%s\n", st.help.Render(fmt.Sprintf(
+			"… %d earlier / %d later line(s) — ↑/↓ to scroll", start, len(lines)-end)))
+	case start > 0:
+		fmt.Fprintf(b, "%s\n", st.help.Render(fmt.Sprintf("… %d earlier line(s) — ↑ to scroll", start)))
+	case end < len(lines):
 		fmt.Fprintf(b, "%s\n", st.help.Render(fmt.Sprintf("… %d more line(s) — ↓ to scroll", len(lines)-end)))
 	}
 	fmt.Fprintf(b, "\n%s", st.help.Render(m.helpLine()))

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -286,6 +286,81 @@ func TestDetailViewRewrapsOnResize(t *testing.T) {
 	}
 }
 
+func TestCapturedPanePreviewKeepsTail(t *testing.T) {
+	m := testModel(t)
+	m.data.cfg.TUI.MaxContentHeight = 3
+	rec := domain.AuditRecord{
+		Signature:   "choice:test",
+		PaneExcerpt: "pane-top\npane-middle\npane-tail-1\npane-tail-2\npane-tail-3",
+	}
+	snapshot := "original-top\noriginal-middle\noriginal-tail-1\noriginal-tail-2\noriginal-tail-3"
+	lines := m.auditDetailLines(rec, snapshot, 80)
+	got := strings.Join(lines, "\n")
+	for _, want := range []string{
+		"Current situation (last 3 of 5 lines", "pane-tail-1", "pane-tail-2", "pane-tail-3",
+		"Original situation (last 3 of 5 lines", "original-tail-1", "original-tail-2", "original-tail-3",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("tail-limited preview missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "pane-top") || strings.Contains(got, "pane-middle") ||
+		strings.Contains(got, "original-top") || strings.Contains(got, "original-middle") {
+		t.Errorf("tail-limited preview retained old top lines:\n%s", got)
+	}
+	rule := frontend.SignatureRow{PaneExcerpt: snapshot}
+	ruleLines := strings.Join(m.signatureDetailLines(rule, nil, 5, 80), "\n")
+	if !strings.Contains(ruleLines, "original-tail-3") || strings.Contains(ruleLines, "original-top") {
+		t.Errorf("Rules detail must apply the same tail preview behavior:\n%s", ruleLines)
+	}
+
+	// Zero is genuinely unlimited: no captured lines are discarded.
+	m.data.cfg.TUI.MaxContentHeight = 0
+	got = strings.Join(m.auditDetailLines(rec, snapshot, 80), "\n")
+	if !strings.Contains(got, "pane-top") || !strings.Contains(got, "pane-tail-3") {
+		t.Errorf("unlimited preview should keep the entire capture:\n%s", got)
+	}
+}
+
+func TestCapturedPaneDetailOpensAtBottom(t *testing.T) {
+	m := testModel(t)
+	m.height = 12
+	m.tab = tabAudit
+	var pane strings.Builder
+	for i := 1; i <= 20; i++ {
+		fmt.Fprintf(&pane, "capture-line-%02d\n", i)
+	}
+	m.data.audit[0].PaneExcerpt = strings.TrimRight(pane.String(), "\n")
+	m = press(t, m, "v")
+	if m.detail == nil || m.detail.offset == 0 {
+		t.Fatal("a captured-pane detail should initially be anchored to its bottom")
+	}
+	view := m.View()
+	if !strings.Contains(view, "capture-line-20") {
+		t.Errorf("initial captured-pane view must show the newest bottom line:\n%s", view)
+	}
+	if strings.Contains(view, "capture-line-01") {
+		t.Errorf("small initial viewport unexpectedly shows the oldest pane line:\n%s", view)
+	}
+	if !strings.Contains(view, "earlier line") {
+		t.Errorf("bottom-anchored detail should advertise upward scrolling:\n%s", view)
+	}
+
+	// Rules details load asynchronously, but must land on their Original
+	// situation tail just like Escalation/Audit details.
+	ruleModel := testModel(t)
+	ruleModel.height = 12
+	upd, _ := ruleModel.Update(sigDetailMsg{row: frontend.SignatureRow{
+		SignatureState: domain.SignatureState{Signature: "choice:tail-test"},
+		PaneExcerpt:    strings.ReplaceAll(pane.String(), "capture-", "rule-"),
+	}})
+	ruleModel = upd.(Model)
+	ruleView := ruleModel.View()
+	if !strings.Contains(ruleView, "rule-line-20") || strings.Contains(ruleView, "rule-line-01") {
+		t.Errorf("Rules detail must initially show the bottom of Original situation:\n%s", ruleView)
+	}
+}
+
 func TestWrapText(t *testing.T) {
 	got := wrapText("abcdefgh\nij", 3)
 	want := []string{"abc", "def", "gh", "ij"}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -288,66 +288,127 @@ func TestDetailViewRewrapsOnResize(t *testing.T) {
 
 func TestCapturedPanePreviewKeepsTail(t *testing.T) {
 	m := testModel(t)
-	m.data.cfg.TUI.MaxContentHeight = 3
+	m.data.cfg.TUI.MaxContentHeight = 4
 	rec := domain.AuditRecord{
 		Signature:   "choice:test",
+		LLMOutput:   "llm-top\nllm-middle\nllm-tail-1\nllm-tail-2\nllm-tail-3",
 		PaneExcerpt: "pane-top\npane-middle\npane-tail-1\npane-tail-2\npane-tail-3",
 	}
 	snapshot := "original-top\noriginal-middle\noriginal-tail-1\noriginal-tail-2\noriginal-tail-3"
-	lines := m.auditDetailLines(rec, snapshot, 80)
+	collapsedOpts := auditDetailOptions{collapseLLMOutput: true, currentSituationLines: 3}
+	lines := m.auditDetailLines(rec, snapshot, 80, collapsedOpts)
 	got := strings.Join(lines, "\n")
 	for _, want := range []string{
-		"Current situation (last 3 of 5 lines", "pane-tail-1", "pane-tail-2", "pane-tail-3",
-		"Original situation (last 3 of 5 lines", "original-tail-1", "original-tail-2", "original-tail-3",
+		"LLM output (preview: last 3 of 5 lines", "llm-tail-1", "llm-tail-2", "llm-tail-3",
+		"Current situation (preview: last 3 of 5 lines", "pane-tail-1", "pane-tail-2", "pane-tail-3",
+		"Original situation (preview: last 3 of 5 lines", "original-tail-1", "original-tail-2", "original-tail-3",
 	} {
 		if !strings.Contains(got, want) {
-			t.Errorf("tail-limited preview missing %q:\n%s", want, got)
+			t.Errorf("collapsed preview missing %q:\n%s", want, got)
 		}
 	}
-	if strings.Contains(got, "pane-top") || strings.Contains(got, "pane-middle") ||
+	if strings.Contains(got, "llm-top") || strings.Contains(got, "llm-middle") ||
+		strings.Contains(got, "pane-top") || strings.Contains(got, "pane-middle") ||
 		strings.Contains(got, "original-top") || strings.Contains(got, "original-middle") {
-		t.Errorf("tail-limited preview retained old top lines:\n%s", got)
+		t.Errorf("collapsed preview retained old top lines:\n%s", got)
 	}
 	rule := frontend.SignatureRow{PaneExcerpt: snapshot}
-	ruleLines := strings.Join(m.signatureDetailLines(rule, nil, 5, 80), "\n")
+	ruleLines := strings.Join(m.signatureDetailLines(rule, nil, 5, 80, false), "\n")
 	if !strings.Contains(ruleLines, "original-tail-3") || strings.Contains(ruleLines, "original-top") {
-		t.Errorf("Rules detail must apply the same tail preview behavior:\n%s", ruleLines)
+		t.Errorf("Rules detail must apply the same collapsed-tail behavior:\n%s", ruleLines)
 	}
 
-	// Zero is genuinely unlimited: no captured lines are discarded.
+	// Expanding reveals more context but still honors the configured cap and
+	// retains the bottom of the capture.
+	expandedOpts := collapsedOpts
+	expandedOpts.expanded = true
+	got = strings.Join(m.auditDetailLines(rec, snapshot, 80, expandedOpts), "\n")
+	if !strings.Contains(got, "pane-middle") || !strings.Contains(got, "pane-tail-3") ||
+		strings.Contains(got, "pane-top") || !strings.Contains(got, "llm-middle") ||
+		strings.Contains(got, "llm-top") {
+		t.Errorf("expanded preview should retain the capped four-line tail:\n%s", got)
+	}
+
+	// Zero is genuinely unlimited in expanded mode: no captured lines are discarded.
 	m.data.cfg.TUI.MaxContentHeight = 0
-	got = strings.Join(m.auditDetailLines(rec, snapshot, 80), "\n")
-	if !strings.Contains(got, "pane-top") || !strings.Contains(got, "pane-tail-3") {
+	got = strings.Join(m.auditDetailLines(rec, snapshot, 80, expandedOpts), "\n")
+	if !strings.Contains(got, "pane-top") || !strings.Contains(got, "pane-tail-3") ||
+		!strings.Contains(got, "llm-top") {
 		t.Errorf("unlimited preview should keep the entire capture:\n%s", got)
 	}
 }
 
-func TestCapturedPaneDetailOpensAtBottom(t *testing.T) {
+func TestEscalationCurrentSituationPreviewUsesTenLines(t *testing.T) {
+	m := testModel(t)
+	var pane strings.Builder
+	for i := 1; i <= 12; i++ {
+		fmt.Fprintf(&pane, "escalation-line-%02d\n", i)
+	}
+	rec := domain.AuditRecord{PaneExcerpt: strings.TrimRight(pane.String(), "\n")}
+	got := strings.Join(m.auditDetailLines(rec, "", 80, auditDetailOptions{
+		currentSituationLines: 10,
+	}), "\n")
+	if !strings.Contains(got, "Current situation (preview: last 10 of 12 lines") ||
+		!strings.Contains(got, "escalation-line-03") || !strings.Contains(got, "escalation-line-12") ||
+		strings.Contains(got, "escalation-line-02") {
+		t.Errorf("Escalation Current situation should show its last ten lines:\n%s", got)
+	}
+
+	// Pin the tab-specific wiring, not just the shared renderer option.
+	m.tab = tabEscalations
+	m.data.escalations[0].PaneExcerpt = rec.PaneExcerpt
+	m = press(t, m, "v")
+	detail := strings.Join(m.detail.lines, "\n")
+	if !strings.Contains(detail, "last 10 of 12 lines") || strings.Contains(detail, "escalation-line-02") {
+		t.Errorf("Escalations detail did not select the ten-line Current situation preview:\n%s", detail)
+	}
+}
+
+func TestCapturedPaneDetailStartsAtTopAndTogglesPreview(t *testing.T) {
 	m := testModel(t)
 	m.height = 12
 	m.tab = tabAudit
+	m.data.cfg.TUI.MaxContentHeight = 5
 	var pane strings.Builder
 	for i := 1; i <= 20; i++ {
 		fmt.Fprintf(&pane, "capture-line-%02d\n", i)
 	}
 	m.data.audit[0].PaneExcerpt = strings.TrimRight(pane.String(), "\n")
+	m.data.audit[0].LLMOutput = strings.ReplaceAll(strings.TrimRight(pane.String(), "\n"), "capture-", "llm-")
 	m = press(t, m, "v")
-	if m.detail == nil || m.detail.offset == 0 {
-		t.Fatal("a captured-pane detail should initially be anchored to its bottom")
+	if m.detail == nil || m.detail.offset != 0 {
+		t.Fatal("a captured-pane detail must always open at the top")
 	}
-	view := m.View()
-	if !strings.Contains(view, "capture-line-20") {
-		t.Errorf("initial captured-pane view must show the newest bottom line:\n%s", view)
+	collapsed := strings.Join(m.detail.lines, "\n")
+	if !strings.Contains(collapsed, "capture-line-18") || !strings.Contains(collapsed, "capture-line-20") ||
+		strings.Contains(collapsed, "capture-line-17") || !strings.Contains(collapsed, "llm-line-18") ||
+		strings.Contains(collapsed, "llm-line-17") {
+		t.Errorf("initial detail should contain only the last three captured lines:\n%s", collapsed)
 	}
-	if strings.Contains(view, "capture-line-01") {
-		t.Errorf("small initial viewport unexpectedly shows the oldest pane line:\n%s", view)
-	}
-	if !strings.Contains(view, "earlier line") {
-		t.Errorf("bottom-anchored detail should advertise upward scrolling:\n%s", view)
+	if !strings.Contains(m.helpLine(), "v: expand previews") {
+		t.Errorf("collapsed detail help should advertise expansion: %s", m.helpLine())
 	}
 
-	// Rules details load asynchronously, but must land on their Original
-	// situation tail just like Escalation/Audit details.
+	m = press(t, m, "v")
+	if m.detail == nil || !m.detail.previewExpanded || m.detail.offset != 0 {
+		t.Fatal("v inside a captured detail should expand it and reset to the top")
+	}
+	expanded := strings.Join(m.detail.lines, "\n")
+	if !strings.Contains(expanded, "capture-line-16") || !strings.Contains(expanded, "capture-line-20") ||
+		strings.Contains(expanded, "capture-line-15") || !strings.Contains(expanded, "llm-line-16") ||
+		strings.Contains(expanded, "llm-line-15") {
+		t.Errorf("expanded detail should contain the configured five-line tail:\n%s", expanded)
+	}
+	if !strings.Contains(m.helpLine(), "v: collapse previews") {
+		t.Errorf("expanded detail help should advertise collapse: %s", m.helpLine())
+	}
+	m = press(t, m, "v")
+	if m.detail == nil || m.detail.previewExpanded || m.detail.offset != 0 {
+		t.Fatal("a second v should collapse the situations without closing the detail")
+	}
+
+	// Rules details load asynchronously but follow the same collapsed mode and
+	// top-start invariant.
 	ruleModel := testModel(t)
 	ruleModel.height = 12
 	upd, _ := ruleModel.Update(sigDetailMsg{row: frontend.SignatureRow{
@@ -355,9 +416,10 @@ func TestCapturedPaneDetailOpensAtBottom(t *testing.T) {
 		PaneExcerpt:    strings.ReplaceAll(pane.String(), "capture-", "rule-"),
 	}})
 	ruleModel = upd.(Model)
-	ruleView := ruleModel.View()
-	if !strings.Contains(ruleView, "rule-line-20") || strings.Contains(ruleView, "rule-line-01") {
-		t.Errorf("Rules detail must initially show the bottom of Original situation:\n%s", ruleView)
+	ruleLines := strings.Join(ruleModel.detail.lines, "\n")
+	if ruleModel.detail.offset != 0 || !strings.Contains(ruleLines, "rule-line-20") ||
+		strings.Contains(ruleLines, "rule-line-17") {
+		t.Errorf("Rules detail must start at top with a three-line Original situation preview:\n%s", ruleLines)
 	}
 }
 

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -49,7 +49,7 @@ max_error_retries = 2              # per error signature
 # come immediately after -p (claude quirk; the plugin auto-repairs it).
 command = [
   "claude", "-p",
-  "You are the auto-answer assistant for herd-auto-prompter (hap). A coding agent running in a herdr terminal pane has stopped and is waiting for input. Your job: answer exactly as the human operator would, using ONLY the two hap MCP tools.\n\nStep 1 — call get_context. It returns the classified situation:\n- situation_type: 'approval' (permission prompt), 'choice' (menu of options), 'error' (the agent hit a failure), or 'idle' (finished or waiting for its next instruction)\n- options: the menu option texts, when the pane shows a menu\n- permission_verb: what the agent is asking permission to do\n- error_summary: short description of the failure, when situation_type is 'error'\n- pane_excerpt: the recent terminal screen — read it carefully; it is the ground truth for what the agent is doing and asking\n- cwd / foreground_cwd and herdr ids (workspace_id, tab_id, pane_id, agent_id): where the agent is working\n\nStep 2 — decide what the operator would answer:\n- approval / choice with options: choose the safest 1-based option number. Approve routine, reversible work (reading files, edits, builds, tests, linters). DENY anything destructive or hard to reverse: deleting data, force-pushing or hard-resetting git history, production/deploy changes, touching secrets or credentials, mass file operations.\n- approval / choice without options: reply with the literal text the prompt expects.\n- error: reply with one short, concrete instruction telling the agent how to diagnose or fix the failure and continue.\n- idle: reply with the most sensible next instruction based on the pane_excerpt; if no reply is needed, use @noop.\n- If the pane_excerpt is ambiguous or does not match the classified situation, choose the most conservative reply.\n\nStep 3 — call submit_decision. For a menu, pass select_options with the chosen 1-based number (one number per tab for a multi-tab form). Otherwise pass recommend_action with the literal reply, or @noop to send nothing. Always include confident_score (0-100) and a one-sentence rationale.",
+  "You are hap's auto-answer assistant. Use ONLY get_context and submit_decision.\n\nCall get_context, treat pane_excerpt as ground truth, and follow answer_format. If proposed_task is present, this is a task review: when the agent is ready and current_task is unfinished, prefer @next_task:declared to send it verbatim—do not make small edits. Return rewritten task text only when its details need a major rewrite. If current_task is clearly done, send an instruction for the next unfinished item in pending_tasks. Use @noop if the agent is busy, no suitable task remains, or evidence is ambiguous. Never invent a task.\n\nOtherwise: for approval/choice, select the safest option and deny destructive or irreversible work; for error, give one concrete recovery instruction; for idle, give the sensible next instruction or @noop.\n\nCall submit_decision with select_options for menus, otherwise recommend_action. Always include confident_score (0-100) and a one-sentence rationale.",
   "--mcp-config", '{"mcpServers":{"hap":{"command":"{self}","args":["mcp"],"env":{"HAP_REQUEST_ID":"{request_id}"}}}}',
   "--allowedTools", "mcp__hap__get_context,mcp__hap__submit_decision",
   "--model", "opus",
@@ -178,6 +178,7 @@ model_context_window = 0
 # ── TUI ─────────────────────────────────────────────────────────────
 [tui]
 max_content_width = 0      # cap on variable-length list columns; 0 = full terminal width
+max_content_height = 0     # captured-pane preview lines; 0 = unlimited; truncation keeps the bottom
 theme = ""                 # named palette: default | dark | light | high-contrast;
                            # empty/unknown = default (the original look)
 
@@ -202,7 +203,7 @@ theme = ""                 # named palette: default | dark | light | high-contra
 # workspace = ""             # "" or "*" = any; wildcards like "codex-*" work
 # path = "/home/me/project/docs/tasks.md"
 # next_task_template placeholders: {next_task_content}, {task_list_path}, {agent_name}, {cwd}
-# next_task_template = "Your next task is {next_task_content}. Read the full tasks list at {task_list_path}."
+# next_task_template = "Your next task is {next_task_content}.\nRead the full tasks list at {task_list_path}. Verify task dependencies before starting. Once you have completed your task, mark it as done (`[x]`) in the tasks list.\nIf you are unsure what to do, ask for clarification. When there is no task available, focus on improving the test coverage of this project."
 # When an [llm].command is configured, each determined task is first REVIEWED by
 # the LLM (via the get_context/submit_decision MCP tools): it sees the live pane
 # and decides whether to send the task now (recommend_action) or skip it (@noop).
@@ -228,4 +229,4 @@ theme = ""                 # named palette: default | dark | light | high-contra
 # [[capture_delay]]
 # agent_type = "claude"      # exact agent type, or "*" for any
 # start_ms = 3000            # first event after the agent starts (default 10000)
-# event_ms = 200             # subsequent events (default 500)
+# event_ms = 200             # subsequent events (default 2000)

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -178,7 +178,7 @@ model_context_window = 0
 # ── TUI ─────────────────────────────────────────────────────────────
 [tui]
 max_content_width = 0      # cap on variable-length list columns; 0 = full terminal width
-max_content_height = 0     # captured-pane preview lines; 0 = unlimited; truncation keeps the bottom
+max_content_height = 0     # expanded long-field lines; 0 = unlimited; collapsed uses short tails
 theme = ""                 # named palette: default | dark | light | high-contrast;
                            # empty/unknown = default (the original look)
 


### PR DESCRIPTION
## Summary

Adds support for **multi-select questions** in Claude's multi-tab `AskUserQuestion` MCQ forms, and bundles concurrent in-flight work from other agents (TUI/config/docs, LLM task-generation frontend) so it all ships together.

### The problem (multi-select)
A Claude multi-tab form can render a **multi-select** question: its options show per-option `[ ]` checkboxes, and the UX is *toggle several options with digit keys, then press Tab/Right to advance* — a multi-select tab does **not** auto-advance on a digit press. hap treated every tab as single-select, so the LLM could only pick one option and the digit-per-tab delivery could neither express nor type multiple toggles. Observed live on a real plan-mode form (question 2, "Stats to show").

### The fix
- **Detect** per-tab multi-select from the `[ ]` markers (`domain.MultiSelectTab`, `OptionCheckStates`); carried on `Situation.TabMultiSelect`, captured during the sweep.
- **Answer format**: MCP `submit_decision.select_options` items are now **int OR array-of-int** — `[1, [1,3], 2]` (tab 2 toggles options 1 and 3). Fully backward compatible with the flat `[1,2,1]` shape. Internally a per-tab token series with comma-grouped toggles (`"1 1,3 2"`), parsed by `ParseTabSelections`; the `len == TabCount` guards still hold (one token per tab).
- **Delivery**: a pure `MultiTabKeys` planner emits the toggle digits plus an explicit advance for multi-select tabs (single-select auto-advances). Shared by the daemon (`sendTabSelections`) and the operator-confirm frontend.
- **Consult context** advertises `tab_select_kinds` so the LLM knows which tabs take an array.
- **Full parity**: learned rules, LLM, and operator paths all deliver multi-select, re-gated by the existing safety controls.

### Safety (toggling is relative)
Toggling a checkbox is a relative flip, so it's only safe from an all-unchecked baseline:
- The sweep **refuses** a multi-select tab that already has a selection (escalates instead of blind-toggling).
- The daemon **re-verifies** the baseline immediately before autonomous delivery (`reverifyMultiSelect` re-runs the capture sweep as a guard), closing the window where an operator toggles a *middle* tab during a long LLM consult (the tab-1 staleness check can't see middle tabs).
- The operator-confirm path is **all-or-nothing**: a read-only baseline pre-pass over every tab runs before any answer keystroke, so a refusal never leaves the form half-answered.
- The advance key + reset count are unified into `domain.MCQAdvanceKey` / `MCQResetKeys`, referenced by both delivery paths so they can't diverge.

## Commits
- `#95 feat` — the multi-select feature (domain, daemon, MCP, frontend).
- `#95 fix` — code-review remediation (delivery-time re-verify, all-or-nothing operator path, shared constants).
- `#1 chore` / `#1 feat` — **bundled concurrent-agent work**: LLM task-generation frontend rendering (`DeclaredTask.Prompt`), TUI content-height config (`config.TUI.MaxContentHeight`) + list rendering, `enhance-tui-ux` plan docs, README/CLAUDE/sample-config/skill docs. Included per operator request so everything ships in one PR.

## Testing
- New unit tests: `MultiSelectTab`, `OptionCheckStates`, `ParseTabSelections`, `MultiTabKeys`, extended `ParseDigitSeries`; MCP mixed int-or-array resolution; daemon multi-select delivery keystroke assertion + a toggle-state-stale (pre-checked) escalation test; frontend all-or-nothing delivery.
- **Full suite green**: `go test -tags "vectors cpu" ./... -count=1` — all 18 test packages pass (including the bundled concurrent work). `gofmt` + `go vet` clean.

## Follow-up
- The real advance key (`"right"` vs `"tab"`) and the MCP `oneOf` schema shape should be confirmed against a live Claude form via the gated integration test (`HAP_ITEST_CLAUDE=1`); the advance key is const-ized for an easy switch.
