### PR TITLE
#1 feat: per-agent lifetime stats + live age in TUI Agents view

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -768,7 +768,7 @@ func (d *Daemon) handleAttention(ctx context.Context, tr domain.AgentTransition)
 		d.audit(ctx, domain.AuditRecord{
 			AgentID: tr.AgentID, AgentType: tr.AgentType, Trigger: trigger(tr),
 			SituationType: domain.SituationUnclassifiable,
-			Action:        "escalated",
+			Action:        domain.AuditActionEscalated,
 			// Bracketed like every escalate()-built rationale, so the one
 			// path that bypasses escalate() renders identically.
 			Rationale: "[" + string(domain.ReasonHerdrUnreachable) + "]",
@@ -1089,7 +1089,7 @@ func (d *Daemon) deliverAutonomous(ctx context.Context, s domain.Situation, sig 
 
 	auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
-		SituationType: s.Type, Action: "auto:" + del.input, Input: del.input,
+		SituationType: s.Type, Action: domain.AuditActionAutoPrefix + del.input, Input: del.input,
 		Confidence: dec.Confidence, Rationale: del.rationale, LLMOutput: del.llmOutput,
 		Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
 	})
@@ -1225,7 +1225,7 @@ func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.Si
 	}
 	rec := domain.AuditRecord{
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
-		SituationType: s.Type, Action: "escalated", Confidence: dec.Confidence,
+		SituationType: s.Type, Action: domain.AuditActionEscalated, Confidence: dec.Confidence,
 		LLMConfidence: dec.LLMConfidence,
 		Rationale:     rationale,
 		Status:        "escalated", Suggestion: dec.Suggestion,
@@ -2237,7 +2237,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 	// Promote: audit-before-act guard applies here too (FR-024).
 	auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: res.sig.Signature, Trigger: "llm-fallback",
-		SituationType: s.Type, Action: "auto:" + llmDec.Action, Input: llmDec.Action,
+		SituationType: s.Type, Action: domain.AuditActionAutoPrefix + llmDec.Action, Input: llmDec.Action,
 		Confidence: computedConf, LLMConfidence: &llmConf,
 		Rationale: "LLM: " + llmDec.Rationale, LLMOutput: llmDec.CapturedOutput,
 		Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
@@ -2456,7 +2456,7 @@ func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domai
 	// correction to something else?
 	suggested := suggestionAction(audit)
 	isConfirmation := suggested != "" && c.CorrectedAction == suggested
-	wasAutonomous := audit.Status == "auto" || strings.HasPrefix(audit.Action, "auto:")
+	wasAutonomous := audit.Status == "auto" || strings.HasPrefix(audit.Action, domain.AuditActionAutoPrefix)
 
 	// Record the operator's decision (corrections count in the recency
 	// window; FR-007).
@@ -2503,9 +2503,9 @@ func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domai
 	// Correction lineage in the audit trail (DR-005).
 	d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: audit.AgentID, AgentType: state.AgentType, Signature: audit.Signature,
-		Trigger:       "operator-correction",
+		Trigger:       domain.TriggerOperatorCorrection,
 		SituationType: audit.SituationType, Action: "corrected:" + c.CorrectedAction,
-		Input: c.CorrectedAction, Rationale: "operator " + map[bool]string{true: "confirmed", false: "corrected"}[isConfirmation],
+		Input: c.CorrectedAction, Rationale: map[bool]string{true: domain.RationaleOperatorConfirmed, false: domain.RationaleOperatorCorrected}[isConfirmation],
 		CorrectsAuditID: c.AuditID, Status: "resolved", CreatedAt: now,
 	})
 	return d.opt.Store.UpdateAuditStatus(ctx, c.AuditID, "resolved")

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -187,6 +187,36 @@ type DecisionRecord struct {
 	CreatedAt     time.Time
 }
 
