### PR TITLE
Keep rate-limited actions confirmable, filter placeholder agent rows

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -296,7 +296,7 @@ edits made through `hap config set` / `set-threshold` apply live — the command
 | `confidence_thresholds.inferred_task_bar` | 0.60 | higher bar for tasks inferred from pane history |
 | `learning.graduation_n` | 5 | consecutive confirmations needed to graduate |
 | `limits.max_consecutive_auto_prompts` | 10 | max consecutive auto-prompts per agent without human interaction |
-| `limits.max_auto_prompts_per_minute` | 3 | rate limit per agent (rolling 1-minute window) |
+| `limits.max_auto_prompts_per_minute` | 5 | rate limit per agent (rolling 1-minute window) |
 | `limits.max_error_retries` | 2 | max retries per error signature |
 | `safety.disable_seed` | false | disable the 38 built-in seed never-auto patterns |
 | `llm.timeout_seconds` | 60 | timeout for LLM fallback calls |

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ graduation_n = 5           # consecutive confirmations to graduate
 
 [limits]
 max_consecutive_auto_prompts = 10  # per agent, without human interaction
-max_auto_prompts_per_minute = 3    # per agent
+max_auto_prompts_per_minute = 5    # per agent
 max_error_retries = 2              # per error signature
 
 # Semantic rule matching: situations are matched to learned rules by

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -297,7 +297,7 @@ func Default() Config {
 		Learning: Learning{GraduationN: 5},
 		Limits: Limits{
 			MaxConsecutiveAutoPrompts: 10,
-			MaxAutoPromptsPerMinute:   3,
+			MaxAutoPromptsPerMinute:   5,
 			MaxErrorRetries:           2,
 			VerifyUnblockMs:           1000,
 		},

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/classify"
 	"github.com/0xGosu/herdr-auto-pilot/internal/control"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store"
 	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
@@ -1100,14 +1101,23 @@ func TestRunawayGuardPausesAgent(t *testing.T) {
 		want := i + 1
 		waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == want })
 	}
-	// 6th: blocked + escalated.
+	// 6th: blocked + escalated, retaining the blocked action so the operator
+	// can explicitly confirm and send it.
 	h.push("agent-8", "blocked")
+	var escalation domain.AuditRecord
 	waitFor(t, 3*time.Second, func() bool {
 		esc, _ := h.raw.PendingEscalations(context.Background())
-		return len(esc) == 1
+		if len(esc) != 1 {
+			return false
+		}
+		escalation = esc[0]
+		return true
 	})
 	if len(h.herdr.sentInputs()) != 5 {
 		t.Fatalf("6th consecutive prompt must be blocked; sent %d", len(h.herdr.sentInputs()))
+	}
+	if escalation.Suggestion != "respond: 1" {
+		t.Fatalf("rate-limit escalation must carry the blocked action, got %q", escalation.Suggestion)
 	}
 	// escalate() persists the pause AFTER the escalation audit row, so the
 	// pause may not be visible yet when PendingEscalations first reports 1 —
@@ -1117,8 +1127,16 @@ func TestRunawayGuardPausesAgent(t *testing.T) {
 		return rate.Paused
 	})
 
