### PR TITLE
#1 feat: add `hap task` CRUD over task-list items

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -459,10 +459,12 @@ task doesn't interrupt a working agent; it's picked up on the agent's next idle.
 
 ### template placeholders
 
-the prompt sent to the agent is rendered from a template. the default is:
+the prompt sent to the agent is rendered from a template. the default steers the
+agent to manage its list through the `hap task` CLI with its own name pre-filled
+in every command (and a `--path` fallback for sources that aren't name-addressable):
 
 ```
-Your next task is {next_task_content}. Read the full tasks list at {task_list_path}.
+Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks: `hap task {agent_name} list` to view them and `hap task {agent_name} done <n>` to mark one complete as you go (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`).
 ```
 
 - `{next_task_content}` — the text of the next unchecked item (or `"none"` when the list is complete)

--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -422,6 +422,41 @@ remove a task source by index:
 hap task-source remove <index>
 ```
 
+### manage the task items (CRUD)
+
+`hap task` edits the checklist items *inside* a source's file (whereas
+`hap task-source` manages which file an agent points at). Address a list either
+by the agent whose task source it is, or with `--path <file>` for any checklist
+(and for workspace-scoped sources, which aren't addressable by agent name).
+
+tasks are numbered by their **position in the file** (1..N, counting checked and
+unchecked alike). the number never changes with a status filter — `done 3`
+always means the third item in the file. numbers *do* shift after `add`/`remove`,
+so every mutating command re-prints the renumbered list. the checkbox is shown
+verbatim, so an in-progress `[-]` item (what the generated-task flow writes for
+the task an agent is actively working) renders as `[-]` and is *not* counted as
+pending (only truly-unchecked `[ ]` items are).
+
+```bash
+hap task backend-dev list                 # all items, with status + number
+hap task backend-dev list --status pending  # or: done | all (default all)
+hap task backend-dev get 3                 # show one item
+hap task backend-dev add "wire up retries" # append a new unchecked item
+hap task backend-dev done 2                # tick item 2 off ([x])
+hap task backend-dev undone 2              # re-open item 2 ([ ])
+hap task backend-dev update 2 "new text"   # edit text, keep status
+hap task backend-dev remove 2              # delete item 2
+
+hap task --path ./docs/tasks.md list       # operate on any checklist file
+```
+
+resolution by agent name matches the `agent` selector a task source was
+registered with (its short name, id, or type). if the name matches no source,
+matches several, or only workspace-scoped sources exist, `hap task` errors and
+tells you to use `--path`. writes go straight to the file (atomically) — the
+daemon re-reads task files live, so no restart or reload is needed. adding a
+task doesn't interrupt a working agent; it's picked up on the agent's next idle.
+
 ### template placeholders
 
 the prompt sent to the agent is rendered from a template. the default is:
@@ -696,7 +731,7 @@ hap signatures reembed
 
 ## notes
 
-- `hap status`, `hap agents`, `hap escalations`, `hap audit`, `hap signatures list`, `hap signatures show`, `hap config show`, `hap config fields`, `hap config path`, `hap rules list`, `hap task-source list`, `hap kill-history`, `hap state-dir`, `hap paths`, and `hap version` are read-only and safe to run anytime.
+- `hap status`, `hap agents`, `hap escalations`, `hap audit`, `hap signatures list`, `hap signatures show`, `hap config show`, `hap config fields`, `hap config path`, `hap rules list`, `hap task-source list`, `hap task <agent> list`, `hap task <agent> get`, `hap kill-history`, `hap state-dir`, `hap paths`, and `hap version` are read-only and safe to run anytime.
 - `hap confirm` and `hap resolve` with `--send` will deliver text to an agent pane — be mindful of what you send.
 - `hap dismiss` drops escalations without responding — safe, nothing is sent or learned, audit rows kept as `dismissed`.
 - `hap escalations prune [minutes]` bulk-dismisses old escalations (default 360 minutes).

--- a/README.md
+++ b/README.md
@@ -352,8 +352,13 @@ error = "#ff5f5f"
 # else the first
 # pending one). Other agent types skip inference entirely and escalate.
 #
-# The prompt sent to the agent is rendered from a template. The default is:
-#   "Your next task is {next_task_content}. Read the full tasks list at {task_list_path}."
+# The prompt sent to the agent is rendered from a template. The default steers
+# the agent to manage its list through the hap CLI with its own name pre-filled
+# (and a --path fallback for sources that aren't name-addressable):
+#   "Your next task is {next_task_content}. Prefer the hap CLI to manage your
+#    tasks: `hap task {agent_name} list` to view them and `hap task {agent_name}
+#    done <n>` to mark one complete as you go (if that name isn't recognized,
+#    use `--path {task_list_path}` in place of `{agent_name}`)."
 # When every item is checked off, the prompt is still sent with
 # {next_task_content} = "none", so the template can steer what an idle agent
 # does when the list is done.

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -66,6 +66,9 @@ Configure:
   config [show|fields|path|set <field> <value>|set-threshold <situation> <value>]
   rules [list|add <regex>|remove <index>]      never-auto patterns
   task-source [add] [--agent A] [--workspace W] [--template T] <checklist.md> | list | remove <index>
+  task [<agent> | --path F] list [--status all|pending|done] | get <n> | add <text>
+                        | done <n> | undone <n> | update <n> <text> | remove <n>
+                        CRUD the checklist items in an agent's task list
   clear-data --yes      reset learned history + audit data
 
   version               print version

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -71,6 +71,8 @@ func Run(ctx context.Context, app *frontend.App, out io.Writer, verb string, arg
 		return rules(ctx, app, out, args)
 	case "task-source":
 		return taskSource(ctx, app, out, args)
+	case "task":
+		return task(ctx, app, out, args)
 	case "rename":
 		return rename(ctx, app, out, args)
 	case "signatures", "sigs":
@@ -842,6 +844,203 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 	}
 	fmt.Fprintf(out, "task source added: %s\n", fs.Arg(0))
 	return nil
+}
+
+// task manages the checklist ITEMS inside a task source's file (as opposed to
+// task-source, which manages the source config). The target is either a
+// positional <agent> (resolved to its configured task source) or --path <file>
+// to operate on any checklist directly. Tasks are addressed by their 1-based
+// position among all items in the file; every mutating op re-prints the
+// renumbered list so the caller always sees fresh numbers.
+func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
+	usage := "usage: task [<agent> | --path <file>] list [--status all|pending|done] | get <n> | add <text> | done <n> | undone <n> | update <n> <text> | remove <n>"
+	agent, path, args, err := taskTarget(args)
+	if err != nil {
+		return err
+	}
+	if agent == "" && path == "" {
+		return fmt.Errorf("%s", usage)
+	}
+	if len(args) == 0 {
+		return fmt.Errorf("%s", usage)
+	}
+	op, rest := args[0], args[1:]
+	switch op {
+	case "list", "ls":
+		return taskList(app, out, agent, path, rest)
+	case "get", "show":
+		idx, err := taskIndexArg(rest)
+		if err != nil {
+			return err
+		}
+		it, err := app.GetTask(agent, path, idx)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(out, formatTask(it))
+		return nil
+	case "add", "create":
+		text := strings.TrimSpace(strings.Join(rest, " "))
+		if text == "" {
+			return fmt.Errorf("usage: task %s add <text>", taskTargetLabel(agent, path))
+		}
+		items, idx, err := app.AddTask(agent, path, text)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "added task #%d\n", idx)
+		printTaskList(out, items, "all")
+		return nil
+	case "done", "check":
+		return taskToggle(app, out, agent, path, rest, true)
+	case "undone", "uncheck", "reopen":
+		return taskToggle(app, out, agent, path, rest, false)
+	case "update", "edit":
+		if len(rest) < 2 {
+			return fmt.Errorf("usage: task %s update <n> <text>", taskTargetLabel(agent, path))
+		}
+		idx, err := taskIndexArg(rest[:1])
+		if err != nil {
+			return err
+		}
+		text := strings.TrimSpace(strings.Join(rest[1:], " "))
+		items, err := app.EditTask(agent, path, idx, text)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "updated task #%d\n", idx)
+		printTaskList(out, items, "all")
+		return nil
+	case "remove", "rm", "delete", "del":
+		idx, err := taskIndexArg(rest)
+		if err != nil {
+			return err
+		}
+		items, err := app.DeleteTask(agent, path, idx)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "removed task #%d\n", idx)
+		printTaskList(out, items, "all")
+		return nil
+	}
+	return fmt.Errorf("unknown task op %q\n%s", op, usage)
+}
+
+// taskTarget peels the leading target off a `task` argument list: either
+// --path <file> (also --path=<file>) or a positional <agent>. It returns the
+// resolved agent/path and the remaining args (the op and its arguments).
+func taskTarget(args []string) (agent, path string, rest []string, err error) {
+	if len(args) == 0 {
+		return "", "", nil, nil
+	}
+	switch {
+	case args[0] == "--path" || args[0] == "-path":
+		if len(args) < 2 {
+			return "", "", nil, fmt.Errorf("--path requires a file argument")
+		}
+		return "", args[1], args[2:], nil
+	case strings.HasPrefix(args[0], "--path="):
+		return "", strings.TrimPrefix(args[0], "--path="), args[1:], nil
+	case strings.HasPrefix(args[0], "-"):
+		return "", "", nil, fmt.Errorf("expected an agent name or --path <file> before the task op, got %q", args[0])
+	default:
+		return args[0], "", args[1:], nil
+	}
+}
+
+func taskTargetLabel(agent, path string) string {
+	if path != "" {
+		return "--path " + path
+	}
+	return agent
+}
+
+func taskIndexArg(args []string) (int, error) {
+	if len(args) == 0 {
+		return 0, fmt.Errorf("a task number is required (see: task ... list)")
+	}
+	n, err := strconv.Atoi(args[0])
+	if err != nil {
+		return 0, fmt.Errorf("invalid task number %q", args[0])
+	}
+	if n < 1 {
+		return 0, fmt.Errorf("task number must be 1 or greater, got %d", n)
+	}
+	return n, nil
+}
+
+func taskToggle(app *frontend.App, out io.Writer, agent, path string, rest []string, done bool) error {
+	idx, err := taskIndexArg(rest)
+	if err != nil {
+		return err
+	}
+	items, err := app.SetTaskDone(agent, path, idx, done)
+	if err != nil {
+		return err
+	}
+	state := "done"
+	if !done {
+		state = "pending"
+	}
+	fmt.Fprintf(out, "task #%d marked %s\n", idx, state)
+	printTaskList(out, items, "all")
+	return nil
+}
+
+func taskList(app *frontend.App, out io.Writer, agent, path string, args []string) error {
+	fs := flag.NewFlagSet("task list", flag.ContinueOnError)
+	status := fs.String("status", "all", "filter by status: all|pending|done")
+	fs.SetOutput(out)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	switch *status {
+	case "all", "pending", "done":
+	default:
+		return fmt.Errorf("invalid --status %q (all|pending|done)", *status)
+	}
+	items, err := app.ListTasks(agent, path)
+	if err != nil {
+		return err
+	}
+	printTaskList(out, items, *status)
+	return nil
+}
+
+// formatTask renders one item, preserving its raw checkbox rune so an
+// in-progress "[-]" (or any non-standard marker) is shown as-is rather than
+// collapsed to "[x]".
+func formatTask(it domain.ChecklistItem) string {
+	return fmt.Sprintf("#%d\t[%s]\t%s", it.Index, it.Mark, it.Text)
+}
+
+// printTaskList prints items matching the status filter, numbered by absolute
+// file position (the number never depends on the filter), then a count summary.
+func printTaskList(out io.Writer, items []domain.ChecklistItem, status string) {
+	shown, done := 0, 0
+	for _, it := range items {
+		if it.Done {
+			done++
+		}
+		if status == "pending" && it.Done {
+			continue
+		}
+		if status == "done" && !it.Done {
+			continue
+		}
+		fmt.Fprintln(out, formatTask(it))
+		shown++
+	}
+	if shown == 0 {
+		if len(items) == 0 {
+			fmt.Fprintln(out, "no tasks in this list")
+		} else {
+			fmt.Fprintf(out, "no %s tasks (%d total)\n", status, len(items))
+		}
+		return
+	}
+	fmt.Fprintf(out, "%d task(s): %d pending, %d done\n", len(items), len(items)-done, done)
 }
 
 func clearData(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -736,3 +736,195 @@ func TestPathsCmd(t *testing.T) {
 		t.Errorf("paths must show the labeled state dir, got:\n%s", out)
 	}
 }