+// Audit literals shared by the daemon (which writes them into audit_log) and
+// the store (which reads them back for per-agent stats). Kept here so the
+// write and read sites cannot silently drift.
+const (
+	// AuditActionEscalated is the audit_log action for an escalation.
+	AuditActionEscalated = "escalated"
+	// AuditActionAutoPrefix prefixes the action of an autonomous send
+	// ("auto:" + the delivered input); a noop uses "noop", not this prefix.
+	AuditActionAutoPrefix = "auto:"
+	// TriggerOperatorCorrection is the audit_log trigger for the correction/
+	// confirmation lineage row an operator decision writes.
+	TriggerOperatorCorrection = "operator-correction"
+	// RationaleOperatorConfirmed / RationaleOperatorCorrected distinguish a
+	// confirmation from a correction on that lineage row (both carry the same
+	// trigger and a "corrected:" action, so the rationale is the only signal).
+	RationaleOperatorConfirmed = "operator confirmed"
+	RationaleOperatorCorrected = "operator corrected"
+)
+
+// AgentStats are lifetime per-agent counters derived from audit_log, keyed by
+// the herdr pane id. A rename preserves them (same pane id); a restart yields
+// a new pane id and thus a fresh, empty set.
+type AgentStats struct {
+	AutoSends   int
+	Escalations int
+	Confirmed   int
+	Corrections int
+	FirstSeen   time.Time // agent_names.created_at; zero when unknown
+}
+
 // AuditRecord is one append-only audit trail entry (FR-020, DR-002).
 type AuditRecord struct {
 	ID            int64

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -164,6 +164,11 @@ type Status struct {
 	MonitoredAgents    []domain.AgentTransition
 	// AgentNames maps agent/pane ids to their short names.
 	AgentNames map[string]string
+	// AgentStats maps agent/pane ids to their lifetime counters (auto-sends,
+	// escalations, operator confirmations/corrections, first-seen). Nil when
+	// the stats query failed; a missing key means a live agent with no stats
+	// row yet.
+	AgentStats map[string]domain.AgentStats
 	// Workspaces / Tabs map ids to display metadata (label, number) for
 	// locating agents; empty when the Herdr adapter cannot report them.
 	Workspaces map[string]domain.WorkspaceInfo
@@ -213,6 +218,10 @@ func (a *App) GetStatus(ctx context.Context) (Status, error) {
 	if names, err := a.Store.AgentNames(ctx); err == nil {
 		st.AgentNames = names
 	}
+	// Best-effort, like AgentNames: a stats-query error just leaves it nil.
+	if stats, err := a.Store.AgentStats(ctx); err == nil {
+		st.AgentStats = stats
+	}
 	// One config load serves both embedding summaries so they cannot
 	// disagree about a mid-edit config within a single status snapshot.
 	if cfg, err := config.Load(a.ConfigPath); err != nil {
@@ -244,6 +253,10 @@ func (a *App) GetStatus(ctx context.Context) (Status, error) {
 
 // AgentName returns the short name for an agent id ("" when unnamed).
 func (st Status) AgentName(agentID string) string { return st.AgentNames[agentID] }
+
+// StatsFor returns the lifetime counters for an agent id (a zero-valued
+// AgentStats when none are recorded).
+func (st Status) StatsFor(agentID string) domain.AgentStats { return st.AgentStats[agentID] }
 
 // embeddingStatus summarizes semantic-matching availability from config,
 // model presence on disk, and the persisted signature-embedding count.

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -244,6 +244,9 @@ type ReadStore interface {
 	LLMDecisionByRequest(ctx context.Context, requestID string) (*domain.LLMDecision, error)
 	// AgentNames returns every agent id → short name mapping.
 	AgentNames(ctx context.Context) (map[string]string, error)
+	// AgentStats returns lifetime per-agent counters keyed by agent/pane id,
+	// including agents with zero recorded events (so their FirstSeen shows).
+	AgentStats(ctx context.Context) (map[string]domain.AgentStats, error)
 	// ResolveAgent maps a short name or agent/pane id to the agent id.
 	ResolveAgent(ctx context.Context, target string) (string, error)
 	// ListSignatures returns learning state rows, newest-updated first;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -105,6 +105,7 @@ CREATE TABLE IF NOT EXISTS audit_log (
 	created_at INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_audit_status ON audit_log(status, id DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_agent ON audit_log(agent_id);
 CREATE TABLE IF NOT EXISTS agent_rate (
 	agent_id TEXT PRIMARY KEY,
 	consecutive_auto INTEGER NOT NULL DEFAULT 0,
@@ -1346,6 +1347,50 @@ func (s *Store) AgentNames(ctx context.Context) (map[string]string, error) {
 		names[id] = name
 	}
 	return names, rows.Err()
+}
+
+// AgentStats returns lifetime per-agent counters keyed by agent/pane id.
+// It is keyed off agent_names (LEFT JOIN audit_log) so an agent with zero
+// events still surfaces, carrying its FirstSeen. The counting rules match the
+// daemon write sites: auto-sends are counted by action prefix (a failed send
+// leaves the "auto:" action but flips status to escalated, so counting by
+// action avoids double counting and excludes the "noop" row); escalations are
+// counted by action so they reflect the lifetime total, not just still-pending
+// rows; confirmed vs. corrected split on the rationale literal. The literals
+// come from domain constants shared with the writer so they cannot drift.
+func (s *Store) AgentStats(ctx context.Context) (map[string]domain.AgentStats, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT n.agent_id, n.created_at,
+			SUM(CASE WHEN a.action_or_escalation LIKE ? THEN 1 ELSE 0 END),
+			SUM(CASE WHEN a.action_or_escalation = ? THEN 1 ELSE 0 END),
+			SUM(CASE WHEN a.trigger = ? AND a.rationale = ? THEN 1 ELSE 0 END),
+			SUM(CASE WHEN a.trigger = ? AND a.rationale = ? THEN 1 ELSE 0 END)
+		FROM agent_names n
+		LEFT JOIN audit_log a ON a.agent_id = n.agent_id
+		GROUP BY n.agent_id, n.created_at`,
+		domain.AuditActionAutoPrefix+"%", domain.AuditActionEscalated,
+		domain.TriggerOperatorCorrection, domain.RationaleOperatorConfirmed,
+		domain.TriggerOperatorCorrection, domain.RationaleOperatorCorrected)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	stats := map[string]domain.AgentStats{}
+	for rows.Next() {
+		var id string
+		var created int64
+		var st domain.AgentStats
+		if err := rows.Scan(&id, &created, &st.AutoSends, &st.Escalations,
+			&st.Confirmed, &st.Corrections); err != nil {
+			return nil, err
+		}
+		if id == "" {
+			continue
+		}
+		st.FirstSeen = fromUnix(created)
+		stats[id] = st
+	}
+	return stats, rows.Err()
 }
 
 // LatestPendingLLMRequest returns the newest pending staged request, or nil.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -548,6 +548,101 @@ func TestLLMRequestDecisionFlow(t *testing.T) {
 	}
 }
 
+func TestAgentStats(t *testing.T) {
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+	base := time.Now().Truncate(time.Millisecond)
+
+	// Seed agent_names directly so FirstSeen (created_at) is deterministic.
+	seedName := func(id, name string, created time.Time) {
+		t.Helper()
+		if _, err := s.db.ExecContext(ctx,
+			`INSERT INTO agent_names (agent_id, name, created_at) VALUES (?, ?, ?)`,
+			id, name, unix(created)); err != nil {
+			t.Fatalf("seed name %q: %v", id, err)
+		}
+	}
+	seedName("w1:p1", "alpha", base)
+	seedName("w1:p2", "beta", base) // zero-event agent
+	seedName("", "empty", base)     // defensive: empty agent_id must be skipped
+
+	audit := func(agentID, action, trigger, rationale, status string) {
+		t.Helper()
+		if _, err := s.AppendAudit(ctx, domain.AuditRecord{
+			AgentID: agentID, SituationType: domain.SituationApproval,
+			Trigger: trigger, Action: action, Rationale: rationale,
+			Status: status, CreatedAt: base,
+		}); err != nil {
+			t.Fatalf("append audit: %v", err)
+		}
+	}
+
+	// w1:p1 activity, exercising every counting rule:
+	audit("w1:p1", domain.AuditActionAutoPrefix+"2", "t", "", "auto")      // Auto
+	audit("w1:p1", domain.AuditActionAutoPrefix+"y", "t", "", "escalated") // Auto (failed send: action stays auto:, status flips)
+	audit("w1:p1", "noop", "t", "", "auto")                                // neither (noop excluded)
+	audit("w1:p1", domain.AuditActionEscalated, "t", "", "escalated")      // Esc
+	audit("w1:p1", domain.AuditActionEscalated, "t", "", "resolved")       // Esc (counted by action, even after handling)
+	audit("w1:p1", "corrected:x", domain.TriggerOperatorCorrection,
+		domain.RationaleOperatorConfirmed, "resolved") // Conf
+	audit("w1:p1", "corrected:z", domain.TriggerOperatorCorrection,
+		domain.RationaleOperatorCorrected, "resolved") // Corr
+
+	stats, err := s.AgentStats(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := stats[""]; ok {
+		t.Errorf("empty agent_id must be skipped, got %+v", stats[""])
+	}
+
+	got := stats["w1:p1"]
+	want := domain.AgentStats{AutoSends: 2, Escalations: 2, Confirmed: 1, Corrections: 1, FirstSeen: base}
+	if got.AutoSends != want.AutoSends || got.Escalations != want.Escalations ||
+		got.Confirmed != want.Confirmed || got.Corrections != want.Corrections {
+		t.Errorf("w1:p1 counts = %+v, want %+v", got, want)
+	}
+	if !got.FirstSeen.Equal(base) {
+		t.Errorf("w1:p1 FirstSeen = %v, want %v", got.FirstSeen, base)
+	}
+
+	// A zero-event agent still surfaces, carrying FirstSeen and zero counts.
+	beta, ok := stats["w1:p2"]
+	if !ok {
+		t.Fatalf("zero-event agent must surface; stats = %+v", stats)
+	}
+	if beta != (domain.AgentStats{FirstSeen: base}) {
+		t.Errorf("zero-event agent = %+v, want only FirstSeen=%v", beta, base)
+	}
+
+	// A rename keeps the same agent_id, so counts are unchanged.
+	if err := s.RenameAgent(ctx, "alpha", "renamed"); err != nil {
+		t.Fatal(err)
+	}
+	after, err := s.AgentStats(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after["w1:p1"].AutoSends != want.AutoSends || after["w1:p1"].Escalations != want.Escalations {
+		t.Errorf("rename changed counts: %+v", after["w1:p1"])
+	}
+	if _, ok := after["renamed"]; ok {
+		t.Error("stats must key on agent id, not the new name")
+	}
+
+	// A restart yields a new pane id → a fresh, empty stat set (its audit rows
+	// belong to the old id).
+	seedName("w1:p3", "gamma", base)
+	restart, err := s.AgentStats(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g := restart["w1:p3"]; g.AutoSends != 0 || g.Escalations != 0 || g.Confirmed != 0 || g.Corrections != 0 {
+		t.Errorf("new pane id must start empty, got %+v", g)
+	}
+}
+
 func TestAgentNames(t *testing.T) {
 	s, _ := openTestStore(t)
 	ctx := context.Background()

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -458,6 +458,44 @@ func TestAgentsListRendersStatColumns(t *testing.T) {
 	}
 }
 
+func TestAgentDetailAgeTicksWithClock(t *testing.T) {
+	open := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	firstSeen := open.Add(-30 * time.Second) // Age at open → 00:00:30
+	m := Model{width: 100, height: 30}
+	msg := refreshMsg{cfg: config.Default()}
+	msg.status.AgentNames = map[string]string{"w1:p1": "alpha"}
+	msg.status.MonitoredAgents = []domain.AgentTransition{
+		{AgentID: "w1:p1", AgentType: "claude", PaneID: "w1:p1", Status: "running"},
+	}
+	msg.status.AgentStats = map[string]domain.AgentStats{
+		"w1:p1": {FirstSeen: firstSeen},
+	}
+	upd, _ := m.Update(msg)
+	m = upd.(Model)
+	m.tab = tabAgents
+	m.cursor = 0
+	m.now = open
+
+	m = press(t, m, "v")
+	if m.detail == nil {
+		t.Fatal("v on the Agents tab should open the detail view")
+	}
+	if !strings.Contains(m.View(), "00:00:30") {
+		t.Fatalf("detail Age at open should be 00:00:30:\n%s", m.View())
+	}
+
+	// A clock tick must advance the detail's live Age (it previously froze:
+	// the build closure captured the open-time clock — PR #105 review).
+	upd, _ = m.Update(clockTickMsg(open.Add(5 * time.Second)))
+	m = upd.(Model)
+	if !strings.Contains(m.View(), "00:00:35") {
+		t.Fatalf("detail Age should advance to 00:00:35 after a clock tick:\n%s", m.View())
+	}
+	if strings.Contains(m.View(), "00:00:30") {
+		t.Errorf("stale Age 00:00:30 must not remain after the tick:\n%s", m.View())
+	}
+}
+
 func TestFormatAge(t *testing.T) {
 	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
 	cases := []struct {

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -416,6 +416,70 @@ func TestSearchEscEmptyQueryLeavesNoFilter(t *testing.T) {
 	}
 }
 
+func TestAgentsListRendersStatColumns(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	firstSeen := now.Add(-90 * time.Minute) // Age → 01:30:00
+	m := Model{width: 120, height: 30}
+	msg := refreshMsg{cfg: config.Default()}
+	msg.status.AgentNames = map[string]string{"w1:p1": "alpha"}
+	msg.status.MonitoredAgents = []domain.AgentTransition{
+		{AgentID: "w1:p1", AgentType: "claude", PaneID: "w1:p1", Status: "running"},
+	}
+	msg.status.AgentStats = map[string]domain.AgentStats{
+		"w1:p1": {AutoSends: 12, Escalations: 5, Confirmed: 3, Corrections: 2, FirstSeen: firstSeen},
+	}
+	upd, _ := m.Update(msg)
+	m = upd.(Model)
+	m.tab = tabAgents
+	m.now = now // pin the Age clock
+
+	view := m.View()
+	// Header labels for all five new columns.
+	for _, want := range []string{"NAME", "STATUS", "AUTO", "ESC", "CONF", "CORR", "AGE"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("agents list missing header %q:\n%s", want, view)
+		}
+	}
+	// The agent's row carries its counts and the live age.
+	var row string
+	for _, ln := range strings.Split(view, "\n") {
+		if strings.Contains(ln, "alpha") {
+			row = ln
+			break
+		}
+	}
+	if row == "" {
+		t.Fatalf("agent row not rendered:\n%s", view)
+	}
+	for _, want := range []string{"12", "5", "3", "2", "01:30:00"} {
+		if !strings.Contains(row, want) {
+			t.Errorf("agent row missing %q: %q", want, row)
+		}
+	}
+}
+
+func TestFormatAge(t *testing.T) {
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name  string
+		first time.Time
+		want  string
+	}{
+		{"zero first-seen", time.Time{}, "-"},
+		{"just now", now, "00:00:00"},
+		{"under an hour", now.Add(-45 * time.Minute), "00:45:00"},
+		{"over a day", now.Add(-25*time.Hour - time.Minute - 5*time.Second), "25:01:05"},
+		{"future clamps to zero", now.Add(time.Hour), "00:00:00"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatAge(tc.first, now); got != tc.want {
+				t.Errorf("formatAge(%v, %v) = %q, want %q", tc.first, now, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSearchEmptyStateMessages(t *testing.T) {
 	cases := []struct {
 		tab  tab

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -83,6 +83,11 @@ type statusNote struct {
 
 type tickMsg time.Time
 
+// clockTickMsg fires once a second to advance the live Age counter on the
+// Agents tab. It only repaints — it never re-queries the store (unlike the
+// slower tickMsg refresh).
+type clockTickMsg time.Time
+
 // prompt is an in-flight inline input.
 type prompt struct {
 	label    string
@@ -142,6 +147,20 @@ type Model struct {
 	searching bool             // search-input mode on the active tab (AR-011)
 	status    *statusNote      // durable action outcome (CR-025)
 	st        *styles          // palette-resolved styles; nil = default palette
+	// now is the clock the live Age counter renders against, advanced by the
+	// 1s clockTickMsg. Zero falls back to time.Now() (see renderNow), so tests
+	// can pin it for deterministic snapshots.
+	now time.Time
+}
+
+// renderNow returns the clock the Agents tab renders Age against: the
+// clock-tick time, or the wall clock when unset (fresh model / tests that
+// don't drive the tick).
+func (m Model) renderNow() time.Time {
+	if m.now.IsZero() {
+		return time.Now()
+	}
+	return m.now
 }
 
 // matchesQuery reports whether any of the row's visible column values
@@ -227,11 +246,16 @@ func New(ctx context.Context, app *frontend.App) Model {
 
 // Init starts the refresh loop.
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(m.refresh(), tick())
+	return tea.Batch(m.refresh(), tick(), clockTick())
 }
 
 func tick() tea.Cmd {
 	return tea.Tick(2*time.Second, func(t time.Time) tea.Msg { return tickMsg(t) })
+}
+
+// clockTick drives the 1s Age repaint; it carries no data query.
+func clockTick() tea.Cmd {
+	return tea.Tick(1*time.Second, func(t time.Time) tea.Msg { return clockTickMsg(t) })
 }
 
 func (m Model) refresh() tea.Cmd {
@@ -405,6 +429,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.refresh()
 	case tickMsg:
 		return m, tea.Batch(m.refresh(), tick())
+	case clockTickMsg:
+		// Repaint only: advance the Age clock, never re-query the store.
+		m.now = time.Time(msg)
+		return m, clockTick()
 	case sigDetailMsg:
 		if msg.err != nil {
 			m.status = &statusNote{text: msg.err.Error(), err: true, at: time.Now()}
@@ -1127,6 +1155,9 @@ func (m Model) listPageSize() int {
 	if m.tab == tabSignatures && m.sigMode != "" {
 		chrome++
 	}
+	if m.tab == tabAgents {
+		chrome++ // the Agents tab renders a column header row
+	}
 	if m.prompt != nil {
 		chrome += 2
 	}
@@ -1306,6 +1337,15 @@ func (m Model) agentDetailLines(a domain.AgentTransition, w int) []string {
 	if !a.At.IsZero() {
 		lines = m.detailField(lines, w, "Last transition", a.At.Format(time.RFC3339))
 	}
+	// Lifetime stats (auto-answered, escalated, operator confirmed/corrected)
+	// and the live age since first seen. Rendered as strings so zero counts
+	// still show (detailField skips empty values).
+	s := m.data.status.StatsFor(a.AgentID)
+	lines = m.detailField(lines, w, "Auto-sends", strconv.Itoa(s.AutoSends))
+	lines = m.detailField(lines, w, "Escalations", strconv.Itoa(s.Escalations))
+	lines = m.detailField(lines, w, "Operator confirmed", strconv.Itoa(s.Confirmed))
+	lines = m.detailField(lines, w, "Operator corrected", strconv.Itoa(s.Corrections))
+	lines = m.detailField(lines, w, "Age", formatAge(s.FirstSeen, m.renderNow()))
 	return lines
 }
 
@@ -1898,6 +1938,11 @@ func (m Model) renderDetail(b *strings.Builder) {
 	fmt.Fprintf(b, "\n%s", st.help.Render(m.helpLine()))
 }
 
+// agentsRowFmt lays out the Agents list: name, id, type, status (all fixed
+// width so the trailing numeric columns line up), then the four lifetime
+// counters right-aligned and the live age last.
+const agentsRowFmt = "%-18s %-12s %-12s %-10s %5s %5s %5s %5s  %s"
+
 func (m Model) renderAgents(b *strings.Builder) {
 	agents := m.visibleAgents()
 	if len(agents) == 0 {
@@ -1908,17 +1953,40 @@ func (m Model) renderAgents(b *strings.Builder) {
 		}
 		return
 	}
+	header := fmt.Sprintf(agentsRowFmt,
+		"NAME", "ID", "TYPE", "STATUS", "AUTO", "ESC", "CONF", "CORR", "AGE")
+	fmt.Fprintln(b, m.styles().section.Render(header))
+	now := m.renderNow()
 	start, end := m.window(len(agents))
 	for i := start; i < end; i++ {
 		a := agents[i]
 		name := orDash(m.data.status.AgentName(a.AgentID))
-		line := fmt.Sprintf("%-18s %-12s %-12s %s", name, a.AgentID, a.AgentType, a.Status)
+		s := m.data.status.StatsFor(a.AgentID)
+		line := fmt.Sprintf(agentsRowFmt,
+			name, a.AgentID, a.AgentType, a.Status,
+			strconv.Itoa(s.AutoSends), strconv.Itoa(s.Escalations),
+			strconv.Itoa(s.Confirmed), strconv.Itoa(s.Corrections),
+			formatAge(s.FirstSeen, now))
 		if i == m.cursor {
 			line = m.styles().selected.Render(line)
 		}
 		fmt.Fprintln(b, line)
 	}
 	m.renderMoreRows(b, len(agents)-end)
+}
+
+// formatAge renders the elapsed time since firstSeen as HH:MM:SS (hours may
+// exceed 24). It returns "-" when firstSeen is zero (first-seen unknown).
+func formatAge(firstSeen, now time.Time) string {
+	if firstSeen.IsZero() {
+		return "-"
+	}
+	d := now.Sub(firstSeen)
+	if d < 0 {
+		d = 0
+	}
+	total := int(d.Seconds())
+	return fmt.Sprintf("%02d:%02d:%02d", total/3600, (total%3600)/60, total%60)
 }
 
 // ruleFor resolves the learned rule an audit/escalation row is keyed to

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -112,6 +112,11 @@ type detailView struct {
 	// cursor. escRetryable snapshots whether "l: retry LLM" is offered.
 	confirmID    int64
 	escRetryable bool
+	// agent snapshots the agent an agents-tab detail was opened for, so the
+	// clock tick can rebuild its lines against the current clock (the live Age
+	// would otherwise freeze at open time — the build closure captures m by
+	// value). nil for non-agent details.
+	agent *domain.AgentTransition
 }
 
 // ruleItem is one navigable row of the Config tab. "indicator" and
@@ -432,6 +437,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case clockTickMsg:
 		// Repaint only: advance the Age clock, never re-query the store.
 		m.now = time.Time(msg)
+		// An open agent detail caches its lines behind a build closure that
+		// captured the open-time clock; rebuild it against the new clock so
+		// its live Age advances too (the list Age already recomputes on paint).
+		if m.detail != nil && m.detail.agent != nil {
+			a := *m.detail.agent
+			build := func(width int, _ bool) []string { return m.agentDetailLines(a, width) }
+			m.detail.build = build
+			m.detail.lines = build(m.wrapWidth(), m.detail.previewExpanded)
+		}
 		return m, clockTick()
 	case sigDetailMsg:
 		if msg.err != nil {
@@ -1072,6 +1086,7 @@ func (m Model) viewSelected() (tea.Model, tea.Cmd) {
 				title: fmt.Sprintf("Agent %s", a.AgentID),
 				lines: build(m.wrapWidth(), false),
 				build: build,
+				agent: &a,
 			}
 		}
 	case tabEscalations, tabAudit:


### PR DESCRIPTION
Show per-agent Auto/Esc/Conf/Corr counts and a live HH:MM:SS age in the
Agents list (new header + columns) and detail view. Stats are derived from
audit_log keyed on the herdr pane id, so they survive a rename (same pane
id) and reset on restart (new pane id) — no schema change to identity.

- domain: extract shared audit literals to constants (auto:/escalated/
  operator-correction/operator confirmed|corrected) so the daemon write
  sites and the new store read query cannot drift; add AgentStats struct.
- store: AgentStats aggregation over agent_names LEFT JOIN audit_log (zero-
  event agents still surface with FirstSeen); add idx_audit_agent.
- frontend: Status.AgentStats populated best-effort in GetStatus + StatsFor.
- tui: 1s clock tick that only repaints (age recomputed from m.now, no extra
  query); renderAgents header/columns; agentDetailLines stat rows; formatAge.
- tests: store counting rules (auto by action, noop excluded, esc lifetime,
  confirm/correct split, zero-event, empty id, rename-keeps/restart-resets);
  tui column render + formatAge cases.

Claude-Session: https://claude.ai/code/session_018ViZHQgXx4qWiKUdQk3yhn