### PR TITLE
Enhance exhausted task generation and handle Codex rate-limit prompts

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -330,8 +330,8 @@ edits made through `hap config set` / `set-threshold` apply live — the command
 | `llm.command_start` | (unset) | argv template for the FIRST consult per agent; empty inherits `llm.command` (opt-in) |
 | `llm.rewrite_command` | (unset) | argv template for the one-shot rewrite CLI (see llm rewrite) |
 | `llm.rewrite_command_start` | (unset) | argv template for the FIRST rewrite per agent; empty inherits `llm.rewrite_command` (opt-in) |
-| `llm.task_generate_command` | (unset) | argv template for the one-shot task suggestion given to an idle agent with NO task source (see task sources); empty keeps today's escalate-only behavior |
-| `llm.task_generate_command_start` | (unset) | argv template for the FIRST task generation per agent; empty inherits `llm.task_generate_command` (opt-in) |
+| `llm.task_generate_command` | (unset) | argv template for the one-shot task suggestion given to an idle agent with NO task source, or a declared source that ran out (see task sources); empty keeps escalate-only behavior |
+| `llm.task_generate_command_start` | (unset) | argv template for the FIRST task generation per agent (no-source case only; empty inherits `llm.task_generate_command`); an exhausted declared source only generates more tasks when BOTH this and `llm.task_generate_command` are set, and always uses `llm.task_generate_command` (never this) since a list already exists |
 | `llm.task_generate_timeout_seconds` | 0 (inherits `timeout_seconds`) | timeout for one task-generation run |
 | `embedding.disabled` | false | disable semantic matching entirely |
 | `embedding.model_path` | (bundled all-minilm-l6-v2-q8_0.gguf) | path to a .gguf embedding model |

--- a/README.md
+++ b/README.md
@@ -371,9 +371,13 @@ error = "#ff5f5f"
 #    tasks: `hap task {agent_name} list` to view them and `hap task {agent_name}
 #    done <n>` to mark one complete as you go (if that name isn't recognized,
 #    use `--path {task_list_path}` in place of `{agent_name}`)."
-# When every item is checked off, the prompt is still sent with
-# {next_task_content} = "none", so the template can steer what an idle agent
-# does when the list is done.
+# When every item is checked off, the templated prompt is never sent: the
+# plugin escalates a confirmable @noop suggestion ("No more pending tasks")
+# instead — unless BOTH llm.task_generate_command and
+# llm.task_generate_command_start are configured, in which case it generates
+# more tasks for the agent instead of escalating (see "Suggesting tasks when
+# no source exists" below; the same generation flow refills an exhausted
+# source, always via task_generate_command since a list already exists).
 [[task_sources]]
 agent = "brave-otter" # agent short name, pane id, or type ("" = any)
 workspace = ""        # workspace name; "" or "*" = any, "*" wildcards work
@@ -410,13 +414,22 @@ bin/hap task-source --agent backend-dev --template 'Do this next: {next_task_con
 
 (Or in the TUI: select the agent and press `n`.)
 
-### Suggesting tasks when no source exists (optional)
+### Suggesting tasks when no source exists, or a source runs out (optional)
 
 If an idle agent has neither a matching `[[task_sources]]` entry nor an
 inferable native todo, `llm.task_generate_command` can run a one-shot local
 CLI to propose one or more next tasks. This is opt-in: without the command,
 the safe default remains a `no_task_source` escalation and hap invents
 nothing.
+
+The same generation flow also refills a declared `[[task_sources]]` entry
+once its checklist is fully checked off — but only when BOTH
+`llm.task_generate_command` and `llm.task_generate_command_start` are
+configured (stricter than the no-source case above, since it replaces content
+in a source that already had operator-relevant tasks). Without both commands
+set, an exhausted source escalates `task_source_exhausted` — a confirmable
+@noop suggestion ("No more pending tasks") — instead of generating or sending
+the old templated "none" prompt.
 
 The command's stdout may be plain lines or a Markdown list/checklist. Hap
 normalizes it and surfaces it as an escalation; it never auto-accepts a
@@ -425,8 +438,8 @@ generated task. Confirming the suggestion creates
 registers the file as that agent's task source, and sends only the first task.
 Later idle events consume the remaining tasks through the normal declared-task
 flow. Dismiss it with `x`; if generation failed or timed out, press `l` to
