### PR TITLE
#0 feat: enhance Claude todo-widget parsing and correction handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,15 +2,23 @@
 
 Herd Auto Prompter (**hap**) — a Go plugin for the herdr terminal multiplexer
 that watches every agent pane, auto-answers when a learned rule is confident,
-and escalates to the operator (or a local LLM CLI) when not.
-`CONTRIBUTING.md` has the full ground rules; this file is the working
-reference for day-to-day development.
+and escalates to the operator (or a local LLM CLI) when not. `CONTRIBUTING.md`
+has the full ground rules; this file is the day-to-day working reference.
+
+## Skills (`.claude/skills/`)
+
+Prefer these for how-to detail — this file keeps only what must stay in view.
+- **`herdr`** — drive herdr from inside it (workspaces, tabs, panes, agents, waits).
+- **`hap`** — operate the plugin: status, escalations, config, safety rules, task
+  sources, LLM fallback, and the runtime architecture (monitor loop, semantic matching).
+- **`hap-development-local`** — the local dev loop: link the working tree, rebuild,
+  hot-swap the daemon (`hap daemon --ensure`), and live-test against a real agent.
 
 ## Build, test, lint
 
-The semantic signature matcher links native code (llama.cpp via CGO,
-FAISS behind bleve's `vectors` build tag), so **every build needs the
-native deps once** and the `vectors cpu` build tags always:
+The semantic matcher links native code (llama.cpp via CGO, FAISS behind bleve's
+`vectors` tag), so **the native deps are needed once** and the `vectors cpu` tags
+always — a build without both fails to link.
 
 ```sh
 bash scripts/setup-native.sh                   # one-time: submodules + llama-go libs + FAISS → /usr/local/lib
@@ -20,226 +28,184 @@ gofmt -l . | grep -v submodule && go vet -tags "vectors cpu" ./...
 golangci-lint run --build-tags "vectors,cpu"   # CI runs this too
 ```
 
-- `cpu` disables llama-go's default GPU (Vulkan/Metal) linkage; `vectors`
-  turns on bleve's FAISS-backed KNN. Both are required — a build without
-  them fails to link or compile.
 - The real-model embedder test skips unless `models/all-minilm-l6-v2-q8_0.gguf`
-  exists (download once from the HF repo in `release.yml`, or set
-  `HAP_TEST_EMBED_MODEL`).
-- Run the full suite before every commit that touches Go code.
+  exists (download once from the HF repo in `release.yml`, or set `HAP_TEST_EMBED_MODEL`).
 - Golden classifier fixtures: `internal/classify/testdata/`; regenerate with
   `UPDATE_GOLDEN=1 go test ./internal/classify/` and review the diff.
-- Try the working tree inside herdr: `go build -o bin/hap ./cmd/hap && herdr plugin link .`
+- Run the full suite before every commit that touches Go code.
 - Full pipeline smoke test (fake herdr → real daemon → real LLM CLI):
   `go build -o /tmp/e2e ./e2e_harness && /tmp/e2e <short-dir> <hap-bin> <config-dir> <state-dir>`,
   then inspect with `hap audit` / replay `get_context` via `hap mcp`.
+- Iterating on the plugin against a live herdr (link the working tree, rebuild,
+  hot-swap the daemon): see the **`hap-development-local`** skill.
 
 ## Local integration suite (real herdr + claude)
 
-`test/integration/` holds real-dependency tests that drive an **actual
-running herdr** (and, when enabled, a **real Claude Code CLI**). They are
-gated by the `integration` build tag, so `go test ./...` and CI never run
-them — run them by hand:
+`test/integration/` drives an **actual running herdr** (and, when enabled, a
+**real Claude Code CLI**), gated by the `integration` build tag so `go test ./...`
+and CI never run them. Each test **skips** (never fails) when its dependency is
+absent, so these are safe to run anywhere:
 
 ```sh
-# from inside a running herdr, or with HERDR_BIN_PATH set:
-go test -tags integration ./test/integration/ -v
-
-# also drive a real, authenticated claude (spends tokens):
-HAP_ITEST_CLAUDE=1 go test -tags integration ./test/integration/ -v
-
-# include the real-model semantic matching case (needs the native deps):
-go test -tags "integration vectors cpu" ./test/integration/ -v
+go test -tags integration ./test/integration/ -v                    # from inside herdr, or set HERDR_BIN_PATH
+HAP_ITEST_CLAUDE=1 go test -tags integration ./test/integration/ -v # also drive a real claude (spends tokens)
+go test -tags "integration vectors cpu" ./test/integration/ -v      # include the real-model semantic case
 ```
 
-- Each test **skips** (never fails) when its dependency is absent, so the
-  command is safe to run anywhere; it only asserts when the real tools are
-  present.
-- The suite loads `test/integration/testdata/config.toml` (the Claude Code
-  recipe) — edit it to match the CLI you want to exercise.
-- Current cases: `TestRealPaneInfo` (herdr `pane get` → cwd/ids),
-  `TestRealConfirmDeliversMenuDigit` (confirming a label reply selects the
-  numbered menu — the send-content regression), `TestRealClaudeConsult`
-  (gated by `HAP_ITEST_CLAUDE=1`) drives a **real Claude Code session
-  (`--model haiku`)** to a real approval menu, confirms it through the
-  plugin, and asserts the menu digit reached claude (the command runs).
-  `TestRealEmbeddingSemanticMatch` (needs the extra `vectors cpu` tags)
-  drives a **real llama.cpp embedding model + FAISS index** through an
-  in-process daemon: a rule learned for one approval auto-answers a
-  paraphrase (cosine ≥ 0.90) and leaves an unrelated approval alone; skips
-  when `models/all-minilm-l6-v2-q8_0.gguf` is absent
-  (`HAP_TEST_EMBED_MODEL` overrides).
-- The claude case skips (never fails) if it can't elicit a prompt; it needs a
-  path OUTSIDE claude's auto-approved dirs (`/tmp`, `/workspaces`,
-  `~/.claude`) to force the permission menu — it touches a `$HOME` dotfile.
-  Override the model with `HAP_ITEST_CLAUDE_MODEL`.
+- Loads `test/integration/testdata/config.toml` (the Claude Code recipe) — edit it
+  to match the CLI you want to exercise.
+- Cases: `TestRealPaneInfo` (herdr `pane get` → cwd/ids); `TestRealConfirmDeliversMenuDigit`
+  (confirming a label reply selects the numbered menu — the send-content regression);
+  `TestRealClaudeConsult` (needs `HAP_ITEST_CLAUDE=1`) drives a real claude
+  (`--model haiku`, override `HAP_ITEST_CLAUDE_MODEL`) to an approval menu and asserts the
+  menu digit reached it — skips if it can't elicit a prompt, so it needs a path OUTSIDE
+  claude's auto-approved dirs (`/tmp`, `/workspaces`, `~/.claude`) and touches a `$HOME`
+  dotfile; `TestRealEmbeddingSemanticMatch` (needs `vectors cpu`) drives a real llama.cpp
+  model + FAISS index so a rule learned for one approval auto-answers a paraphrase
+  (cosine ≥ 0.90) and leaves an unrelated one alone — skips without the model.
 
-**Recommended: run the integration suite once after finishing any feature**,
-before opening the PR — the unit suite fakes herdr, so only this catches real
-CLI-shape drift (e.g. `pane read --source recent` vs `visible`, `agent send`
-delivering a menu digit vs a label).
+**Recommended: run the integration suite once after finishing any feature**, before the
+PR — the unit suite fakes herdr, so only this catches real CLI-shape drift (e.g.
+`pane read --source recent` vs `visible`, `agent send` delivering a digit vs a label).
 
 ## Commits
 
