### PR TITLE
#1 feat: explain why an escalation matched its rule

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -485,10 +485,19 @@ func escalations(ctx context.Context, app *frontend.App, out io.Writer, args []s
 		rule := "none yet"
 		if row, ok := rules[e.Signature]; ok {
 			rule = frontend.RuleSummary(row, gradN)
+			// Rule-gated: how this situation resolved to that rule.
+			if via := frontend.MatchSummary(e); via != "" {
+				rule += "; " + via
+			}
 		}
 		fmt.Fprintf(out, "#%d\t%s\t%s\t%s\tagent=%s\tllm=%s\tsuggestion=%q\trule=[%s]\n",
 			e.ID, e.CreatedAt.Format("15:04:05"), e.SituationType, e.Rationale, agent,
 			llmConfCLI(e.LLMConfidence), e.Suggestion, rule)
+		// Embedding failure is shown even without a matched rule — it explains
+		// why a paraphrase may have failed to match semantically.
+		if e.EmbedError != "" {
+			fmt.Fprintf(out, "\tembedding failed: %s\n", e.EmbedError)
+		}
 	}
 	fmt.Fprintf(out, "\n%d pending; respond with: confirm <id> | resolve <id> --action TEXT [--send] | dismiss <id>...\n", len(esc))
 	return nil

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -501,6 +501,27 @@ func TestEscalationsAndAuditShowMatchedRule(t *testing.T) {
 		t.Errorf("unmatched escalation should read none yet, got:\n%s", out)
 	}
 
+	// A cosine-matched escalation (sharing the seeded rule's signature) names
+	// the governing knob next to the rule.
+	st.AppendAudit(context.Background(), domain.AuditRecord{Signature: "approval:aaaa1111bbbb2222",
+		Trigger: "apply?", SituationType: domain.SituationApproval, Action: "escalated",
+		Rationale: "shadow mode", Status: "escalated",
+		MatchMethod: domain.MatchCosine, MatchScore: 0.94, CreatedAt: time.Now()})
+	out, _ = run(t, app, "escalations")
+	if !strings.Contains(out, "matched by `similarity_threshold` (cosine 0.94)") {
+		t.Errorf("cosine escalation should name similarity_threshold, got:\n%s", out)
+	}
+
+	// An escalation whose embedding failed shows the failure even with no rule.
+	st.AppendAudit(context.Background(), domain.AuditRecord{Signature: "error:8888eeee",
+		Trigger: "boom", SituationType: domain.SituationError, Action: "escalated",
+		Rationale: "fresh", Status: "escalated", EmbedError: "embedder degraded",
+		CreatedAt: time.Now()})
+	out, _ = run(t, app, "escalations")
+	if !strings.Contains(out, "embedding failed: embedder degraded") {
+		t.Errorf("embed-failure escalation should show the error, got:\n%s", out)
+	}
+
 	out, err = run(t, app, "audit")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -709,7 +709,7 @@ func (d *Daemon) hasOpenEscalation(ctx context.Context, agentID string) bool {
 // than being ignored (the "never a silent drop" architecture rule).
 func (d *Daemon) duplicatePendingEscalation(ctx context.Context, s domain.Situation) bool {
 	dup, err := d.opt.Store.DuplicatePendingEscalation(ctx, s.AgentID, s.AgentType,
-		s.Type, truncateRunes(s.Content, snapshotMaxRunes))
+		s.Type, truncateTailRunes(s.Content, snapshotMaxRunes))
 	if err != nil {
 		slog.Warn("duplicate-escalation check failed; processing event",
 			"agent", s.AgentID, "pane", s.PaneID, "error", err)
@@ -727,7 +727,7 @@ func (d *Daemon) ignoreDuplicate(ctx context.Context, s domain.Situation,
 		AgentID: s.AgentID, AgentType: s.AgentType, Trigger: trigger(tr),
 		SituationType: s.Type, Action: "ignored", Status: "ignored",
 		Rationale:   "duplicated event",
-		PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes),
+		PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes),
 		CreatedAt:   now,
 	})
 	slog.Info("ignored duplicate event: matching pending escalation exists",
@@ -808,8 +808,9 @@ func (d *Daemon) handleAttention(ctx context.Context, tr domain.AgentTransition)
 	d.decideAndAct(ctx, situation, tr, agentName, now)
 }
 
-// snapshotMaxRunes caps the stored rule-provenance pane snapshot; big
-// enough for a full classification read or a multi-tab aggregate head.
+// snapshotMaxRunes caps stored Current/Original Situation pane snapshots.
+// Captures keep the tail because shell/CLI results and prompts land at the
+// bottom; older scrollback is discarded first.
 const snapshotMaxRunes = 4000
 
 // decideAndAct is the decision tail shared by handleTransition and the