-	// Human interaction (agent starts working without our input) resumes.
-	h.push("agent-8", "working")
+	// Confirming the escalation is a human-initiated send: it delivers the
+	// retained action and resumes this agent's automation.
+	app := frontend.App{Store: h.raw, Herdr: h.herdr, ControlPath: h.ctlPath, Author: "test"}
+	if err := app.Confirm(context.Background(), escalation.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 6 })
+	if got := h.herdr.sentInputs()[5]; got != "1" {
+		t.Fatalf("confirmed rate-limited action = %q, want %q", got, "1")
+	}
 	waitFor(t, 3*time.Second, func() bool {
 		r, _ := h.raw.GetAgentRate(context.Background(), "agent-8")
 		return !r.Paused && r.ConsecutiveAuto == 0

--- a/internal/domain/agent.go
+++ b/internal/domain/agent.go
@@ -1,0 +1,20 @@
+package domain
+
+import "strings"
+
+// IsPlaceholderAgent reports whether Herdr returned an agent-list/event row
+// with no usable agent identity or status. Both fields must be placeholders:
+// a real agent whose status is temporarily unknown, or a transitioning row
+// whose type has not arrived yet, must remain visible.
+func IsPlaceholderAgent(agentType, status string) bool {
+	return isPlaceholderAgentField(agentType) && isPlaceholderAgentField(status)
+}
+
+func isPlaceholderAgentField(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "undefined", "unknown":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/domain/agent_test.go
+++ b/internal/domain/agent_test.go
@@ -1,0 +1,28 @@
+package domain
+
+import "testing"
+
+func TestIsPlaceholderAgentRequiresBothFieldsToBeUnknown(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentType string
+		status    string
+		want      bool
+	}{
+		{name: "both empty", want: true},
+		{name: "herdr sentinels", agentType: "undefined", status: "unknown", want: true},
+		{name: "mixed sentinels", agentType: " UNKNOWN ", status: " Undefined ", want: true},
+		{name: "real type unknown status", agentType: "claude", status: "unknown", want: false},
+		{name: "unknown type active status", agentType: "undefined", status: "working", want: false},
+		{name: "real agent", agentType: "codex", status: "blocked", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPlaceholderAgent(tt.agentType, tt.status); got != tt.want {
+				t.Fatalf("IsPlaceholderAgent(%q, %q) = %v, want %v",
+					tt.agentType, tt.status, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/domain/agent_test.go
+++ b/internal/domain/agent_test.go
@@ -15,6 +15,13 @@ func TestIsPlaceholderAgentRequiresBothFieldsToBeUnknown(t *testing.T) {
 		{name: "real type unknown status", agentType: "claude", status: "unknown", want: false},
 		{name: "unknown type active status", agentType: "undefined", status: "working", want: false},
 		{name: "real agent", agentType: "codex", status: "blocked", want: false},
+		// Detection events never carry a status (it decodes as ""), so the
+		// empty-string form of each field — not just the literal
+		// "undefined"/"unknown" sentinels — must be exercised on both sides.
+		{name: "real type empty status", agentType: "claude", status: "", want: false},
+		{name: "empty type real status", agentType: "", status: "working", want: false},
+		{name: "empty type explicit unknown status", agentType: "", status: "unknown", want: true},
+		{name: "explicit undefined type empty status", agentType: "undefined", status: "", want: true},
 	}
 
 	for _, tt := range tests {

--- a/internal/domain/decide.go
+++ b/internal/domain/decide.go
@@ -150,8 +150,15 @@ func Decide(in DecideInput) Decision {
 		return esc(ReasonVarianceGuard, "contradictory history", conf.Score, "")
 	}
 
+	// Resolve the would-be action before applying the rate guard. Resolution is
+	// pure and does not authorize a send; it gives a rate-limit escalation the
+	// same confirmable suggestion that would otherwise have been acted on.
+	// Without this, the early safety veto produced a tag-only escalation that
+	// the operator could not confirm.
+	candidate, suggestion, resolveEsc := resolveSituation(in, conf)
+
 	if ok, reason := CheckRate(in.Rate, in.Now, in.RateLimits); !ok {
-		return esc(reason, "", conf.Score, "")
+		return esc(reason, "", conf.Score, suggestion)
 	}
 
 	// The suspected-irreversible heuristic biases to escalation before any
@@ -173,8 +180,6 @@ func Decide(in DecideInput) Decision {
 
 	threshold := in.ConfidenceThresholds.ForType(in.Situation.Type)
 
-	// Resolve the candidate action per situation type.
-	candidate, suggestion, resolveEsc := resolveSituation(in, conf)
 	if resolveEsc != ReasonNone {
 		// "No confident learned rule applies" is exactly the LLM fallback's
 		// job (FR-010): a signature with no history yet, or a learned option

--- a/internal/domain/decide_test.go
+++ b/internal/domain/decide_test.go
@@ -104,6 +104,103 @@ func TestRunawayGuardBlocksEleventhInMinute(t *testing.T) {
 	}
 }
 
+func TestRunawayGuardWhenPausedRetainsSuggestion(t *testing.T) {
+	// The rate guard's other trip condition — an already-paused agent — must
+	// retain the resolved suggestion exactly like the consecutive/per-minute
+	// trips do, so confirming still delivers and resumes.
+	in := autonomous(baseInput(SituationApproval), "y", "y", "y", "y", "y", "y", "y", "y")
+	in.Rate = AgentRate{Paused: true}
+	d := Decide(in)
+	if d.Action != ActionEscalate || d.Reason != ReasonRateLimited {
+		t.Fatalf("paused agent must escalate as rate-limited, got %+v", d)
+	}
+	if d.Suggestion != "respond: y" {
+		t.Fatalf("paused rate-limit escalation must remain confirmable, suggestion = %q", d.Suggestion)
+	}
+}
+
+func TestRunawayGuardRetainsNoopSuggestion(t *testing.T) {
+	// A learned noop is a valid resolved candidate too: the rate-limited
+	// escalation must surface the human-readable noop suggestion, not lose
+	// it or leak the raw "@noop" sentinel.
+	in := autonomous(baseInput(SituationApproval), ActionNoop, ActionNoop, ActionNoop, ActionNoop, ActionNoop, ActionNoop, ActionNoop, ActionNoop)
+	in.Rate = AgentRate{ConsecutiveAuto: 5}
+	d := Decide(in)
+	if d.Action != ActionEscalate || d.Reason != ReasonRateLimited {
+		t.Fatalf("rate-limited noop situation must escalate, got %+v", d)
+	}
+	if d.Suggestion != ActionNoopSuggestion {
+		t.Fatalf("rate-limited noop suggestion = %q, want %q", d.Suggestion, ActionNoopSuggestion)
+	}
+}
+
+func TestRunawayGuardIdleRetainsDeclaredTaskSuggestion(t *testing.T) {
+	// A rate-limited idle situation with a declared task source must retain
+	// the rendered next-task suggestion, not just a bare reason tag.
+	in := baseInput(SituationIdle)
+	in.State = &SignatureState{Mode: ModeAutonomous, ConsecutiveConfirmations: 10}
+	in.DeclaredTask = &DeclaredTask{Task: "write the changelog", Path: "/tasks.md"}
+	in.Rate = AgentRate{ConsecutiveAuto: 5}
+	d := Decide(in)
+	if d.Action != ActionEscalate || d.Reason != ReasonRateLimited {
+		t.Fatalf("rate-limited idle situation must escalate, got %+v", d)
+	}
+	want := "send next declared task: Your next task is write the changelog. Read the full tasks list at /tasks.md."
+	if d.Suggestion != want {
+		t.Fatalf("suggestion = %q, want %q", d.Suggestion, want)
+	}
+}
+
+func TestRunawayGuardErrorRetainsSuggestion(t *testing.T) {
+	// The Error resolver branch must retain its suggestion under the rate
+	// guard exactly like Approval/Choice/Idle do.
+	in := autonomous(baseInput(SituationError), "retry", "retry", "retry", "retry", "retry", "retry", "retry", "retry")
+	in.Rate = AgentRate{ConsecutiveAuto: 5}
+	d := Decide(in)
+	if d.Action != ActionEscalate || d.Reason != ReasonRateLimited {
+		t.Fatalf("rate-limited error situation must escalate, got %+v", d)
+	}
+	if d.Suggestion != "on error: retry" {
+		t.Fatalf("suggestion = %q, want %q", d.Suggestion, "on error: retry")
+	}
+}
+
+func TestRunawayGuardChoiceRetainsAnswerSeriesSuggestion(t *testing.T) {
+	// A rate-limited multi-tab MCQ form must retain the full learned digit
+	// series, not a partial or bare-tag suggestion.
+	in := autonomous(baseInput(SituationChoice),
+		"1 2 3 2 1", "1 2 3 2 1", "1 2 3 2 1", "1 2 3 2 1",
+		"1 2 3 2 1", "1 2 3 2 1", "1 2 3 2 1", "1 2 3 2 1")
+	in.Situation.TabCount = 5
+	in.Rate = AgentRate{ConsecutiveAuto: 5}
+	d := Decide(in)
+	if d.Action != ActionEscalate || d.Reason != ReasonRateLimited {
+		t.Fatalf("rate-limited multi-tab situation must escalate, got %+v", d)
+	}
+	if d.Suggestion != "answer series: 1 2 3 2 1" {
+		t.Fatalf("suggestion = %q, want %q", d.Suggestion, "answer series: 1 2 3 2 1")
+	}
+}
+
+func TestRunawayGuardNoSuggestionWithoutLearnedHistory(t *testing.T) {
+	// A brand-new signature has nothing to resolve yet (ReasonNoHistory): the
+	// rate-limited escalation must degrade to an empty suggestion instead of
+	// panicking or fabricating one. This does not pin the resolve-before-
+	// rate-guard ordering itself (an empty suggestion would also result from
+	// the old tag-only veto) — it guards the no-fabrication property of the
+	// resolve call that ordering change introduced.
+	in := baseInput(SituationApproval)
+	in.State = &SignatureState{Mode: ModeAutonomous, ConsecutiveConfirmations: 10}
+	in.Rate = AgentRate{ConsecutiveAuto: 5}
+	d := Decide(in)
+	if d.Action != ActionEscalate || d.Reason != ReasonRateLimited {
+		t.Fatalf("rate-limited situation with no history must still escalate as rate-limited, got %+v", d)
+	}
+	if d.Suggestion != "" {
+		t.Fatalf("suggestion with no learned history = %q, want empty", d.Suggestion)
+	}
+}
+
 func TestShadowModeSuggestsNeverActs(t *testing.T) {
 	// FR-004: shadow mode presents a suggestion, takes no action.
 	in := baseInput(SituationApproval)

--- a/internal/domain/decide_test.go
+++ b/internal/domain/decide_test.go
@@ -76,12 +76,16 @@ func TestSuspectedIrreversibleRationaleNamesIndicator(t *testing.T) {
 }
 
 func TestRunawayGuardBlocksSixthConsecutive(t *testing.T) {
-	// FR-019 acceptance: a 6th consecutive auto-prompt is blocked.
+	// FR-019 acceptance: a 6th consecutive auto-prompt is blocked, but the
+	// proposed reply remains available for a human to confirm.
 	in := autonomous(baseInput(SituationApproval), "y", "y", "y", "y", "y", "y", "y", "y")
 	in.Rate = AgentRate{ConsecutiveAuto: 5}
 	d := Decide(in)
 	if d.Action != ActionEscalate || d.Reason != ReasonRateLimited {
 		t.Fatalf("6th consecutive auto-prompt must be blocked, got %+v", d)
+	}
+	if d.Suggestion != "respond: y" {
+		t.Fatalf("rate-limited prompt must remain confirmable, suggestion = %q", d.Suggestion)
 	}
 }
 
@@ -94,6 +98,9 @@ func TestRunawayGuardBlocksEleventhInMinute(t *testing.T) {
 	d := Decide(in)
 	if d.Action != ActionEscalate || d.Reason != ReasonRateLimited {
 		t.Fatalf("11th auto-prompt in a minute must be blocked, got %+v", d)
+	}
+	if d.Suggestion != "respond: y" {
+		t.Fatalf("rate-limited prompt must remain confirmable, suggestion = %q", d.Suggestion)
 	}
 }
 

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -198,7 +198,13 @@ func (a *App) GetStatus(ctx context.Context) (Status, error) {
 	st.PendingEscalations = int(pending)
 	if a.Herdr != nil {
 		if agents, err := a.Herdr.ListAgents(ctx); err == nil {
-			st.MonitoredAgents = agents
+			// Keep the view boundary defensive even if an alternate Herdr
+			// adapter does not normalize placeholder side-panel rows.
+			for _, agent := range agents {
+				if !domain.IsPlaceholderAgent(agent.AgentType, agent.Status) {
+					st.MonitoredAgents = append(st.MonitoredAgents, agent)
+				}
+			}
 		}
 		if loc, ok := a.Herdr.(ports.LocatorPort); ok {
 			if wss, err := loc.ListWorkspaces(ctx); err == nil {

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -1361,6 +1361,27 @@ func (f *fakeHerdrPort) ListAgents(ctx context.Context) ([]domain.AgentTransitio
 	return f.agents, nil
 }
 
+func TestStatusHidesOnlyDoublePlaceholderAgents(t *testing.T) {
+	app, _ := testApp(t)
+	app.Herdr = &fakeHerdrPort{agents: []domain.AgentTransition{
+		{AgentID: "panel", PaneID: "panel", AgentType: "undefined", Status: "unknown"},
+		{AgentID: "real-unknown-status", PaneID: "real-unknown-status", AgentType: "claude", Status: "unknown"},
+		{AgentID: "active-unknown-type", PaneID: "active-unknown-type", AgentType: "undefined", Status: "working"},
+	}}
+
+	status, err := app.GetStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(status.MonitoredAgents) != 2 {
+		t.Fatalf("TUI agents = %+v, want two non-double-placeholder rows", status.MonitoredAgents)
+	}
+	if status.MonitoredAgents[0].AgentID != "real-unknown-status" ||
+		status.MonitoredAgents[1].AgentID != "active-unknown-type" {
+		t.Fatalf("wrong agents remained visible: %+v", status.MonitoredAgents)
+	}
+}
+
 func TestRenameLiveButUnnamedAgent(t *testing.T) {
 	// Regression: the TUI/CLI list agents straight from Herdr, but the
 	// daemon only creates a name row when the agent first transitions. A

--- a/internal/herdr/cli.go
+++ b/internal/herdr/cli.go
@@ -140,6 +140,12 @@ func (c *CLI) ListAgents(ctx context.Context) ([]domain.AgentTransition, error) 
 	}
 	var agents []domain.AgentTransition
 	for _, a := range resp.Result.Agents {
+		// Herdr can expose non-agent plugin/side-panel panes as placeholder
+		// rows (for example agent=undefined, agent_status=unknown). They are
+		// not monitorable agents and must not leak into the HAP TUI.
+		if domain.IsPlaceholderAgent(a.Agent, a.AgentStatus) {
+			continue
+		}
 		agents = append(agents, domain.AgentTransition{
 			AgentID:     a.PaneID,
 			PaneID:      a.PaneID,

--- a/internal/herdr/events.go
+++ b/internal/herdr/events.go
@@ -166,6 +166,13 @@ func (s *Subscriber) runDiscovery(ctx context.Context, out chan<- domain.AgentTr
 			if d.PaneID == "" {
 				return nil
 			}
+			// Some plugin/side-panel panes are announced with Herdr's
+			// placeholder agent values. A detection event has no meaningful
+			// status yet, so the empty status participates in the same two-field
+			// filter used for live agent-list rows.
+			if domain.IsPlaceholderAgent(d.Agent, d.AgentStatus) {
+				return nil
+			}
 			s.upsertPane(d.PaneID, d.WorkspaceID, d.TabID, d.Agent)
 			// Surface the discovery as a transition so the daemon can name
 			// the agent immediately — herdr replays agent_detected for
@@ -246,6 +253,9 @@ func (s *Subscriber) runStatus(ctx context.Context, out chan<- domain.AgentTrans
 		agentType := d.Agent
 		if agentType == "" {
 			agentType = s.agentLabel(d.PaneID)
+		}
+		if domain.IsPlaceholderAgent(agentType, d.AgentStatus) {
+			return nil
 		}
 		tabID := d.TabID
 		if tabID == "" {
@@ -433,7 +443,7 @@ func (s *Subscriber) listPanes(ctx context.Context) ([]string, error) {
 		if p.TabID != "" {
 			info.tabID = p.TabID
 		}
-		if p.Agent != "" {
+		if !domain.IsPlaceholderAgent(p.Agent, "") {
 			info.agentLabel = p.Agent
 		}
 		s.panes[p.PaneID] = info

--- a/internal/herdr/herdr_test.go
+++ b/internal/herdr/herdr_test.go
@@ -328,6 +328,30 @@ func TestListAgentsFiltersOnlyDoublePlaceholderRows(t *testing.T) {
 	}
 }
 
+func TestListAgentsFiltersCaseInsensitiveAndEmptyPlaceholders(t *testing.T) {
+	// Placeholder detection must not depend on herdr sending the exact
+	// lowercase sentinel or a non-empty field: mixed case, surrounding
+	// whitespace, and the empty string are all placeholder forms.
+	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second}
+	fake.SetAgentList(`{"id":"cli:agent:list","result":{"agents":[` +
+		`{"agent":"UNDEFINED","agent_status":" Unknown ","pane_id":"panel-mixed-case"},` +
+		`{"agent":"","agent_status":"","pane_id":"panel-empty"},` +
+		`{"agent":"claude","agent_status":"","pane_id":"real-empty-status"}` +
+		`],"type":"agent_list"}}`)
+
+	agents, err := cli.ListAgents(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(agents) != 1 || agents[0].PaneID != "real-empty-status" {
+		t.Fatalf("visible agents = %+v, want only real-empty-status", agents)
+	}
+}
+
 func TestCLIFailureSurfaced(t *testing.T) {
 	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
 	if err != nil {

--- a/internal/herdr/herdr_test.go
+++ b/internal/herdr/herdr_test.go
@@ -43,6 +43,60 @@ func TestSubscriberReceivesTransitions(t *testing.T) {
 	t.Fatal("no transition received (IR-001)")
 }
 
+func TestSubscriberIgnoresDoublePlaceholderAgents(t *testing.T) {
+	srv, err := fakeherdr.NewServer(testutil.SocketDir(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	srv.AddPane("w1:p1", "w1")
+
+	sub := NewSubscriber(srv.SocketPath)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := make(chan domain.AgentTransition, 16)
+	go sub.Subscribe(ctx, out)
+
+	// Establish the status subscription with a real transition first.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		srv.PushTransition("w1:p1", "w1", "claude", "working")
+		select {
+		case tr := <-out:
+			if tr.AgentType == "claude" && tr.Status == "working" {
+				goto established
+			}
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	t.Fatal("status subscription was not established")
+
+established:
+	// Neither a placeholder status update nor a placeholder detection for a
+	// plugin side panel may reach the daemon.
+	srv.PushTransition("w1:p1", "w1", "undefined", "unknown")
+	srv.PushAgentDetected("w1:panel", "w1", "undefined")
+	select {
+	case tr := <-out:
+		t.Fatalf("placeholder agent transition leaked through: %+v", tr)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	// Only one unknown field is legitimate and must still flow.
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		srv.PushTransition("w1:p1", "w1", "claude", "unknown")
+		select {
+		case tr := <-out:
+			if tr.AgentType == "claude" && tr.Status == "unknown" {
+				return
+			}
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	t.Fatal("real agent with unknown status was incorrectly filtered")
+}
+
 func TestSubscriberDiscoversNewPanes(t *testing.T) {
 	srv, err := fakeherdr.NewServer(testutil.SocketDir(t))
 	if err != nil {
@@ -247,6 +301,30 @@ func TestSendSubmitsWithEnter(t *testing.T) {
 	if len(calls) != 2 || calls[0] != "agent send w1:p1 run the tests" ||
 		calls[1] != "pane send-keys w1:p1 enter" {
 		t.Errorf("send should write text then press enter, got %v", calls)
+	}
+}
+
+func TestListAgentsFiltersOnlyDoublePlaceholderRows(t *testing.T) {
+	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second}
+	fake.SetAgentList(`{"id":"cli:agent:list","result":{"agents":[` +
+		`{"agent":"undefined","agent_status":"unknown","pane_id":"panel"},` +
+		`{"agent":"claude","agent_status":"unknown","pane_id":"real-unknown-status"},` +
+		`{"agent":"undefined","agent_status":"working","pane_id":"active-unknown-type"}` +
+		`],"type":"agent_list"}}`)
+
+	agents, err := cli.ListAgents(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(agents) != 2 {
+		t.Fatalf("visible agents = %+v, want two non-double-placeholder rows", agents)
+	}
+	if agents[0].PaneID != "real-unknown-status" || agents[1].PaneID != "active-unknown-type" {
+		t.Fatalf("wrong agents survived placeholder filtering: %+v", agents)
 	}
 }
 

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -35,7 +35,7 @@ irreversible_indicators = []     # extra suspected-irreversible patterns, all ag
 # ── Rate limits ─────────────────────────────────────────────────────
 [limits]
 max_consecutive_auto_prompts = 10  # per agent, without human interaction
-max_auto_prompts_per_minute = 3    # per agent
+max_auto_prompts_per_minute = 5    # per agent
 max_error_retries = 2              # per error signature
 
 # ── Operator LLM (consulted on unknown situations) ──────────────────


### PR DESCRIPTION
## Summary
- Rate-limited escalations now retain the resolved suggestion so the operator can confirm the blocked action directly; confirming delivers it and resumes the agent's automation (previously the action was lost and only ordinary agent activity resumed automation).
- `internal/domain.IsPlaceholderAgent` filters herdr agent-list rows, discovery events, and status transitions that are plugin/side-panel panes announced with placeholder identity (`agent`/`agent_status` both empty/"undefined"/"unknown") — these no longer leak into the daemon or TUI agent list. A row is only hidden when *both* fields are placeholders, so a real agent with a temporarily unknown status stays visible.
- Raises the default `max_auto_prompts_per_minute` from 3 to 5, with docs/sample config updated to match (`README.md`, `sample/config.toml`, `.claude/skills/hap/SKILL.md`).

## Test plan
- [x] `gofmt -l .` clean
- [x] `go build -tags "vectors cpu" ./...`
- [x] `go vet -tags "vectors cpu" ./...`
- [x] `golangci-lint run --build-tags "vectors,cpu"` — 0 issues
- [x] `go test -tags "vectors cpu" ./... -count=1` — full suite passes (~67s)

https://claude.ai/code/session_016LEnXqxPFzYhbr4HFuhZKN