-Format: `#<issue> <type>: <subject>` — a Conventional Commit prefixed with a
-GitHub issue reference. A commit-msg hook **rejects messages that don't start
-with a ticket/issue id**. Examples from history:
+Format: `#<issue> <type>: <subject>` — a Conventional Commit prefixed with a GitHub
+issue reference. A commit-msg hook **rejects messages that don't start with a
+ticket/issue id**. Examples:
 
 ```
 #1 feat: enrich LLM consult context — location ids, cwd, configurable pane excerpt
 #1 fix: run daemon from state dir, self-heal stale daemons on upgrade
-#1 chore: bump plugin version to 0.1.14
 ```
 
 - Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`; breaking → `feat!:`.
-- Pre-commit hooks also check large files, secrets, trailing whitespace, and
-  line endings — let them run (don't `--no-verify`).
+- Pre-commit hooks also check large files, secrets, trailing whitespace, and line
+  endings — let them run (don't `--no-verify`).
 - Never commit directly to `main`. Branch (`feat/…`, `fix/…`), open a PR.
-- For any non-trivial change, prefer an isolated worktree
-  (`worktree-agent-noN` beside the repo) so `main`'s checkout stays clean;
-  remove the worktree and delete the branch (local + origin) after merge.
+- For any non-trivial change, prefer an isolated worktree (`worktree-agent-noN` beside
+  the repo) so `main`'s checkout stays clean; remove the worktree and delete the branch
+  (local + origin) after merge.
 
 ## Version bump & release
 
 Releases are **automated on merge to main** with a bump-then-tag model
-(`.github/workflows/auto-release.yml`); `version` in `herdr-plugin.toml`
-is the single source of truth and always names a version whose GitHub
-release exists — it TRAILS releases, never leads them. This is
-load-bearing: `herdr plugin install` clones main and `scripts/install.sh`
-downloads the release assets named by the manifest version, so a manifest
-pointing at an unreleased version 404s every install.
+(`.github/workflows/auto-release.yml`); `version` in `herdr-plugin.toml` is the single
+source of truth and always names a version whose GitHub release exists — it TRAILS
+releases, never leads them. This is load-bearing: `herdr plugin install` clones main and
+`scripts/install.sh` downloads the release assets named by the manifest version, so a
+manifest pointing at an unreleased version 404s every install.
 
-- **Patch (the default)** — just merge your feature PR. The workflow finds
-  the manifest version already tagged (the last release), auto-merges a
-  bump PR (`release/bump-vX.Y.Z+1`, commit marked `[skip release]`), tags
-  that bump commit with the owner's `RELEASE_PAT`, and the tag fires the
-  standard tag-driven `release.yml`. Never bump the manifest for patch
-  work.
-- **Minor/major (the reserved manual path)** — overwrite `version` in
-  `herdr-plugin.toml` INSIDE your feature PR (e.g. `0.4.0`); on merge the
-  workflow finds that version untagged, skips the bump, and tags the
-  merge commit directly. (The same branch self-heals a crashed run that
-  bumped but never tagged.)
-- Doc/workflow-only pushes (`**.md`, `docs/**`, `.github/**`) and merge
-  commits containing `[skip release]` do not release. Hand-pushing a
-  `v*.*.*` tag still works (release.yml is unchanged and tag-driven).
-- Never put `[skip ci]`-family keywords ANYWHERE in the squash-merge
-  message (title or body) of a PR that should release: GitHub suppresses
-  ALL workflows for refs whose head commit carries one — including the
-  tag push onto that commit, so the release silently never builds. The
-  workflow refuses to tag such a commit. `[skip release]` (our custom
-  marker) is safe on tagged commits but suppresses auto-release itself,
-  so keep the literal string out of ordinary merge messages too.
-- Between the bump merge and the release publishing (~15 min), installs
-  from main can fail with 404 — install.sh's ~60 s curl retry only
-  bridges the post-publish upload gap, not the build. Retry once the
-  release publishes; pinned `--ref vX.Y.Z` installs are never affected.
-- If the release BUILD fails after the tag exists, re-run the failed
-  release.yml run; do not re-run auto-release (it would advance versions).
+- **Patch (the default)** — just merge your feature PR. The workflow finds the manifest
+  version already tagged, auto-merges a bump PR (`release/bump-vX.Y.Z+1`, commit marked
+  `[skip release]`), tags that bump commit with the owner's `RELEASE_PAT`, and the tag
+  fires the standard tag-driven `release.yml`. Never bump the manifest for patch work.
+- **Minor/major (the reserved manual path)** — overwrite `version` in `herdr-plugin.toml`
+  INSIDE your feature PR (e.g. `0.4.0`); on merge the workflow finds that version untagged,
+  skips the bump, and tags the merge commit directly. (The same branch self-heals a crashed
+  run that bumped but never tagged.)
+- Doc/workflow-only pushes (`**.md`, `docs/**`, `.github/**`) and merge commits containing
+  `[skip release]` do not release. Hand-pushing a `v*.*.*` tag still works (release.yml is
+  unchanged and tag-driven).
+- Never put `[skip ci]`-family keywords ANYWHERE in the squash-merge message (title or
+  body) of a PR that should release: GitHub suppresses ALL workflows for refs whose head
+  commit carries one — including the tag push onto that commit, so the release silently
+  never builds. The workflow refuses to tag such a commit. `[skip release]` (our custom
+  marker) is safe on tagged commits but suppresses auto-release itself, so keep the literal
+  string out of ordinary merge messages too.
+- Between the bump merge and the release publishing (~15 min), installs from main can fail
+  with 404 — install.sh's ~60 s curl retry only bridges the post-publish upload gap, not
+  the build. Retry once the release publishes; pinned `--ref vX.Y.Z` installs are never
+  affected.
+- If the release BUILD fails after the tag exists, re-run the failed release.yml run; do
+  not re-run auto-release (it would advance versions).
 
-`release.yml` (tag-driven, unchanged) runs the full CI gate, then builds
-on THREE native runners (CGO cannot cross-compile; Intel macOS is
-deliberately unsupported): `hap-{linux-amd64,linux-arm64,darwin-arm64}`
-(llama.cpp statically linked in), a `hap-native-<os>-<arch>.tar.gz` per
-platform (FAISS shared libs, plus libomp on macOS, rpath'd to
-`<plugin>/lib`), the `all-minilm-l6-v2-q8_0.gguf` embedding model fetched
-from Hugging Face (sha256-pinned), and `SHA256SUMS`; then publishes the
-GitHub Release. `install.sh` treats the binary and native tarball as
-REQUIRED and the model as optional (BM25 fallback).
+`release.yml` (tag-driven, unchanged) runs the full CI gate, then builds on THREE native
+runners (CGO cannot cross-compile; Intel macOS is deliberately unsupported):
+`hap-{linux-amd64,linux-arm64,darwin-arm64}` (llama.cpp statically linked in), a
+`hap-native-<os>-<arch>.tar.gz` per platform (FAISS shared libs, plus libomp on macOS,
+rpath'd to `<plugin>/lib`), the `all-minilm-l6-v2-q8_0.gguf` embedding model fetched from
+Hugging Face (sha256-pinned), and `SHA256SUMS`; then publishes the GitHub Release.
+`install.sh` treats the binary and native tarball as REQUIRED and the model as optional
+(BM25 fallback).
 
-The invariant: **the tagged commit's `herdr-plugin.toml` version and the
-git tag MUST match** — the automation preserves it by construction (the
-tag always lands on a commit whose manifest carries exactly that
-version). `scripts/install.sh` downloads the release asset named by the
-manifest version.
+The invariant: **the tagged commit's `herdr-plugin.toml` version and the git tag MUST
+match** — the automation preserves it by construction (the tag always lands on a commit
+whose manifest carries exactly that version).
 
-Verify after any release: `gh release view vX.Y.Z` — expect 3 binaries,
-3 native tarballs, the model, and SHA256SUMS.
-
-- `internal/buildinfo.Version` is stamped by the release build via ldflags —
-  never edit it by hand.
+- Verify after any release: `gh release view vX.Y.Z` — expect 3 binaries, 3 native
+  tarballs, the model, and SHA256SUMS.
+- `internal/buildinfo.Version` is stamped by the release build via ldflags — never edit
+  it by hand.
 - Bump `min_herdr_version` only when adopting new herdr APIs.
-- Release assets can 504 for a minute or two right after publishing;
-  `scripts/install.sh` retries through that window.
-- Upgraded daemons self-replace on version mismatch (`hap daemon --ensure`
-  detects a stale flock holder via the pid+version lock file); `hap status`
-  flags a STALE daemon.
+- Release assets can 504 for a minute or two right after publishing; `scripts/install.sh`
+  retries through that window.
 
 ## Architecture rules (enforced)
 
-- **`internal/domain` stays pure** — no imports of herdr/SQLite/LLM/adapter
-  packages; `TestDomainPurity` fails otherwise. Side effects live behind the
-  interfaces in `internal/ports` (implementations: `internal/herdr`,
-  `internal/store`, `internal/llm`).
-- **Optional capabilities are optional interfaces** — extend the herdr
-  surface with a new port interface (see `LocatorPort`, `InspectorPort`) and
-  type-assert at the call site, degrading gracefully; don't grow
-  `HerdrPort` and break every fake.
-- **Fail safe on the daemon path** — no panics; every error resolves to
-  escalate + audit + log. Wrap new handler/adapter calls in `logging.Guard`.
-- **Safety controls are never bypassed** — LLM submissions and learned rules
-  alike are re-gated through kill switch, never-auto patterns, rate guard, and retry
-  ceiling. Changes touching these must keep/extend the safety-invariant
-  tests; new destructive-command shapes go in
-  `internal/domain/testdata/irreversible_corpus.txt` (CI fails if seed
-  patterns miss a corpus entry).
-- **Don't stall the main loop** — the daemon's select loop handles all
-  agents; anything that shells out repeatedly (LLM CLI, deep pane reads)
-  belongs in a goroutine that funnels results back through a channel
-  (see `consultLLM` / `llmResults`).
-- **Attention events are delay-captured** — the classification pane read
-  waits `[[capture_delay]]` (default 10s on an agent's first event, 2000ms
-  after) via a per-pane `time.AfterFunc` → `delayedTr`, so the agent TUI
-  has painted and event bursts coalesce (latest wins, one capture per
-  burst). Daemon tests inherit a 1ms wildcard rule from the harness.
-- **Semantic matching degrades, never blocks** — situations resolve to
-  learned signatures via embedding + vector search over the MASKED salient
-  content (`daemon.resolveSignature`, `internal/match`, `internal/embedder`),
-  falling back to normalized-BM25 text matching, then to today's exact hash.
-  `SignatureResult.Raw` is the never-remapped content hash (the LLM drift
-  check depends on it); SQLite's `signature_embeddings` is the source of
-  truth and the bleve index under `<state>/match-index` is a disposable
-  cache (mem-only scorch does NOT serve KNN — keep it disk-backed). Embed
-  calls are stall-guarded and latch a degraded mode after 3 consecutive
+- **`internal/domain` stays pure** — no imports of herdr/SQLite/LLM/adapter packages;
+  `TestDomainPurity` fails otherwise. Side effects live behind the interfaces in
+  `internal/ports` (implementations: `internal/herdr`, `internal/store`, `internal/llm`).
+- **Optional capabilities are optional interfaces** — extend the herdr surface with a new
+  port interface (see `LocatorPort`, `InspectorPort`) and type-assert at the call site,
+  degrading gracefully; don't grow `HerdrPort` and break every fake.
+- **Fail safe on the daemon path** — no panics; every error resolves to escalate + audit +
+  log. Wrap new handler/adapter calls in `logging.Guard`.
+- **Safety controls are never bypassed** — LLM submissions and learned rules alike are
+  re-gated through kill switch, never-auto patterns, rate guard, and retry ceiling. Changes
+  touching these must keep/extend the safety-invariant tests; new destructive-command shapes
+  go in `internal/domain/testdata/irreversible_corpus.txt` (CI fails if seed patterns miss a
+  corpus entry).
+- **Don't stall the main loop** — the daemon's select loop handles all agents; anything that
+  shells out repeatedly (LLM CLI, deep pane reads) belongs in a goroutine that funnels
+  results back through a channel (see `consultLLM` / `llmResults`).
+- **Attention events are delay-captured** — the classification pane read waits
+  `[[capture_delay]]` (default 10s on an agent's first event, 2000ms after) via a per-pane
+  `time.AfterFunc` → `delayedTr`, so the agent TUI has painted and event bursts coalesce
+  (latest wins, one capture per burst). Daemon tests inherit a 1ms wildcard rule from the
+  harness.
+- **Semantic matching degrades, never blocks** — situations resolve to learned signatures via
+  embedding + vector search over the MASKED salient content (`daemon.resolveSignature`,
+  `internal/match`, `internal/embedder`), falling back to normalized-BM25 text matching, then
+  exact hash. `SignatureResult.Raw` is the never-remapped content hash (the LLM drift check
+  depends on it); SQLite's `signature_embeddings` is the source of truth and the bleve index
+  under `<state>/match-index` is a disposable cache (mem-only scorch does NOT serve KNN — keep
+  it disk-backed). Embed calls are stall-guarded and latch a degraded mode after 3 consecutive
   failures.
 
 ## Testing practices
 
-- Unit tests are mandatory for behavior changes — table-driven where natural,
-  fakes over mocks (`internal/fakeherdr` fakes the herdr socket + CLI;
-  `daemon_test.go` has in-process fakes and a `newHarness` helper).
-- **Unix socket paths are length-capped** (~104 bytes on macOS): tests must
-  use `testutil.SocketDir(t)`, never `t.TempDir()`, for socket paths.
-- macOS temp dirs live under the `/var → /private/var` symlink — compare
-  paths via `filepath.EvalSymlinks`, not string equality.
-- Anything spawning real subprocesses should tolerate a deleted cwd
-  (see `llm.Adapter.WorkDir` and `chdirStable`) — the daemon can outlive the
-  directory herdr launched it from.
+- Unit tests are mandatory for behavior changes — table-driven where natural, fakes over
+  mocks (`internal/fakeherdr` fakes the herdr socket + CLI; `daemon_test.go` has in-process
+  fakes and a `newHarness` helper).
+- **Unix socket paths are length-capped** (~104 bytes on macOS): tests must use
+  `testutil.SocketDir(t)`, never `t.TempDir()`, for socket paths.
+- macOS temp dirs live under the `/var → /private/var` symlink — compare paths via
+  `filepath.EvalSymlinks`, not string equality.
+- Anything spawning real subprocesses should tolerate a deleted cwd (see `llm.Adapter.WorkDir`
+  and `chdirStable`) — the daemon can outlive the directory herdr launched it from.
 
 ## herdr integration gotchas (verified against herdr 0.7)
 
-- CLI reads print JSON envelopes (`{"id":…,"result":{…}}`); `pane read
-  --format text` prints plain text. `pane get` exposes `cwd` /
-  `foreground_cwd` (a deleted dir renders as `"/path (deleted)"`).
-- `agent send` writes text WITHOUT Enter — follow with
-  `pane send-keys <pane> enter`.
-- **Numbered menus want the digit, not the label.** A Claude approval/choice
-  (`1. Yes / 2. No`) only accepts the option's number; sending the literal
-  label ("Yes") is silently ignored — it reads as "nothing happened" on
-  confirm. Map the chosen option to its digit with `domain.MenuKeystroke`
-  before delivering (both the daemon `act` and frontend confirm paths do).
-- **`pane read --source recent` is a consuming delta**, not the screen: after
-  one read (e.g. the daemon's classification read) it can return just the
-  cursor line. To recover a standing menu at confirm time, read
-  `--source visible` (`herdr.CLI.ReadPaneVisible` /
-  `ports.VisiblePaneReader`).
-- One `events.subscribe` per socket connection; status subscriptions require
-  a concrete `pane_id`; existing panes are replayed as `pane_created`.
-- Adding a pane makes the subscriber reconnect ("pane set changed", 1s
-  backoff) — tests pushing transitions right after `AddPane` must wait past
-  the resubscribe.
-- The herdr binary is resolved via `HERDR_BIN_PATH` (fallback: `herdr` on
-  PATH); the events socket via `HERDR_SOCKET_PATH`.
+The **`herdr`** skill covers CLI usage; these are the hap-specific protocol facts.
+
+- CLI reads print JSON envelopes (`{"id":…,"result":{…}}`); `pane read --format text` prints
+  plain text. `pane get` exposes `cwd` / `foreground_cwd` (a deleted dir renders as
+  `"/path (deleted)"`).
+- `agent send` writes text WITHOUT Enter — follow with `pane send-keys <pane> enter`.
+- **Numbered menus want the digit, not the label.** A Claude approval/choice (`1. Yes / 2. No`)
+  only accepts the option's number; sending the literal label ("Yes") is silently ignored — it
+  reads as "nothing happened" on confirm. Map the chosen option to its digit with
+  `domain.MenuKeystroke` before delivering (both the daemon `act` and frontend confirm paths do).
+- **`pane read --source recent` is a consuming delta**, not the screen: after one read (e.g. the
+  daemon's classification read) it can return just the cursor line. To recover a standing menu at
+  confirm time, read `--source visible` (`herdr.CLI.ReadPaneVisible` / `ports.VisiblePaneReader`).
+- One `events.subscribe` per socket connection; status subscriptions require a concrete
+  `pane_id`; existing panes are replayed as `pane_created`.
+- Adding a pane makes the subscriber reconnect ("pane set changed", 1s backoff) — tests pushing
+  transitions right after `AddPane` must wait past the resubscribe.
+- The herdr binary is resolved via `HERDR_BIN_PATH` (fallback: `herdr` on PATH); the events
+  socket via `HERDR_SOCKET_PATH`.
 
 ## Where things live
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,10 @@ type Limits struct {
 	MaxConsecutiveAutoPrompts int `toml:"max_consecutive_auto_prompts"`
 	MaxAutoPromptsPerMinute   int `toml:"max_auto_prompts_per_minute"`
 	MaxErrorRetries           int `toml:"max_error_retries"`
+	// VerifyUnblockMs is the delay before the post-action self-check re-queries
+	// a blocked agent's status to confirm a delivered reply unblocked it; 0
+	// disables the self-check. Default 1000ms.
+	VerifyUnblockMs int `toml:"verify_unblock_ms"`
 }
 
 // LLM configures the optional local LLM/agent CLI fallback (FR-010, IR-005).
@@ -292,6 +296,7 @@ func Default() Config {
 			MaxConsecutiveAutoPrompts: 10,
 			MaxAutoPromptsPerMinute:   3,
 			MaxErrorRetries:           2,
+			VerifyUnblockMs:           1000,
 		},
 		// RewriteTimeoutSeconds stays zero here: Load seeds from Default
 		// before unmarshalling, and a non-zero seed would mask "omitted →
@@ -502,6 +507,9 @@ func (c *Config) fillZeroes() {
 	if c.Limits.MaxErrorRetries <= 0 {
 		c.Limits.MaxErrorRetries = d.Limits.MaxErrorRetries
 	}
+	// VerifyUnblockMs is deliberately NOT restored here: Load seeds it from
+	// Default() (1000), so an absent key keeps the default, while an explicit
+	// 0 must survive to DISABLE the self-check.
 	if c.LLM.TimeoutSeconds <= 0 {
 		c.LLM.TimeoutSeconds = d.LLM.TimeoutSeconds
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,6 +41,43 @@ func TestLoadPartialConfigFillsDefaults(t *testing.T) {
 	if cfg.Embedding.PaneSalientChars != 0 {
 		t.Errorf("unset pane_salient_chars should stay 0 (use-default), got %d", cfg.Embedding.PaneSalientChars)
 	}
+	// verify_unblock_ms is absent here → defaults to 1000.
+	if cfg.Limits.VerifyUnblockMs != Default().Limits.VerifyUnblockMs {
+		t.Errorf("unset verify_unblock_ms should default to %d, got %d",
+			Default().Limits.VerifyUnblockMs, cfg.Limits.VerifyUnblockMs)
+	}
+}
+
+// TestVerifyUnblockMsExplicitZeroDisables: an explicit 0 must survive Load
+// (fillZeroes must not restore the default), so operators can disable the
+// post-action self-check.
+func TestVerifyUnblockMsExplicitZeroDisables(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	os.WriteFile(path, []byte("[limits]\nverify_unblock_ms = 0\n"), 0o600)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Limits.VerifyUnblockMs != 0 {
+		t.Errorf("explicit verify_unblock_ms = 0 must stay 0 (disabled), got %d", cfg.Limits.VerifyUnblockMs)
+	}
+	// A sibling limit omitted in the same [limits] block still gets its default.
+	if cfg.Limits.MaxErrorRetries != Default().Limits.MaxErrorRetries {
+		t.Errorf("sibling default lost: %d", cfg.Limits.MaxErrorRetries)
+	}
+}
+
+// TestVerifyUnblockMsExplicitValueKept: a positive override round-trips.
+func TestVerifyUnblockMsExplicitValueKept(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	os.WriteFile(path, []byte("[limits]\nverify_unblock_ms = 250\n"), 0o600)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Limits.VerifyUnblockMs != 250 {
+		t.Errorf("verify_unblock_ms override lost, got %d", cfg.Limits.VerifyUnblockMs)
+	}
 }
 
 func TestPaneSalientCharsRoundTrip(t *testing.T) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -26,6 +26,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/logging"
 	"github.com/0xGosu/herdr-auto-pilot/internal/match"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/verifyunblock"
 )
 
 // Options configures a Daemon.
@@ -1150,6 +1151,51 @@ func (d *Daemon) deliverAutonomous(ctx context.Context, s domain.Situation, sig 
 	slog.Info("automated action delivered",
 		"agent", s.AgentID, "situation", s.Type, "confidence", dec.Confidence,
 		"rationale", del.rationale, "audit_id", auditID)
+
+	d.scheduleUnblockCheck(verifyunblock.Params{
+		PaneID: s.PaneID, AgentID: s.AgentID, AgentType: s.AgentType,
+		Signature: sig.Signature, Input: del.input, Excerpt: s.Content, SituationType: s.Type,
+	})
+}
+
+// scheduleUnblockCheck arms the post-action self-check: after the configured
+// delay (limits.verify_unblock_ms) it re-queries the agent's status and, if the
+// agent is STILL blocked, appends a delivery_failed audit row and notifies the
+// operator. It is a no-op when the check is disabled (delay <= 0) or the
+// situation type does not block an agent (idle). The check runs in its own
+// guarded goroutine via time.AfterFunc so it never stalls the monitor loop.
+func (d *Daemon) scheduleUnblockCheck(p verifyunblock.Params) {
+	cfg, _, _ := d.snapshot()
+	delayMs := cfg.Limits.VerifyUnblockMs
+	if delayMs <= 0 || !verifyunblock.Relevant(p.SituationType) || p.PaneID == "" {
+		return
+	}
+	// Keep the diagnostic row's excerpt the same size as the normal audit rows.
+	p.Excerpt = truncateRunes(p.Excerpt, snapshotMaxRunes)
+	delay := time.Duration(delayMs) * time.Millisecond
+	time.AfterFunc(delay, func() {
+		_ = logging.Guard("verify-unblock", func() error {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			blocked, _, err := verifyunblock.Check(ctx, d.opt.Herdr, d.opt.Store, p, d.opt.Clock.Now())
+			if err != nil {
+				slog.Warn("post-action unblock self-check failed", "agent", p.AgentID, "error", err)
+				return nil
+			}
+			if blocked {
+				// NOTE: this only checks status == blocked; it cannot tell the
+				// original prompt from a NEW one the agent raised after
+				// answering. A fast agent that answers and immediately blocks on
+				// a follow-up may trip a benign false positive (raise
+				// limits.verify_unblock_ms if that is noisy).
+				slog.Warn("agent still blocked after delivered action",
+					"agent", p.AgentID, "situation", p.SituationType, "input", p.Input)
+				d.notify(ctx, "Herd Auto Prompter: agent still blocked after action",
+					fmt.Sprintf("Agent %s is still blocked ~%dms after the delivered reply — it may not have landed (or the agent raised a new prompt). See hap audit.", p.AgentID, delayMs))
+			}
+			return nil
+		})
+	})
 }
 
 // deliverNoop applies a graduated "do nothing" rule autonomously: audit-first
@@ -2290,6 +2336,11 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 	d.lastAutoSend[s.AgentID] = now
 	d.mu.Unlock()
 	slog.Info("LLM decision promoted and delivered", "agent", s.AgentID, "action", llmDec.Action)
+
+	d.scheduleUnblockCheck(verifyunblock.Params{
+		PaneID: s.PaneID, AgentID: s.AgentID, AgentType: s.AgentType,
+		Signature: res.sig.Signature, Input: llmDec.Action, Excerpt: s.Content, SituationType: s.Type,
+	})
 }
 
 // processCorrections consumes front-end-written correction records and
@@ -2303,7 +2354,8 @@ func (d *Daemon) processCorrections(ctx context.Context) {
 		return
 	}
 	for _, c := range corrections {
-		if err := d.applyCorrection(ctx, cfg, c); err != nil {
+		arm, err := d.applyCorrection(ctx, cfg, c)
+		if err != nil {
 			slog.Error("applying correction failed", "correction", c.ID, "error", err)
 			continue
 		}
@@ -2312,6 +2364,11 @@ func (d *Daemon) processCorrections(ctx context.Context) {
 			// would double-record decisions and inflate confidence.
 			slog.Error("marking correction processed failed; aborting batch", "correction", c.ID, "error", err)
 			return
+		}
+		// Arm the post-action self-check only after the correction is committed,
+		// so a correction retried on a transient error never arms it twice.
+		if arm != nil {
+			d.scheduleUnblockCheck(*arm)
 		}
 	}
 }
@@ -2409,13 +2466,19 @@ func (d *Daemon) applyLLMRetry(ctx context.Context, r domain.LLMRetry) {
 	d.scheduleCapture(ctx, live)
 }
 
-func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domain.CorrectionRecord) error {
+// applyCorrection re-derives the affected signature's learning state from one
+// operator correction. When the correction was DELIVERED to the agent
+// (c.Sent), it returns the params to arm the post-action unblock self-check;
+// the caller arms it only after the correction is committed (see
+// processCorrections), so a correction retried on a transient error never arms
+// the check twice.
+func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domain.CorrectionRecord) (*verifyunblock.Params, error) {
 	audit, err := d.opt.Store.GetAudit(ctx, c.AuditID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if audit == nil {
-		return fmt.Errorf("correction %d references missing audit %d", c.ID, c.AuditID)
+		return nil, fmt.Errorf("correction %d references missing audit %d", c.ID, c.AuditID)
 	}
 	now := d.opt.Clock.Now()
 
@@ -2425,20 +2488,33 @@ func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domai
 		d.registerHumanInteraction(ctx, audit.AgentID)
 	}
 
+	// A delivered correction (c.Sent) arms the post-action self-check so a
+	// still-blocked agent surfaces a delivery_failed audit row, exactly as the
+	// daemon's own autonomous sends do. (AgentID is the pane id.) The params
+	// are returned rather than armed here so the caller arms once, after commit.
+	var arm *verifyunblock.Params
+	if c.Sent && audit.AgentID != "" {
+		arm = &verifyunblock.Params{
+			PaneID: audit.AgentID, AgentID: audit.AgentID, AgentType: audit.AgentType,
+			Signature: audit.Signature, Input: c.CorrectedAction, Excerpt: audit.PaneExcerpt,
+			SituationType: audit.SituationType,
+		}
+	}
+
 	if audit.Signature == "" {
 		// Nothing learnable (e.g. herdr-unreachable escalation).
-		return d.opt.Store.UpdateAuditStatus(ctx, c.AuditID, "resolved")
+		return arm, d.opt.Store.UpdateAuditStatus(ctx, c.AuditID, "resolved")
 	}
 
 	history, err := d.opt.Store.DecisionsForSignature(ctx, audit.Signature, 50)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	prior := domain.Confidence(history)
 
 	state, err := d.opt.Store.GetSignature(ctx, audit.Signature)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if state == nil {
 		state = &domain.SignatureState{
@@ -2465,7 +2541,7 @@ func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domai
 		AgentType: state.AgentType, ChosenAction: c.CorrectedAction,
 		Source: domain.SourceOperator, IsCorrection: !isConfirmation, CreatedAt: now,
 	}); err != nil {
-		return err
+		return nil, err
 	}
 
 	newState := *state
@@ -2483,7 +2559,7 @@ func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domai
 
 	refreshed, err := d.opt.Store.DecisionsForSignature(ctx, audit.Signature, 50)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	conf := domain.Confidence(refreshed)
 	newState.CachedConfidence = conf.Score
@@ -2492,7 +2568,7 @@ func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domai
 		thresholds(cfg).ForType(audit.SituationType), cfg.Learning.GraduationN)
 
 	if err := d.opt.Store.UpsertSignature(ctx, newState); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Error corrections clear the retry counter (FR-014).
@@ -2508,7 +2584,7 @@ func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domai
 		Input: c.CorrectedAction, Rationale: "operator " + map[bool]string{true: "confirmed", false: "corrected"}[isConfirmation],
 		CorrectsAuditID: c.AuditID, Status: "resolved", CreatedAt: now,
 	})
-	return d.opt.Store.UpdateAuditStatus(ctx, c.AuditID, "resolved")
+	return arm, d.opt.Store.UpdateAuditStatus(ctx, c.AuditID, "resolved")
 }
 
 // expireStaleLLMWork marks dangling pending LLM decisions AND pending consult

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -10,6 +10,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/logging"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/verifyunblock"
 )
 
 // Multi-tab MCQ forms (Claude AskUserQuestion / plan-mode) show ONE question
@@ -353,6 +354,10 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 			}
 			slog.Info("multi-tab answer series delivered",
 				"agent", s.AgentID, "tabs", s.TabCount, "confidence", dec.Confidence, "audit_id", auditID)
+			d.scheduleUnblockCheck(verifyunblock.Params{
+				PaneID: s.PaneID, AgentID: s.AgentID, AgentType: s.AgentType,
+				Signature: sig.Signature, Input: dec.Input, Excerpt: s.Content, SituationType: s.Type,
+			})
 			return nil
 		})
 	}()
@@ -401,6 +406,10 @@ func (d *Daemon) deliverSeriesLLM(ctx context.Context, ks ports.KeystrokeSender,
 			d.lastAutoSend[s.AgentID] = now
 			d.mu.Unlock()
 			slog.Info("LLM answer series promoted and delivered", "agent", s.AgentID, "tabs", s.TabCount)
+			d.scheduleUnblockCheck(verifyunblock.Params{
+				PaneID: s.PaneID, AgentID: s.AgentID, AgentType: s.AgentType,
+				Signature: sigKey, Input: llmDec.Action, Excerpt: s.Content, SituationType: s.Type,
+			})
 			return nil
 		})
 	}()

--- a/internal/daemon/verifyunblock_test.go
+++ b/internal/daemon/verifyunblock_test.go
@@ -1,0 +1,187 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/control"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/verifyunblock"
+)
+
+// countDeliveryFailed returns how many audit rows the post-action self-check
+// has written (Status == delivery_failed).
+func (h *harness) countDeliveryFailed() int {
+	h.t.Helper()
+	rows, err := h.raw.AuditLog(context.Background(), 50)
+	if err != nil {
+		h.t.Fatalf("audit log: %v", err)
+	}
+	n := 0
+	for _, r := range rows {
+		if r.Status == verifyunblock.StatusFailed {
+			n++
+		}
+	}
+	return n
+}
+
+// TestSelfCheckAuditsStillBlocked: when an autonomous approval is delivered but
+// the agent is STILL blocked a moment later, the daemon writes a
+// delivery_failed audit row.
+func TestSelfCheckAuditsStillBlocked(t *testing.T) {
+	h := newHarness(t, "[limits]\nverify_unblock_ms = 20\n")
+	h.herdr.setPane(approvalPane)
+	h.seedAutonomous(approvalPane, domain.SituationApproval, "1")
+	// The agent is reported as still blocked after the send.
+	h.herdr.setAgents([]domain.AgentTransition{{AgentID: "agent-vb", PaneID: "agent-vb", Status: "blocked"}})
+
+	h.push("agent-vb", "blocked")
+
+	// The auto-send lands first.
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	// Then the self-check surfaces the still-blocked agent.
+	waitFor(t, 3*time.Second, func() bool { return h.countDeliveryFailed() == 1 })
+
+	rows, _ := h.raw.AuditLog(context.Background(), 50)
+	var failed *domain.AuditRecord
+	for i := range rows {
+		if rows[i].Status == verifyunblock.StatusFailed {
+			failed = &rows[i]
+			break
+		}
+	}
+	if failed == nil {
+		t.Fatal("no delivery_failed audit row")
+	}
+	if failed.Input != "1" || failed.AgentID != "agent-vb" || failed.SituationType != domain.SituationApproval {
+		t.Errorf("delivery_failed row fields mismatch: %+v", failed)
+	}
+}
+
+// TestSelfCheckSilentWhenUnblocked: when the agent has left "blocked" by the
+// time the self-check runs, no delivery_failed row is written.
+func TestSelfCheckSilentWhenUnblocked(t *testing.T) {
+	h := newHarness(t, "[limits]\nverify_unblock_ms = 20\n")
+	h.herdr.setPane(approvalPane)
+	h.seedAutonomous(approvalPane, domain.SituationApproval, "1")
+	// The agent has moved on (no longer blocked).
+	h.herdr.setAgents([]domain.AgentTransition{{AgentID: "agent-ok", PaneID: "agent-ok", Status: "working"}})
+
+	h.push("agent-ok", "blocked")
+
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	// Give the self-check (20ms) ample time to run, then assert it stayed quiet.
+	time.Sleep(300 * time.Millisecond)
+	if n := h.countDeliveryFailed(); n != 0 {
+		t.Fatalf("want no delivery_failed rows for an unblocked agent, got %d", n)
+	}
+}
+
+// TestSelfCheckDisabled: verify_unblock_ms = 0 disables the self-check even when
+// the agent stays blocked.
+func TestSelfCheckDisabled(t *testing.T) {
+	h := newHarness(t, "[limits]\nverify_unblock_ms = 0\n")
+	h.herdr.setPane(approvalPane)
+	h.seedAutonomous(approvalPane, domain.SituationApproval, "1")
+	h.herdr.setAgents([]domain.AgentTransition{{AgentID: "agent-off", PaneID: "agent-off", Status: "blocked"}})
+
+	h.push("agent-off", "blocked")
+
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	time.Sleep(300 * time.Millisecond)
+	if n := h.countDeliveryFailed(); n != 0 {
+		t.Fatalf("disabled self-check wrote %d rows", n)
+	}
+}
+
+// seedEscalation inserts a pending approval escalation and returns its audit id,
+// so an operator-correction self-check can be exercised.
+func (h *harness) seedEscalationAudit(agentID string) int64 {
+	h.t.Helper()
+	id, err := h.raw.AppendAudit(context.Background(), domain.AuditRecord{
+		AgentID: agentID, AgentType: "claude", Signature: "approval:opsig", Trigger: "t",
+		SituationType: domain.SituationApproval, Action: "escalated", Status: "escalated",
+		Suggestion: "respond: 1", PaneExcerpt: approvalPane, CreatedAt: time.Now(),
+	})
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	return id
+}
+
+// TestSelfCheckOperatorSendStillBlocked: an operator correction DELIVERED to the
+// agent (Sent=true) arms the self-check via the daemon's correction drain; a
+// still-blocked agent gets a delivery_failed row.
+func TestSelfCheckOperatorSendStillBlocked(t *testing.T) {
+	h := newHarness(t, "[limits]\nverify_unblock_ms = 20\n")
+	h.herdr.setAgents([]domain.AgentTransition{{AgentID: "agent-op", PaneID: "agent-op", Status: "blocked"}})
+	ctx := context.Background()
+	auditID := h.seedEscalationAudit("agent-op")
+
+	if _, err := h.raw.InsertCorrection(ctx, domain.CorrectionRecord{
+		AuditID: auditID, CorrectedAction: "1", Author: "operator", Sent: true, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := control.Nudge(ctx, h.ctlPath, control.KindReload); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 3*time.Second, func() bool { return h.countDeliveryFailed() == 1 })
+}
+
+// TestSelfCheckOperatorRecordOnly: a record-only correction (Sent=false) never
+// arms the self-check, even against a still-blocked agent.
+func TestSelfCheckOperatorRecordOnly(t *testing.T) {
+	h := newHarness(t, "[limits]\nverify_unblock_ms = 20\n")
+	h.herdr.setAgents([]domain.AgentTransition{{AgentID: "agent-ro", PaneID: "agent-ro", Status: "blocked"}})
+	ctx := context.Background()
+	auditID := h.seedEscalationAudit("agent-ro")
+
+	if _, err := h.raw.InsertCorrection(ctx, domain.CorrectionRecord{
+		AuditID: auditID, CorrectedAction: "1", Author: "operator", Sent: false, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := control.Nudge(ctx, h.ctlPath, control.KindReload); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the correction lineage row (proves the drain ran), then assert
+	// no delivery_failed row was written.
+	waitFor(t, 3*time.Second, func() bool {
+		log, _ := h.raw.AuditLog(ctx, 10)
+		for _, r := range log {
+			if r.CorrectsAuditID == auditID {
+				return true
+			}
+		}
+		return false
+	})
+	time.Sleep(200 * time.Millisecond)
+	if n := h.countDeliveryFailed(); n != 0 {
+		t.Fatalf("record-only correction must not arm the self-check, got %d rows", n)
+	}
+}
+
+// TestSelfCheckSeriesStillBlocked: the multi-tab series delivery path also arms
+// the self-check.
+func TestSelfCheckSeriesStillBlocked(t *testing.T) {
+	h := newHarness(t, "[limits]\nverify_unblock_ms = 20\n")
+	h.herdr.setFrames(mcqFrames)
+	h.seedSeriesRule(t, "1 2 1")
+	h.herdr.setAgents([]domain.AgentTransition{{AgentID: "agent-mcq", PaneID: "agent-mcq", Status: "blocked"}})
+
+	h.push("agent-mcq", "blocked")
+
+	// The series delivery uses paced keystrokes; give it time, then the
+	// self-check (armed after delivery) surfaces the still-blocked agent.
+	waitFor(t, 10*time.Second, func() bool { return h.countDeliveryFailed() == 1 })
+	// Sanity: the series went out as keystrokes, not text.
+	if got := strings.Join(h.herdr.sentInputs(), " "); got != "" {
+		t.Errorf("series must deliver as keystrokes, text sent: %q", got)
+	}
+}

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -151,12 +151,22 @@ func InferNextTask(agentType, transcript string) InferredTask {
 	return infer(transcript)
 }
 
+// claudeWS is the whitespace class used across the Claude todo-widget
+// patterns. Go's regexp (RE2) makes \s ASCII-only ([\t\n\f\r ]), but Claude
+// pads the widget's first row — the ⎿ connector line — with a NON-BREAKING
+// SPACE (U+00A0) between the connector and the status marker. Matching NBSP
+// as whitespace everywhere the widget can inject padding keeps that first
+// item (often the in-progress one) from being dropped, which would make the
+// idle resolver infer the second item as the next task.
+const claudeWS = `[\s\x{00A0}]`
+
 // claudeTodoItemRE matches one line of Claude Code's todo-widget rendering:
 // optional indent, an optional ⎿/└ connector, a status marker rune, then
 // the task text. Marker runes vary across Claude Code versions/fonts —
 // verified against real TUI copies in test/samples/claude_todo_sample*.txt:
-// completed ✔ ✓ ☒, in-progress ■ ▪ ◼ ◾, pending □ ▫ ☐ ◻ ◽.
-var claudeTodoItemRE = regexp.MustCompile(`^\s*(?:[⎿└]\s*)?([✔✓☒■▪◼◾□▫☐◻◽])\s+(\S.*)$`)
+// completed ✔ ✓ ☒, in-progress ■ ▪ ◼ ◾, pending □ ▫ ☐ ◻ ◽. Whitespace slots
+// use claudeWS so the NBSP-padded connector row still parses.
+var claudeTodoItemRE = regexp.MustCompile(`^` + claudeWS + `*(?:[⎿└]` + claudeWS + `*)?([✔✓☒■▪◼◾□▫☐◻◽])` + claudeWS + `+(\S.*)$`)
 
 // claudeTodoHeaderRE matches the widget's header/status line — a spinner
 // glyph (frames vary: · * ✽ ✻ ✶ ✳ ✢, or the ● message bullet), a space,
@@ -165,7 +175,7 @@ var claudeTodoItemRE = regexp.MustCompile(`^\s*(?:[⎿└]\s*)?([✔✓☒■▪
 // the current block so back-to-back renders with no blank line between
 // them never concatenate; requiring the ellipsis keeps an item's wrapped
 // continuation line from ever matching.
-var claudeTodoHeaderRE = regexp.MustCompile(`^\s*[·✻✽✶✳✢*●]\s.*…`)
+var claudeTodoHeaderRE = regexp.MustCompile(`^` + claudeWS + `*[·✻✽✶✳✢*●]` + claudeWS + `.*…`)
 
 // inferClaudeNextTask parses Claude Code's native todo widget, e.g. (a
 // real TUI copy; the header spinner varies — · * ✽ ✻ — and a footer like

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -224,6 +224,20 @@ func TestInferNextTask(t *testing.T) {
 			structured: true,
 		},
 		{
+			// Regression: Claude Code pads the ⎿ connector row (the widget's
+			// first item) with a non-breaking space (U+00A0) before the marker.
+			// Go's ASCII-only \s used to skip that whole row, so the resolver
+			// inferred the SECOND item. Verified against a live captured pane.
+			name:      "NBSP-padded connector row keeps the first item",
+			agentType: "claude",
+			transcript: "· Bunning… (29m 52s · ↓ 81.5k tokens)\n" +
+				"  ⎿  ■ Wire daemon self-check into send paths\n" +
+				"     ◻ Wire frontend Resolve self-check\n" +
+				"     ✔ Add verifyunblock shared helper\n",
+			wantTask:   "Wire daemon self-check into send paths",
+			structured: true,
+		},
+		{
 			name:      "all completed yields nothing",
 			agentType: "claude",
 			transcript: "  ⎿  ✔ everything\n" +

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -240,7 +240,12 @@ type CorrectionRecord struct {
 	CorrectedAction string
 	Author          string
 	Processed       bool
-	CreatedAt       time.Time
+	// Sent reports whether the front-end actually delivered this corrected
+	// action to the agent pane (confirm/correct with --send). The daemon uses
+	// it to schedule the post-action unblock self-check only for deliveries —
+	// a record-only correction leaves the agent expectedly blocked.
+	Sent      bool
+	CreatedAt time.Time
 }
 
 // KillEvent is one row of the append-only pause/kill/resume event log.

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -463,15 +463,21 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 	if action == domain.SuggestGenerateTask {
 		return a.acceptGeneratedTask(ctx, audit, send)
 	}
+	// willSend mirrors the delivery gate below: it records on the correction
+	// whether this action is actually delivered to the agent, so the daemon
+	// (which owns audit writes) can arm the post-action unblock self-check for
+	// operator sends — a record-only correction leaves the agent expectedly
+	// blocked and must NOT trip the check.
+	willSend := send && action != domain.ActionNoop && a.Herdr != nil && audit.AgentID != ""
 	if _, err := a.Store.InsertCorrection(ctx, domain.CorrectionRecord{
-		AuditID: auditID, CorrectedAction: action, Author: a.Author, CreatedAt: time.Now(),
+		AuditID: auditID, CorrectedAction: action, Author: a.Author, Sent: willSend, CreatedAt: time.Now(),
 	}); err != nil {
 		return err
 	}
 	// A confirmed/resolved noop records the correction — the learning event
 	// — but never writes the sentinel into the pane: "do nothing" means
 	// exactly that.
-	if send && action != domain.ActionNoop && a.Herdr != nil && audit.AgentID != "" {
+	if willSend {
 		outbound := materializeForSend(action, audit)
 		// A numbered menu (Claude approvals/choices) only accepts the
 		// option's digit, not the label. Re-read the pane's CURRENT screen
@@ -850,6 +856,7 @@ var ConfigFields = []ConfigFieldDef{
 	{Key: "limits.max_consecutive_auto_prompts", TUIEditable: true},
 	{Key: "limits.max_auto_prompts_per_minute", TUIEditable: true},
 	{Key: "limits.max_error_retries", TUIEditable: true},
+	{Key: "limits.verify_unblock_ms", TUIEditable: true},
 	{Key: "safety.disable_seed", TUIEditable: true},
 	{Key: "llm.command"},       // argv template
 	{Key: "llm.command_start"}, // argv template (first consult; inherits command)
@@ -923,6 +930,11 @@ func FieldValue(cfg config.Config, key string) string {
 		return strconv.Itoa(cfg.Limits.MaxAutoPromptsPerMinute)
 	case "limits.max_error_retries":
 		return strconv.Itoa(cfg.Limits.MaxErrorRetries)
+	case "limits.verify_unblock_ms":
+		if cfg.Limits.VerifyUnblockMs <= 0 {
+			return "0 (disabled)"
+		}
+		return strconv.Itoa(cfg.Limits.VerifyUnblockMs)
 	case "llm.command":
 		if len(cfg.LLM.Command) == 0 {
 			return "(disabled)"
@@ -1036,6 +1048,15 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 		*dst = v
 		return nil
 	}
+	// setNonNegInt allows 0 (used by fields where 0 is a meaningful "disable").
+	setNonNegInt := func(dst *int) error {
+		v, err := strconv.Atoi(value)
+		if err != nil || v < 0 {
+			return fmt.Errorf("%s must be a non-negative integer, got %q", key, value)
+		}
+		*dst = v
+		return nil
+	}
 	return a.UpdateConfig(ctx, func(cfg *config.Config) error {
 		switch key {
 		case "thresholds.idle":
@@ -1058,6 +1079,8 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 			return setInt(&cfg.Limits.MaxAutoPromptsPerMinute)
 		case "limits.max_error_retries":
 			return setInt(&cfg.Limits.MaxErrorRetries)
+		case "limits.verify_unblock_ms":
+			return setNonNegInt(&cfg.Limits.VerifyUnblockMs)
 		case "llm.timeout_seconds":
 			return setInt(&cfg.LLM.TimeoutSeconds)
 		case "llm.auto_act_confidence_threshold":

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -463,17 +463,23 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 	if action == domain.SuggestGenerateTask {
 		return a.acceptGeneratedTask(ctx, audit, send)
 	}
-	// willSend mirrors the delivery gate below: it records on the correction
-	// whether this action is actually delivered to the agent, so the daemon
-	// (which owns audit writes) can arm the post-action unblock self-check for
-	// operator sends — a record-only correction leaves the agent expectedly
-	// blocked and must NOT trip the check.
+	// willSend is the delivery gate. The correction is recorded FIRST (the
+	// learning event, preserved even when delivery fails) but with Sent=false;
+	// it is flipped to Sent=true only AFTER delivery actually succeeds. The
+	// daemon arms the post-action unblock self-check off the Sent flag, so a
+	// failed pane read / form-validation / keystroke series / Send must never
+	// leave a Sent=true correction (which would fire a bogus delivery_failed).
 	willSend := send && action != domain.ActionNoop && a.Herdr != nil && audit.AgentID != ""
-	if _, err := a.Store.InsertCorrection(ctx, domain.CorrectionRecord{
-		AuditID: auditID, CorrectedAction: action, Author: a.Author, Sent: willSend, CreatedAt: time.Now(),
-	}); err != nil {
+	corrID, err := a.Store.InsertCorrection(ctx, domain.CorrectionRecord{
+		AuditID: auditID, CorrectedAction: action, Author: a.Author, Sent: false, CreatedAt: time.Now(),
+	})
+	if err != nil {
 		return err
 	}
+	// markSent flags the correction delivered so the daemon arms the self-check.
+	// Best-effort: the send already succeeded, so a flag-write failure only
+	// skips the (safety-net) check rather than failing the operator's action.
+	markSent := func() { _ = a.Store.MarkCorrectionSent(ctx, corrID) }
 	// A confirmed/resolved noop records the correction — the learning event
 	// — but never writes the sentinel into the pane: "do nothing" means
 	// exactly that.
@@ -504,6 +510,7 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 			if err := a.deliverTabSeries(ctx, ks, audit.AgentID, groups); err != nil {
 				return fmt.Errorf("correction recorded, but %w", err)
 			}
+			markSent()
 			return a.nudge(ctx, control.KindReload)
 		}
 		if rerr == nil {
@@ -512,6 +519,7 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 		if err := a.Herdr.Send(ctx, audit.AgentID, outbound); err != nil {
 			return fmt.Errorf("correction recorded, but sending to the agent failed: %w", err)
 		}
+		markSent()
 	}
 	return a.nudge(ctx, control.KindReload)
 }

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -308,10 +308,14 @@ type fakeHerdr struct {
 	inputs  []string
 	pane    string // returned by ReadPane (live menu content)
 	readErr error
+	sendErr error                    // when set, Send fails (delivery failure)
 	agents  []domain.AgentTransition // returned by ListAgents (live statuses)
 }
 
 func (f *fakeHerdr) Send(_ context.Context, paneID, input string) error {
+	if f.sendErr != nil {
+		return f.sendErr
+	}
 	f.panes = append(f.panes, paneID)
 	f.inputs = append(f.inputs, input)
 	return nil
@@ -387,6 +391,30 @@ func TestResolveNoopNeverSent(t *testing.T) {
 	}
 	if len(fake.inputs) != 0 {
 		t.Errorf("@noop must not deliver anything, got %v", fake.inputs)
+	}
+}
+
+// TestResolveFailedSendLeavesUnsent: when delivery fails, the correction is
+// still recorded (learning) but stays Sent=false, so the daemon never arms the
+// self-check for an action that never reached the agent.
+func TestResolveFailedSendLeavesUnsent(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeHerdr{pane: "Enter a commit message:\n> ", sendErr: errAny}
+	app.Herdr = fake
+	ctx := context.Background()
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "a1", SituationType: domain.SituationApproval, Trigger: "t",
+		Action: "escalated", Status: "escalated", Suggestion: "respond: y", CreatedAt: time.Now(),
+	})
+	if err := app.Resolve(ctx, id, "proceed", true); err == nil {
+		t.Fatal("expected a delivery error")
+	}
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 1 {
+		t.Fatalf("correction must still be recorded on send failure: %+v", corr)
+	}
+	if corr[0].Sent {
+		t.Errorf("a failed send must leave the correction Sent=false: %+v", corr)
 	}
 }
 

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -325,6 +325,71 @@ func (f *fakeHerdr) ListAgents(context.Context) ([]domain.AgentTransition, error
 	return f.agents, nil
 }
 
+// TestResolveMarksSentOnDelivery: a delivered correction is recorded with
+// Sent=true so the daemon arms the post-action unblock self-check.
+func TestResolveMarksSentOnDelivery(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeHerdr{pane: "Do you want to proceed?\n❯ 1. Yes\n  2. No\n"}
+	app.Herdr = fake
+	ctx := context.Background()
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "a1", SituationType: domain.SituationApproval, Trigger: "t",
+		Action: "escalated", Status: "escalated", Suggestion: "respond: y", CreatedAt: time.Now(),
+	})
+	if err := app.Resolve(ctx, id, "Yes", true); err != nil {
+		t.Fatal(err)
+	}
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 1 || !corr[0].Sent {
+		t.Errorf("delivered correction should be Sent=true: %+v", corr)
+	}
+	if len(fake.inputs) != 1 {
+		t.Errorf("expected one delivery, got %v", fake.inputs)
+	}
+}
+
+// TestResolveRecordOnlyNotSent: a record-only correction (no --send) leaves
+// Sent=false so the daemon does NOT run the self-check on an expectedly-blocked
+// agent.
+func TestResolveRecordOnlyNotSent(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "a1", SituationType: domain.SituationApproval, Trigger: "t",
+		Action: "escalated", Status: "escalated", Suggestion: "respond: y", CreatedAt: time.Now(),
+	})
+	if err := app.Resolve(ctx, id, "n", false); err != nil {
+		t.Fatal(err)
+	}
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 1 || corr[0].Sent {
+		t.Errorf("record-only correction should be Sent=false: %+v", corr)
+	}
+}
+
+// TestResolveNoopNeverSent: a @noop resolution sends nothing and is Sent=false
+// even with --send.
+func TestResolveNoopNeverSent(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	ctx := context.Background()
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "a1", SituationType: domain.SituationApproval, Trigger: "t",
+		Action: "escalated", Status: "escalated", Suggestion: "respond: y", CreatedAt: time.Now(),
+	})
+	if err := app.Resolve(ctx, id, "@noop", true); err != nil {
+		t.Fatal(err)
+	}
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 1 || corr[0].Sent {
+		t.Errorf("@noop correction must be Sent=false: %+v", corr)
+	}
+	if len(fake.inputs) != 0 {
+		t.Errorf("@noop must not deliver anything, got %v", fake.inputs)
+	}
+}
+
 func TestConfirmSendsRenderedDeclaredTaskPrompt(t *testing.T) {
 	// The confirm path must deliver the exact rendered prompt carried in the
 	// "send next declared task: " suggestion (the SuggestedAction /
@@ -913,6 +978,7 @@ func TestConfigFieldRegistryParity(t *testing.T) {
 		"limits.max_consecutive_auto_prompts": "5",
 		"limits.max_auto_prompts_per_minute":  "10",
 		"limits.max_error_retries":            "2",
+		"limits.verify_unblock_ms":            "1000",
 		"safety.disable_seed":                 "true",
 		"llm.command":                         `claude -p "decide"`,
 		"llm.command_start":                   `claude -p "first: decide"`,

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -170,6 +170,11 @@ type FrontendStore interface {
 	ReadStore
 
 	InsertCorrection(ctx context.Context, c domain.CorrectionRecord) (int64, error)
+	// MarkCorrectionSent flags a recorded correction as delivered to the agent
+	// (front-ends record the correction first, then flip this once delivery
+	// succeeds), so the daemon arms the post-action unblock self-check only for
+	// corrections that actually reached the pane.
+	MarkCorrectionSent(ctx context.Context, id int64) error
 	// InsertLLMRetry queues a request to re-invoke the LLM on an escalation
 	// whose consult failed/timed out; the daemon drains it on reload.
 	InsertLLMRetry(ctx context.Context, auditID int64, now time.Time) (int64, error)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -369,6 +369,17 @@ func (s *Store) MarkCorrectionProcessed(ctx context.Context, id int64) error {
 	})
 }
 
+// MarkCorrectionSent flags a recorded correction as delivered to the agent
+// (front-ends record it first, then flip this once the send succeeds), so the
+// daemon arms the post-action unblock self-check only for delivered corrections.
+func (s *Store) MarkCorrectionSent(ctx context.Context, id int64) error {
+	return s.tx(ctx, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx,
+			`UPDATE corrections SET sent = 1 WHERE id = ?`, id)
+		return err
+	})
+}
+
 // StageLLMRequest stores the context for one LLM consultation (daemon-owned).
 func (s *Store) StageLLMRequest(ctx context.Context, r domain.LLMRequest) (int64, error) {
 	var id int64

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -124,6 +124,7 @@ CREATE TABLE IF NOT EXISTS corrections (
 	corrected_action TEXT NOT NULL,
 	author TEXT NOT NULL DEFAULT 'operator',
 	processed INTEGER NOT NULL DEFAULT 0,
+	sent INTEGER NOT NULL DEFAULT 0,
 	created_at INTEGER NOT NULL
 );
 CREATE TABLE IF NOT EXISTS kill_events (
@@ -209,6 +210,9 @@ func (s *Store) migrate() error {
 		`ALTER TABLE audit_log ADD COLUMN llm_confidence INTEGER`,
 		`ALTER TABLE llm_decisions ADD COLUMN confident_score INTEGER NOT NULL DEFAULT -1`,
 		`ALTER TABLE llm_requests ADD COLUMN agent_id TEXT NOT NULL DEFAULT ''`,
+		// sent = 1 when the front-end delivered the correction to the agent;
+		// drives the daemon's post-action unblock self-check.
+		`ALTER TABLE corrections ADD COLUMN sent INTEGER NOT NULL DEFAULT 0`,
 	} {
 		if _, err := s.db.Exec(ddl); err != nil &&
 			!strings.Contains(err.Error(), "duplicate column name") {
@@ -454,11 +458,15 @@ func (s *Store) UpdateLLMDecisionStatus(ctx context.Context, id int64, status st
 // InsertCorrection appends a front-end-written correction record.
 func (s *Store) InsertCorrection(ctx context.Context, c domain.CorrectionRecord) (int64, error) {
 	var id int64
+	sent := 0
+	if c.Sent {
+		sent = 1
+	}
 	err := s.tx(ctx, func(tx *sql.Tx) error {
 		res, err := tx.ExecContext(ctx, `
-			INSERT INTO corrections (audit_id, corrected_action, author, processed, created_at)
-			VALUES (?, ?, ?, 0, ?)`,
-			c.AuditID, c.CorrectedAction, orDefault(c.Author, "operator"), unix(c.CreatedAt))
+			INSERT INTO corrections (audit_id, corrected_action, author, processed, sent, created_at)
+			VALUES (?, ?, ?, 0, ?, ?)`,
+			c.AuditID, c.CorrectedAction, orDefault(c.Author, "operator"), sent, unix(c.CreatedAt))
 		if err != nil {
 			return err
 		}
@@ -1093,7 +1101,7 @@ func (s *Store) DuplicatePendingEscalation(ctx context.Context, agentID, agentTy
 // UnprocessedCorrections returns corrections the daemon has not consumed.
 func (s *Store) UnprocessedCorrections(ctx context.Context) ([]domain.CorrectionRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, audit_id, corrected_action, author, processed, created_at
+		SELECT id, audit_id, corrected_action, author, processed, sent, created_at
 		FROM corrections WHERE processed = 0 ORDER BY id ASC`)
 	if err != nil {
 		return nil, err
@@ -1102,12 +1110,13 @@ func (s *Store) UnprocessedCorrections(ctx context.Context) ([]domain.Correction
 	var out []domain.CorrectionRecord
 	for rows.Next() {
 		var c domain.CorrectionRecord
-		var processed int
+		var processed, sent int
 		var created int64
-		if err := rows.Scan(&c.ID, &c.AuditID, &c.CorrectedAction, &c.Author, &processed, &created); err != nil {
+		if err := rows.Scan(&c.ID, &c.AuditID, &c.CorrectedAction, &c.Author, &processed, &sent, &created); err != nil {
 			return nil, err
 		}
 		c.Processed = processed != 0
+		c.Sent = sent != 0
 		c.CreatedAt = fromUnix(created)
 		out = append(out, c)
 	}

--- a/internal/tui/correct_test.go
+++ b/internal/tui/correct_test.go
@@ -123,7 +123,7 @@ func TestCorrectLiveSendPath(t *testing.T) {
 	upd, _ = m.Update(msg.(openSendPromptMsg))
 	m = upd.(Model)
 
-	m, _ = runPromptSubmit(t, m, "y")
+	runPromptSubmit(t, m, "y")
 	corr, _ := st.UnprocessedCorrections(context.Background())
 	if len(corr) != 1 || !corr[0].Sent {
 		t.Errorf("sent correction should be Sent=true: %+v", corr)
@@ -141,7 +141,7 @@ func TestCorrectNonLiveRecordsWithoutSendPrompt(t *testing.T) {
 
 	upd, _ := m.correctByID(id, false)
 	m = upd.(Model)
-	m, msg := runPromptSubmit(t, m, "n")
+	_, msg := runPromptSubmit(t, m, "n")
 	if _, ok := msg.(openSendPromptMsg); ok {
 		t.Fatal("non-live correction must NOT chain a send prompt")
 	}

--- a/internal/tui/correct_test.go
+++ b/internal/tui/correct_test.go
@@ -1,0 +1,155 @@
+package tui
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// fakeHerdrTUI captures Send calls so the "also send?" yes-path can be
+// asserted; ReadPane returns a standing menu for digit mapping.
+type fakeHerdrTUI struct {
+	inputs []string
+	pane   string
+}
+
+func (f *fakeHerdrTUI) Send(_ context.Context, _, input string) error {
+	f.inputs = append(f.inputs, input)
+	return nil
+}
+func (f *fakeHerdrTUI) ReadPane(context.Context, string, int) (string, error) { return f.pane, nil }
+func (f *fakeHerdrTUI) ListAgents(context.Context) ([]domain.AgentTransition, error) {
+	return nil, nil
+}
+
+func correctTestModel(t *testing.T) (Model, *store.Store, *fakeHerdrTUI) {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	fh := &fakeHerdrTUI{pane: "Do you want to proceed?\n❯ 1. Yes\n  2. No\n"}
+	app := &frontend.App{
+		Store:      st,
+		Herdr:      fh,
+		ConfigPath: filepath.Join(dir, "config.toml"),
+		Author:     "operator",
+	}
+	return Model{width: 100, height: 30, app: app, ctx: context.Background()}, st, fh
+}
+
+func seedEscalation(t *testing.T, st *store.Store, status string) int64 {
+	t.Helper()
+	id, err := st.AppendAudit(context.Background(), domain.AuditRecord{
+		AgentID: "w1:p1", Signature: "sig", Trigger: "t",
+		SituationType: domain.SituationApproval, Action: "escalated",
+		Status: status, Suggestion: "respond: y", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// runPromptSubmit fills the active prompt with input and presses Enter,
+// returning the resulting model and the message its command produced.
+func runPromptSubmit(t *testing.T, m Model, input string) (Model, tea.Msg) {
+	t.Helper()
+	if m.prompt == nil {
+		t.Fatal("no active prompt")
+	}
+	m.prompt.input = input
+	upd, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = upd.(Model)
+	if cmd == nil {
+		return m, nil
+	}
+	return m, cmd()
+}
+
+// TestCorrectLiveOpensSendPromptAndRecords: correcting a live escalation opens
+// the "also send?" prompt; answering "n" records the correction as not sent.
+func TestCorrectLiveRecordOnlyPath(t *testing.T) {
+	m, st, fh := correctTestModel(t)
+	id := seedEscalation(t, st, "escalated")
+
+	upd, _ := m.correctByID(id, true)
+	m = upd.(Model)
+	if m.prompt == nil {
+		t.Fatal("correct should open the action prompt")
+	}
+
+	// Submit the corrected action → chains to the send prompt.
+	m, msg := runPromptSubmit(t, m, "Yes")
+	sp, ok := msg.(openSendPromptMsg)
+	if !ok {
+		t.Fatalf("live correction should chain openSendPromptMsg, got %T", msg)
+	}
+	upd, _ = m.Update(sp)
+	m = upd.(Model)
+	if m.prompt == nil || m.prompt.input != "n" {
+		t.Fatalf("send prompt should open defaulting to 'n', got %+v", m.prompt)
+	}
+
+	// Answer "n": record only, nothing sent.
+	m, _ = runPromptSubmit(t, m, "n")
+	corr, _ := st.UnprocessedCorrections(context.Background())
+	if len(corr) != 1 || corr[0].Sent {
+		t.Errorf("record-only correction should be Sent=false: %+v", corr)
+	}
+	if len(fh.inputs) != 0 {
+		t.Errorf("answering 'n' must not deliver anything, got %v", fh.inputs)
+	}
+}
+
+// TestCorrectLiveSendPath: answering "y" delivers the corrected action and
+// records it as sent.
+func TestCorrectLiveSendPath(t *testing.T) {
+	m, st, fh := correctTestModel(t)
+	id := seedEscalation(t, st, "escalated")
+
+	upd, _ := m.correctByID(id, true)
+	m = upd.(Model)
+	m, msg := runPromptSubmit(t, m, "Yes")
+	upd, _ = m.Update(msg.(openSendPromptMsg))
+	m = upd.(Model)
+
+	m, _ = runPromptSubmit(t, m, "y")
+	corr, _ := st.UnprocessedCorrections(context.Background())
+	if len(corr) != 1 || !corr[0].Sent {
+		t.Errorf("sent correction should be Sent=true: %+v", corr)
+	}
+	if len(fh.inputs) != 1 {
+		t.Errorf("answering 'y' should deliver exactly one keystroke, got %v", fh.inputs)
+	}
+}
+
+// TestCorrectNonLiveRecordsWithoutSendPrompt: correcting a historical record
+// (e.g. a past auto decision) records only and never opens the send prompt.
+func TestCorrectNonLiveRecordsWithoutSendPrompt(t *testing.T) {
+	m, st, fh := correctTestModel(t)
+	id := seedEscalation(t, st, "auto") // not a pending escalation
+
+	upd, _ := m.correctByID(id, false)
+	m = upd.(Model)
+	m, msg := runPromptSubmit(t, m, "n")
+	if _, ok := msg.(openSendPromptMsg); ok {
+		t.Fatal("non-live correction must NOT chain a send prompt")
+	}
+	corr, _ := st.UnprocessedCorrections(context.Background())
+	if len(corr) != 1 || corr[0].Sent {
+		t.Errorf("non-live correction should be Sent=false: %+v", corr)
+	}
+	if len(fh.inputs) != 0 {
+		t.Errorf("non-live correction must not deliver, got %v", fh.inputs)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -72,6 +72,15 @@ type actionResultMsg struct {
 	err     error
 }
 
+// openSendPromptMsg re-opens a second prompt after a LIVE escalation's
+// correction text is captured, asking whether to also deliver it to the
+// (blocked) agent. Chaining goes through a message because a prompt's onSubmit
+// returns a tea.Cmd and cannot mutate the model directly.
+type openSendPromptMsg struct {
+	id     int64
+	action string
+}
+
 // statusNote is a durable action outcome shown in the status area until
 // the next outcome replaces it (CR-025) — unlike the transient m.message
 // hint line, navigation never clears it.
@@ -403,6 +412,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// The status area shrinks the page by 2 — keep the cursor visible.
 		m.clampListViewport()
 		return m, m.refresh()
+	case openSendPromptMsg:
+		return m.openSendPrompt(msg.id, msg.action)
 	case tickMsg:
 		return m, tea.Batch(m.refresh(), tick())
 	case sigDetailMsg:
@@ -469,10 +480,12 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.detail = nil
 		case "c":
 			// Per-entry actions mirror the list, acting on the snapshotted
-			// escalation id (confirmID), never the live cursor.
+			// escalation id (confirmID), never the live cursor. A non-zero
+			// confirmID is only set for pending escalations, so this is a live
+			// correction (offers the "also send?" step).
 			if id := m.detail.confirmID; id != 0 {
 				m.detail = nil
-				return m.correctByID(id)
+				return m.correctByID(id, true)
 			}
 		case "x", "delete":
 			if id := m.detail.confirmID; id != 0 {
@@ -785,23 +798,58 @@ func (m Model) correctSelected() (tea.Model, tea.Cmd) {
 	if rec == nil {
 		return m, nil
 	}
-	return m.correctByID(rec.ID)
+	return m.correctByID(rec.ID, rec.Status == "escalated")
 }
 
 // correctByID opens the correction prompt for a specific audit id — used by
 // the list and by the detail overlay (which corrects its snapshotted record,
-// not the live cursor).
-func (m Model) correctByID(id int64) (tea.Model, tea.Cmd) {
+// not the live cursor). live reports whether the record is a pending
+// escalation (agent waiting): for those, capturing the action chains a second
+// "also send?" prompt so the corrected reply can be delivered; for a
+// historical record (e.g. correcting a past auto decision) the correction is
+// recorded only, never sent.
+func (m Model) correctByID(id int64, live bool) (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	m.message = ""
 	m.prompt = &prompt{
 		label: fmt.Sprintf("correct #%d — action to record", id),
 		onSubmit: func(input string) tea.Cmd {
+			if live {
+				// Defer recording to the send prompt so exactly one correction
+				// is written with the chosen send flag.
+				return func() tea.Msg { return openSendPromptMsg{id: id, action: input} }
+			}
 			return func() tea.Msg {
 				if err := app.Resolve(ctx, id, input, false); err != nil {
 					return actionResultMsg{err: err}
 				}
 				return actionResultMsg{message: fmt.Sprintf("correction recorded for #%d", id)}
+			}
+		},
+	}
+	return m, nil
+}
+
+// openSendPrompt is the second step of correcting a live escalation: it asks
+// whether to deliver the corrected action to the blocked agent, then records
+// the correction once with the chosen send flag. It defaults to "n" (record
+// only) so a bare Enter never sends unintentionally.
+func (m Model) openSendPrompt(id int64, action string) (tea.Model, tea.Cmd) {
+	app, ctx := m.app, m.ctx
+	m.message = ""
+	m.prompt = &prompt{
+		label: fmt.Sprintf("send corrected action to the agent now? [y/N] (#%d)", id),
+		input: "n",
+		onSubmit: func(input string) tea.Cmd {
+			send := strings.HasPrefix(strings.ToLower(strings.TrimSpace(input)), "y")
+			return func() tea.Msg {
+				if err := app.Resolve(ctx, id, action, send); err != nil {
+					return actionResultMsg{err: err}
+				}
+				if send {
+					return actionResultMsg{message: fmt.Sprintf("correction recorded and sent for #%d", id)}
+				}
+				return actionResultMsg{message: fmt.Sprintf("correction recorded for #%d (not sent)", id)}
 			}
 		},
 	}
@@ -1804,7 +1852,7 @@ func (m Model) helpLine() string {
 			if m.detail.escRetryable {
 				retry = "  l: retry LLM"
 			}
-			return "enter: confirm+send  c: correct  x: delete" + retry +
+			return "enter: confirm+send  c: correct (+send?)  x: delete" + retry +
 				preview + "  ↑/↓: scroll  tab: switch tab  " + closeKeys
 		}
 		return "↑/↓: scroll  tab: switch tab" + preview + "  " + closeKeys
@@ -1820,7 +1868,7 @@ func (m Model) helpLine() string {
 	case tabAgents:
 		return "v: details  n: rename agent  /: search  " + common
 	case tabEscalations:
-		return "enter/y: confirm+send  c: correct  l: retry LLM  space: mark  x: delete  X: prune old  v: details  /: search  " + common
+		return "enter/y: confirm+send  c: correct (+send?)  l: retry LLM  space: mark  x: delete  X: prune old  v: details  /: search  " + common
 	case tabAudit:
 		return "c: correct decision  v: details  /: search  " + common
 	case tabSignatures:

--- a/internal/verifyunblock/verifyunblock.go
+++ b/internal/verifyunblock/verifyunblock.go
@@ -1,0 +1,117 @@
+// Package verifyunblock is the post-action self-check: after the plugin
+// delivers a reply to a blocked agent (an approval/choice/error prompt), it
+// re-queries the agent's status a short delay later and, if the agent is STILL
+// blocked, appends a diagnostic audit row so the operator can see the action
+// did not unblock the agent.
+//
+// The check degrades safely: a herdr read failure or a vanished pane never
+// writes a false failure. It is defined against minimal interfaces so both the
+// daemon (autonomous sends) and, indirectly via the daemon's correction drain,
+// operator sends reuse one implementation — and it unit-tests without the full
+// store or herdr adapter.
+//
+// LIMITATION: the check looks only at the agent's reported status
+// (agent_status == "blocked"); it cannot distinguish the original prompt from a
+// NEW one the agent raised after answering. An agent that answers and then
+// immediately blocks on a follow-up prompt within the delay window can trip a
+// benign false-positive delivery_failed row. Operators should read
+// delivery_failed as "still blocked shortly after the action" and raise
+// limits.verify_unblock_ms if a fast multi-prompt agent is noisy.
+package verifyunblock
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// StatusFailed is the audit Status recorded when a delivered action left the
+// agent still blocked. It is distinct from the decision-audit statuses
+// ("auto"/"escalated"/"resolved"/"dismissed") so it shows plainly in
+// `hap audit` without matching the pending-escalation filters.
+const StatusFailed = "delivery_failed"
+
+// reasonStillBlocked prefixes the failure Rationale (mirrors the daemon's
+// bracketed reason convention).
+const reasonStillBlocked = "[still_blocked]"
+
+// StatusLister reports the current agent set; herdr's ListAgents satisfies it.
+// PaneInfo does NOT carry agent_status, so ListAgents is the on-demand source.
+type StatusLister interface {
+	ListAgents(ctx context.Context) ([]domain.AgentTransition, error)
+}
+
+// Auditer appends a diagnostic audit row. Only the daemon's store implements
+// this (audit writes are daemon-owned); the frontend routes its checks through
+// the daemon instead of calling this directly.
+type Auditer interface {
+	AppendAudit(ctx context.Context, a domain.AuditRecord) (int64, error)
+}
+
+// Params describes one delivered action to verify.
+type Params struct {
+	PaneID        string
+	AgentID       string
+	AgentType     string
+	Signature     string
+	Input         string // the reply that was delivered
+	Excerpt       string // pane content the action was decided from
+	SituationType domain.SituationType
+}
+
+// Relevant reports whether a situation type is one that leaves an agent
+// blocked/waiting for input, so the self-check applies. idle is excluded — an
+// idle agent is not blocked.
+func Relevant(t domain.SituationType) bool {
+	switch t {
+	case domain.SituationApproval, domain.SituationChoice, domain.SituationError:
+		return true
+	}
+	return false
+}
+
+// stillBlocked reports whether the named pane is present in agents and its
+// reported status is "blocked".
+func stillBlocked(agents []domain.AgentTransition, paneID string) bool {
+	for _, a := range agents {
+		if a.PaneID == paneID {
+			return a.Status == "blocked"
+		}
+	}
+	return false
+}
+
+// Check re-queries the agent's status and, when it is still blocked, appends a
+// delivery_failed audit row. It returns whether the agent was still blocked and
+// the new audit id (0 when none was written). A herdr list error or a pane no
+// longer present resolves to "not blocked" and writes nothing — the check never
+// invents a failure. The audit-write error (if any) is returned so the caller
+// can log it; the blocked verdict is still reported.
+func Check(ctx context.Context, herdr StatusLister, store Auditer, p Params, now time.Time) (bool, int64, error) {
+	agents, err := herdr.ListAgents(ctx)
+	if err != nil {
+		return false, 0, fmt.Errorf("verify unblock: list agents: %w", err)
+	}
+	if !stillBlocked(agents, p.PaneID) {
+		return false, 0, nil
+	}
+	id, err := store.AppendAudit(ctx, domain.AuditRecord{
+		AgentID:       p.AgentID,
+		AgentType:     p.AgentType,
+		Signature:     p.Signature,
+		Trigger:       "self-check",
+		SituationType: p.SituationType,
+		Action:        "unblock_failed:" + p.Input,
+		Input:         p.Input,
+		Rationale:     reasonStillBlocked + " agent still blocked after action",
+		Status:        StatusFailed,
+		PaneExcerpt:   p.Excerpt,
+		CreatedAt:     now,
+	})
+	if err != nil {
+		return true, 0, fmt.Errorf("verify unblock: append audit: %w", err)
+	}
+	return true, id, nil
+}

--- a/internal/verifyunblock/verifyunblock_test.go
+++ b/internal/verifyunblock/verifyunblock_test.go
@@ -1,0 +1,129 @@
+package verifyunblock
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+type fakeLister struct {
+	agents []domain.AgentTransition
+	err    error
+}
+
+func (f *fakeLister) ListAgents(_ context.Context) ([]domain.AgentTransition, error) {
+	return f.agents, f.err
+}
+
+type fakeAuditer struct {
+	rows []domain.AuditRecord
+	err  error
+}
+
+func (f *fakeAuditer) AppendAudit(_ context.Context, a domain.AuditRecord) (int64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	f.rows = append(f.rows, a)
+	return int64(len(f.rows)), nil
+}
+
+func agents(paneID, status string) []domain.AgentTransition {
+	return []domain.AgentTransition{{AgentID: paneID, PaneID: paneID, Status: status}}
+}
+
+func TestRelevant(t *testing.T) {
+	for _, tc := range []struct {
+		typ  domain.SituationType
+		want bool
+	}{
+		{domain.SituationApproval, true},
+		{domain.SituationChoice, true},
+		{domain.SituationError, true},
+		{domain.SituationIdle, false},
+		{domain.SituationUnclassifiable, false},
+	} {
+		if got := Relevant(tc.typ); got != tc.want {
+			t.Errorf("Relevant(%v) = %v, want %v", tc.typ, got, tc.want)
+		}
+	}
+}
+
+func TestCheck(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	p := Params{
+		PaneID: "w1:p1", AgentID: "w1:p1", AgentType: "claude",
+		Signature: "approval:abcd", Input: "1", Excerpt: "Do you want to proceed?",
+		SituationType: domain.SituationApproval,
+	}
+
+	t.Run("still blocked writes a failure row", func(t *testing.T) {
+		l := &fakeLister{agents: agents("w1:p1", "blocked")}
+		a := &fakeAuditer{}
+		blocked, id, err := Check(context.Background(), l, a, p, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !blocked || id == 0 {
+			t.Fatalf("want blocked=true id>0, got blocked=%v id=%d", blocked, id)
+		}
+		if len(a.rows) != 1 {
+			t.Fatalf("want 1 audit row, got %d", len(a.rows))
+		}
+		row := a.rows[0]
+		if row.Status != StatusFailed {
+			t.Errorf("Status = %q, want %q", row.Status, StatusFailed)
+		}
+		if row.Input != "1" || row.AgentID != "w1:p1" || row.SituationType != domain.SituationApproval {
+			t.Errorf("row fields mismatch: %+v", row)
+		}
+		if row.Action != "unblock_failed:1" {
+			t.Errorf("Action = %q, want unblock_failed:1", row.Action)
+		}
+		if !row.CreatedAt.Equal(now) {
+			t.Errorf("CreatedAt = %v, want %v", row.CreatedAt, now)
+		}
+	})
+
+	t.Run("unblocked writes nothing", func(t *testing.T) {
+		l := &fakeLister{agents: agents("w1:p1", "idle")}
+		a := &fakeAuditer{}
+		blocked, id, err := Check(context.Background(), l, a, p, now)
+		if err != nil || blocked || id != 0 || len(a.rows) != 0 {
+			t.Fatalf("want no failure; got blocked=%v id=%d rows=%d err=%v", blocked, id, len(a.rows), err)
+		}
+	})
+
+	t.Run("pane gone writes nothing", func(t *testing.T) {
+		l := &fakeLister{agents: agents("w9:p9", "blocked")} // different pane
+		a := &fakeAuditer{}
+		blocked, _, err := Check(context.Background(), l, a, p, now)
+		if err != nil || blocked || len(a.rows) != 0 {
+			t.Fatalf("want no failure for absent pane; got blocked=%v rows=%d err=%v", blocked, len(a.rows), err)
+		}
+	})
+
+	t.Run("list error degrades without a false failure", func(t *testing.T) {
+		l := &fakeLister{err: errors.New("herdr unreachable")}
+		a := &fakeAuditer{}
+		blocked, _, err := Check(context.Background(), l, a, p, now)
+		if err == nil {
+			t.Fatal("want an error surfaced")
+		}
+		if blocked || len(a.rows) != 0 {
+			t.Fatalf("must not write on list error; got blocked=%v rows=%d", blocked, len(a.rows))
+		}
+	})
+
+	t.Run("audit write error still reports blocked", func(t *testing.T) {
+		l := &fakeLister{agents: agents("w1:p1", "blocked")}
+		a := &fakeAuditer{err: errors.New("db closed")}
+		blocked, id, err := Check(context.Background(), l, a, p, now)
+		if !blocked || id != 0 || err == nil {
+			t.Fatalf("want blocked=true id=0 err!=nil, got blocked=%v id=%d err=%v", blocked, id, err)
+		}
+	})
+}

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -48,11 +48,10 @@ max_error_retries = 2              # per error signature
 # is the agent's short name ({db}/{control} also available). The prompt must
 # come immediately after -p (claude quirk; the plugin auto-repairs it).
 command = [
-  "claude", "-p",
+  "claude", "--model", "opus", "-p",
   "You are hap's auto-answer assistant. Use ONLY get_context and submit_decision.\n\nCall get_context, treat pane_excerpt as ground truth, and follow answer_format. If proposed_task is present, this is a task review: when the agent is ready and current_task is unfinished, prefer @next_task:declared to send it verbatim—do not make small edits. Return rewritten task text only when its details need a major rewrite. If current_task is clearly done, send an instruction for the next unfinished item in pending_tasks. Use @noop if the agent is busy, no suitable task remains, or evidence is ambiguous. Never invent a task.\n\nOtherwise: for approval/choice, select the safest option and deny destructive or irreversible work; for error, give one concrete recovery instruction; for idle, give the sensible next instruction or @noop.\n\nCall submit_decision with select_options for menus, otherwise recommend_action. Always include confident_score (0-100) and a one-sentence rationale.",
   "--mcp-config", '{"mcpServers":{"hap":{"command":"{self}","args":["mcp"],"env":{"HAP_REQUEST_ID":"{request_id}"}}}}',
   "--allowedTools", "mcp__hap__get_context,mcp__hap__submit_decision",
-  "--model", "opus",
 ]
 
 # ── First-consult variant (optional) ──
@@ -64,11 +63,10 @@ command = [
 # If the preferred command exits with an error in under one second without
 # submitting a decision, hap retries once with the other command template.
 # command_start = [
-#   "claude", "-p",
+#   "claude", "--model", "opus", "-p",
 #   "This is your first interaction with this agent. ...same MCP flow as command...",
 #   "--mcp-config", '{"mcpServers":{"hap":{"command":"{self}","args":["mcp"],"env":{"HAP_REQUEST_ID":"{request_id}"}}}}',
 #   "--allowedTools", "mcp__hap__get_context,mcp__hap__submit_decision",
-#   "--model", "opus",
 # ]
 
 # ── OpenAI Codex CLI recipe (commented; swap in to use codex) ──
@@ -79,14 +77,14 @@ command = [
 # environment, so the db/control paths must be passed explicitly via
 # {db}/{control}.
 # command = [
-#   "codex", "exec", "--skip-git-repo-check",
+#   "codex", "--model", "gpt-5.6-terra", "exec", "--skip-git-repo-check",
 #   "--dangerously-bypass-approvals-and-sandbox",
 #   "-c", 'mcp_servers.hap.command="{self}"',
 #   "-c", 'mcp_servers.hap.args=["mcp"]',
 #   "-c", 'mcp_servers.hap.env.HAP_REQUEST_ID="{request_id}"',
 #   "-c", 'mcp_servers.hap.env.HAP_DB_PATH="{db}"',
 #   "-c", 'mcp_servers.hap.env.HAP_CONTROL_PATH="{control}"',
-#   "Use only the hap MCP tools. Call get_context, choose the safest response, then call submit_decision with select_options for a menu or recommend_action for literal text/@noop. Always include confident_score and rationale.",
+#   "You are hap's auto-answer assistant. Use ONLY get_context and submit_decision.\n\nCall get_context, treat pane_excerpt as ground truth, and follow answer_format. If proposed_task is present, this is a task review: when the agent is ready and current_task is unfinished, prefer @next_task:declared to send it verbatim—do not make small edits. Return rewritten task text only when its details need a major rewrite. If current_task is clearly done, send an instruction for the next unfinished item in pending_tasks. Use @noop if the agent is busy, no suitable task remains, or evidence is ambiguous. Never invent a task.\n\nOtherwise: for approval/choice, select the safest option and deny destructive or irreversible work; for error, give one concrete recovery instruction; for idle, give the sensible next instruction or @noop.\n\nCall submit_decision with select_options for menus, otherwise recommend_action. Always include confident_score (0-100) and a one-sentence rationale.",
 # ]
 
 timeout_seconds = 120              # codex is slower to start; 180 is a safer value there
@@ -97,9 +95,8 @@ pane_excerpt_chars = 5000          # pane context included in the consult
 # A one-shot text transform, no MCP round-trip: the CLI runs once and its
 # stdout is the rewritten text.
 rewrite_command = [
-  "claude", "-p",
+  "claude", "--model", "haiku", "-p",
   "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
-  "--model", "haiku",
 ]
 
 # ── First-rewrite variant (optional) ──
@@ -109,14 +106,13 @@ rewrite_command = [
 # rewrite_command. Omit or leave empty to reuse rewrite_command.
 # A sub-one-second error exit is retried once with the other rewrite template.
 # rewrite_command_start = [
-#   "claude", "-p",
+#   "claude", "--model", "haiku", "-p",
 #   "First rewrite for this agent. Rewrite this instruction given its screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
-#   "--model", "haiku",
 # ]
 
 # ── Rewrite recipe — OpenAI Codex (commented; swap in to use codex) ──
 # rewrite_command = [
-#   "codex", "exec", "--skip-git-repo-check",
+#   "codex", "--model", "gpt-5.6-luna", "exec", "--skip-git-repo-check",
 #   "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
 # ]
 
@@ -138,10 +134,16 @@ rewrite_fallback_template = "You must act based on the following: {original_text
 # safe default: idle with no task source escalates and hap synthesizes nothing.
 # (Renamed from generate_task_command; the old key no longer loads — update it.)
 # task_generate_command = [
-#   "claude", "-p",
-#   "Suggest concrete next tasks for the coding agent in this project, most important first. Reply with ONLY the tasks, one per line.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
-#   "--model", "haiku",
+#   "claude", "--model", "opus", "-p",
+#   "Suggest concrete next tasks (up to 3) for the coding agent in this project, most important first. Reply with ONLY the tasks, one per line.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
 # ]
+
+# ── Idle task suggestion — OpenAI Codex (commented; swap in to use codex) ──
+# task_generate_command = [
+#   "codex", "--model", "gpt-5.6-sol", "exec", "--skip-git-repo-check",
+#   "Suggest concrete next tasks (up to 3) for the coding agent in this project, most important first. Reply with ONLY the tasks, one per line.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
+# ]
+
 # task_generate_command_start runs INSTEAD on the agent's first generation
 # (tracked independently); omit to reuse task_generate_command.
 # task_generate_command_start = [ ... ]


### PR DESCRIPTION
- Updated regex patterns in tasklist.go to accommodate non-breaking spaces (U+00A0) in the Claude todo-widget, ensuring accurate parsing of tasks.
- Added regression test in tasklist_test.go to verify that the first item in the todo list is correctly inferred even with NBSP padding.
- Modified CorrectionRecord in types.go to include a 'Sent' field, indicating whether a correction was delivered to the agent.
- Enhanced the Resolve function in frontend.go to set the 'Sent' field based on whether the action was delivered.
- Implemented tests in frontend_test.go to confirm that corrections are recorded with the correct 'Sent' status based on delivery.
- Introduced a new verifyunblock package to perform post-action self-checks, ensuring agents are unblocked after corrections are sent.
- Added tests for the verifyunblock functionality to validate its behavior under various scenarios.
- Updated sample configuration to reflect changes in command structure for Claude.

## 📌 Background

<!-- Provide context or background to help reviewers understand why this change is necessary. Include links to related issues, user stories, or documentation (reference to design.md, requirements.md, plan, PRD) if applicable. -->

## 🔧 Reason for Changes

<!-- Explain the problem(s) being solved or what motivated the changes. Include bug report references, feature requests, or business needs. -->

## ✅ Changes Implemented

<!-- Summarize the changes introduced in this pull request. Bullet points are encouraged for clarity. -->

## 🔍 Testing Results

<!-- Describe how the changes were tested and what the results were. Include test cases, screenshots, or logs if beneficial. -->

- [ ] Unit tests passed
- [ ] Integration tests passed
- [ ] Manually tested in local/dev environment

## 🚀 Deployment / Migration Details

<!-- Specify any steps needed for deployment, such as database migrations, environment variable updates, or cron jobs. -->

---

### 📝 Additional Notes (Optional)

<!-- Any extra information or considerations for reviewers or testers. -->

<!-- Mention relevant team members or reviewers if needed. -->