@@ -835,7 +836,7 @@ func (d *Daemon) decideAndAct(ctx context.Context, situation domain.Situation,
 	d.mu.Unlock()
 	if sig.Signature != "" && !saved {
 		if err := d.opt.Store.SaveSignatureSnapshot(ctx, sig.Signature,
-			truncateRunes(situation.Content, snapshotMaxRunes), now); err != nil {
+			truncateTailRunes(situation.Content, snapshotMaxRunes), now); err != nil {
 			slog.Warn("signature snapshot write failed", "error", err)
 		} else {
 			d.mu.Lock()
@@ -956,6 +957,17 @@ func truncateRunes(s string, n int) string {
 		return s
 	}
 	return string(runes[:n]) + "…"
+}
+
+// truncateTailRunes shortens shell/CLI context to its final n runes. The
+// actionable prompt or error is normally at the bottom, so stored situation
+// snapshots must discard old scrollback from the top rather than the result.
+func truncateTailRunes(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return "…" + string(runes[len(runes)-n:])
 }
 
 // cancelRewriteExcept invalidates the agent's in-flight rewrite unless it is
@@ -1092,7 +1104,7 @@ func (d *Daemon) deliverAutonomous(ctx context.Context, s domain.Situation, sig 
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
 		SituationType: s.Type, Action: domain.AuditActionAutoPrefix + del.input, Input: del.input,
 		Confidence: dec.Confidence, Rationale: del.rationale, LLMOutput: del.llmOutput,
-		Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
+		Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
 	})
 	if err != nil {
 		slog.Error("audit write failed; blocking autonomous action (FR-024)", "error", err)
@@ -1171,7 +1183,7 @@ func (d *Daemon) scheduleUnblockCheck(p verifyunblock.Params) {
 		return
 	}
 	// Keep the diagnostic row's excerpt the same size as the normal audit rows.
-	p.Excerpt = truncateRunes(p.Excerpt, snapshotMaxRunes)
+	p.Excerpt = truncateTailRunes(p.Excerpt, snapshotMaxRunes)
 	delay := time.Duration(delayMs) * time.Millisecond
 	time.AfterFunc(delay, func() {
 		_ = logging.Guard("verify-unblock", func() error {
@@ -1212,7 +1224,7 @@ func (d *Daemon) deliverNoop(ctx context.Context, s domain.Situation, sig domain
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
 		SituationType: s.Type, Action: "noop", Input: "",
 		Confidence: dec.Confidence, Rationale: dec.Rationale,
-		Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
+		Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
 	})
 	if err != nil {
 		slog.Error("audit write failed; blocking autonomous noop (FR-024)", "error", err)
@@ -1277,7 +1289,13 @@ func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.Si
 		Status:        "escalated", Suggestion: dec.Suggestion,
 		// The content THIS escalation was classified from — per entry,
 		// unlike the signature's first-seen provenance snapshot.
-		PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes),
+		PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes),
+		// How this situation resolved to its rule (cosine / BM25 / exact) and
+		// any embedding failure for this event, so the operator can see WHY
+		// the matched rule was chosen. Auto-send rows leave these empty.
+		MatchMethod: sig.Match.Method,
+		MatchScore:  sig.Match.Score,
+		EmbedError:  sig.Match.EmbedError,
 		CreatedAt:   now,
 	}
 	if _, err := d.opt.Store.AppendAudit(ctx, rec); err != nil {
@@ -2197,7 +2215,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 			SituationType: s.Type, Action: "noop", Input: "",
 			Confidence: computedConf, LLMConfidence: &llmConf,
 			Rationale: "LLM: " + llmDec.Rationale, LLMOutput: llmDec.CapturedOutput,
-			Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
+			Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
 		}); err != nil {
 			slog.Error("audit write failed; blocking LLM noop (FR-024)", "error", err)
 			d.notify(ctx, "Herd Auto Prompter: persistence failure",
@@ -2287,7 +2305,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		SituationType: s.Type, Action: domain.AuditActionAutoPrefix + llmDec.Action, Input: llmDec.Action,
 		Confidence: computedConf, LLMConfidence: &llmConf,
 		Rationale: "LLM: " + llmDec.Rationale, LLMOutput: llmDec.CapturedOutput,
-		Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
+		Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
 	})
 	if err != nil {
 		slog.Error("audit write failed; blocking LLM action (FR-024)", "error", err)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1615,7 +1615,9 @@ func TestConfigReloadPropagatesWithinBudget(t *testing.T) {
 func TestLLMFallbackStagingRegateAndPromotion(t *testing.T) {
 	// FR-010/SC-5: LLM staged decision is re-gated and promoted; timeout
 	// and no-submit escalate.
-	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n"
+	// Pin approval = 0.8 so the seeded 0.73 history stays below threshold and
+	// takes the consult path (the default dropped to 0.70 in c8b3e82).
+	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n[confidence_thresholds]\napproval = 0.8\n"
 	h := newHarness(t, cfg)
 	h.herdr.setPane(approvalPane)
 	var requestID atomicString
@@ -1809,7 +1811,9 @@ func (a *atomicString) set(v string) { a.mu.Lock(); a.v = v; a.mu.Unlock() }
 func (a *atomicString) get() string  { a.mu.Lock(); defer a.mu.Unlock(); return a.v }
 
 func TestLLMFailureEscalates(t *testing.T) {
-	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 0\ntimeout_seconds = 1\n"
+	// Pin approval = 0.8 so the seeded 0.73 history stays below threshold and
+	// takes the consult path (the default dropped to 0.70 in c8b3e82).
+	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 0\ntimeout_seconds = 1\n[confidence_thresholds]\napproval = 0.8\n"
 	h := newHarness(t, cfg)
 	h.herdr.setPane(approvalPane)
 	h.llm.configured = true
@@ -2289,6 +2293,55 @@ func TestTailTrimsAtRuneBoundary(t *testing.T) {
 	}
 	if got := tail(strings.Repeat("界", 10), 7); !utf8.ValidString(got) {
 		t.Errorf("tail must never emit invalid UTF-8, got %q", got)
+	}
+}
+
+func TestTruncateTailRunesKeepsBottomContext(t *testing.T) {
+	if got := truncateTailRunes("short", 10); got != "short" {
+		t.Errorf("short input must pass through, got %q", got)
+	}
+	if got := truncateTailRunes("abcdef", 3); got != "…def" {
+		t.Errorf("tail cut = %q, want %q", got, "…def")
+	}
+	if got := truncateTailRunes("top界界bottom", 8); got != "…界界bottom" {
+		t.Errorf("rune-safe tail cut = %q, want %q", got, "…界界bottom")
+	}
+}
+
+func TestStoredSituationSnapshotsKeepBottomContext(t *testing.T) {
+	h := newHarness(t, "")
+	pane := "TOP-SCROLLBACK-MARKER\n" + strings.Repeat("old shell output 界\n", 400) + approvalPane
+	h.herdr.setPane(pane)
+
+	h.push("agent-tail-snapshot", "blocked")
+	ctx := context.Background()
+	var current domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		escalations, _ := h.raw.PendingEscalations(ctx)
+		if len(escalations) == 0 {
+			return false
+		}
+		current = escalations[0]
+		return true
+	})
+
+	original, err := h.raw.GetSignatureSnapshot(ctx, current.Signature)
+	if err != nil {
+		t.Fatalf("original situation: %v", err)
+	}
+	for label, got := range map[string]string{
+		"Current situation":  current.PaneExcerpt,
+		"Original situation": original,
+	} {
+		if !strings.HasPrefix(got, "…") || !strings.HasSuffix(got, approvalPane) {
+			t.Errorf("%s must retain the bottom of oversized context, got %q", label, got)
+		}
+		if strings.Contains(got, "TOP-SCROLLBACK-MARKER") {
+			t.Errorf("%s retained the top of oversized context", label)
+		}
+		if n := len([]rune(got)); n != snapshotMaxRunes+1 {
+			t.Errorf("%s length = %d runes, want %d including marker", label, n, snapshotMaxRunes+1)
+		}
 	}
 }
 

--- a/internal/daemon/noop_test.go
+++ b/internal/daemon/noop_test.go
@@ -69,9 +69,13 @@ func TestLLMNoopPromotionRecordsWithoutSend(t *testing.T) {
 	h.push("agent-llmnoop", "blocked")
 
 	ctx := context.Background()
+	// The promotion writes the audit first, then records the decision and
+	// registers the auto-prompt rate LAST (daemon.go). Wait on that final side
+	// effect so the decision/rate assertions below never race a half-finished
+	// promotion — waiting only for the audit row is too early.
 	waitFor(t, 5*time.Second, func() bool {
-		audits, _ := h.raw.AuditLog(ctx, 10)
-		return len(audits) > 0 && audits[0].Action == "noop"
+		rate, _ := h.raw.GetAgentRate(ctx, "agent-llmnoop")
+		return rate != nil && rate.ConsecutiveAuto == 1
 	})
 	audits, _ := h.raw.AuditLog(ctx, 10)
 	if audits[0].Status != "auto" || audits[0].Trigger != "llm-fallback" || audits[0].Input != "" {

--- a/internal/daemon/semantic.go
+++ b/internal/daemon/semantic.go
@@ -77,16 +77,24 @@ func (d *Daemon) resolveSignature(ctx context.Context, cfg config.Config,
 	sig domain.SignatureResult, s domain.Situation) domain.SignatureResult {
 
 	if sig.Signature == "" || cfg.Embedding.Disabled || !d.semanticReady.Load() {
+		// Non-empty signature with semantic off/not-ready: matching is
+		// exact-hash only, so a rule can only match by exact content hash.
+		if sig.Signature != "" {
+			sig.Match.Method = domain.MatchExact
+		}
 		return sig
 	}
 
 	existing, err := d.opt.Store.GetSignature(ctx, sig.Raw)
 	if err != nil {
+		// Read failed before any match ran: leave MatchNone so we don't assert
+		// an "exact" match that was never actually checked.
 		slog.Warn("semantic resolve: signature read failed; using hash key", "error", err)
 		return sig
 	}
 	if existing != nil {
-		return sig // known situation: cheap deterministic fast path
+		sig.Match.Method = domain.MatchExact // known situation: cheap deterministic fast path
+		return sig
 	}
 
 	scope := match.Scope{SituationType: s.Type, AgentType: s.AgentType}
@@ -99,6 +107,9 @@ func (d *Daemon) resolveSignature(ctx context.Context, cfg config.Config,
 		v, err := emb.EmbedText(ctx, sig.Salient)
 		switch {
 		case err != nil:
+			// Record the failure for THIS event so the escalation can explain
+			// why it fell back (covers the degraded latch, ErrDegraded).
+			sig.Match.EmbedError = err.Error()
 			slog.Warn("embed failed; trying text match", "error", err)
 		default:
 			vec = v
@@ -109,6 +120,8 @@ func (d *Daemon) resolveSignature(ctx context.Context, cfg config.Config,
 				slog.Info("semantic match: reusing learned signature",
 					"signature", hit.Signature, "cosine", hit.Score, "raw", sig.Raw)
 				sig.Signature = hit.Signature
+				sig.Match.Method = domain.MatchCosine
+				sig.Match.Score = hit.Score
 				return sig
 			}
 		}
@@ -124,6 +137,8 @@ func (d *Daemon) resolveSignature(ctx context.Context, cfg config.Config,
 			slog.Info("text match: reusing learned signature",
 				"signature", hit.Signature, "bm25", hit.Score, "raw", sig.Raw)
 			sig.Signature = hit.Signature
+			sig.Match.Method = domain.MatchBM25
+			sig.Match.Score = hit.Score
 			return sig
 		}
 	}

--- a/internal/daemon/semantic_test.go
+++ b/internal/daemon/semantic_test.go
@@ -151,6 +151,20 @@ func TestResolveSignatureMintsThenRemapsSemantically(t *testing.T) {
 	if sig2.Raw != raw2.Raw {
 		t.Errorf("Raw must never be remapped: %s vs %s", sig2.Raw, raw2.Raw)
 	}
+	// The remap records HOW it matched: cosine, with the similarity score.
+	if sig2.Match.Method != domain.MatchCosine {
+		t.Errorf("match method = %q, want cosine", sig2.Match.Method)
+	}
+	if sig2.Match.Score < 0.9 {
+		t.Errorf("cosine score = %.3f, want ≥ 0.9", sig2.Match.Score)
+	}
+	if sig2.Match.EmbedError != "" {
+		t.Errorf("embed did not fail; EmbedError should be empty, got %q", sig2.Match.EmbedError)
+	}
+	// A freshly-minted key records no match method (nothing to explain).
+	if sig1.Match.Method != domain.MatchNone {
+		t.Errorf("new key match method = %q, want none", sig1.Match.Method)
+	}
 	// No new identity is persisted for a remapped situation.
 	if n, _ := d.opt.Store.CountSignatureEmbeddings(ctx); n != 1 {
 		t.Errorf("embedding rows after remap = %d, want 1", n)
@@ -191,6 +205,9 @@ func TestResolveSignatureExactHitSkipsEmbedding(t *testing.T) {
 	if emb.callCount() != before {
 		t.Errorf("exact hit must not embed (calls %d → %d)", before, emb.callCount())
 	}
+	if resolved.Match.Method != domain.MatchExact {
+		t.Errorf("exact hit match method = %q, want exact", resolved.Match.Method)
+	}
 }
 
 func TestResolveSignatureBM25FallbackOnEmbedFailure(t *testing.T) {
@@ -216,12 +233,30 @@ func TestResolveSignatureBM25FallbackOnEmbedFailure(t *testing.T) {
 	if sig2.Signature != sig1.Signature {
 		t.Errorf("BM25 fallback resolved to %s, want %s", sig2.Signature, sig1.Signature)
 	}
+	// The fallback records the BM25 method + score, and the embed failure that
+	// forced it — both surface on the escalation so the operator sees WHY.
+	if sig2.Match.Method != domain.MatchBM25 {
+		t.Errorf("match method = %q, want bm25", sig2.Match.Method)
+	}
+	if sig2.Match.Score <= 0 {
+		t.Errorf("bm25 score = %.3f, want > 0", sig2.Match.Score)
+	}
+	if sig2.Match.EmbedError == "" {
+		t.Error("embed failed for this event; EmbedError should be set")
+	}
 
-	// Unrelated text stays unmatched under BM25 and mints its own key.
+	// Unrelated text stays unmatched under BM25 and mints its own key. The
+	// embed failure is still recorded even though nothing matched.
 	s3 := approvalSituation("launch nuclear missiles")
 	sig3 := d.resolveSignature(ctx, cfg, domain.ComputeSignature(s3), s3)
 	if sig3.Signature == sig1.Signature {
 		t.Error("unrelated text must not BM25-match the learned signature")
+	}
+	if sig3.Match.Method != domain.MatchNone {
+		t.Errorf("unmatched key match method = %q, want none", sig3.Match.Method)
+	}
+	if sig3.Match.EmbedError == "" {
+		t.Error("embed failure should be recorded even when nothing matched")
 	}
 }
 
@@ -257,6 +292,10 @@ func TestResolveSignatureDisabledPassesThrough(t *testing.T) {
 	resolved := d.resolveSignature(context.Background(), cfg, sig, s)
 	if resolved.Signature != sig.Raw || emb.callCount() != 0 {
 		t.Errorf("disabled embedding must pass hash keys through untouched (calls=%d)", emb.callCount())
+	}
+	// Disabled = exact-hash-only matching, so a rule can only match by hash.
+	if resolved.Match.Method != domain.MatchExact {
+		t.Errorf("disabled embedding match method = %q, want exact", resolved.Match.Method)
 	}
 	if n, _ := raw.CountSignatureEmbeddings(context.Background()); n != 0 {
 		t.Errorf("disabled embedding must not persist identity rows, got %d", n)

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -309,7 +309,7 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
 		SituationType: s.Type, Action: "auto:" + dec.Input, Input: dec.Input,
 		Confidence: dec.Confidence, Rationale: dec.Rationale,
-		Status: "auto", PaneExcerpt: truncateRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
+		Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
 	})
 	if err != nil {
 		d.releasePane(s.AgentID)

--- a/internal/domain/signature.go
+++ b/internal/domain/signature.go
@@ -68,6 +68,39 @@ const overMaskMaxRatio = 0.6
 // stays clear of 512 even before the embedder's own truncation guard.
 const DefaultPaneSalientChars = 500
 
+// MatchMethod identifies how a situation's signature was resolved to its
+// learning key (FR-003), so an escalation can explain WHY it matched a rule.
+type MatchMethod string
+
+const (
+	// MatchNone: a fresh signature, or resolution did not run (over-masked).
+	MatchNone MatchMethod = ""
+	// MatchExact: the raw content hash was already known, or semantic matching
+	// was disabled/not-ready so only exact-hash matching was possible.
+	MatchExact MatchMethod = "exact"
+	// MatchCosine: an embedding cosine similarity met similarity_threshold.
+	MatchCosine MatchMethod = "cosine"
+	// MatchBM25: a normalized BM25 text similarity met bm25_min_score, the
+	// fallback taken when embedding failed or produced no vector.
+	MatchBM25 MatchMethod = "bm25"
+)
+
+// MatchDetail records how a signature was resolved, for operator-facing
+// explanation of an escalation's matched rule. It is populated by the daemon's
+// semantic resolution, not by ComputeSignature.
+type MatchDetail struct {
+	// Method is the path that resolved the learning key.
+	Method MatchMethod
+	// Score is the cosine similarity (MatchCosine) or normalized BM25 score in
+	// (0,1] (MatchBM25); 0 for exact/none.
+	Score float64
+	// EmbedError is the embedding failure message for THIS event, when the
+	// embed call errored (including the degraded latch); "" when embedding
+	// succeeded or was skipped. Set independently of Method — an embed failure
+	// may still resolve via BM25 or mint a new key.
+	EmbedError string
+}
+
 // SignatureResult is the output of signature generation.
 type SignatureResult struct {
 	// Signature is the learning key situations are matched under. Semantic
@@ -78,6 +111,9 @@ type SignatureResult struct {
 	Raw     string
 	Salient string
 	Verdict GuardVerdict
+	// Match records how semantic resolution mapped this signature to its
+	// learning key (zero value until resolveSignature runs).
+	Match MatchDetail
 }
 
 // ComputeSignature derives a stable situation signature (FR-003): situation

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -245,6 +245,14 @@ type AuditRecord struct {
 	// (per-entry, unlike the signature's first-seen provenance snapshot);
 	// "" on legacy rows and paths with no pane read (herdr unreachable).
 	PaneExcerpt string
+	// MatchMethod / MatchScore / EmbedError record HOW this situation's
+	// signature was resolved to its rule (semantic cosine, BM25 fallback, or
+	// exact hash) and any embedding failure for this event, so an escalation
+	// can explain why it matched. Populated on escalation rows; empty/zero on
+	// auto-send and legacy rows.
+	MatchMethod MatchMethod
+	MatchScore  float64
+	EmbedError  string
 	CreatedAt   time.Time
 }
 

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -1440,6 +1440,25 @@ func RuleSummary(row SignatureRow, graduationN int) string {
 	return s
 }
 
+// MatchSummary explains HOW an escalation's situation resolved to its matched
+// rule, naming the config knob that governed the match so operators can tune
+// it. It intentionally omits the threshold VALUE (that lives in live config and
+// can drift from the value at match time); the knob name is stable. Returns ""
+// when there is nothing to explain (a fresh key or a legacy row) — callers show
+// no line in that case.
+func MatchSummary(rec domain.AuditRecord) string {
+	switch rec.MatchMethod {
+	case domain.MatchCosine:
+		return fmt.Sprintf("matched by `similarity_threshold` (cosine %.2f)", rec.MatchScore)
+	case domain.MatchBM25:
+		return fmt.Sprintf("matched by `bm25_min_score` (bm25 %.2f, embedding fallback)", rec.MatchScore)
+	case domain.MatchExact:
+		return "exact content hash"
+	default:
+		return ""
+	}
+}
+
 // IndexSignatures keys signature rows by signature for O(1) rule lookups
 // from escalation/audit rows (they share the signature string; with
 // semantic matching the stored signature is the possibly-remapped learned

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -1869,3 +1869,27 @@ func TestSignatureSnapshotAccessor(t *testing.T) {
 		t.Errorf("empty signature should be empty, got %q", got)
 	}
 }
+
+func TestMatchSummary(t *testing.T) {
+	cases := []struct {
+		name string
+		rec  domain.AuditRecord
+		want string
+	}{
+		{"cosine names similarity_threshold",
+			domain.AuditRecord{MatchMethod: domain.MatchCosine, MatchScore: 0.94},
+			"matched by `similarity_threshold` (cosine 0.94)"},
+		{"bm25 names bm25_min_score and notes fallback",
+			domain.AuditRecord{MatchMethod: domain.MatchBM25, MatchScore: 0.42},
+			"matched by `bm25_min_score` (bm25 0.42, embedding fallback)"},
+		{"exact", domain.AuditRecord{MatchMethod: domain.MatchExact}, "exact content hash"},
+		{"none is empty", domain.AuditRecord{MatchMethod: domain.MatchNone}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := frontend.MatchSummary(c.rec); got != c.want {
+				t.Errorf("MatchSummary = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -102,6 +102,9 @@ CREATE TABLE IF NOT EXISTS audit_log (
 	status TEXT NOT NULL DEFAULT '',
 	suggestion TEXT NOT NULL DEFAULT '',
 	pane_excerpt TEXT NOT NULL DEFAULT '',
+	match_method TEXT NOT NULL DEFAULT '',
+	match_score REAL NOT NULL DEFAULT 0,
+	embed_error TEXT NOT NULL DEFAULT '',
 	created_at INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_audit_status ON audit_log(status, id DESC);
@@ -209,6 +212,11 @@ func (s *Store) migrate() error {
 		// Nullable: NULL = no LLM score (learned/operator/pre-decision rows),
 		// distinct from a reported 0.
 		`ALTER TABLE audit_log ADD COLUMN llm_confidence INTEGER`,
+		// How an escalation's signature resolved to its rule, plus any
+		// per-event embedding failure (empty/zero on legacy and auto rows).
+		`ALTER TABLE audit_log ADD COLUMN match_method TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE audit_log ADD COLUMN match_score REAL NOT NULL DEFAULT 0`,
+		`ALTER TABLE audit_log ADD COLUMN embed_error TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE llm_decisions ADD COLUMN confident_score INTEGER NOT NULL DEFAULT -1`,
 		`ALTER TABLE llm_requests ADD COLUMN agent_id TEXT NOT NULL DEFAULT ''`,
 		// sent = 1 when the front-end delivered the correction to the agent;
@@ -298,11 +306,12 @@ func (s *Store) AppendAudit(ctx context.Context, a domain.AuditRecord) (int64, e
 		res, err := tx.ExecContext(ctx, `
 			INSERT INTO audit_log (decision_id, agent_id, agent_type, signature, trigger, situation_type,
 				action_or_escalation, input, confidence, llm_confidence, rationale, llm_output,
-				corrects_audit_id, status, suggestion, pane_excerpt, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				corrects_audit_id, status, suggestion, pane_excerpt, match_method, match_score, embed_error, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			a.DecisionID, a.AgentID, a.AgentType, a.Signature, a.Trigger, string(a.SituationType),
 			a.Action, a.Input, a.Confidence, llmConfArg(a.LLMConfidence), a.Rationale, a.LLMOutput,
-			a.CorrectsAuditID, a.Status, a.Suggestion, a.PaneExcerpt, unix(a.CreatedAt))
+			a.CorrectsAuditID, a.Status, a.Suggestion, a.PaneExcerpt,
+			string(a.MatchMethod), a.MatchScore, a.EmbedError, unix(a.CreatedAt))
 		if err != nil {
 			return err
 		}
@@ -1013,13 +1022,16 @@ func (s *Store) scanAudits(rows *sql.Rows) ([]domain.AuditRecord, error) {
 	for rows.Next() {
 		var a domain.AuditRecord
 		var situationType string
+		var matchMethod string
 		var created int64
 		var llmConf sql.NullInt64
 		if err := rows.Scan(&a.ID, &a.DecisionID, &a.AgentID, &a.AgentType, &a.Signature, &a.Trigger,
 			&situationType, &a.Action, &a.Input, &a.Confidence, &llmConf, &a.Rationale,
-			&a.LLMOutput, &a.CorrectsAuditID, &a.Status, &a.Suggestion, &a.PaneExcerpt, &created); err != nil {
+			&a.LLMOutput, &a.CorrectsAuditID, &a.Status, &a.Suggestion, &a.PaneExcerpt,
+			&matchMethod, &a.MatchScore, &a.EmbedError, &created); err != nil {
 			return nil, err
 		}
+		a.MatchMethod = domain.MatchMethod(matchMethod)
 		if llmConf.Valid {
 			v := int(llmConf.Int64)
 			a.LLMConfidence = &v
@@ -1033,7 +1045,7 @@ func (s *Store) scanAudits(rows *sql.Rows) ([]domain.AuditRecord, error) {
 
 const auditCols = `id, decision_id, agent_id, agent_type, signature, trigger, situation_type,
 	action_or_escalation, input, confidence, llm_confidence, rationale, llm_output,
-	corrects_audit_id, status, suggestion, pane_excerpt, created_at`
+	corrects_audit_id, status, suggestion, pane_excerpt, match_method, match_score, embed_error, created_at`
 
 // llmConfArg maps the optional LLM confidence to a SQL argument: nil stores
 // NULL (no LLM score), a value stores the 0-100 score.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -226,6 +226,65 @@ func TestAuditLLMConfidenceRoundTrip(t *testing.T) {
 	}
 }
 
+func TestAuditMatchDetailRoundTrip(t *testing.T) {
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+
+	// A cosine-matched escalation carries method, score, and no embed error.
+	cosID, err := s.AppendAudit(ctx, domain.AuditRecord{
+		Signature: "approval:x", Trigger: "agent-status: blocked", SituationType: domain.SituationApproval,
+		Action: "escalated", Status: "escalated",
+		MatchMethod: domain.MatchCosine, MatchScore: 0.94, CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetAudit(ctx, cosID)
+	if err != nil || got == nil {
+		t.Fatalf("get cosine audit: %v", err)
+	}
+	if got.MatchMethod != domain.MatchCosine || got.MatchScore != 0.94 || got.EmbedError != "" {
+		t.Errorf("cosine round trip = (%q, %.2f, %q), want (cosine, 0.94, \"\")",
+			got.MatchMethod, got.MatchScore, got.EmbedError)
+	}
+
+	// A BM25 fallback triggered by an embed failure carries the error text.
+	bmID, err := s.AppendAudit(ctx, domain.AuditRecord{
+		Signature: "approval:y", Trigger: "agent-status: blocked", SituationType: domain.SituationApproval,
+		Action: "escalated", Status: "escalated",
+		MatchMethod: domain.MatchBM25, MatchScore: 0.42, EmbedError: "embedder degraded",
+		CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err = s.GetAudit(ctx, bmID)
+	if err != nil || got == nil {
+		t.Fatalf("get bm25 audit: %v", err)
+	}
+	if got.MatchMethod != domain.MatchBM25 || got.MatchScore != 0.42 || got.EmbedError != "embedder degraded" {
+		t.Errorf("bm25 round trip = (%q, %.2f, %q), want (bm25, 0.42, embedder degraded)",
+			got.MatchMethod, got.MatchScore, got.EmbedError)
+	}
+
+	// A legacy/auto row leaves the match fields at their zero values.
+	autoID, err := s.AppendAudit(ctx, domain.AuditRecord{
+		Signature: "approval:z", Trigger: "agent-status: blocked", SituationType: domain.SituationApproval,
+		Action: "auto:1", Status: "auto", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err = s.GetAudit(ctx, autoID)
+	if err != nil || got == nil {
+		t.Fatalf("get auto audit: %v", err)
+	}
+	if got.MatchMethod != domain.MatchNone || got.MatchScore != 0 || got.EmbedError != "" {
+		t.Errorf("auto row match fields = (%q, %.2f, %q), want zero values",
+			got.MatchMethod, got.MatchScore, got.EmbedError)
+	}
+}
+
 func TestAuditAndCorrectionLineage(t *testing.T) {
 	s, _ := openTestStore(t)
 	ctx := context.Background()

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1481,10 +1481,21 @@ func (m Model) auditDetailLines(r domain.AuditRecord, snapshot string, w int, op
 		if row, ok := m.ruleFor(r.Signature); ok {
 			lines = m.detailField(lines, w, "Matched rule",
 				frontend.RuleSummary(row, m.data.cfg.Learning.GraduationN))
+			// How this situation resolved to that rule (rule-gated: no method
+			// label without a rule behind it).
+			if via := frontend.MatchSummary(r); via != "" {
+				lines = m.detailField(lines, w, "Matched via", via)
+			}
 		} else {
 			lines = m.detailField(lines, w, "Matched rule",
 				"none yet — learned when the operator confirms or resolves this")
 		}
+	}
+	// Embedding failure is NOT rule-gated: it is most useful exactly when a
+	// paraphrase that should have matched fell back (or matched nothing)
+	// because embedding was down.
+	if r.EmbedError != "" {
+		lines = m.detailField(lines, w, "Embedding", "failed: "+r.EmbedError)
 	}
 	if r.DecisionID != 0 {
 		lines = m.detailField(lines, w, "Decision id", fmt.Sprintf("%d", r.DecisionID))

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -40,7 +40,8 @@ func testModel(t *testing.T) Model {
 				Status: "escalated", Confidence: 0.42,
 				Trigger:    "Do you want to apply this edit to internal/store/store.go?\n1. Yes\n2. No",
 				Suggestion: "1", Rationale: longRationale,
-				Signature: "approval:1234abcd5678efab", // matches the shadow rule below
+				Signature:   "approval:1234abcd5678efab", // matches the shadow rule below
+				MatchMethod: domain.MatchCosine, MatchScore: 0.93,
 				CreatedAt: time.Date(2026, 7, 9, 11, 0, 0, 0, time.UTC)},
 		},
 		audit: []domain.AuditRecord{
@@ -1019,6 +1020,11 @@ func TestEscalationShowsMatchedRule(t *testing.T) {
 	if !strings.Contains(view, "Matched rule") || !strings.Contains(view, want) {
 		t.Errorf("escalation detail should describe the matched rule %q:\n%s", want, view)
 	}
+	// The detail also explains HOW it matched, naming the governing knob.
+	if !strings.Contains(view, "Matched via") ||
+		!strings.Contains(view, "matched by `similarity_threshold` (cosine 0.93)") {
+		t.Errorf("escalation detail should explain the match method:\n%s", view)
+	}
 	if !strings.Contains(view, "Agent type") {
 		t.Errorf("escalation detail should show the agent type:\n%s", view)
 	}
@@ -1038,6 +1044,37 @@ func TestEscalationWithoutRuleShowsNoneYet(t *testing.T) {
 	m2.tab = tabAudit
 	if list := m2.View(); !strings.Contains(list, "rule=-") {
 		t.Errorf("audit list should dash-mark rows without a rule:\n%s", list)
+	}
+}
+
+func TestEscalationShowsEmbeddingFailureWithoutRule(t *testing.T) {
+	// The embed-failure indicator is NOT rule-gated: it must show even when
+	// nothing matched (a paraphrase that should have matched but embedding was
+	// down). Signature "error:nomatch0000" has no learned rule.
+	m := Model{width: 100, height: 40}
+	upd, _ := m.Update(refreshMsg{
+		escalations: []domain.AuditRecord{
+			{ID: 9, AgentID: "w6:p1", AgentType: "claude", SituationType: domain.SituationError,
+				Status: "escalated", Trigger: "boom", Rationale: "fresh",
+				Signature:  "error:nomatch0000",
+				EmbedError: "embedder degraded after 3 consecutive failures",
+				CreatedAt:  time.Date(2026, 7, 9, 11, 0, 0, 0, time.UTC)},
+		},
+		cfg: func() config.Config { c := config.Default(); c.Learning.GraduationN = 5; return c }(),
+	})
+	m = upd.(Model)
+	m.tab = tabEscalations
+	m = press(t, m, "v")
+	if m.detail == nil {
+		t.Fatal("v should open the escalation detail")
+	}
+	view := m.View()
+	if !strings.Contains(view, "none yet") {
+		t.Errorf("no rule should render the none-yet hint:\n%s", view)
+	}
+	if !strings.Contains(view, "Embedding") ||
+		!strings.Contains(view, "failed: embedder degraded after 3 consecutive failures") {
+		t.Errorf("embed failure must show even without a matched rule:\n%s", view)
 	}
 }
 


### PR DESCRIPTION
## What & why

When hap escalates a situation, the operator sees a **Matched rule** line but never *how* the situation matched it. `resolveSignature` already computes the method (exact hash / embedding cosine ≥ `similarity_threshold` / BM25 ≥ `bm25_min_score`) and logs it, then throws it away. This surfaces that reasoning on the escalation, plus a per-event embedding-failure indicator so a paraphrase that *should* have matched semantically but fell back to BM25 (or matched nothing) is explainable.

The match is a **point-in-time** fact (index + thresholds drift), so it's persisted on the audit row rather than recomputed at display time.

## Changes

- **domain**: `MatchMethod` (`exact`/`cosine`/`bm25`) + `MatchDetail{Method, Score, EmbedError}` on `SignatureResult`; three match fields on `AuditRecord`.
- **daemon**: `resolveSignature` records the method/score at each return and captures the per-event embed error (covers the degraded latch); `escalate()` copies them onto the audit row.
- **store**: three new `audit_log` columns (`match_method`, `match_score`, `embed_error`) with idempotent migrations, wired through the INSERT / `auditCols` / `scanAudits` in lockstep. Legacy/auto rows read back as zero values.
- **frontend**: `MatchSummary()` names the governing knob — e.g. ``matched by `similarity_threshold` (cosine 0.94)`` / ``matched by `bm25_min_score` (bm25 0.42, embedding fallback)``. The threshold *number* is deliberately not stored/shown (it drifts with live config); the knob name is stable.
- **TUI + CLI**: the "matched by …" line is rule-gated; the **embedding-failure indicator shows even with no matched rule** (it's most useful exactly when nothing matched).

### Folded-in maintenance (was pending in the working tree)

- **Tail-truncate pane excerpts**: `truncateRunes` → `truncateTailRunes` (ellipsis prefix, keeps the final n runes) across the daemon audit/snapshot paths.
- **Test fixes for the threshold-lowering commit (`c8b3e82`)**: that change lowered the default approval threshold `0.80 → 0.70` and updated most tests but overlooked two. Their seeded `[1,1,1,1,2]` history scores `0.73` — below the old `0.80` (→ consult, what they test) but above the new `0.70` (→ auto-act). Pinned `approval = 0.8` in `TestLLMFallbackStagingRegateAndPromotion` and `TestLLMFailureEscalates`, matching the repo's own convention.
- **Flake fix**: `TestLLMNoopPromotionRecordsWithoutSend` waited only for the audit row, then read the decision/rate the promotion writes afterward. Now waits on the rate write (the promotion's last side effect), matching the sibling `TestNoopRuleAutonomousNoSend`. Verified 100/100 under stress.

## Tests

- New coverage: domain, store (round-trip + legacy zero-value), frontend (`MatchSummary`), TUI (rule-gated "Matched via" + un-gated embed-failure), daemon (cosine/bm25/exact/none + embed-error).
- `go test -tags "vectors cpu" ./... -count=1` — all pass · daemon `-count=3` green
- `golangci-lint` 0 issues · `gofmt`/`go vet` clean

https://claude.ai/code/session_016LEnXqxPFzYhbr4HFuhZKN