-retry. Suggestions are dropped or refused if the agent has started working or
-gained a task source in the meantime.
+retry. Suggestions are dropped or refused if the agent has started working, or
+now has a task source with a real pending item, in the meantime.
 
 ```toml
 [llm]
@@ -442,8 +455,11 @@ task_generate_command = [
 
 Available placeholders are `{self}`, `{agent_name}`, `{agent_type}`,
 `{pane_excerpt}`, and `{cwd}`. The first-generation state is tracked
-independently from LLM consults and rewrites. (These keys were renamed from
-`generate_task_command*`; the old spellings no longer load, so update an
+independently from LLM consults and rewrites, and only applies to the
+no-source-at-all case: `task_generate_command_start` bootstraps a list from
+nothing, so refilling an already-exhausted declared source is never treated
+as "first" — it always uses `task_generate_command`. (These keys were renamed
+from `generate_task_command*`; the old spellings no longer load, so update an
 existing config.)
 
 ### Task source info in every consult

--- a/internal/classify/classify.go
+++ b/internal/classify/classify.go
@@ -60,10 +60,9 @@ func DefaultRules() []config.ClassifierRule {
 			Regex: nil,
 		},
 		{
-			// Codex's interrupt screen ("Conversation interrupted - tell the
-			// model what to do differently") is detected structurally via
-			// domain.CodexErrorForm at the error position in Classify, same
-			// as Claude above.
+			// Codex's interrupt screen and footer-anchored rate-limit model
+			// switch modal are detected structurally via domain.CodexErrorForm
+			// at the error position in Classify, same as Claude above.
 			AgentType: "codex", Situation: "error",
 			Regex: nil,
 		},
@@ -133,6 +132,7 @@ func (c *Classifier) Classify(agentType, agentStatus, pane string) domain.Situat
 	}
 	s := domain.Situation{AgentType: agentType, Content: pane, Type: domain.SituationUnclassifiable}
 	codexPlanApproval := strings.EqualFold(agentType, "codex") && domain.CodexPlanApprovalForm(pane)
+	codexRateLimit := strings.EqualFold(agentType, "codex") && domain.CodexRateLimitForm(pane)
 
 	// Approval and choice are normally BLOCKED situations (constitution
 	// taxonomy): their content rules are gated on herdr reporting the agent
@@ -145,6 +145,13 @@ func (c *Classifier) Classify(agentType, agentStatus, pane string) domain.Situat
 			continue
 		}
 		matched := matchRule(r, pane)
+		// The Codex rate-limit modal says "Press enter to confirm", which also
+		// matches the generic approval rule. Its full footer-anchored structure
+		// identifies an error/remediation choice, so keep it at the error rule's
+		// position regardless of agent status.
+		if r.situation == domain.SituationApproval && codexRateLimit {
+			matched = false
+		}
 		// Codex's Plan-mode approval is a structural form, not a generic
 		// permission sentence. Detect it at the approval rule's position so
 		// approval retains priority over numbered-choice parsing.
@@ -163,8 +170,8 @@ func (c *Classifier) Classify(agentType, agentStatus, pane string) domain.Situat
 		if !matched && r.situation == domain.SituationError && strings.EqualFold(agentType, "claude") {
 			_, matched = domain.ClaudeErrorForm(pane)
 		}
-		// Codex's interrupt screen ("Conversation interrupted") is detected
-		// structurally the same way, scoped to codex.
+		// Codex's interrupt screen and rate-limit model switch modal are
+		// detected structurally the same way, scoped to codex.
 		if !matched && r.situation == domain.SituationError && strings.EqualFold(agentType, "codex") {
 			_, matched = domain.CodexErrorForm(pane)
 		}
@@ -260,8 +267,11 @@ func enrich(s *domain.Situation) {
 			// use the stable kind so paraphrases share one signature.
 			s.ErrorSummary = kind
 		} else if kind, ok := domain.CodexErrorForm(s.Content); ok {
-			// Same reasoning as Claude above, for Codex's interrupt screen.
+			// Same reasoning as Claude above, for Codex's built-in error forms.
 			s.ErrorSummary = kind
+		}
+		if strings.EqualFold(s.AgentType, "codex") && domain.CodexRateLimitForm(s.Content) {
+			s.Options = append(s.Options, domain.OptionLabels(domain.ExtractCodexRateLimitForm(s.Content))...)
 		}
 	}
 }

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -19,15 +19,17 @@ func TestGoldenTranscripts(t *testing.T) {
 	c := New(nil)
 
 	statusFor := map[string]string{
-		"idle_finished.txt":       "idle",
-		"codex_idle.txt":          "idle",
-		"approval_codex_plan.txt": "idle",
+		"idle_finished.txt":          "idle",
+		"codex_idle.txt":             "idle",
+		"approval_codex_plan.txt":    "idle",
+		"error_codex_rate_limit.txt": "idle",
 	}
 	agentTypeFor := map[string]string{
 		"approval_codex_plan.txt":     "codex",
 		"codex_idle.txt":              "codex",
 		"choice_codex_mcq.txt":        "codex",
 		"error_codex_interrupted.txt": "codex",
+		"error_codex_rate_limit.txt":  "codex",
 	}
 
 	entries, err := os.ReadDir("testdata/transcripts")
@@ -343,7 +345,7 @@ func TestClaudeErrorSituations(t *testing.T) {
 
 func TestCodexErrorSituations(t *testing.T) {
 	c := New(nil)
-	for _, name := range []string{"error_codex_interrupted.txt"} {
+	for _, name := range []string{"error_codex_interrupted.txt", "error_codex_rate_limit.txt"} {
 		data, err := os.ReadFile(filepath.Join("testdata", "transcripts", name))
 		if err != nil {
 			t.Fatal(err)
@@ -356,6 +358,26 @@ func TestCodexErrorSituations(t *testing.T) {
 		if s := c.Classify("claude", "blocked", string(data)); s.Type == domain.SituationError {
 			t.Errorf("%s on non-codex agent must not classify error, got %v", name, s.Type)
 		}
+	}
+}
+
+func TestCodexRateLimitErrorCarriesApprovalLikeOptions(t *testing.T) {
+	c := New(nil)
+	data, err := os.ReadFile(filepath.Join("testdata", "transcripts", "error_codex_rate_limit.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, status := range []string{"blocked", "idle", "done"} {
+		s := c.Classify("codex", status, string(data))
+		if s.Type != domain.SituationError || s.ErrorSummary != domain.CodexErrorRateLimit {
+			t.Fatalf("rate-limit modal at %s = type %v summary %q", status, s.Type, s.ErrorSummary)
+		}
+		if len(s.Options) != 3 || !strings.HasPrefix(s.Options[0], "Switch to gpt-5.4-mini") || s.Options[1] != "Keep current model" {
+			t.Fatalf("rate-limit options at %s = %v", status, s.Options)
+		}
+	}
+	if other := c.Classify("claude", "blocked", string(data)); other.Type == domain.SituationError {
+		t.Fatal("Codex rate-limit modal must remain scoped to codex")
 	}
 }
 

--- a/internal/classify/testdata/classifications.golden
+++ b/internal/classify/testdata/classifications.golden
@@ -13,5 +13,6 @@ error_claude_api_retry.txt status=blocked type=error verb= options=0
 error_claude_interrupted.txt status=blocked type=error verb= options=0
 error_claude_limit.txt status=blocked type=error verb= options=0
 error_codex_interrupted.txt status=blocked type=error verb= options=0
+error_codex_rate_limit.txt status=idle type=error verb= options=3
 idle_finished.txt status=idle type=idle verb= options=0
 unclassifiable_blocked.txt status=blocked type=unclassifiable verb= options=0

--- a/internal/classify/testdata/transcripts/error_codex_rate_limit.txt
+++ b/internal/classify/testdata/transcripts/error_codex_rate_limit.txt
@@ -1,0 +1,10 @@
+• The unrelated existing edits were left untouched.
+
+Approaching rate limits
+Switch to gpt-5.4-mini for lower credit usage?
+
+› 1. Switch to gpt-5.4-mini                 Small, fast, and cost-efficient model for simpler coding tasks.
+  2. Keep current model
+  3. Keep current model (never show again)  Hide future rate limit reminders about switching models.
+
+Press enter to confirm or esc to go back

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,17 +135,28 @@ type LLM struct {
 	RewriteFallbackTemplate string `toml:"rewrite_fallback_template"`
 	// GenerateTaskCommand is the argv template for the one-shot task
 	// suggestion an idle agent gets when it has NO task source (no declared
-	// [[task_sources]] and nothing inferable from the pane). Placeholders:
-	// {self}, {agent_name}, {agent_type}, {pane_excerpt}, {cwd}. The suggested
-	// task is read from the CLI's stdout and surfaced as an escalation the
-	// operator confirms (writing a per-agent tasks.md) or dismisses. Empty
-	// keeps today's behavior: idle with no task source escalates as
-	// no_task_source and the plugin never synthesizes a prompt (FR-011).
+	// [[task_sources]] and nothing inferable from the pane) — or when a
+	// declared source matched but its checklist is fully checked off, AND
+	// GenerateTaskCommandStart is also set (see below). Placeholders: {self},
+	// {agent_name}, {agent_type}, {pane_excerpt}, {cwd}. The suggested task is
+	// read from the CLI's stdout and surfaced as an escalation the operator
+	// confirms (writing a per-agent tasks.md) or dismisses. Empty keeps
+	// today's behavior: idle with no task source escalates as no_task_source
+	// and the plugin never synthesizes a prompt (FR-011); an exhausted
+	// declared source escalates task_source_exhausted (a confirmable @noop
+	// suggestion, "No more pending tasks") instead of sending the templated
+	// "none" prompt.
 	GenerateTaskCommand []string `toml:"task_generate_command"`
 	// GenerateTaskCommandStart is the argv template used on the FIRST task
 	// generation per agent (same first-interaction boundary as CommandStart).
-	// Same placeholders as GenerateTaskCommand. Empty inherits
-	// GenerateTaskCommand; tracked independently of the consult "first".
+	// Same placeholders as GenerateTaskCommand. For the no-task-source-at-all
+	// case, empty inherits GenerateTaskCommand (tracked independently of the
+	// consult "first"). For an EXHAUSTED declared source, generating more
+	// tasks instead of escalating requires BOTH GenerateTaskCommand and this
+	// field to be set — a stricter, explicit opt-in, since it replaces
+	// content in a source that already had operator-relevant tasks; a list
+	// already exists in that case, so GenerateTaskCommandStart is never
+	// selected there (only GenerateTaskCommand is used, every time).
 	GenerateTaskCommandStart []string `toml:"task_generate_command_start,omitempty"`
 	// GenerateTaskTimeoutSeconds bounds one task-generation run; zero or
 	// omitted inherits timeout_seconds.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -221,6 +221,11 @@ type taskGenOutcome struct {
 	request   domain.LLMRequest
 	task      string
 	err       error
+	// reason is the escalate reason that triggered this generation —
+	// ReasonNoTaskSource (no source at all) or ReasonTaskSourceExhausted (a
+	// declared source matched but ran out) — carried through so the eventual
+	// success escalation is tagged with the reason that actually applies.
+	reason domain.EscalateReason
 }
 
 // sweepOutcome carries a finished multi-tab form sweep back into the main
@@ -967,16 +972,17 @@ func (d *Daemon) decideAndAct(ctx context.Context, situation domain.Situation,
 			MaxConsecutive: cfg.Limits.MaxConsecutiveAutoPrompts,
 			MaxPerMinute:   cfg.Limits.MaxAutoPromptsPerMinute,
 		},
-		Now:                    now,
-		RetryCount:             retries,
-		MaxRetries:             cfg.Limits.MaxErrorRetries,
-		DeclaredTask:           declared,
-		LLMConfigured:          d.llmPort() != nil && d.llmPort().Configured(),
-		GenerateTaskConfigured: d.taskGenPort() != nil,
-		NeverAutoRuleHit:       allowHit,
-		NeverAutoMatched:       allowMatched,
-		SuspectedIrreversible:  suspected,
-		IrreversibleHit:        irrevHit,
+		Now:                         now,
+		RetryCount:                  retries,
+		MaxRetries:                  cfg.Limits.MaxErrorRetries,
+		DeclaredTask:                declared,
+		LLMConfigured:               d.llmPort() != nil && d.llmPort().Configured(),
+		GenerateTaskConfigured:      d.taskGenPort() != nil,
+		GenerateTaskStartConfigured: len(cfg.LLM.GenerateTaskCommandStart) > 0,
+		NeverAutoRuleHit:            allowHit,
+		NeverAutoMatched:            allowMatched,
+		SuspectedIrreversible:       suspected,
+		IrreversibleHit:             irrevHit,
 	}
 
 	decision := domain.Decide(in)
@@ -998,7 +1004,11 @@ func (d *Daemon) decideAndAct(ctx context.Context, situation domain.Situation,
 	case domain.ActionConsult:
 		d.consultLLM(ctx, cfg, situation, sig, now)
 	case domain.ActionGenerateTask:
-		d.generateTask(ctx, cfg, situation, sig, tr, now)
+		// ActionGenerateTask for an idle situation only fires when there's no
+		// REAL pending task: declared != nil here means a task source matched
+		// but its checklist is exhausted (Task == NoTaskContent), not that
+		// none was ever declared.
+		d.generateTask(ctx, cfg, situation, sig, tr, now, declared != nil)
 	default:
 		d.escalate(ctx, situation, sig, decision, tr, now)
 	}
@@ -1542,14 +1552,18 @@ func (d *Daemon) taskGenPort() ports.TaskGeneratorPort {
 }
 
 // generateTask asks the operator LLM to SUGGEST a task for an idle agent that
-// has no task source (FR-011 relaxation). Like consultLLM the subprocess runs
-// in a goroutine — it shells out to herdr for the pane excerpt and cwd — and
-// the suggestion funnels back through handleTaskGenOutcome as an escalation the
+// has no real pending task — either no task source at all, or a declared
+// source whose checklist is exhausted (FR-011 relaxation, and its
+// task-source-exhausted extension). Like consultLLM the subprocess runs in a
+// goroutine — it shells out to herdr for the pane excerpt and cwd — and the
+// suggestion funnels back through handleTaskGenOutcome as an escalation the
 // operator confirms or dismisses; it is never auto-acted. A pending
 // llm_requests row guards against concurrent generations from bursty idle
-// events and lets `l`-retry reuse the same in-flight check.
+// events and lets `l`-retry reuse the same in-flight check. sourceExhausted
+// reports whether a declared source currently matches (exhausted) rather
+// than none existing at all — see the First computation below.
 func (d *Daemon) generateTask(ctx context.Context, cfg config.Config, s domain.Situation,
-	sig domain.SignatureResult, tr domain.AgentTransition, now time.Time) {
+	sig domain.SignatureResult, tr domain.AgentTransition, now time.Time, sourceExhausted bool) {
 
 	tg := d.taskGenPort()
 	if tg == nil {
@@ -1564,12 +1578,28 @@ func (d *Daemon) generateTask(ctx context.Context, cfg config.Config, s domain.S
 		return
 	}
 
-	// The first generation for this agent selects task_generate_command_start
-	// (when configured); mark it consumed on the main loop, before the goroutine.
+	// task_generate_command_start is only for bootstrapping a list from
+	// nothing: when a declared source already exists (even exhausted), a list
+	// already exists, so this is never a "first" generation. That case must
+	// NOT touch firstTaskGen — it tracks the no-source path's own "has
+	// generation ever fired for this agent" independently, so a LATER no-
+	// source bootstrap for the same agent (e.g. its exhausted source's file
+	// is later deleted) still correctly sees first=true and selects
+	// task_generate_command_start.
 	d.mu.Lock()
-	first := !d.firstTaskGen[s.AgentID]
-	d.firstTaskGen[s.AgentID] = true
+	var first bool
+	if sourceExhausted {
+		first = false
+	} else {
+		first = !d.firstTaskGen[s.AgentID]
+		d.firstTaskGen[s.AgentID] = true
+	}
 	d.mu.Unlock()
+
+	reason := domain.ReasonNoTaskSource
+	if sourceExhausted {
+		reason = domain.ReasonTaskSourceExhausted
+	}
 
 	req := domain.LLMRequest{
 		RequestID: fmt.Sprintf("gentask-%s-%d", s.AgentID, now.UnixNano()),
@@ -1588,7 +1618,7 @@ func (d *Daemon) generateTask(ctx context.Context, cfg config.Config, s domain.S
 	}
 
 	go func() {
-		outcome := taskGenOutcome{situation: s, sig: sig, tr: tr, request: req}
+		outcome := taskGenOutcome{situation: s, sig: sig, tr: tr, request: req, reason: reason}
 		err := logging.Guard("generate-task", func() error {
 			agentName, nerr := d.opt.Store.EnsureAgentName(ctx, s.AgentID)
 			if nerr != nil {
@@ -1640,16 +1670,20 @@ func (d *Daemon) handleTaskGenOutcome(ctx context.Context, res taskGenOutcome) {
 
 	// Staleness: generation took up to its timeout — never surface a suggestion
 	// for an agent that moved on. If the agent STARTED WORKING (its live herdr
-	// status is no longer idle/done), or it now has a matching task source, the
-	// suggestion is moot — drop it instead of leaving a stale, confirmable
-	// escalation. Unknown status (list error / agent absent) falls through and
-	// still surfaces the outcome (fail-safe). The confirm path re-checks too,
-	// since the operator may act minutes later.
+	// status is no longer idle/done), or it now has a matching task source
+	// with a REAL pending item, the suggestion is moot — drop it instead of
+	// leaving a stale, confirmable escalation. A still-exhausted declared
+	// source (the res.reason == ReasonTaskSourceExhausted trigger) must NOT
+	// count as "now has a task source": it's the same exhausted source that
+	// triggered this generation, and dropping here would silently discard
+	// every exhausted-source suggestion. Unknown status (list error / agent
+	// absent) falls through and still surfaces the outcome (fail-safe). The
+	// confirm path re-checks too, since the operator may act minutes later.
 	if d.agentNotCleanlyIdle(ctx, s.AgentID) {
 		slog.Info("generate-task: agent no longer idle; dropping suggestion", "agent", s.AgentID)
 		return
 	}
-	if d.declaredTaskFor(ctx, s) != nil {
+	if dt := d.declaredTaskFor(ctx, s); dt != nil && dt.Task != domain.NoTaskContent {
 		slog.Info("generate-task: agent now has a task source; dropping suggestion", "agent", s.AgentID)
 		return
 	}
@@ -1666,12 +1700,13 @@ func (d *Daemon) handleTaskGenOutcome(ctx context.Context, res taskGenOutcome) {
 		return
 	}
 
-	// Success: surface the suggestion for confirmation. The reason stays
-	// no_task_source (the agent IS still without a source) so the escalation
-	// is NOT retryable — the operator confirms or dismisses it — while the
-	// suggestion carries the generated task for the confirm path.
+	// Success: surface the suggestion for confirmation. The reason carries
+	// what triggered this generation (no_task_source, or
+	// task_source_exhausted for a declared source that ran out) so the
+	// escalation stays NOT retryable — the operator confirms or dismisses it
+	// — while the suggestion carries the generated task for the confirm path.
 	d.escalate(ctx, s, res.sig, domain.Decision{
-		Action: domain.ActionEscalate, Reason: domain.ReasonNoTaskSource,
+		Action: domain.ActionEscalate, Reason: res.reason,
 		Suggestion: domain.SuggestTaskPrefix + res.task,
 	}, res.tr, now)
 }
@@ -2918,8 +2953,11 @@ func (d *Daemon) taskSourceSummary(ctx context.Context, cfg config.Config, s dom
 // or the agent's short name; the workspace selector matches the workspace's
 // herdr name (label) with "*" wildcards, falling back to the raw workspace
 // id when no name is resolvable. A matched source with a fully completed
-// list still resolves (task content "none") so the templated prompt is
-// delivered; sources with a real remaining task take precedence.
+// list still resolves (task content NoTaskContent, "none") so callers can
+// tell "matched but exhausted" from "nothing matched" — the decision core
+// (domain.Decide) never sends that templated "none" prompt, escalating or
+// generating more tasks instead; sources with a real remaining task take
+// precedence.
 func (d *Daemon) declaredTask(ctx context.Context, cfg config.Config, tr domain.AgentTransition, agentName string) *domain.DeclaredTask {
 	m, ok := d.matchTaskSource(ctx, cfg, tr.AgentID, tr.AgentType, tr.WorkspaceID, agentName)
 	if !ok {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1115,7 +1115,7 @@ func (d *Daemon) act(ctx context.Context, s domain.Situation, sig domain.Signatu
 	// not the label text; deliver the keystroke the menu expects. Free-text
 	// situations deliver the literal reply. s.Content is the classification
 	// snapshot, which carries the menu for the situation being acted on.
-	outbound, menuMapped := domain.DeliverOutbound(s.Type, s.Content, dec.Input)
+	outbound, menuMapped := domain.DeliverOutbound(s.Type, s.AgentType, s.Content, dec.Input)
 
 	// Literal free text can be adapted to the live pane by the optional
 	// rewrite CLI; menu digits must reach the menu untouched. The send
@@ -2500,7 +2500,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		return
 	}
 	if err := ports.SendToAgent(ctx, d.opt.Herdr, s.PaneID, s.AgentType,
-		domain.DeliverKeystroke(s.Type, pane, llmDec.Action)); err != nil {
+		domain.DeliverKeystroke(s.Type, s.AgentType, pane, llmDec.Action)); err != nil {
 		d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
 		d.notify(ctx, "Herd Auto Prompter: action delivery failed", err.Error())
 		return

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1513,9 +1513,9 @@ func TestIdleNonChecklistTaskFileDoesNotResolve(t *testing.T) {
 	}
 }
 
-func TestIdleDeclaredTaskCompletedListSendsNone(t *testing.T) {
-	// A matched source with every item checked still delivers the templated
-	// prompt with task content "none" instead of escalating.
+func TestIdleDeclaredTaskCompletedListEscalatesNoop(t *testing.T) {
+	// A matched source with every item checked never delivers the templated
+	// "none" prompt: it escalates a confirmable @noop suggestion instead.
 	dir := t.TempDir()
 	taskFile := filepath.Join(dir, "tasks.md")
 	os.WriteFile(taskFile, []byte("- [x] step one\n- [x] step two\n"), 0o600)
@@ -1526,15 +1526,21 @@ func TestIdleDeclaredTaskCompletedListSendsNone(t *testing.T) {
 	h.herdr.setPane(idlePane)
 	h.seedAutonomous(idlePane, domain.SituationIdle, domain.ActionNextDeclaredTask)
 
-	name, err := h.raw.EnsureAgentName(context.Background(), "agent-20")
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctx := context.Background()
 	h.push("agent-20", "idle")
-	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
-	want := (&domain.DeclaredTask{Task: domain.NoTaskContent, Path: taskFile, AgentName: name}).Prompt()
-	if got := h.herdr.sentInputs()[0]; got != want {
-		t.Errorf("sent %q, want completed-list prompt %q", got, want)
+	var esc []domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	if !strings.Contains(esc[0].Rationale, string(domain.ReasonTaskSourceExhausted)) {
+		t.Errorf("rationale should carry the exhausted tag, got %q", esc[0].Rationale)
+	}
+	if esc[0].Suggestion != domain.ActionNoopSuggestion {
+		t.Errorf("completed source should suggest doing nothing, got %q", esc[0].Suggestion)
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Fatal("no templated \"none\" prompt may be sent for a completed source")
 	}
 }
 
@@ -1805,6 +1811,102 @@ func TestIdleTaskGenDropsStaleSuggestion(t *testing.T) {
 	}
 	if len(h.herdr.sentInputs()) != 0 {
 		t.Errorf("nothing may be sent for a dropped suggestion, got %v", h.herdr.sentInputs())
+	}
+}
+
+func TestIdleDeclaredTaskExhaustedGeneratesMoreTasks(t *testing.T) {
+	// With BOTH task_generate_command and task_generate_command_start
+	// configured, an exhausted declared source generates more tasks instead
+	// of escalating @noop — and the suggestion must actually surface
+	// (regression: handleTaskGenOutcome's staleness re-check used to treat
+	// the same still-matched exhausted source as "now has a task source" and
+	// silently drop every exhausted-source suggestion). The very first
+	// generation for this agent must still use the base command, not
+	// task_generate_command_start — a list already exists, so this is never
+	// a bootstrap-from-nothing generation.
+	dir := t.TempDir()
+	taskFile := filepath.Join(dir, "tasks.md")
+	os.WriteFile(taskFile, []byte("- [x] old task\n"), 0o600)
+
+	idlePane := "All tests pass. Task is complete.\n"
+	cfg := fmt.Sprintf(
+		"[[task_sources]]\nagent = \"agent-41\"\npath = %q\n\n[llm]\ntask_generate_command = [\"fake\"]\ntask_generate_command_start = [\"fake-start\"]\n",
+		taskFile)
+	h, tg := newHarnessTaskGen(t, cfg, func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+		return "Add more regression tests", nil
+	})
+	h.herdr.setPane(idlePane)
+
+	ctx := context.Background()
+	h.push("agent-41", "idle")
+	var esc []domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	want := domain.SuggestTaskPrefix + "Add more regression tests"
+	if esc[0].Suggestion != want {
+		t.Errorf("escalation suggestion = %q, want %q", esc[0].Suggestion, want)
+	}
+	if !strings.Contains(esc[0].Rationale, string(domain.ReasonTaskSourceExhausted)) {
+		t.Errorf("escalation should be tagged task_source_exhausted, got %q", esc[0].Rationale)
+	}
+	if domain.IsRetryableLLMEscalation(&esc[0]) {
+		t.Error("a successful task suggestion must NOT be retryable (operator confirms/dismisses)")
+	}
+	calls := tg.genCalls()
+	if len(calls) != 1 {
+		t.Fatalf("generator should be called once, got %d", len(calls))
+	}
+	if calls[0].First {
+		t.Error("an exhausted declared source already has a list; generation must use the base command, not task_generate_command_start")
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Fatal("nothing may be sent to the pane before the operator confirms")
+	}
+}
+
+func TestGenerateTaskFirstFlagIndependentOfExhaustedSource(t *testing.T) {
+	// Regression: a generation triggered by an EXHAUSTED declared source must
+	// never mark firstTaskGen for the agent — that map tracks only the
+	// no-task-source-at-all path's own "first ever" state. If the exhausted
+	// path polluted it, a LATER no-source bootstrap for the same agent (e.g.
+	// its exhausted source's file is later removed) would incorrectly skip
+	// task_generate_command_start and use the regular command instead.
+	h, tg := newHarnessTaskGen(t, "[llm]\ntask_generate_command = [\"fake\"]\ntask_generate_command_start = [\"fake-start\"]\n",
+		func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+			return "a generated task", nil
+		})
+
+	ctx := context.Background()
+	cfg, _, _ := h.daemon.snapshot()
+	agentID := "agent-99"
+	sig := domain.SignatureResult{Signature: "sig-99"}
+	situation := domain.Situation{Type: domain.SituationIdle, AgentID: agentID, AgentType: "claude"}
+	tr := domain.AgentTransition{AgentID: agentID, PaneID: agentID, Status: "idle"}
+
+	// First call: triggered by an EXHAUSTED declared source. Each call needs
+	// its own timestamp — generateTask derives the staged request's unique id
+	// from it (gentask-<agent>-<nanos>), and a repeated value collides.
+	h.daemon.generateTask(ctx, cfg, situation, sig, tr, time.Now(), true)
+	waitFor(t, 3*time.Second, func() bool {
+		pending, _ := h.raw.HasPendingLLMConsult(ctx, agentID)
+		return !pending && len(tg.genCalls()) == 1
+	})
+
+	// Second call: the SAME agent later has NO task source at all.
+	h.daemon.generateTask(ctx, cfg, situation, sig, tr, time.Now(), false)
+	waitFor(t, 3*time.Second, func() bool {
+		pending, _ := h.raw.HasPendingLLMConsult(ctx, agentID)
+		return !pending && len(tg.genCalls()) == 2
+	})
+
+	calls := tg.genCalls()
+	if calls[0].First {
+		t.Error("exhausted-source generation must never report First=true")
+	}
+	if !calls[1].First {
+		t.Error("a later no-source generation for the same agent must still see First=true — firstTaskGen must not be polluted by the exhausted-source path")
 	}
 }
 

--- a/internal/domain/codex_test.go
+++ b/internal/domain/codex_test.go
@@ -91,6 +91,48 @@ func TestCodexPlanApprovalFormRejectsStaleAndIncompleteCopies(t *testing.T) {
 	}
 }
 
+const codexRateLimitFrame = `older numbered narration:
+1. This is not a modal option.
+
+Approaching rate limits
+Switch to gpt-5.4-mini for lower credit usage?
+
+› 1. Switch to gpt-5.4-mini                 Small, fast, and cost-efficient model for simpler coding tasks.
+  2. Keep current model
+  3. Keep current model (never show again)  Hide future rate limit reminders about switching models.
+
+Press enter to confirm or esc to go back
+`
+
+func TestCodexRateLimitForm(t *testing.T) {
+	if !CodexRateLimitForm(codexRateLimitFrame) {
+		t.Fatal("Codex rate-limit modal was not recognized")
+	}
+	region := ExtractCodexRateLimitForm(codexRateLimitFrame)
+	if strings.Contains(region, "older numbered narration") {
+		t.Fatalf("rate-limit extraction retained scrollback: %q", region)
+	}
+	if got := OptionLabels(region); len(got) != 3 || !strings.HasPrefix(got[0], "Switch to gpt-5.4-mini") {
+		t.Fatalf("rate-limit options = %v", got)
+	}
+	if kind, ok := CodexErrorForm(codexRateLimitFrame); !ok || kind != CodexErrorRateLimit {
+		t.Fatalf("CodexErrorForm = (%q, %v), want (%q, true)", kind, ok, CodexErrorRateLimit)
+	}
+}
+
+func TestCodexRateLimitFormRejectsStaleAndIncompleteCopies(t *testing.T) {
+	for _, pane := range []string{
+		codexRateLimitFrame + "\nnewer output\n",
+		strings.Replace(codexRateLimitFrame, "Press enter to confirm or esc to go back", "ordinary footer", 1),
+		strings.Replace(codexRateLimitFrame, "Keep current model (never show again)", "Maybe later", 1),
+		"Approaching rate limits\nSwitch to gpt-5.4-mini for lower credit usage?\n",
+	} {
+		if CodexRateLimitForm(pane) {
+			t.Fatalf("false positive for %q", pane)
+		}
+	}
+}
+
 func TestStripCodexComposer(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/domain/codexerror.go
+++ b/internal/domain/codexerror.go
@@ -1,6 +1,9 @@
 package domain
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 // Codex surfaces a blocking interrupt screen when a run is manually
 // interrupted (e.g. Escape mid-turn): "Conversation interrupted - tell the
@@ -9,13 +12,24 @@ import "regexp"
 // minor spacing drift), so ordinary narration that merely contains the word
 // "interrupted" (a printed log line, a description of some other
 // interruption) does not become a live error.
-var codexInterruptedRE = regexp.MustCompile(`(?i)conversation interrupted\b.{0,20}tell the model what to do differently`)
+var (
+	codexInterruptedRE = regexp.MustCompile(`(?i)conversation interrupted\b.{0,20}tell the model what to do differently`)
+
+	// Codex parks this model-switch reminder at the bottom of the pane when
+	// account credits approach their limit. The header/question/footer form a
+	// narrow live-modal envelope; the footer's \z anchor prevents an older copy
+	// in scrollback from being treated as a current error.
+	codexRateLimitHeaderRE   = regexp.MustCompile(`(?im)^[ \t]*Approaching rate limits[ \t]*$`)
+	codexRateLimitQuestionRE = regexp.MustCompile(`(?im)^[ \t]*Switch to[ \t]+.+[ \t]+for lower credit usage\?[ \t]*$`)
+	codexRateLimitFooterRE   = regexp.MustCompile(`(?im)^[ \t]*Press enter to confirm or esc to go back[ \t]*\s*\z`)
+)
 
 // Stable ErrorSummary label for Codex's built-in error forms — used as the
 // error signature (`error:<kind>`) so paraphrased instances dedup to one
 // learned signature.
 const (
 	CodexErrorInterrupted = "interrupted"
+	CodexErrorRateLimit   = "rate-limit"
 )
 
 // CodexErrorForm reports whether pane content shows one of Codex's blocking
@@ -23,8 +37,47 @@ const (
 // false.
 func CodexErrorForm(pane string) (kind string, ok bool) {
 	switch {
+	case CodexRateLimitForm(pane):
+		return CodexErrorRateLimit, true
 	case codexInterruptedRE.MatchString(pane):
 		return CodexErrorInterrupted, true
 	}
 	return "", false
+}
+
+// CodexRateLimitForm reports whether pane ends in Codex's live
+// "Approaching rate limits" model-switch modal. Callers must additionally
+// gate it on agent_type == "codex".
+func CodexRateLimitForm(pane string) bool {
+	region := ExtractCodexRateLimitForm(pane)
+	if region == "" || !codexRateLimitQuestionRE.MatchString(region) {
+		return false
+	}
+	opts := ParseNumberedOptions(region)
+	if len(opts) != 3 || opts[0].Number != "1" || opts[1].Number != "2" || opts[2].Number != "3" {
+		return false
+	}
+	labels := []string{
+		strings.ToLower(strings.TrimSpace(opts[0].Label)),
+		strings.ToLower(strings.TrimSpace(opts[1].Label)),
+		strings.ToLower(strings.TrimSpace(opts[2].Label)),
+	}
+	return strings.HasPrefix(labels[0], "switch to ") &&
+		labels[1] == "keep current model" &&
+		strings.HasPrefix(labels[2], "keep current model (never show again)")
+}
+
+// ExtractCodexRateLimitForm returns only the final live modal, excluding
+// preceding conversation and any numbered lists it may contain.
+func ExtractCodexRateLimitForm(pane string) string {
+	headers := codexRateLimitHeaderRE.FindAllStringIndex(pane, -1)
+	footer := codexRateLimitFooterRE.FindStringIndex(pane)
+	if len(headers) == 0 || footer == nil {
+		return ""
+	}
+	header := headers[len(headers)-1]
+	if footer[0] <= header[0] {
+		return ""
+	}
+	return strings.TrimSpace(pane[header[0]:footer[1]])
 }

--- a/internal/domain/decide.go
+++ b/internal/domain/decide.go
@@ -103,6 +103,13 @@ type DecideInput struct {
 	// an idle agent with no task source generates a task suggestion instead of
 	// escalating no_task_source (FR-011 relaxation).
 	GenerateTaskConfigured bool
+	// GenerateTaskStartConfigured reports that llm.task_generate_command_start
+	// is also set. An exhausted DECLARED task source (every item checked off)
+	// only generates more tasks instead of escalating task_source_exhausted
+	// when BOTH commands are configured — a stricter, explicit opt-in than the
+	// no-task-source-at-all case above, since it replaces content in a source
+	// that already had operator-relevant tasks.
+	GenerateTaskStartConfigured bool
 	// NeverAutoRuleHit and SuspectedIrreversible are precomputed by the caller
 	// from the compiled NeverAutoList so the core stays free of regex state.
 	// IrreversibleHit carries the matching indicator for the rationale.
@@ -127,28 +134,13 @@ func Decide(in DecideInput) Decision {
 		}
 	}
 
-	// Safety controls veto first (Constitution: safety over throughput).
-	// Rationales are tag-only where the reason token self-explains — the
-	// escalation line's budget belongs to the suggestion, not to prose
-	// repeating the tag or the operator's own config.
-	if in.KillActive {
-		return esc(ReasonKilled, "", 0, "")
-	}
-	if in.Situation.Type == SituationUnclassifiable {
-		return esc(ReasonUnclassifiable, "", 0, "")
-	}
-	if in.Signature.Verdict == GuardOverMasked {
-		return esc(ReasonOverMasked, "", 0, "")
-	}
-	if in.NeverAutoMatched {
-		return esc(ReasonNeverAutoMatch, in.NeverAutoRuleHit.Diagnostic(), 0, "")
-	}
-
-	// Confidence and the variance guard consider only post-reset decisions (id
-	// > the signature's floor); pre-reset rows are kept but no longer count. The
-	// suggested action, however, still comes from the FULL learned history: a
-	// reset rule keeps offering its learned answer while its score/graduation
-	// start fresh, so re-earning trust is just re-confirming it.
+	// Confidence considers only post-reset decisions (id > the signature's
+	// floor); pre-reset rows are kept but no longer count. The suggested
+	// action, however, still comes from the FULL learned history: a reset
+	// rule keeps offering its learned answer while its score/graduation start
+	// fresh, so re-earning trust is just re-confirming it. Computed before the
+	// safety vetoes below so an escalation forced by one of them still
+	// reports the rule's actual confidence instead of a bare 0.
 	var floor int64
 	if in.State != nil {
 		floor = in.State.DecisionFloorID
@@ -157,6 +149,23 @@ func Decide(in DecideInput) Decision {
 	conf := Confidence(post, in.ConfirmationWeight)
 	if len(post) == 0 {
 		conf.TopAction = Confidence(in.History, in.ConfirmationWeight).TopAction
+	}
+
+	// Safety controls veto first (Constitution: safety over throughput).
+	// Rationales are tag-only where the reason token self-explains — the
+	// escalation line's budget belongs to the suggestion, not to prose
+	// repeating the tag or the operator's own config.
+	if in.KillActive {
+		return esc(ReasonKilled, "", conf.Score, "")
+	}
+	if in.Situation.Type == SituationUnclassifiable {
+		return esc(ReasonUnclassifiable, "", conf.Score, "")
+	}
+	if in.Signature.Verdict == GuardOverMasked {
+		return esc(ReasonOverMasked, "", conf.Score, "")
+	}
+	if in.NeverAutoMatched {
+		return esc(ReasonNeverAutoMatch, in.NeverAutoRuleHit.Diagnostic(), conf.Score, "")
 	}
 
 	if VarianceGuardTripped(post, in.ConfidenceThresholds.Minimum, in.ConfirmationWeight) {
@@ -212,6 +221,20 @@ func Decide(in DecideInput) Decision {
 			in.GenerateTaskConfigured {
 			return Decision{Action: ActionGenerateTask, Confidence: conf.Score,
 				Rationale: "idle with no task source; generating a task suggestion"}
+		}
+		// A declared task source that matched but has nothing left to do never
+		// sends the templated "none" prompt. Generating more tasks requires
+		// BOTH task_generate_command and task_generate_command_start — a
+		// stricter, explicit opt-in than the no-source case above, since this
+		// replaces content in a source that already had operator-relevant
+		// tasks. Without that opt-in, the safe default is a confirmable @noop
+		// suggestion: the list is done, nothing to send.
+		if in.Situation.Type == SituationIdle && resolveEsc == ReasonTaskSourceExhausted {
+			if in.GenerateTaskConfigured && in.GenerateTaskStartConfigured {
+				return Decision{Action: ActionGenerateTask, Confidence: conf.Score,
+					Rationale: "declared task source exhausted; generating more tasks"}
+			}
+			return esc(ReasonTaskSourceExhausted, "No more pending tasks", conf.Score, ActionNoopSuggestion)
 		}
 		return esc(resolveEsc, rationaleFor(resolveEsc), conf.Score, suggestion)
 	}
@@ -291,10 +314,14 @@ func resolveSituation(in DecideInput, conf ConfidenceResult) (candidate, suggest
 		if conf.TopAction == ActionNoop {
 			return ActionNoop, ActionNoopSuggestion, ReasonNone
 		}
-		// Two-tier next-task resolution (FR-011). A matched source always
-		// yields a candidate — even a completed list, whose templated prompt
-		// (task content "none") lets the operator steer idle agents.
+		// Two-tier next-task resolution (FR-011). A matched source with a real
+		// pending item drives the next prompt; a matched source whose
+		// checklist is fully checked off never sends the templated "none"
+		// prompt — Decide() escalates or generates more tasks instead.
 		if in.DeclaredTask != nil {
+			if in.DeclaredTask.Task == NoTaskContent {
+				return "", "", ReasonTaskSourceExhausted
+			}
 			return ActionNextDeclaredTask, "send next declared task: " + in.DeclaredTask.Prompt(), ReasonNone
 		}
 		inferred := InferNextTask(in.Situation.AgentType, in.Situation.Content)

--- a/internal/domain/decide_test.go
+++ b/internal/domain/decide_test.go
@@ -39,6 +39,9 @@ func TestKillSwitchVetoesEverything(t *testing.T) {
 	if d.Action != ActionEscalate || d.Reason != ReasonKilled {
 		t.Fatalf("kill switch must escalate, got %+v", d)
 	}
+	if d.Confidence != 1 {
+		t.Errorf("veto must still report the rule's actual confidence, got %.3f", d.Confidence)
+	}
 }
 
 func TestDecisionFloorGatesButKeepsSuggestion(t *testing.T) {
@@ -75,6 +78,9 @@ func TestNeverAutoVetoesRegardlessOfConfidence(t *testing.T) {
 	}
 	if !strings.Contains(d.Rationale, `git push --force`) || !strings.Contains(d.Rationale, `matched "git push --force"`) {
 		t.Fatalf("never-auto rationale must name pattern and excerpt, got %q", d.Rationale)
+	}
+	if d.Confidence != 1 {
+		t.Errorf("veto must still report the rule's actual confidence, got %.3f", d.Confidence)
 	}
 }
 
@@ -280,18 +286,25 @@ func TestVarianceGuardForcesEscalation(t *testing.T) {
 }
 
 func TestOverMaskedEscalates(t *testing.T) {
-	in := baseInput(SituationApproval)
+	in := autonomous(baseInput(SituationApproval), "y", "y", "y", "y", "y", "y", "y", "y")
 	in.Signature.Verdict = GuardOverMasked
 	d := Decide(in)
 	if d.Action != ActionEscalate || d.Reason != ReasonOverMasked {
 		t.Fatalf("over-masked must escalate, got %+v", d)
 	}
+	if d.Confidence != 1 {
+		t.Errorf("veto must still report the rule's actual confidence, got %.3f", d.Confidence)
+	}
 }
 
 func TestUnclassifiableEscalates(t *testing.T) {
-	d := Decide(baseInput(SituationUnclassifiable))
+	in := autonomous(baseInput(SituationUnclassifiable), "y", "y", "y", "y", "y", "y", "y", "y")
+	d := Decide(in)
 	if d.Action != ActionEscalate || d.Reason != ReasonUnclassifiable {
 		t.Fatalf("unclassifiable must escalate, got %+v", d)
+	}
+	if d.Confidence != 1 {
+		t.Errorf("veto must still report the rule's actual confidence, got %.3f", d.Confidence)
 	}
 }
 
@@ -324,17 +337,52 @@ func TestIdleDeclaredTaskCustomTemplate(t *testing.T) {
 	}
 }
 
-func TestIdleDeclaredTaskCompletedListStillSends(t *testing.T) {
-	// A matched source whose checklist is complete still delivers the
-	// templated prompt with task content "none" — never an escalation.
+func TestIdleDeclaredTaskExhaustedEscalatesWithoutGenerateConfig(t *testing.T) {
+	// A matched source whose checklist is complete never sends the templated
+	// "none" prompt: without a generate-task opt-in it escalates a
+	// confirmable @noop suggestion instead.
 	in := autonomous(baseInput(SituationIdle),
 		ActionNextDeclaredTask, ActionNextDeclaredTask, ActionNextDeclaredTask,
 		ActionNextDeclaredTask, ActionNextDeclaredTask, ActionNextDeclaredTask)
 	in.DeclaredTask = &DeclaredTask{Task: NoTaskContent, Path: "/docs/tasks.md"}
 	d := Decide(in)
-	want := in.DeclaredTask.Prompt()
-	if d.Action != ActionSend || d.Input != want {
-		t.Fatalf("completed declared list should still send the templated prompt, got %+v", d)
+	if d.Action != ActionEscalate || d.Reason != ReasonTaskSourceExhausted {
+		t.Fatalf("exhausted declared list must escalate task_source_exhausted, got %+v", d)
+	}
+	if d.Suggestion != ActionNoopSuggestion {
+		t.Errorf("exhausted declared list should suggest doing nothing, got %q", d.Suggestion)
+	}
+	if d.Rationale != "No more pending tasks" {
+		t.Errorf("exhausted declared list rationale mismatch, got %q", d.Rationale)
+	}
+}
+
+func TestIdleDeclaredTaskExhaustedRequiresBothGenerateCommands(t *testing.T) {
+	// Generating more tasks for an exhausted declared source needs BOTH
+	// task_generate_command and task_generate_command_start configured — a
+	// stricter opt-in than the no-task-source-at-all case. Only the base
+	// command being set must still escalate, not generate.
+	in := autonomous(baseInput(SituationIdle),
+		ActionNextDeclaredTask, ActionNextDeclaredTask, ActionNextDeclaredTask,
+		ActionNextDeclaredTask, ActionNextDeclaredTask, ActionNextDeclaredTask)
+	in.DeclaredTask = &DeclaredTask{Task: NoTaskContent, Path: "/docs/tasks.md"}
+	in.GenerateTaskConfigured = true
+	d := Decide(in)
+	if d.Action != ActionEscalate || d.Reason != ReasonTaskSourceExhausted {
+		t.Fatalf("exhausted declared list with only the base command configured must still escalate, got %+v", d)
+	}
+}
+
+func TestIdleDeclaredTaskExhaustedGeneratesWhenBothConfigured(t *testing.T) {
+	in := autonomous(baseInput(SituationIdle),
+		ActionNextDeclaredTask, ActionNextDeclaredTask, ActionNextDeclaredTask,
+		ActionNextDeclaredTask, ActionNextDeclaredTask, ActionNextDeclaredTask)
+	in.DeclaredTask = &DeclaredTask{Task: NoTaskContent, Path: "/docs/tasks.md"}
+	in.GenerateTaskConfigured = true
+	in.GenerateTaskStartConfigured = true
+	d := Decide(in)
+	if d.Action != ActionGenerateTask {
+		t.Fatalf("exhausted declared list with both generate commands configured should generate more tasks, got %+v", d)
 	}
 }
 

--- a/internal/domain/menu.go
+++ b/internal/domain/menu.go
@@ -109,16 +109,17 @@ func MenuKeystroke(content, chosen string) (string, bool) {
 	return chosen, false
 }
 
-// DeliverOutbound maps a chosen reply to the numbered-menu digit, but ONLY
-// for approval/choice situations. Free-text prompts — idle next-task prompts,
-// error-retry commands — are always delivered literally, so a pane that
-// happens to contain an ordinary numbered list (e.g. a summary "1. ran tests")
-// can never hijack the reply into a bare digit. paneContent is the live
-// screen. The bool reports whether a menu digit was mapped: false means the
-// returned text is free text (callers deciding whether to rewrite literal
-// outbound text key off this).
+// DeliverOutbound maps a chosen reply to the numbered-menu digit for
+// approval/choice situations and Codex's structural rate-limit error modal.
+// Other error retries and idle prompts remain literal free text, so an
+// ordinary numbered list cannot hijack their reply into a bare digit.
+// paneContent is the live screen. The bool reports whether a menu digit was
+// mapped: false means the returned text is free text (callers deciding whether
+// to rewrite literal outbound text key off this).
 func DeliverOutbound(sitType SituationType, paneContent, chosen string) (string, bool) {
-	if sitType != SituationApproval && sitType != SituationChoice {
+	menuSituation := sitType == SituationApproval || sitType == SituationChoice ||
+		(sitType == SituationError && CodexRateLimitForm(paneContent))
+	if !menuSituation {
 		return chosen, false
 	}
 	return MenuKeystroke(paneContent, chosen)

--- a/internal/domain/menu.go
+++ b/internal/domain/menu.go
@@ -113,12 +113,14 @@ func MenuKeystroke(content, chosen string) (string, bool) {
 // approval/choice situations and Codex's structural rate-limit error modal.
 // Other error retries and idle prompts remain literal free text, so an
 // ordinary numbered list cannot hijack their reply into a bare digit.
-// paneContent is the live screen. The bool reports whether a menu digit was
-// mapped: false means the returned text is free text (callers deciding whether
-// to rewrite literal outbound text key off this).
-func DeliverOutbound(sitType SituationType, paneContent, chosen string) (string, bool) {
+// agentType is required because the rate-limit shape has Codex-only semantics;
+// approval and choice menus remain agent-agnostic. paneContent is the live
+// screen. The bool reports whether a menu digit was mapped: false means the
+// returned text is free text (callers deciding whether to rewrite literal
+// outbound text key off this).
+func DeliverOutbound(sitType SituationType, agentType, paneContent, chosen string) (string, bool) {
 	menuSituation := sitType == SituationApproval || sitType == SituationChoice ||
-		(sitType == SituationError && CodexRateLimitForm(paneContent))
+		(sitType == SituationError && strings.EqualFold(strings.TrimSpace(agentType), "codex") && CodexRateLimitForm(paneContent))
 	if !menuSituation {
 		return chosen, false
 	}
@@ -126,8 +128,8 @@ func DeliverOutbound(sitType SituationType, paneContent, chosen string) (string,
 }
 
 // DeliverKeystroke is DeliverOutbound for callers that only need the text.
-func DeliverKeystroke(sitType SituationType, paneContent, chosen string) string {
-	out, _ := DeliverOutbound(sitType, paneContent, chosen)
+func DeliverKeystroke(sitType SituationType, agentType, paneContent, chosen string) string {
+	out, _ := DeliverOutbound(sitType, agentType, paneContent, chosen)
 	return out
 }
 

--- a/internal/domain/menu_test.go
+++ b/internal/domain/menu_test.go
@@ -101,6 +101,7 @@ func TestDeliverOutbound(t *testing.T) {
 		{"approval free text without menu stays literal", SituationApproval, "Enter a message:", "looks good", "looks good", false},
 		{"idle never maps even over a numbered list", SituationIdle, "done:\n1. ran tests\n2. built", "continue with the plan", "continue with the plan", false},
 		{"error retry command stays literal", SituationError, menu, "go test ./...", "go test ./...", false},
+		{"Codex rate-limit error option maps", SituationError, codexRateLimitFrame, "Keep current model", "2", true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/domain/menu_test.go
+++ b/internal/domain/menu_test.go
@@ -89,29 +89,31 @@ func TestMenuKeystrokeAmbiguousPrefixStaysLiteral(t *testing.T) {
 func TestDeliverOutbound(t *testing.T) {
 	menu := "Allow this tool?\n❯ 1. Yes\n  2. No\n"
 	tests := []struct {
-		name    string
-		sitType SituationType
-		content string
-		chosen  string
-		want    string
-		mapped  bool
+		name      string
+		sitType   SituationType
+		agentType string
+		content   string
+		chosen    string
+		want      string
+		mapped    bool
 	}{
-		{"approval label maps to digit", SituationApproval, menu, "Yes", "1", true},
-		{"choice numeric selection maps", SituationChoice, menu, "2", "2", true},
-		{"approval free text without menu stays literal", SituationApproval, "Enter a message:", "looks good", "looks good", false},
-		{"idle never maps even over a numbered list", SituationIdle, "done:\n1. ran tests\n2. built", "continue with the plan", "continue with the plan", false},
-		{"error retry command stays literal", SituationError, menu, "go test ./...", "go test ./...", false},
-		{"Codex rate-limit error option maps", SituationError, codexRateLimitFrame, "Keep current model", "2", true},
+		{"approval label maps to digit", SituationApproval, "claude", menu, "Yes", "1", true},
+		{"choice numeric selection maps", SituationChoice, "claude", menu, "2", "2", true},
+		{"approval free text without menu stays literal", SituationApproval, "claude", "Enter a message:", "looks good", "looks good", false},
+		{"idle never maps even over a numbered list", SituationIdle, "codex", "done:\n1. ran tests\n2. built", "continue with the plan", "continue with the plan", false},
+		{"error retry command stays literal", SituationError, "claude", menu, "go test ./...", "go test ./...", false},
+		{"Codex rate-limit error option maps", SituationError, "codex", codexRateLimitFrame, "Keep current model", "2", true},
+		{"non-Codex rate-limit-shaped error stays literal", SituationError, "claude", codexRateLimitFrame, "Keep current model", "Keep current model", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, mapped := DeliverOutbound(tc.sitType, tc.content, tc.chosen)
+			got, mapped := DeliverOutbound(tc.sitType, tc.agentType, tc.content, tc.chosen)
 			if got != tc.want || mapped != tc.mapped {
 				t.Errorf("DeliverOutbound(%v, %q) = (%q, %v), want (%q, %v)",
 					tc.sitType, tc.chosen, got, mapped, tc.want, tc.mapped)
 			}
 			// DeliverKeystroke must stay in lockstep with DeliverOutbound.
-			if ks := DeliverKeystroke(tc.sitType, tc.content, tc.chosen); ks != got {
+			if ks := DeliverKeystroke(tc.sitType, tc.agentType, tc.content, tc.chosen); ks != got {
 				t.Errorf("DeliverKeystroke = %q, DeliverOutbound text = %q", ks, got)
 			}
 		})

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -152,11 +152,17 @@ const (
 	// confidence was below the operator's auto_act_confidence_threshold (or
 	// it reported no score), so the suggestion is surfaced for confirmation
 	// instead of being auto-acted.
-	ReasonLLMLowConfidence     EscalateReason = "llm_low_confidence"
-	ReasonHerdrUnreachable     EscalateReason = "herdr_unreachable"
-	ReasonPersistenceFailed    EscalateReason = "persistence_failed"
-	ReasonShadowMode           EscalateReason = "shadow_mode"
-	ReasonNoTaskSource         EscalateReason = "no_task_source"
+	ReasonLLMLowConfidence  EscalateReason = "llm_low_confidence"
+	ReasonHerdrUnreachable  EscalateReason = "herdr_unreachable"
+	ReasonPersistenceFailed EscalateReason = "persistence_failed"
+	ReasonShadowMode        EscalateReason = "shadow_mode"
+	ReasonNoTaskSource      EscalateReason = "no_task_source"
+	// ReasonTaskSourceExhausted: a declared task source matched but every
+	// item is checked off. Not retryable — the operator confirms or
+	// dismisses it (or, when both task_generate_command and
+	// task_generate_command_start are configured, the plugin generates more
+	// tasks instead of escalating this reason at all).
+	ReasonTaskSourceExhausted  EscalateReason = "task_source_exhausted"
 	ReasonUnfamiliarOptions    EscalateReason = "unfamiliar_options"
 	ReasonNoHistory            EscalateReason = "no_history"
 	ReasonNotConsecutiveEnough EscalateReason = "graduation_pending"

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -758,7 +758,7 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 			return a.nudge(ctx, control.KindReload)
 		}
 		if rerr == nil {
-			outbound = domain.DeliverKeystroke(audit.SituationType, pane, outbound)
+			outbound = domain.DeliverKeystroke(audit.SituationType, audit.AgentType, pane, outbound)
 		}
 		if err := ports.SendToAgent(ctx, a.Herdr, audit.AgentID, audit.AgentType, outbound); err != nil {
 			return fmt.Errorf("correction recorded, but sending to the agent failed: %w", err)

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -352,6 +352,35 @@ func TestResolveMarksSentOnDelivery(t *testing.T) {
 	}
 }
 
+func TestConfirmCodexRateLimitErrorSendsSelectedMenuDigit(t *testing.T) {
+	app, st := testApp(t)
+	pane := "Approaching rate limits\n" +
+		"Switch to gpt-5.4-mini for lower credit usage?\n\n" +
+		"› 1. Switch to gpt-5.4-mini                 Small, fast, and cost-efficient model for simpler coding tasks.\n" +
+		"  2. Keep current model\n" +
+		"  3. Keep current model (never show again)  Hide future rate limit reminders about switching models.\n\n" +
+		"Press enter to confirm or esc to go back\n"
+	fake := &fakeHerdr{pane: pane}
+	app.Herdr = fake
+	ctx := context.Background()
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "codex-pane", AgentType: "codex", SituationType: domain.SituationError,
+		Trigger: "agent-status: idle", Action: "escalated", Status: "escalated",
+		Suggestion: "on error: Keep current model", PaneExcerpt: pane, CreatedAt: time.Now(),
+	})
+
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.inputs) != 1 || fake.inputs[0] != "2" {
+		t.Fatalf("Codex rate-limit confirmation sent %v, want menu digit 2", fake.inputs)
+	}
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 1 || corr[0].CorrectedAction != "Keep current model" || !corr[0].Sent {
+		t.Fatalf("rate-limit confirmation correction = %+v", corr)
+	}
+}
+
 // TestResolveRecordOnlyNotSent: a record-only correction (no --send) leaves
 // Sent=false so the daemon does NOT run the self-check on an expectedly-blocked
 // agent.

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -381,6 +381,31 @@ func TestConfirmCodexRateLimitErrorSendsSelectedMenuDigit(t *testing.T) {
 	}
 }
 
+func TestConfirmNonCodexRateLimitShapedErrorStaysLiteral(t *testing.T) {
+	app, st := testApp(t)
+	pane := "Approaching rate limits\n" +
+		"Switch to gpt-5.4-mini for lower credit usage?\n\n" +
+		"› 1. Switch to gpt-5.4-mini                 Small, fast, and cost-efficient model for simpler coding tasks.\n" +
+		"  2. Keep current model\n" +
+		"  3. Keep current model (never show again)  Hide future rate limit reminders about switching models.\n\n" +
+		"Press enter to confirm or esc to go back\n"
+	fake := &fakeHerdr{pane: pane}
+	app.Herdr = fake
+	ctx := context.Background()
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "claude-pane", AgentType: "claude", SituationType: domain.SituationError,
+		Trigger: "agent-status: blocked", Action: "escalated", Status: "escalated",
+		Suggestion: "on error: Keep current model", PaneExcerpt: pane, CreatedAt: time.Now(),
+	})
+
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.inputs) != 1 || fake.inputs[0] != "Keep current model" {
+		t.Fatalf("non-Codex rate-limit-shaped error sent %v, want literal reply", fake.inputs)
+	}
+}
+
 // TestResolveRecordOnlyNotSent: a record-only correction (no --send) leaves
 // Sent=false so the daemon does NOT run the self-check on an expectedly-blocked
 // agent.

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -132,6 +132,13 @@ rewrite_fallback_template = "You must act based on the following: {original_text
 # the agent starts working before it is surfaced/confirmed. Placeholders:
 # {self}, {agent_name}, {agent_type}, {pane_excerpt}, {cwd}. Omit to keep the
 # safe default: idle with no task source escalates and hap synthesizes nothing.
+#
+# The same command also refills a declared [[task_sources]] entry once its
+# checklist is fully checked off — but ONLY when BOTH task_generate_command
+# and task_generate_command_start are set (below); a list already exists in
+# that case, so task_generate_command is always used, never *_start. Without
+# both set, an exhausted source escalates a confirmable @noop suggestion
+# ("No more pending tasks") instead of the old "none" prompt.
 # (Renamed from generate_task_command; the old key no longer loads — update it.)
 # task_generate_command = [
 #   "claude", "--model", "opus", "-p",
@@ -199,7 +206,11 @@ theme = ""                 # named palette: default | dark | light | high-contra
 # ── Declared task lists for idle agents (repeatable) ────────────────
 # Without a declared source, the plugin falls back to inferring the next
 # task from the agent's own todo rendering, held to inferred_task_bar, then
-# uses generate_task_command (when configured) to surface a suggestion.
+# uses task_generate_command (when configured) to surface a suggestion. When
+# a declared source's checklist is fully checked off, the templated prompt is
+# never sent: it escalates a confirmable @noop ("No more pending tasks")
+# unless BOTH task_generate_command and task_generate_command_start are set,
+# in which case more tasks are generated instead (see above).
 # [[task_sources]]
 # agent = ""                 # short name, pane id, or type; "" = any
 # workspace = ""             # "" or "*" = any; wildcards like "codex-*" work


### PR DESCRIPTION
## Summary

- improve exhausted task-source handling so configured generation commands can propose or start follow-up work
- update configuration, decision logic, daemon behavior, documentation, and regression coverage for the expanded task-generation flow
- recognize Codex's footer-anchored “Approaching rate limits” modal as a Codex-specific error situation
- expose the modal's three options and map an operator-confirmed label back to the numbered Codex menu input

## Why

Exhausted task sources needed clearer continuation behavior when generation commands are configured. Separately, Codex's rate-limit model-switch reminder was reported as an idle pane and its “Press enter to confirm” footer could resemble a generic approval, leaving the remediation options outside the error workflow.

The new structural detector keys on the complete live Codex modal, remains scoped to Codex, and excludes stale scrollback. Ordinary error retries continue to use literal free-text input.

## Impact

Operators can review and approve the coding agent's suggested rate-limit action through the normal escalation flow. Task sources can also continue through the configured generation behavior after their declared items are exhausted.

## Validation

- live herdr pane classification: `type=error summary=rate-limit options=3`
- live option mapping verified as `1 → 1`, `2 → 2`, and `3 → 3` without sending input
- `go test -tags 'vectors cpu' ./...`
- `git diff --check`