### PR TITLE
docs: fix stale learning.graduation_n example after default change

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -622,7 +622,7 @@ hap task-source add --agent frontend-dev ./docs/frontend-tasks.md
 hap task-source add --agent backend-dev --template 'Do this next: {next_task_content} (full list: {task_list_path})' ./docs/backend-tasks.md
 
 # lower the graduation bar during initial training
-hap config set learning.graduation_n 3
+hap config set learning.graduation_n 1
 ```
 
 ### handle a batch of escalations


### PR DESCRIPTION
## Summary
- `learning.graduation_n`'s default dropped from 3 to 2 in a prior commit (509d7d5d), but `.claude/skills/hap/SKILL.md`'s "lower the graduation bar during initial training" example still set it to `3` — no longer lower than the new default of 2. Fixed to `1`, the only value below 2 in the valid 1–10 range.
- Audited the rest of the repo for other stale references to the old default (config validation bounds, tests, other docs/examples): none found. `config.go`'s zero-fallback and the 1–10 bound in `frontend.go` are default-value-agnostic, and existing tests (`config_test.go`, `daemon_test.go`, `decide_test.go`) already read the default dynamically via `Default()` or set their own explicit override — none hardcode the old default of 3.

## Test plan
- [x] `go test -tags "vectors cpu" ./... -count=1` — full suite passes
- [x] `gofmt -l .` / `go vet -tags "vectors cpu" ./...` — clean
- [x] Repo-wide grep audit of every `graduation_n`/`GraduationN` reference for staleness