+
+// writeTaskFile writes a checklist file in a fresh temp dir and returns its
+// path. Kept off the config dir so the daemon/config lock is never involved.
+func writeTaskFile(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "tasks.md")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestTaskListStatusFilterPreservesNumbers(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] one\n- [x] two\n- [ ] three\n")
+
+	out, err := run(t, app, "task", "--path", path, "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"#1", "#2", "#3", "one", "two", "three", "3 task(s): 2 pending, 1 done"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list missing %q, got:\n%s", want, out)
+		}
+	}
+
+	// A pending filter drops item #2 but must keep #1 and #3 numbered by their
+	// absolute file position — never renumbered 1,2.
+	out, err = run(t, app, "task", "--path", path, "list", "--status", "pending")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "#1") || !strings.Contains(out, "#3") {
+		t.Errorf("pending filter must keep absolute numbers #1 and #3, got:\n%s", out)
+	}
+	if strings.Contains(out, "two") || strings.Contains(out, "#2") {
+		t.Errorf("pending filter must hide the done item #2, got:\n%s", out)
+	}
+
+	if _, err := run(t, app, "task", "--path", path, "list", "--status", "bogus"); err == nil {
+		t.Error("invalid --status must error")
+	}
+}
+
+// TestTaskInProgressMarkerFaithful pins that an in-progress "[-]" item (what
+// this codebase's generated-task flow writes for the active task) renders as
+// "[-]", not "[x]", and is treated as not-pending by the filters.
+func TestTaskInProgressMarkerFaithful(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [-] working on it\n- [ ] queued\n")
+
+	out, err := run(t, app, "task", "--path", path, "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "[-]\tworking on it") {
+		t.Errorf("in-progress marker must render as [-], got:\n%s", out)
+	}
+
+	out, err = run(t, app, "task", "--path", path, "list", "--status", "pending")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "working on it") {
+		t.Errorf("in-progress item must not count as pending, got:\n%s", out)
+	}
+	if !strings.Contains(out, "queued") {
+		t.Errorf("pending filter must show the truly-unchecked item, got:\n%s", out)
+	}
+}
+
+func TestTaskCRUDByPath(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] first\n- [x] second\n")
+
+	// add appends an unchecked item and echoes the renumbered list.
+	out, err := run(t, app, "task", "--path", path, "add", "third task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "added task #3") || !strings.Contains(out, "third task") {
+		t.Errorf("add must report #3 and echo the list, got:\n%s", out)
+	}
+
+	// done toggles the checkbox in the file.
+	if _, err := run(t, app, "task", "--path", path, "done", "1"); err != nil {
+		t.Fatal(err)
+	}
+	// update edits text but keeps status.
+	if _, err := run(t, app, "task", "--path", path, "update", "1", "first task edited"); err != nil {
+		t.Fatal(err)
+	}
+	// remove deletes item #2 (the done "second").
+	if _, err := run(t, app, "task", "--path", path, "remove", "2"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "- [x] first task edited\n- [ ] third task\n"
+	if string(data) != want {
+		t.Errorf("file after CRUD:\n got %q\nwant %q", string(data), want)
+	}
+
+	// get returns a single item by number.
+	out, err = run(t, app, "task", "--path", path, "get", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "first task edited") || !strings.Contains(out, "[x]") {
+		t.Errorf("get #1 must show the edited done item, got:\n%s", out)
+	}
+
+	if _, err := run(t, app, "task", "--path", path, "get", "99"); err == nil {
+		t.Error("out-of-range get must error")
+	}
+}
+
+func TestTaskByAgentResolvesSource(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] alpha\n- [ ] beta\n")
+	if err := app.AddTaskSource(context.Background(), "backend", "", path, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "task", "backend", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "alpha") || !strings.Contains(out, "beta") {
+		t.Errorf("agent-resolved list must show the source's items, got:\n%s", out)
+	}
+
+	if _, err := run(t, app, "task", "backend", "done", "2"); err != nil {
+		t.Fatal(err)
+	}
+	// AddTaskSource abs-resolves the path, so read it back from the source.
+	cfg, _ := app.Config()
+	data, _ := os.ReadFile(cfg.TaskSources[0].Path)
+	if want := "- [ ] alpha\n- [x] beta\n"; string(data) != want {
+		t.Errorf("done via agent name:\n got %q\nwant %q", string(data), want)
+	}
+}
+
+func TestTaskResolutionErrors(t *testing.T) {
+	app, _ := testApp(t)
+	pathA := writeTaskFile(t, "- [ ] a\n")
+	pathB := writeTaskFile(t, "- [ ] b\n")
+
+	// Unknown agent → error pointing at task-source add.
+	if _, err := run(t, app, "task", "ghost", "list"); err == nil {
+		t.Error("unknown agent must error")
+	} else if !strings.Contains(err.Error(), "task-source add") {
+		t.Errorf("unknown-agent error should suggest adding a source, got: %v", err)
+	}
+
+	// Workspace-only source (empty agent) is not addressable by name.
+	if err := app.AddTaskSource(context.Background(), "", "codex-*", pathA, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run(t, app, "task", "anyone", "list"); err == nil {
+		t.Error("workspace-only source must not be addressable by agent name")
+	} else if !strings.Contains(err.Error(), "--path") {
+		t.Errorf("workspace-only error should point at --path, got: %v", err)
+	}
+
+	// Two sources for the same agent → ambiguous.
+	if err := app.AddTaskSource(context.Background(), "dup", "", pathA, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(context.Background(), "dup", "", pathB, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run(t, app, "task", "dup", "list"); err == nil {
+		t.Error("ambiguous agent must error")
+	} else if !strings.Contains(err.Error(), "matches 2 task sources") {
+		t.Errorf("ambiguous error should name the count, got: %v", err)
+	}
+}
+
+func TestTaskMissingTargetOrOp(t *testing.T) {
+	app, _ := testApp(t)
+	if _, err := run(t, app, "task"); err == nil {
+		t.Error("task with no args must show usage error")
+	}
+	path := writeTaskFile(t, "- [ ] a\n")
+	if _, err := run(t, app, "task", "--path", path); err == nil {
+		t.Error("task with a target but no op must error")
+	}
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1307,9 +1307,13 @@ func TestIdleDeclaredTaskSourceDrivesNextPrompt(t *testing.T) {
 	h.herdr.setPane(idlePane)
 	h.seedAutonomous(idlePane, domain.SituationIdle, domain.ActionNextDeclaredTask)
 
+	name, err := h.raw.EnsureAgentName(context.Background(), "agent-9")
+	if err != nil {
+		t.Fatal(err)
+	}
 	h.push("agent-9", "idle")
 	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
-	want := fmt.Sprintf("Your next task is step two. Read the full tasks list at %s.", taskFile)
+	want := (&domain.DeclaredTask{Task: "step two", Path: taskFile, AgentName: name}).Prompt()
 	if got := h.herdr.sentInputs()[0]; got != want {
 		t.Errorf("sent %q, want templated prompt for next unchecked item %q", got, want)
 	}
@@ -1381,9 +1385,13 @@ func TestIdleDeclaredTaskRealTaskBeatsCompletedSource(t *testing.T) {
 	h.herdr.setPane(idlePane)
 	h.seedAutonomous(idlePane, domain.SituationIdle, domain.ActionNextDeclaredTask)
 
+	name, err := h.raw.EnsureAgentName(context.Background(), "agent-21")
+	if err != nil {
+		t.Fatal(err)
+	}
 	h.push("agent-21", "idle")
 	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
-	want := fmt.Sprintf("Your next task is real task. Read the full tasks list at %s.", nextFile)
+	want := (&domain.DeclaredTask{Task: "real task", Path: nextFile, AgentName: name}).Prompt()
 	if got := h.herdr.sentInputs()[0]; got != want {
 		t.Errorf("sent %q, want the real remaining task to win over the completed source: %q", got, want)
 	}
@@ -1426,9 +1434,13 @@ func TestIdleDeclaredTaskCompletedListSendsNone(t *testing.T) {
 	h.herdr.setPane(idlePane)
 	h.seedAutonomous(idlePane, domain.SituationIdle, domain.ActionNextDeclaredTask)
 
+	name, err := h.raw.EnsureAgentName(context.Background(), "agent-20")
+	if err != nil {
+		t.Fatal(err)
+	}
 	h.push("agent-20", "idle")
 	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
-	want := fmt.Sprintf("Your next task is none. Read the full tasks list at %s.", taskFile)
+	want := (&domain.DeclaredTask{Task: domain.NoTaskContent, Path: taskFile, AgentName: name}).Prompt()
 	if got := h.herdr.sentInputs()[0]; got != want {
 		t.Errorf("sent %q, want completed-list prompt %q", got, want)
 	}
@@ -1448,9 +1460,13 @@ func TestIdleTaskSourceMatchesWorkspaceNameWildcard(t *testing.T) {
 	h.herdr.setPane(idlePane)
 	h.seedAutonomous(idlePane, domain.SituationIdle, domain.ActionNextDeclaredTask)
 
+	name, err := h.raw.EnsureAgentName(context.Background(), "agent-23")
+	if err != nil {
+		t.Fatal(err)
+	}
 	h.pushIn("agent-23", "w7", "idle")
 	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
-	want := fmt.Sprintf("Your next task is workspace task. Read the full tasks list at %s.", taskFile)
+	want := (&domain.DeclaredTask{Task: "workspace task", Path: taskFile, AgentName: name}).Prompt()
 	if got := h.herdr.sentInputs()[0]; got != want {
 		t.Errorf("sent %q, want workspace-name-matched prompt %q", got, want)
 	}
@@ -1493,9 +1509,13 @@ func TestIdleTaskSourceWorkspaceIdFallback(t *testing.T) {
 	h.herdr.setPane(idlePane)
 	h.seedAutonomous(idlePane, domain.SituationIdle, domain.ActionNextDeclaredTask)
 
+	name, err := h.raw.EnsureAgentName(context.Background(), "agent-25")
+	if err != nil {
+		t.Fatal(err)
+	}
 	h.pushIn("agent-25", "w9", "idle")
 	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
-	want := fmt.Sprintf("Your next task is fallback task. Read the full tasks list at %s.", taskFile)
+	want := (&domain.DeclaredTask{Task: "fallback task", Path: taskFile, AgentName: name}).Prompt()
 	if got := h.herdr.sentInputs()[0]; got != want {
 		t.Errorf("sent %q, want id-fallback-matched prompt %q", got, want)
 	}
@@ -1534,7 +1554,7 @@ func TestIdleTaskSourceMatchesAgentShortName(t *testing.T) {
 
 	h.push("agent-15", "idle")
 	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
-	want := fmt.Sprintf("Your next task is short-name task. Read the full tasks list at %s.", taskFile)
+	want := (&domain.DeclaredTask{Task: "short-name task", Path: taskFile, AgentName: "docs-writer"}).Prompt()
 	if got := h.herdr.sentInputs()[0]; got != want {
 		t.Errorf("sent %q, want the short-name-matched task prompt %q", got, want)
 	}

--- a/internal/daemon/rewrite_test.go
+++ b/internal/daemon/rewrite_test.go
@@ -32,7 +32,11 @@ func idleRewriteHarness(t *testing.T, agent, extraCfg string,
 	h, fr := newHarnessRewriter(t, cfg, rewrite)
 	h.herdr.setPane(idlePane)
 	h.seedAutonomous(idlePane, domain.SituationIdle, domain.ActionNextDeclaredTask)
-	original := fmt.Sprintf("Your next task is step two. Read the full tasks list at %s.", taskFile)
+	name, err := h.raw.EnsureAgentName(context.Background(), agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := (&domain.DeclaredTask{Task: "step two", Path: taskFile, AgentName: name}).Prompt()
 	return h, fr, original
 }
 

--- a/internal/daemon/taskreview_test.go
+++ b/internal/daemon/taskreview_test.go
@@ -152,8 +152,12 @@ func TestDeclaredTaskLLMReviewSendProposedSentinel(t *testing.T) {
 			Rationale: "ready to go", ConfidentScore: 90, Status: "pending"}, nil
 	}
 
+	name, err := h.raw.EnsureAgentName(context.Background(), "agent-sentinel")
+	if err != nil {
+		t.Fatal(err)
+	}
 	h.push("agent-sentinel", "idle")
-	want := "Your next task is refactor the parser. Read the full tasks list at " + taskFile + "."
+	want := (&domain.DeclaredTask{Task: "refactor the parser", Path: taskFile, AgentName: name}).Prompt()
 	waitFor(t, 5*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
 	if got := h.herdr.sentInputs()[0]; got != want {
 		t.Errorf("sentinel should send the rendered task verbatim, got %q, want %q", got, want)
@@ -186,6 +190,10 @@ func TestDeclaredTaskLLMReviewDeclineEscalates(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	name, err := h.raw.EnsureAgentName(ctx, "agent-dec")
+	if err != nil {
+		t.Fatal(err)
+	}
 	h.push("agent-dec", "idle")
 	var esc []domain.AuditRecord
 	waitFor(t, 5*time.Second, func() bool {
@@ -198,7 +206,7 @@ func TestDeclaredTaskLLMReviewDeclineEscalates(t *testing.T) {
 	if esc[0].Suggestion != "LLM suggested: "+domain.ActionNoopSuggestion {
 		t.Errorf("decline suggestion = %q, want the LLM's exact recommendation (no reply)", esc[0].Suggestion)
 	}
-	wantTask := "Your next task is update the changelog. Read the full tasks list at " + taskFile + "."
+	wantTask := (&domain.DeclaredTask{Task: "update the changelog", Path: taskFile, AgentName: name}).Prompt()
 	if !strings.Contains(esc[0].Rationale, wantTask) {
 		t.Errorf("decline rationale should show the original proposed task, got %q", esc[0].Rationale)
 	}
@@ -410,9 +418,13 @@ func TestDeclaredTaskLLMReviewOptOut(t *testing.T) {
 	}
 	h.seedAutonomous(idlePane, domain.SituationIdle, domain.ActionNextDeclaredTask)
 
+	name, err := h.raw.EnsureAgentName(context.Background(), "agent-opt")
+	if err != nil {
+		t.Fatal(err)
+	}
 	h.push("agent-opt", "idle")
 	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
-	want := "Your next task is write the docs. Read the full tasks list at " + taskFile + "."
+	want := (&domain.DeclaredTask{Task: "write the docs", Path: taskFile, AgentName: name}).Prompt()
 	if got := h.herdr.sentInputs()[0]; got != want {
 		t.Errorf("opt-out source should send the templated prompt directly, got %q", got)
 	}

--- a/internal/domain/decide_test.go
+++ b/internal/domain/decide_test.go
@@ -145,7 +145,7 @@ func TestRunawayGuardIdleRetainsDeclaredTaskSuggestion(t *testing.T) {
 	if d.Action != ActionEscalate || d.Reason != ReasonRateLimited {
 		t.Fatalf("rate-limited idle situation must escalate, got %+v", d)
 	}
-	want := "send next declared task: Your next task is write the changelog. Read the full tasks list at /tasks.md."
+	want := "send next declared task: " + in.DeclaredTask.Prompt()
 	if d.Suggestion != want {
 		t.Fatalf("suggestion = %q, want %q", d.Suggestion, want)
 	}
@@ -277,7 +277,7 @@ func TestIdleDeclaredTaskSource(t *testing.T) {
 		ActionNextDeclaredTask, ActionNextDeclaredTask, ActionNextDeclaredTask)
 	in.DeclaredTask = &DeclaredTask{Task: "Implement the config loader", Path: "/docs/tasks.md"}
 	d := Decide(in)
-	want := "Your next task is Implement the config loader. Read the full tasks list at /docs/tasks.md."
+	want := in.DeclaredTask.Prompt()
 	if d.Action != ActionSend || d.Input != want {
 		t.Fatalf("declared task source should drive the next prompt, got %+v", d)
 	}
@@ -306,7 +306,7 @@ func TestIdleDeclaredTaskCompletedListStillSends(t *testing.T) {
 		ActionNextDeclaredTask, ActionNextDeclaredTask, ActionNextDeclaredTask)
 	in.DeclaredTask = &DeclaredTask{Task: NoTaskContent, Path: "/docs/tasks.md"}
 	d := Decide(in)
-	want := "Your next task is none. Read the full tasks list at /docs/tasks.md."
+	want := in.DeclaredTask.Prompt()
 	if d.Action != ActionSend || d.Input != want {
 		t.Fatalf("completed declared list should still send the templated prompt, got %+v", d)
 	}

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -23,7 +23,14 @@ var inProgressItemRE = regexp.MustCompile(`^\s*(?:[-*+]\s+)?\[-\]\s*(.+)$`)
 // item (or NoTaskContent when the list is complete), {task_list_path} is
 // the task-source file path, {agent_name} is the agent's short name, {cwd}
 // is the agent's working directory (the project it is in).
-const DefaultNextTaskTemplate = "Your next task is {next_task_content}. Read the full tasks list at {task_list_path}."
+//
+// The default steers the agent to manage its list through the `hap task` CLI
+// with the agent's own name pre-filled in every command (so `hap task
+// {agent_name} done <n>` resolves this exact source). It also spells out the
+// `--path {task_list_path}` form so a source that isn't name-addressable (one
+// scoped by agent type, pane id, workspace, or "any") is still manageable —
+// `hap task {agent_name}` errors on those, and the path form always works.
+const DefaultNextTaskTemplate = "Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks: `hap task {agent_name} list` to view them and `hap task {agent_name} done <n>` to mark one complete as you go (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`)."
 
 // NoTaskContent is the {next_task_content} value when a declared list has
 // no unchecked item left: the templated prompt is still delivered so the

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -204,6 +204,22 @@ func ParseChecklist(content string) []ChecklistItem {
 	return items
 }
 
+// validateTaskText trims surrounding whitespace and rejects empty or
+// multi-line text. A checklist item is a single physical line, so an embedded
+// newline or carriage return would silently inject extra items — or a forged
+// "[x]" status — into the file while the command reports one task written.
+// Every helper that writes operator-supplied item text goes through this.
+func validateTaskText(text string) (string, error) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", fmt.Errorf("task text must not be empty")
+	}
+	if strings.ContainsAny(text, "\r\n") {
+		return "", fmt.Errorf("task text must be a single line (no embedded newlines)")
+	}
+	return text, nil
+}
+
 // outOfRangeErr reports a task number that names no item, quoting the valid
 // range so a caller (or coding agent) can re-list and retry.
 func outOfRangeErr(index, count int) error {
@@ -245,12 +261,12 @@ func SetChecklistItemDone(content string, index int, done bool) (string, error) 
 }
 
 // EditChecklistItemText replaces item index's text, preserving its prefix and
-// its current checkbox marker (a done item stays done). The new text must be
-// non-empty.
+// its current checkbox marker (a done item stays done). The new text must be a
+// non-empty single line.
 func EditChecklistItemText(content string, index int, text string) (string, error) {
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return "", fmt.Errorf("task text must not be empty")
+	text, err := validateTaskText(text)
+	if err != nil {
+		return "", err
 	}
 	return rewriteChecklistLine(content, index, func(prefix, marker, _ string) string {
 		return prefix + "[" + marker + "] " + text
@@ -281,11 +297,11 @@ func DeleteChecklistItem(content string, index int) (string, error) {
 // item's indent+bullet — usually the list's top-level style — so appending
 // never accidentally nests the new task under a preceding sub-item. With no
 // existing items it is appended at end of file with a default "- " bullet. The
-// text must be non-empty.
+// text must be a non-empty single line.
 func AppendChecklistItem(content, text string) (string, int, error) {
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return "", 0, fmt.Errorf("task text must not be empty")
+	text, err := validateTaskText(text)
+	if err != nil {
+		return "", 0, err
 	}
 	items := ParseChecklist(content)
 	newIndex := len(items) + 1

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -140,6 +141,159 @@ func InProgressDeclaredTasks(content string) []string {
 		}
 	}
 	return inProgress
+}
+
+// checklistItemRE matches a single checklist line, capturing three groups:
+// the prefix (indent plus an optional "- "/"* "/"+ " bullet), the single
+// checkbox marker rune, and the task text. Its marker class is exactly the
+// union of uncheckedItemRE's space and checkedItemRE's [xX+\-*], so an item's
+// done-ness derived here (marker != space) always agrees with what those two
+// authoritative regexes classify — TestChecklistDoneAgreesWithNextDeclared
+// guards that. The prefix is preserved verbatim on rewrite so an item's
+// indentation and bullet style survive a toggle/edit; the whitespace between
+// the checkbox and the text is normalized to a single space.
+var checklistItemRE = regexp.MustCompile(`^(\s*(?:[-*+]\s+)?)\[([ xX+\-*])\]\s*(.+)$`)
+
+// ChecklistItem is one parsed checklist line addressed by its absolute
+// position among all checklist items (FR-011, CRUD surface). Index is the
+// stable-within-a-snapshot task number the `hap task` CLI exposes: it counts
+// checked and unchecked items alike in file order, so it never depends on a
+// status filter. LineNo is the item's 0-based line in the file; Prefix is the
+// original indent+bullet, preserved when the line is rewritten.
+type ChecklistItem struct {
+	Index  int
+	LineNo int
+	Prefix string
+	// Mark is the raw checkbox rune (" ", "x", "X", "+", "-", "*"). Done is the
+	// binary pending/not-pending classification used for filtering; Mark is kept
+	// so a display can render a third state faithfully — notably the "-"
+	// in-progress marker this codebase's own generated-task flow writes for the
+	// task an agent is currently working on (RenderGeneratedTaskList), which
+	// would otherwise read as "[x] done".
+	Mark string
+	Done bool
+	Text string
+}
+
+// ParseChecklist returns every checklist item in content, in file order,
+// numbered from 1. Non-item lines (headers, prose, blanks) are skipped for
+// numbering and left untouched by the mutation helpers below.
+func ParseChecklist(content string) []ChecklistItem {
+	var items []ChecklistItem
+	for lineNo, line := range strings.Split(content, "\n") {
+		m := checklistItemRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		items = append(items, ChecklistItem{
+			Index:  len(items) + 1,
+			LineNo: lineNo,
+			Prefix: m[1],
+			Mark:   m[2],
+			Done:   m[2] != " ",
+			Text:   strings.TrimSpace(m[3]),
+		})
+	}
+	return items
+}
+
+// outOfRangeErr reports a task number that names no item, quoting the valid
+// range so a caller (or coding agent) can re-list and retry.
+func outOfRangeErr(index, count int) error {
+	if count == 0 {
+		return fmt.Errorf("no task #%d: the checklist has no items", index)
+	}
+	return fmt.Errorf("no task #%d: valid task numbers are 1..%d", index, count)
+}
+
+// rewriteChecklistLine replaces the target item's line with fn(prefix, marker,
+// text), preserving every other line. index is 1-based over all items.
+func rewriteChecklistLine(content string, index int, fn func(prefix, marker, text string) string) (string, error) {
+	lines := strings.Split(content, "\n")
+	count := 0
+	for i, line := range lines {
+		m := checklistItemRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		count++
+		if count == index {
+			lines[i] = fn(m[1], m[2], strings.TrimSpace(m[3]))
+			return strings.Join(lines, "\n"), nil
+		}
+	}
+	return "", outOfRangeErr(index, count)
+}
+
+// SetChecklistItemDone toggles item index's checkbox to [x] (done) or [ ]
+// (pending), preserving its prefix and text.
+func SetChecklistItemDone(content string, index int, done bool) (string, error) {
+	return rewriteChecklistLine(content, index, func(prefix, _, text string) string {
+		box := "[ ]"
+		if done {
+			box = "[x]"
+		}
+		return prefix + box + " " + text
+	})
+}
+
+// EditChecklistItemText replaces item index's text, preserving its prefix and
+// its current checkbox marker (a done item stays done). The new text must be
+// non-empty.
+func EditChecklistItemText(content string, index int, text string) (string, error) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", fmt.Errorf("task text must not be empty")
+	}
+	return rewriteChecklistLine(content, index, func(prefix, marker, _ string) string {
+		return prefix + "[" + marker + "] " + text
+	})
+}
+
+// DeleteChecklistItem removes item index's line entirely, leaving every other
+// line untouched.
+func DeleteChecklistItem(content string, index int) (string, error) {
+	lines := strings.Split(content, "\n")
+	count := 0
+	for i, line := range lines {
+		if !checklistItemRE.MatchString(line) {
+			continue
+		}
+		count++
+		if count == index {
+			lines = append(lines[:i], lines[i+1:]...)
+			return strings.Join(lines, "\n"), nil
+		}
+	}
+	return "", outOfRangeErr(index, count)
+}
+
+// AppendChecklistItem adds a new unchecked item with the given text and
+// returns the updated content plus the new item's 1-based number. The item is
+// inserted just after the last existing checklist item and takes the FIRST
+// item's indent+bullet — usually the list's top-level style — so appending
+// never accidentally nests the new task under a preceding sub-item. With no
+// existing items it is appended at end of file with a default "- " bullet. The
+// text must be non-empty.
+func AppendChecklistItem(content, text string) (string, int, error) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", 0, fmt.Errorf("task text must not be empty")
+	}
+	items := ParseChecklist(content)
+	newIndex := len(items) + 1
+	if len(items) == 0 {
+		out := content
+		if out != "" && !strings.HasSuffix(out, "\n") {
+			out += "\n"
+		}
+		return out + "- [ ] " + text + "\n", newIndex, nil
+	}
+	newLine := items[0].Prefix + "[ ] " + text
+	lines := strings.Split(content, "\n")
+	insertAt := items[len(items)-1].LineNo + 1
+	lines = append(lines[:insertAt], append([]string{newLine}, lines[insertAt:]...)...)
+	return strings.Join(lines, "\n"), newIndex, nil
 }
 
 // InferredTask is a next task inferred from the agent's own transcript.

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -413,3 +413,165 @@ func TestInferNextTask(t *testing.T) {
 		})
 	}
 }
+
+func TestParseChecklist(t *testing.T) {
+	content := "# Backend tasks\n" +
+		"- [x] scaffold\n" +
+		"prose in the middle, not an item\n" +
+		"  * [ ] nested pending\n" +
+		"- [-] in progress\n" +
+		"\n" +
+		"+ [ ] final\n"
+	items := ParseChecklist(content)
+	want := []ChecklistItem{
+		{Index: 1, LineNo: 1, Prefix: "- ", Mark: "x", Done: true, Text: "scaffold"},
+		{Index: 2, LineNo: 3, Prefix: "  * ", Mark: " ", Done: false, Text: "nested pending"},
+		{Index: 3, LineNo: 4, Prefix: "- ", Mark: "-", Done: true, Text: "in progress"},
+		{Index: 4, LineNo: 6, Prefix: "+ ", Mark: " ", Done: false, Text: "final"},
+	}
+	if len(items) != len(want) {
+		t.Fatalf("ParseChecklist returned %d items, want %d: %+v", len(items), len(want), items)
+	}
+	for i := range want {
+		if items[i] != want[i] {
+			t.Errorf("item %d = %+v, want %+v", i, items[i], want[i])
+		}
+	}
+}
+
+// TestChecklistDoneAgreesWithNextDeclared pins the invariant that an item's
+// Done flag (marker != space) agrees with the authoritative unchecked/checked
+// regexes: the first !Done item ParseChecklist reports is exactly the one
+// NextDeclaredTask (the daemon's send path) would pick.
+func TestChecklistDoneAgreesWithNextDeclared(t *testing.T) {
+	cases := []string{
+		"- [x] a\n- [ ] b\n- [ ] c",
+		"- [X] a\n- [-] b\n- [ ] target",
+		"[ ] bare\n[x] done",
+		"- [x] all\n- [X] done",
+	}
+	for _, content := range cases {
+		next := NextDeclaredTask(content)
+		var firstPending string
+		for _, it := range ParseChecklist(content) {
+			if !it.Done {
+				firstPending = it.Text
+				break
+			}
+		}
+		if firstPending != next {
+			t.Errorf("first pending %q disagrees with NextDeclaredTask %q for:\n%s", firstPending, next, content)
+		}
+	}
+}
+
+// TestChecklistNumberingIsAbsolute proves task numbers are file positions, not
+// positions within a status-filtered view: filtering to pending items keeps
+// each item's original Index, so `done <N>` refers to the same item regardless
+// of any filter the operator listed with.
+func TestChecklistNumberingIsAbsolute(t *testing.T) {
+	content := "- [ ] one\n- [x] two\n- [ ] three\n- [x] four\n- [ ] five"
+	items := ParseChecklist(content)
+	var pendingIndexes []int
+	for _, it := range items {
+		if !it.Done {
+			pendingIndexes = append(pendingIndexes, it.Index)
+		}
+	}
+	want := []int{1, 3, 5}
+	if len(pendingIndexes) != len(want) {
+		t.Fatalf("pending indexes = %v, want %v", pendingIndexes, want)
+	}
+	for i := range want {
+		if pendingIndexes[i] != want[i] {
+			t.Fatalf("pending indexes = %v, want %v", pendingIndexes, want)
+		}
+	}
+}
+
+func TestSetChecklistItemDone(t *testing.T) {
+	content := "# tasks\n- [ ] first\n  * [ ] second\n- [x] third"
+	got, err := SetChecklistItemDone(content, 2, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "# tasks\n- [ ] first\n  * [x] second\n- [x] third"
+	if got != want {
+		t.Errorf("SetChecklistItemDone marked wrong line:\n got %q\nwant %q", got, want)
+	}
+	// Un-checking a done item preserves prefix and text.
+	back, err := SetChecklistItemDone(want, 3, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wantBack := "# tasks\n- [ ] first\n  * [x] second\n- [ ] third"; back != wantBack {
+		t.Errorf("un-check: got %q, want %q", back, wantBack)
+	}
+	if _, err := SetChecklistItemDone(content, 9, true); err == nil {
+		t.Error("out-of-range index must error")
+	}
+}
+
+func TestEditChecklistItemText(t *testing.T) {
+	content := "- [x] old done text\n- [ ] pending"
+	got, err := EditChecklistItemText(content, 1, "new text")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Editing preserves the item's done marker.
+	if want := "- [x] new text\n- [ ] pending"; got != want {
+		t.Errorf("EditChecklistItemText: got %q, want %q", got, want)
+	}
+	if _, err := EditChecklistItemText(content, 1, "   "); err == nil {
+		t.Error("empty text must error")
+	}
+	if _, err := EditChecklistItemText(content, 5, "x"); err == nil {
+		t.Error("out-of-range index must error")
+	}
+}
+
+func TestDeleteChecklistItem(t *testing.T) {
+	content := "intro line\n- [ ] a\n- [x] b\n- [ ] c"
+	got, err := DeleteChecklistItem(content, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "intro line\n- [ ] a\n- [ ] c"; got != want {
+		t.Errorf("DeleteChecklistItem: got %q, want %q", got, want)
+	}
+	if _, err := DeleteChecklistItem(content, 9); err == nil {
+		t.Error("out-of-range index must error")
+	}
+}
+
+func TestAppendChecklistItem(t *testing.T) {
+	cases := []struct {
+		name, content, text, want string
+		wantIndex                 int
+	}{
+		{"after last item, reuse bullet", "- [x] a\n- [ ] b\n", "c", "- [x] a\n- [ ] b\n- [ ] c\n", 3},
+		{"no trailing newline", "- [ ] a", "b", "- [ ] a\n- [ ] b", 2},
+		{"nested bullet reused", "  * [ ] a\n", "b", "  * [ ] a\n  * [ ] b\n", 2},
+		{"top-level style, not the nested last item's", "- [ ] a\n  * [ ] sub\n", "b", "- [ ] a\n  * [ ] sub\n- [ ] b\n", 3},
+		{"empty file", "", "first", "- [ ] first\n", 1},
+		{"non-checklist file", "just notes\n", "first", "just notes\n- [ ] first\n", 1},
+		{"trailing prose after list", "- [ ] a\nnotes\n", "b", "- [ ] a\n- [ ] b\nnotes\n", 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, idx, err := AppendChecklistItem(c.content, c.text)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != c.want {
+				t.Errorf("content: got %q, want %q", got, c.want)
+			}
+			if idx != c.wantIndex {
+				t.Errorf("index: got %d, want %d", idx, c.wantIndex)
+			}
+		})
+	}
+	if _, _, err := AppendChecklistItem("- [ ] a", "  "); err == nil {
+		t.Error("empty text must error")
+	}
+}

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -528,6 +528,17 @@ func TestEditChecklistItemText(t *testing.T) {
 	if _, err := EditChecklistItemText(content, 5, "x"); err == nil {
 		t.Error("out-of-range index must error")
 	}
+	// An embedded newline must be rejected — it would inject an extra item (and
+	// a forged status) rather than editing one line.
+	for _, bad := range []string{"one\n- [x] injected", "a\r- [x] injected", "line1\nline2"} {
+		if _, err := EditChecklistItemText(content, 1, bad); err == nil {
+			t.Errorf("EditChecklistItemText must reject embedded newline in %q", bad)
+		}
+	}
+	// The item is unchanged after a rejected edit (validation happens before rewrite).
+	if got, _ := EditChecklistItemText(content, 1, "clean text"); got == content {
+		t.Error("a valid edit should change the content")
+	}
 }
 
 func TestDeleteChecklistItem(t *testing.T) {
@@ -573,5 +584,12 @@ func TestAppendChecklistItem(t *testing.T) {
 	}
 	if _, _, err := AppendChecklistItem("- [ ] a", "  "); err == nil {
 		t.Error("empty text must error")
+	}
+	// Embedded CR/LF must be rejected so `add` can never inject a second item
+	// (or a forged "[x]" status) while reporting a single task.
+	for _, bad := range []string{"one\n- [x] injected", "a\r\n- [x] injected", "a\rb"} {
+		if _, _, err := AppendChecklistItem("- [ ] a", bad); err == nil {
+			t.Errorf("AppendChecklistItem must reject embedded newline in %q", bad)
+		}
 	}
 }

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -87,14 +87,14 @@ func TestDeclaredTaskPrompt(t *testing.T) {
 		want string
 	}{
 		{
-			name: "default template",
-			task: DeclaredTask{Task: "add validation", Path: "/docs/tasks.md"},
-			want: "Your next task is add validation. Read the full tasks list at /docs/tasks.md.",
+			name: "default template crafts CLI commands with the agent name and a --path fallback",
+			task: DeclaredTask{Task: "add validation", Path: "/docs/tasks.md", AgentName: "brave-otter"},
+			want: "Your next task is add validation. Prefer the hap CLI to manage your tasks: `hap task brave-otter list` to view them and `hap task brave-otter done <n>` to mark one complete as you go (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`).",
 		},
 		{
 			name: "completed list uses none",
-			task: DeclaredTask{Task: NoTaskContent, Path: "/docs/tasks.md"},
-			want: "Your next task is none. Read the full tasks list at /docs/tasks.md.",
+			task: DeclaredTask{Task: NoTaskContent, Path: "/docs/tasks.md", AgentName: "brave-otter"},
+			want: "Your next task is none. Prefer the hap CLI to manage your tasks: `hap task brave-otter list` to view them and `hap task brave-otter done <n>` to mark one complete as you go (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`).",
 		},
 		{
 			name: "custom template",

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -1437,6 +1437,195 @@ func (a *App) AddTaskSource(ctx context.Context, agent, workspace, path, templat
 	})
 }
 
+// --- Task-item CRUD (the `hap task` surface) -----------------------------
+//
+// These operate on the checklist items INSIDE a task source's markdown file,
+// not on the source config. The daemon re-reads task files live on every idle
+// event (Daemon.declaredTask → ReadTaskFile), so a direct file write is picked
+// up with no config lock and no daemon nudge — writes just go through an
+// atomic temp+rename so a concurrent daemon read never sees a half-written file.
+
+// resolveTaskFilePath finds the checklist file for an agent by matching the
+// task-source Agent selector (the id/name/type the source was registered with)
+// against the token the caller supplied. Exactly one match wins; zero or many
+// is an error, as is a source addressable only by workspace — the caller falls
+// back to --path in those cases. This deliberately does NOT reuse the daemon's
+// declaredTask precedence (live workspace, first-real-task-wins): here we are
+// choosing a file to edit, not a task to send.
+func resolveTaskFilePath(cfg config.Config, agent string) (string, error) {
+	var matches []config.TaskSource
+	workspaceOnly := false
+	for _, src := range cfg.TaskSources {
+		if src.Agent == "" {
+			if src.Workspace != "" && src.Workspace != "*" {
+				workspaceOnly = true
+			}
+			continue
+		}
+		if src.Agent == agent {
+			matches = append(matches, src)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0].Path, nil
+	case 0:
+		if workspaceOnly {
+			return "", fmt.Errorf("no task source is scoped to agent %q; workspace-scoped sources exist but aren't addressable by name — use --path <file>", agent)
+		}
+		return "", fmt.Errorf("no task source for agent %q; add one first: hap task-source add --agent %s <checklist.md>", agent, agent)
+	default:
+		paths := make([]string, len(matches))
+		for i, m := range matches {
+			paths[i] = m.Path
+		}
+		return "", fmt.Errorf("agent %q matches %d task sources (%s); use --path <file> to pick one", agent, len(matches), strings.Join(paths, ", "))
+	}
+}
+
+// taskFilePath resolves the checklist file to operate on: an explicit --path
+// (relative paths are made absolute so they mean what the caller's shell sees)
+// takes precedence; otherwise the agent's configured source is resolved.
+func (a *App) taskFilePath(agent, path string) (string, error) {
+	if path != "" {
+		if abs, err := filepath.Abs(path); err == nil {
+			return abs, nil
+		}
+		return path, nil
+	}
+	if agent == "" {
+		return "", fmt.Errorf("specify an agent name, or --path <file>")
+	}
+	cfg, err := a.Config()
+	if err != nil {
+		return "", err
+	}
+	return resolveTaskFilePath(cfg, agent)
+}
+
+// writeFileAtomic writes data to path via a temp file in the same directory
+// then renames it into place, so a concurrent reader (the daemon) sees either
+// the old or the new file, never a partial write.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".hap-task-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // best-effort cleanup; a no-op after a successful rename
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// mutateTaskFile reads path, applies fn to its content, writes the result
+// atomically, and returns the re-parsed item list so callers can echo the
+// freshly renumbered checklist.
+func mutateTaskFile(path string, fn func(content string) (string, error)) ([]domain.ChecklistItem, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	out, err := fn(string(data))
+	if err != nil {
+		return nil, err
+	}
+	if err := writeFileAtomic(path, []byte(out), 0o600); err != nil {
+		return nil, err
+	}
+	return domain.ParseChecklist(out), nil
+}
+
+// ListTasks returns every checklist item in the resolved source file, numbered
+// by absolute file position (checked and unchecked alike). Filtering by status
+// is the CLI's job — the numbers here never depend on a filter.
+func (a *App) ListTasks(agent, path string) ([]domain.ChecklistItem, error) {
+	p, err := a.taskFilePath(agent, path)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+	return domain.ParseChecklist(string(data)), nil
+}
+
+// GetTask returns the single item addressed by its 1-based number.
+func (a *App) GetTask(agent, path string, index int) (domain.ChecklistItem, error) {
+	items, err := a.ListTasks(agent, path)
+	if err != nil {
+		return domain.ChecklistItem{}, err
+	}
+	for _, it := range items {
+		if it.Index == index {
+			return it, nil
+		}
+	}
+	if len(items) == 0 {
+		return domain.ChecklistItem{}, fmt.Errorf("no task #%d: the checklist has no items", index)
+	}
+	return domain.ChecklistItem{}, fmt.Errorf("no task #%d: valid task numbers are 1..%d", index, len(items))
+}
+
+// AddTask appends a new unchecked item and returns the updated list plus the
+// new item's number.
+func (a *App) AddTask(agent, path, text string) ([]domain.ChecklistItem, int, error) {
+	p, err := a.taskFilePath(agent, path)
+	if err != nil {
+		return nil, 0, err
+	}
+	newIndex := 0
+	items, err := mutateTaskFile(p, func(content string) (string, error) {
+		out, idx, e := domain.AppendChecklistItem(content, text)
+		newIndex = idx
+		return out, e
+	})
+	return items, newIndex, err
+}
+
+// SetTaskDone toggles an item's status and returns the renumbered list.
+func (a *App) SetTaskDone(agent, path string, index int, done bool) ([]domain.ChecklistItem, error) {
+	p, err := a.taskFilePath(agent, path)
+	if err != nil {
+		return nil, err
+	}
+	return mutateTaskFile(p, func(content string) (string, error) {
+		return domain.SetChecklistItemDone(content, index, done)
+	})
+}
+
+// EditTask replaces an item's text (keeping its status) and returns the list.
+func (a *App) EditTask(agent, path string, index int, text string) ([]domain.ChecklistItem, error) {
+	p, err := a.taskFilePath(agent, path)
+	if err != nil {
+		return nil, err
+	}
+	return mutateTaskFile(p, func(content string) (string, error) {
+		return domain.EditChecklistItemText(content, index, text)
+	})
+}
+
+// DeleteTask removes an item and returns the renumbered list.
+func (a *App) DeleteTask(agent, path string, index int) ([]domain.ChecklistItem, error) {
+	p, err := a.taskFilePath(agent, path)
+	if err != nil {
+		return nil, err
+	}
+	return mutateTaskFile(p, func(content string) (string, error) {
+		return domain.DeleteChecklistItem(content, index)
+	})
+}
+
 // SignatureRow is a learned signature enriched for display: the persisted
 // state plus the dominant action and decision count recomputed from history.
 type SignatureRow struct {

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -10,6 +10,8 @@ package frontend
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -1527,10 +1529,40 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	return os.Rename(tmpName, path)
 }
 
+// taskLockPath returns a stable, hap-owned lock-file path for a task file,
+// keyed by the file's (already absolute) path. Keeping the lock in a shared
+// temp dir — rather than a `<file>.lock` sidecar — serializes concurrent
+// mutations without dropping a stray lock file into the user's repo next to a
+// --path checklist.
+func taskLockPath(path string) string {
+	sum := sha256.Sum256([]byte(path))
+	return filepath.Join(os.TempDir(), "hap-task-locks", hex.EncodeToString(sum[:16])+".lock")
+}
+
 // mutateTaskFile reads path, applies fn to its content, writes the result
 // atomically, and returns the re-parsed item list so callers can echo the
-// freshly renumbered checklist.
+// freshly renumbered checklist. The whole read-modify-rename is serialized
+// under a per-path advisory lock so two concurrent `hap task` mutations (e.g.
+// add racing done) can't both derive from the same content and have the last
+// rename silently drop the other — the atomic rename alone only guards a
+// reader against a partial write, not two writers against each other.
 func mutateTaskFile(path string, fn func(content string) (string, error)) ([]domain.ChecklistItem, error) {
+	lockPath := taskLockPath(path)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return nil, err
+	}
+	unlock, err := lockFile(lockPath)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	// Preserve the checklist's existing permission bits: a user's 0644 --path
+	// file must not be narrowed to 0600 on every edit.
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -1539,7 +1571,7 @@ func mutateTaskFile(path string, fn func(content string) (string, error)) ([]dom
 	if err != nil {
 		return nil, err
 	}
-	if err := writeFileAtomic(path, []byte(out), 0o600); err != nil {
+	if err := writeFileAtomic(path, []byte(out), info.Mode().Perm()); err != nil {
 		return nil, err
 	}
 	return domain.ParseChecklist(out), nil

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -1960,3 +1960,65 @@ func (h *focusPortHerdr) FocusPane(ctx context.Context, tabID, paneID string) er
 	h.calls = append(h.calls, focusPaneCall{tabID, paneID})
 	return nil
 }
+
+// TestConcurrentTaskMutationsDoNotLose exercises the per-path lock in
+// mutateTaskFile: many concurrent AddTask calls on the same checklist must all
+// land, since each read-modify-rename is serialized. Without the lock, two
+// mutations reading the same content would have the last rename drop the other.
+func TestConcurrentTaskMutationsDoNotLose(t *testing.T) {
+	app, _ := testApp(t)
+	path := filepath.Join(t.TempDir(), "tasks.md")
+	if err := os.WriteFile(path, []byte("- [ ] seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const n = 20
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _, errs[i] = app.AddTask("", path, fmt.Sprintf("task-%d", i))
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent AddTask #%d failed: %v", i, err)
+		}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	items := domain.ParseChecklist(string(data))
+	if len(items) != n+1 { // seed + n added
+		t.Fatalf("after %d concurrent adds got %d items, want %d — a mutation was lost", n, len(items), n+1)
+	}
+}
+
+// TestMutatePreservesFileMode covers the reviewer's compatibility fix: editing
+// a normal 0644 checklist must not narrow it to 0600 on every write.
+func TestMutatePreservesFileMode(t *testing.T) {
+	app, _ := testApp(t)
+	path := filepath.Join(t.TempDir(), "tasks.md")
+	if err := os.WriteFile(path, []byte("- [ ] a\n- [ ] b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil { // defeat umask so the baseline is exactly 0644
+		t.Fatal(err)
+	}
+
+	if _, err := app.SetTaskDone("", path, 1, true); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Errorf("file mode after edit = %o, want preserved 0644 (not narrowed to 0600)", got)
+	}
+}

--- a/internal/tui/shortcut_test.go
+++ b/internal/tui/shortcut_test.go
@@ -107,7 +107,16 @@ func TestEnsureExecutableSymlinkCreatesAndIsIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want, err := filepath.Abs(source)
+	// ensureExecutableSymlink resolves the source through EvalSymlinks before
+	// linking, so the expected value must resolve it the same way. On macOS a
+	// t.TempDir() path lives under the /var → /private/var symlink, so a plain
+	// filepath.Abs(source) would mismatch the resolved link target (no-op on
+	// Linux, where the temp dir has no such indirection).
+	resolved, err := filepath.EvalSymlinks(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.Abs(resolved)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Manage the checklist items inside a task source's file directly from the CLI,
so a coding agent (or operator) can list, add, tick off, edit, and remove tasks
by agent name (or --path) and task number.

- domain: ChecklistItem + ParseChecklist and pure mutation helpers
  (SetChecklistItemDone, EditChecklistItemText, DeleteChecklistItem,
  AppendChecklistItem), reusing the existing unchecked/checked regexes so
  done-ness stays consistent with the daemon's send path. Task numbers are
  absolute file positions, never renumbered by a status filter. The raw
  checkbox rune is preserved so an in-progress "[-]" item (what the
  generated-task flow writes for the active task) renders faithfully and is
  not counted as pending.
- frontend: agent->source resolution (single match wins; 0/many/workspace-only
  error toward --path), atomic temp+rename writes so a concurrent daemon read
  never sees a partial file, and List/Get/Add/SetDone/Edit/Delete methods. No
  config lock or daemon nudge — task files are re-read live each idle event and
  the CLI is the sole writer.
- cli: `hap task [<agent> | --path F] list [--status all|pending|done] |
  get|add|done|undone|update|remove`; every mutation re-prints the renumbered
  list so position IDs stay safe to reuse.
- docs: SKILL.md "manage the task items" section + usage string.

Claude-Session: https://claude.ai/code/session_016m7RSQHTdorYBWgjQVEqtC