### PR TITLE
fix: strip codex's composer placeholder line from captured pane text

### DIFF
--- a/internal/classify/classify.go
+++ b/internal/classify/classify.go
@@ -120,6 +120,9 @@ func New(operatorRules []config.ClassifierRule) *Classifier {
 // Classify assigns pane content to exactly one situation type or
 // unclassifiable (FR-002). agentStatus is Herdr's semantic agent state.
 func (c *Classifier) Classify(agentType, agentStatus, pane string) domain.Situation {
+	if strings.EqualFold(agentType, "codex") {
+		pane = domain.StripCodexComposer(pane)
+	}
 	s := domain.Situation{AgentType: agentType, Content: pane, Type: domain.SituationUnclassifiable}
 
 	// Approval and choice are BLOCKED situations (constitution taxonomy): only

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -20,6 +20,10 @@ func TestGoldenTranscripts(t *testing.T) {
 
 	statusFor := map[string]string{
 		"idle_finished.txt": "idle",
+		"codex_idle.txt":    "idle",
+	}
+	agentTypeFor := map[string]string{
+		"codex_idle.txt": "codex",
 	}
 
 	entries, err := os.ReadDir("testdata/transcripts")
@@ -42,7 +46,11 @@ func TestGoldenTranscripts(t *testing.T) {
 		if status == "" {
 			status = "blocked"
 		}
-		s := c.Classify("claude", status, string(data))
+		agentType := agentTypeFor[name]
+		if agentType == "" {
+			agentType = "claude"
+		}
+		s := c.Classify(agentType, status, string(data))
 		verb := ""
 		if s.PermissionVerb != "" {
 			verb = strings.Fields(s.PermissionVerb)[0]
@@ -382,5 +390,31 @@ func TestApprovalFixturesStillApproval(t *testing.T) {
 		if s := c.Classify("claude", "blocked", string(data)); s.Type != domain.SituationApproval {
 			t.Errorf("%s: type = %v, want approval", name, s.Type)
 		}
+	}
+}
+
+// TestCodexComposerStrippedOnlyForCodex proves the codex composer-line strip
+// (domain.StripCodexComposer) is gated strictly on agent_type == "codex":
+// claude's Content must come out byte-identical to the raw pane, while
+// codex's Content has the "› ..." line gone and keeps the footer.
+func TestCodexComposerStrippedOnlyForCodex(t *testing.T) {
+	c := New(nil)
+	pane := "─ Worked for 10m 49s ─────\n\n› Summarize recent commits\n\n  gpt-5.6-sol high · /workspaces/herdr-auto-pilot\n"
+
+	codex := c.Classify("codex", "idle", pane)
+	if strings.Contains(codex.Content, "›") {
+		t.Errorf("codex situation content must have composer line stripped, got %q", codex.Content)
+	}
+	if !strings.Contains(codex.Content, "gpt-5.6-sol high") {
+		t.Errorf("codex situation content must keep the footer, got %q", codex.Content)
+	}
+
+	claude := c.Classify("claude", "idle", pane)
+	if claude.Content != pane {
+		t.Errorf("claude situation content must be untouched, got %q, want %q", claude.Content, pane)
+	}
+
+	if codex.Content == claude.Content {
+		t.Error("expected codex and claude content to differ after gating")
 	}
 }

--- a/internal/classify/testdata/classifications.golden
+++ b/internal/classify/testdata/classifications.golden
@@ -5,6 +5,7 @@ choice_claude_mcq.txt status=blocked type=choice verb= options=5
 choice_claude_mcq_tabs.txt status=blocked type=choice verb= options=5
 choice_claude_mcq_tabs_v2.txt status=blocked type=choice verb= options=3
 choice_library.txt status=blocked type=choice verb= options=3
+codex_idle.txt status=idle type=idle verb= options=0
 error_build.txt status=blocked type=unclassifiable verb= options=0
 error_claude_api_retry.txt status=blocked type=error verb= options=0
 error_claude_interrupted.txt status=blocked type=error verb= options=0

--- a/internal/classify/testdata/transcripts/codex_idle.txt
+++ b/internal/classify/testdata/transcripts/codex_idle.txt
@@ -1,0 +1,6 @@
+─ Worked for 10m 49s ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+
+› Summarize recent commits
+
+  gpt-5.6-sol high · /workspaces/herdr-auto-pilot

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1775,6 +1775,9 @@ func (d *Daemon) paneExcerpt(ctx context.Context, cfg config.Config, s domain.Si
 		slog.Warn("deep pane read for LLM context failed; using classification snapshot",
 			"pane", s.PaneID, "error", err)
 	}
+	if strings.EqualFold(s.AgentType, "codex") {
+		excerpt = domain.StripCodexComposer(excerpt)
+	}
 	return tail(excerpt, chars)
 }
 

--- a/internal/daemon/paneexcerpt_test.go
+++ b/internal/daemon/paneexcerpt_test.go
@@ -1,0 +1,53 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// TestPaneExcerptStripsCodexComposer proves paneExcerpt's independent "deep"
+// visible read (which bypasses classify.Classify entirely) also strips
+// codex's composer/input-box line before it reaches the LLM-facing excerpt,
+// while leaving another agent type's excerpt byte-identical to the raw read.
+// fakeHerdr implements ReadPane but not ports.VisiblePaneReader, so
+// d.readVisible falls back to ReadPane, deterministically exercising the
+// "deep" branch with the content set by setPane.
+func TestPaneExcerptStripsCodexComposer(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	raw, err := store.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { raw.Close() })
+
+	fh := &fakeHerdr{}
+	fh.setPane("─ Worked for 10m 49s ─────\n\n› Summarize recent commits\n\n  gpt-5.6-sol high · /workspaces/herdr-auto-pilot\n")
+	d, err := New(Options{ConfigPath: cfgPath, Store: raw, Herdr: fh, LLM: &fakeLLM{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	cfg, _, _ := d.snapshot()
+
+	codexSituation := domain.Situation{AgentType: "codex", PaneID: "pane-1", Content: "stale snapshot"}
+	excerpt := d.paneExcerpt(ctx, cfg, codexSituation)
+	if strings.Contains(excerpt, "›") {
+		t.Errorf("codex pane excerpt must have composer line stripped, got %q", excerpt)
+	}
+	if !strings.Contains(excerpt, "gpt-5.6-sol high") {
+		t.Errorf("footer must survive in codex excerpt, got %q", excerpt)
+	}
+
+	claudeSituation := domain.Situation{AgentType: "claude", PaneID: "pane-1", Content: "stale snapshot"}
+	claudeExcerpt := d.paneExcerpt(ctx, cfg, claudeSituation)
+	if !strings.Contains(claudeExcerpt, "› Summarize recent commits") {
+		t.Errorf("claude pane excerpt must be untouched, got %q", claudeExcerpt)
+	}
+}

--- a/internal/domain/codex.go
+++ b/internal/domain/codex.go
@@ -1,0 +1,49 @@
+package domain
+
+import "regexp"
+
+// codexComposerBeforeFooterRE matches Codex's live composer/input-box line —
+// prefixed with "›" (U+203A) at line start — ONLY when it directly precedes
+// (modulo blank lines) the composer's status footer, a line naming the model
+// and the working directory (e.g. "gpt-5.6-sol high · /tmp"), AND that
+// footer is the very last thing in the captured text (anchored on \z, not
+// end-of-line): every live capture shows the composer+footer pair sitting at
+// the true bottom of the screen, so requiring end-of-text is what actually
+// distinguishes the live footer from an agent response that merely contains
+// the same " · /" shape (e.g. "the config lives at foo · /etc/app.conf")
+// mid-transcript — a per-line "$" anchor alone would wrongly accept that as
+// a footer and delete the real submitted message above it. Confirmed via
+// live capture: Codex reuses the SAME "›" glyph to render a past SUBMITTED
+// message in the transcript (e.g. "› Just reply with one short fact about
+// octopuses...") — that is real conversation content and must survive. Only
+// the trailing, not-yet-submitted composer line is directly followed by the
+// footer; a submitted message is followed by the agent's actual response
+// instead, so anchoring on the footer (rather than stripping every "›" line)
+// distinguishes UI chrome from real history. If a "recent" read concatenates
+// a stale composer+footer pair earlier in scrollback, only the TRAILING pair
+// (the live render) matches and strips — mirroring this codebase's existing
+// "last occurrence is the live render" convention (domain.MultiTabForm). The
+// footer itself is kept: it is captured in group 1, trailing newline
+// included, and the replacement puts it back, so only the composer line and
+// its own newline (matched outside the group) disappear.
+//
+// Residual, accepted risk: this is a text-only heuristic, not a real parse —
+// if a genuinely-submitted message's real response is itself the literal
+// last thing in the captured text AND that response happens to contain the
+// same " · /" shape, the message above it is misidentified as a composer
+// line and stripped. Narrower than the mid-transcript case \z closes (the
+// confusable text must be the true tail of the buffer, which in practice is
+// almost always the real footer), and not fully closeable without semantic
+// understanding of the pane, so it is left as a known limitation rather than
+// chased further.
+var codexComposerBeforeFooterRE = regexp.MustCompile(`(?m)^[ \t]*›[^\n]*\n((?:[ \t]*\r?\n)*[ \t]*[^\n]*\s·\s+/[^\n]*\r?\n?)\z`)
+
+// StripCodexComposer removes Codex's live composer/input-box line from pane
+// text, keeping its footer (model name + cwd) and any real submitted
+// message in the transcript untouched. No-op when no composer-before-footer
+// shape is present at the very end of the text. Callers MUST gate this on
+// agent_type == "codex" — "›" carries no special meaning for other agent
+// types and must never be touched for them.
+func StripCodexComposer(pane string) string {
+	return codexComposerBeforeFooterRE.ReplaceAllString(pane, "$1")
+}

--- a/internal/domain/codex_test.go
+++ b/internal/domain/codex_test.go
@@ -1,0 +1,175 @@
+package domain
+
+import "testing"
+
+func TestStripCodexComposer(t *testing.T) {
+	cases := []struct {
+		name string
+		pane string
+		want string
+	}{
+		{
+			"placeholder A stripped, footer kept",
+			"some output\n\n› Summarize recent commits\n\n  gpt-5.6-sol high · /tmp\n",
+			"some output\n\n\n  gpt-5.6-sol high · /tmp\n",
+		},
+		{
+			"placeholder B stripped (content-agnostic)",
+			"some output\n\n› Explain the auth flow\n\n  gpt-5.6-sol high · /tmp\n",
+			"some output\n\n\n  gpt-5.6-sol high · /tmp\n",
+		},
+		{
+			"bare composer line stripped",
+			"some output\n\n›\n\n  gpt-5.6-sol high · /tmp\n",
+			"some output\n\n\n  gpt-5.6-sol high · /tmp\n",
+		},
+		{
+			"no composer line is a no-op",
+			"some output\n\n  gpt-5.6-sol high · /tmp\n",
+			"some output\n\n  gpt-5.6-sol high · /tmp\n",
+		},
+		{
+			"leading whitespace before glyph stripped",
+			"some output\n\n  › draft text\n\n  gpt-5.6-sol high · /tmp\n",
+			"some output\n\n\n  gpt-5.6-sol high · /tmp\n",
+		},
+		{
+			"mid-line glyph left untouched",
+			"note: press › to open menu\n\n  gpt-5.6-sol high · /tmp\n",
+			"note: press › to open menu\n\n  gpt-5.6-sol high · /tmp\n",
+		},
+		{
+			// Live-observed: Codex renders a past SUBMITTED message with the
+			// same "›" prefix as the live composer. It is real conversation
+			// content, distinguished from the composer only by what follows
+			// it — the agent's actual response, not the status footer — and
+			// must survive untouched.
+			"submitted message followed by a real response survives",
+			"› Just reply with one short interesting fact about octopuses.\n\n" +
+				"• Octopuses have three hearts and blue blood.\n\n  gpt-5.6-sol high · /tmp\n",
+			"› Just reply with one short interesting fact about octopuses.\n\n" +
+				"• Octopuses have three hearts and blue blood.\n\n  gpt-5.6-sol high · /tmp\n",
+		},
+		{
+			// Adversarial: the agent's real response happens to contain the
+			// same " · /" shape as the footer ("foo · /etc/app.conf"), mid-
+			// transcript, well before the true end of the text. A per-line "$"
+			// anchor alone would wrongly treat that response as the footer and
+			// delete the real submitted message above it; anchoring on \z (the
+			// true end of the captured text) keeps this response — and the
+			// question that produced it — untouched. Only the genuine trailing
+			// composer+footer pair at the very end strips.
+			"response line resembling a footer mid-transcript survives",
+			"› Where does the config live?\n\n" +
+				"• Sure, the config lives at foo · /etc/app.conf\n\n" +
+				"› Write tests for @filename\n\n  gpt-5.6-sol high · /tmp\n",
+			"› Where does the config live?\n\n" +
+				"• Sure, the config lives at foo · /etc/app.conf\n\n" +
+				"\n  gpt-5.6-sol high · /tmp\n",
+		},
+		{
+			// A "recent" read can concatenate a STALE composer+footer pair
+			// earlier in scrollback with the live one at the true end. Only the
+			// TRAILING pair (anchored on \z) strips — the stale middle pair is
+			// left alone, mirroring this codebase's "last occurrence is the
+			// live render" convention (domain.MultiTabForm).
+			"only the trailing footer-anchored composer line strips",
+			"› first draft\n\n  gpt-5.6-sol high · /tmp\n\nmore scrollback\n\n" +
+				"› second draft\n\n  gpt-5.6-sol high · /tmp\n",
+			"› first draft\n\n  gpt-5.6-sol high · /tmp\n\nmore scrollback\n\n" +
+				"\n  gpt-5.6-sol high · /tmp\n",
+		},
+		{
+			"empty input is a no-op",
+			"",
+			"",
+		},
+		{
+			"CRLF line ending stripped cleanly, footer kept",
+			"some output\r\n\r\n› Summarize recent commits\r\n\r\n  gpt-5.6-sol high · /tmp\r\n",
+			"some output\r\n\r\n\r\n  gpt-5.6-sol high · /tmp\r\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StripCodexComposer(tc.pane)
+			if got != tc.want {
+				t.Errorf("StripCodexComposer(%q) = %q, want %q", tc.pane, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStripCodexComposerRealCapture pins the exact output against a real
+// codex idle pane capture (herdr pane read --source recent --format text)
+// byte-for-byte: the composer line itself is gone (its own blank-line
+// artifact removed), surrounding blank lines are preserved as-is, and the
+// footer (model name + cwd) survives untouched.
+func TestStripCodexComposerRealCapture(t *testing.T) {
+	pane := "─ Worked for 10m 49s ─────────────────────────────────────────\n" +
+		"\n" +
+		"› Summarize recent commits\n" +
+		"\n" +
+		"  gpt-5.6-sol high · /workspaces/herdr-auto-pilot\n"
+	want := "─ Worked for 10m 49s ─────────────────────────────────────────\n" +
+		"\n" +
+		"\n" +
+		"  gpt-5.6-sol high · /workspaces/herdr-auto-pilot\n"
+	got := StripCodexComposer(pane)
+	if got != want {
+		t.Errorf("StripCodexComposer real capture = %q, want %q", got, want)
+	}
+}
+
+// TestStripCodexComposerRealSubmittedMessageSurvives pins a second real
+// capture (herdr pane read --source recent --format text on a live codex
+// pane, after submitting a real prompt): the operator's own submitted
+// message must survive verbatim, only the fresh trailing composer
+// placeholder is removed.
+func TestStripCodexComposerRealSubmittedMessageSurvives(t *testing.T) {
+	pane := "• You have 3 usage limit resets available. Run /usage to use one.\n" +
+		"\n" +
+		"› Just reply with one short interesting fact about octopuses. No tools, no code, no file edits.\n" +
+		"\n" +
+		"\n" +
+		"• Octopuses have three hearts and blue blood.\n" +
+		"\n" +
+		"\n" +
+		"› Write tests for @filename\n" +
+		"\n" +
+		"  gpt-5.6-sol high · /tmp\n"
+	want := "• You have 3 usage limit resets available. Run /usage to use one.\n" +
+		"\n" +
+		"› Just reply with one short interesting fact about octopuses. No tools, no code, no file edits.\n" +
+		"\n" +
+		"\n" +
+		"• Octopuses have three hearts and blue blood.\n" +
+		"\n" +
+		"\n" +
+		"\n" +
+		"  gpt-5.6-sol high · /tmp\n"
+	got := StripCodexComposer(pane)
+	if got != want {
+		t.Errorf("StripCodexComposer real capture = %q, want %q", got, want)
+	}
+}
+
+// TestStripCodexComposerKnownLimitation pins a documented, accepted residual
+// risk (see the "Residual, accepted risk" note on codexComposerBeforeFooterRE):
+// a genuinely-submitted message whose real, unfootered response is itself the
+// literal LAST thing in the captured text, and that response happens to
+// contain the same " · /" shape as the status footer, is misidentified as a
+// composer line and stripped. This differs from the fixed mid-transcript case
+// (a footer-shaped response with real content after it, which correctly
+// survives) only in that the confusable text must be the true tail of the
+// buffer — in practice almost always the real footer, not a coincidence. This
+// test pins the CURRENT behavior so any future change here is a visible,
+// intentional diff rather than a silent regression.
+func TestStripCodexComposerKnownLimitation(t *testing.T) {
+	pane := "› Tell me a fact\n\n• fact is at foo · /bar\n"
+	want := "\n• fact is at foo · /bar\n"
+	got := StripCodexComposer(pane)
+	if got != want {
+		t.Errorf("known-limitation pin drifted: StripCodexComposer(%q) = %q, want %q", pane, got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Codex's TUI always renders a persistent `› <suggested prompt>` line in its idle composer/input box (a randomized placeholder, or an unsent operator draft), which was leaking into pane text sent to classification and the LLM consult context — the LLM would misread it as a real instruction or agent statement.
- Adds `domain.StripCodexComposer`, gated strictly on `agent_type == "codex"` (`claude`/other agent types are byte-for-byte untouched), wired into both places raw pane text reaches classification/LLM context: `classify.Classifier.Classify` and `daemon.paneExcerpt`'s independent deep-read path.
- The strip only removes a `›` line when it's immediately followed (modulo blank lines) by the composer's status footer (e.g. `gpt-5.6-sol high · /tmp`), anchored on true end-of-text. This distinguishes the live, not-yet-submitted composer from a **past submitted message** that Codex renders with the same `›` prefix — discovered via live testing, where an earlier, more aggressive version of this fix was deleting real conversation history. A documented, narrow residual limitation remains (see the doc comment on `codexComposerBeforeFooterRE`) and is pinned by a test.

## Test plan
- [x] `go test -tags "vectors cpu" ./... -count=1` — full suite passes
- [x] `gofmt -l .` / `go vet -tags "vectors cpu" ./...` — clean
- [x] New unit tests: `internal/domain/codex_test.go` (table-driven + 2 real-capture pins + adversarial/known-limitation cases), `internal/classify/classify_test.go` (`TestCodexComposerStrippedOnlyForCodex`), `internal/daemon/paneexcerpt_test.go`
- [x] New golden fixture: `internal/classify/testdata/transcripts/codex_idle.txt`
- [x] Live-verified against 3 real codex sessions (local dev build, `hap daemon --ensure`), reading the daemon's own `audit_log.pane_excerpt`: confirmed the trailing composer placeholder is stripped, real submitted messages + agent responses survive intact, and the status footer survives
- [x] Two rounds of code review (initial + fresh re-review after a mid-implementation redesign), findings addressed