### PR TITLE
#1 fix: learn @next_task:declared for LLM-reviewed task sends

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1149,6 +1149,32 @@ func (d *Daemon) learnedAction(ctx context.Context, s domain.Situation, dec doma
 	return dec.Input
 }
 
+// llmLearnedAction is the action recorded in decision history for an LLM
+// decision — the counterpart of learnedAction on the consult path.
+//
+// A task-review send learns SYMBOLICALLY, whatever the LLM actually sent: the
+// rule is "send the next declared task", not the text of one particular task.
+// Recording the literal text instead would bucket every task separately in
+// domain.Confidence, which groups on the raw action string — the signature
+// would never reach agreement, and a couple of @noop records could even win
+// the plurality and stand the agent down (resolveSituation checks @noop before
+// the declared task). A task review always has a declared task
+// (consultDeclaredTask), so there is no inferred variant to distinguish here.
+//
+// Every other situation (approval / choice / error, and an idle consult with no
+// task source, where the LLM authors free text) learns llmDec.Action — which is
+// exactly what gets delivered below. Deliberately NOT llmDec.OptionID, even
+// though learnedAction prefers dec.OptionID: that one comes from domain.Decide
+// and agrees with the send by construction, whereas llmDec.OptionID is supplied
+// by the model and can survive unresolved on the legacy option_id alias, which
+// would learn an answer the daemon never sent.
+func (d *Daemon) llmLearnedAction(llmDec *domain.LLMDecision, taskReviewSend bool) string {
+	if taskReviewSend {
+		return domain.ActionNextDeclaredTask
+	}
+	return llmDec.Action
+}
+
 // delivery describes one autonomous send: what to write to the pane, what
 // to audit, and what to learn.
 type delivery struct {
@@ -2180,13 +2206,31 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 	// row staged by an older binary (or written directly) must not slip a
 	// noop spelling into the pane as literal text.
 	llmDec.Action = domain.NormalizeNoopAction(llmDec.Action)
+	// A task-review send — the LLM approved the queued task, edited it, or
+	// picked another pending item. Only a decline (@noop) is not one, so
+	// classify AFTER the noop normalization above. The action is symbolic for
+	// learning (llmLearnedAction) but literal for the gates and the send below.
+	taskReviewSend := res.request.TaskReview && res.request.ProposedTask != "" &&
+		!domain.IsNoopAction(llmDec.Action)
 	// Task-review shorthand: the LLM may approve the queued task verbatim with
 	// the send-proposed sentinel instead of re-typing it. Expand it to the
 	// reviewed task BEFORE the re-gates/send so every safety scan and the
 	// escalation suggestion operate on the real instruction, never the sentinel.
-	if res.request.TaskReview && res.request.ProposedTask != "" &&
-		llmDec.Action == domain.ActionSendProposed {
+	if taskReviewSend && llmDec.Action == domain.ActionSendProposed {
 		llmDec.Action = res.request.ProposedTask
+	}
+	// The sentinel only means "send the reviewed task" on a task review that
+	// carries one. Anywhere else there is nothing to expand it to, so it must
+	// never reach the pane as literal text. Escalate WITHOUT a suggestion
+	// rather than via reject(), which would surface the raw sentinel as
+	// confirmable — an operator confirm --send would then type it into the pane.
+	if llmDec.Action == domain.ActionSendProposed {
+		d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "rejected")
+		d.escalate(ctx, s, res.sig, domain.Decision{
+			Action: domain.ActionEscalate, Reason: domain.ReasonLLMNoSubmit,
+			Rationale: "LLM submitted the send-proposed sentinel outside a task review with a proposed task",
+		}, tr, now)
+		return
 	}
 	isNoop := domain.IsNoopAction(llmDec.Action)
 	if isNoop {
@@ -2198,6 +2242,12 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		if isNoop {
 			// Raw "@noop" is never surfaced to humans.
 			suggested = domain.ActionNoopSuggestion
+		} else if taskReviewSend {
+			// Carry the task-send prefix so a confirm round-trips to the
+			// symbolic action (suggestionAction / frontend.SuggestedAction)
+			// while the operator still sees the real instruction, and
+			// materializeForSend can recover it for a confirm --send.
+			suggested = "send next declared task: " + suggested
 		}
 		// Surface the agent's self-reported confidence on the escalation so
 		// the operator can weigh the suggestion (-1 = not reported).
@@ -2373,8 +2423,11 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		}
 	}
 	// The variance guard compares the LLM's action to the signature's dominant
-	// learned action; it does not apply to a declared-task review, whose action
-	// is novel task text (each task differs) rather than a repeated answer.
+	// learned action; it does not apply to a declared-task review. A review's
+	// history is symbolic ("@next_task:declared") while llmDec.Action here is
+	// the expanded task text, so the two never compare equal — the guard would
+	// reject every review. The review has its own gate: the LLM judged the live
+	// pane, and the re-gates below still apply.
 	if !res.request.TaskReview {
 		if conf := domain.Confidence(history, cfg.Learning.ConfirmationWeight); conf.TopAction != "" && conf.TopAction != llmDec.Action {
 			reject(domain.ReasonVarianceGuard, "LLM contradicts history")
@@ -2530,7 +2583,8 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 	d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "accepted")
 	d.opt.Store.RecordDecision(ctx, domain.DecisionRecord{
 		Signature: res.sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
-		ChosenAction: llmDec.Action, Source: domain.SourceLLM, CreatedAt: now,
+		ChosenAction: d.llmLearnedAction(llmDec, taskReviewSend),
+		Source:       domain.SourceLLM, CreatedAt: now,
 	})
 	if rate2, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
 		updated := domain.RegisterAutoPrompt(*rate2, now)

--- a/internal/daemon/taskreview_test.go
+++ b/internal/daemon/taskreview_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xGosu/herdr-auto-pilot/internal/control"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 )
 
@@ -161,6 +162,251 @@ func TestDeclaredTaskLLMReviewSendProposedSentinel(t *testing.T) {
 	waitFor(t, 5*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
 	if got := h.herdr.sentInputs()[0]; got != want {
 		t.Errorf("sentinel should send the rendered task verbatim, got %q, want %q", got, want)
+	}
+}
+
+// reviewConsult returns a consult stub that stages and returns one LLM decision
+// with the given action and score — the shape every task-review test needs.
+func reviewConsult(h *harness, action string, score int) func(context.Context, domain.LLMRequest) (*domain.LLMDecision, error) {
+	return func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+		id, err := h.raw.InsertLLMDecision(ctx, domain.LLMDecision{
+			RequestID: req.RequestID, Signature: req.Signature,
+			SituationType: req.SituationType, AgentType: req.AgentType,
+			Action: action, Rationale: "reviewed the pane", ConfidentScore: score,
+			Status: "pending", CreatedAt: time.Now(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &domain.LLMDecision{ID: id, RequestID: req.RequestID, Action: action,
+			Rationale: "reviewed the pane", ConfidentScore: score, Status: "pending"}, nil
+	}
+}
+
+// onlyDecision waits for exactly one decision recorded against the signature
+// of the most recent audit row, and returns it. The signature is read from the
+// audit log rather than ListSignatures: a signature only gets a state row once
+// it is observed for learning, which has not happened on the auto path.
+func onlyDecision(t *testing.T, h *harness) domain.DecisionRecord {
+	t.Helper()
+	ctx := context.Background()
+	var got []domain.DecisionRecord
+	waitFor(t, 5*time.Second, func() bool {
+		audits, err := h.raw.AuditLog(ctx, 1)
+		if err != nil || len(audits) == 0 || audits[0].Signature == "" {
+			return false
+		}
+		got, err = h.raw.DecisionsForSignature(ctx, audits[0].Signature, 10)
+		return err == nil && len(got) == 1
+	})
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 recorded decision, got %d: %+v", len(got), got)
+	}
+	return got[0]
+}
+
+// A task-review send must learn the SYMBOLIC action, whatever text the LLM
+// actually sent: the rule is "send the next declared task", not the text of one
+// particular task. Learning the literal instead buckets every task separately
+// in domain.Confidence, so the signature never agrees with itself — and a
+// couple of @noop records can win the plurality and stand the agent down.
+// The pane must still receive the real task text in every case.
+func TestDeclaredTaskLLMReviewLearnsSymbolicAction(t *testing.T) {
+	edited := "Your next task is refactor the parser (start with the lexer)."
+	for _, tc := range []struct {
+		name     string
+		action   func(proposed string) string
+		wantSent func(proposed string) string
+	}{
+		{
+			// The shorthand: the LLM approves without re-typing the task.
+			name:     "sentinel",
+			action:   func(string) string { return domain.ActionSendProposed },
+			wantSent: func(proposed string) string { return proposed },
+		},
+		{
+			// The LLM copied the task text instead of using the sentinel —
+			// same decision, so it must learn the same symbolic action.
+			name:     "literal copy",
+			action:   func(proposed string) string { return proposed },
+			wantSent: func(proposed string) string { return proposed },
+		},
+		{
+			// An edited task still sends the LLM's text but learns
+			// symbolically: the edit is situational, not a reusable rule.
+			name:     "edited",
+			action:   func(string) string { return edited },
+			wantSent: func(string) string { return edited },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			taskFile := writeReviewTaskFile(t, "- [ ] refactor the parser\n")
+			cfg := fmt.Sprintf("[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n\n[[task_sources]]\nagent = \"agent-sym\"\npath = %q\n", taskFile)
+			h := newHarness(t, cfg)
+			h.herdr.setPane("All tests pass. Task is complete.\n")
+			h.llm.configured = true
+
+			name, err := h.raw.EnsureAgentName(context.Background(), "agent-sym")
+			if err != nil {
+				t.Fatal(err)
+			}
+			proposed := (&domain.DeclaredTask{Task: "refactor the parser", Path: taskFile, AgentName: name}).Prompt()
+			h.llm.consult = reviewConsult(h, tc.action(proposed), 90)
+
+			h.push("agent-sym", "idle")
+			waitFor(t, 5*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+			if got, want := h.herdr.sentInputs()[0], tc.wantSent(proposed); got != want {
+				t.Errorf("sent %q, want the real task text %q", got, want)
+			}
+			rec := onlyDecision(t, h)
+			if rec.ChosenAction != domain.ActionNextDeclaredTask {
+				t.Errorf("learned %q, want the symbolic %q", rec.ChosenAction, domain.ActionNextDeclaredTask)
+			}
+			if rec.Source != domain.SourceLLM {
+				t.Errorf("learned source = %q, want %q", rec.Source, domain.SourceLLM)
+			}
+		})
+	}
+}
+
+func TestDeclaredTaskLLMReviewEscalationSuggestionRoundTrips(t *testing.T) {
+	// A sub-threshold review escalates. Its suggestion must carry the task-send
+	// prefix so a confirm round-trips to the symbolic action, while the operator
+	// still reads the real instruction.
+	taskFile := writeReviewTaskFile(t, "- [ ] refactor the parser\n")
+	cfg := fmt.Sprintf("[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 95\ntimeout_seconds = 5\n\n[[task_sources]]\nagent = \"agent-rt\"\npath = %q\n", taskFile)
+	h := newHarness(t, cfg)
+	h.herdr.setPane("All tests pass. Task is complete.\n")
+	h.llm.configured = true
+	h.llm.consult = reviewConsult(h, domain.ActionSendProposed, 40)
+
+	ctx := context.Background()
+	name, err := h.raw.EnsureAgentName(ctx, "agent-rt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proposed := (&domain.DeclaredTask{Task: "refactor the parser", Path: taskFile, AgentName: name}).Prompt()
+	h.push("agent-rt", "idle")
+	var esc []domain.AuditRecord
+	waitFor(t, 5*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	want := "LLM suggested: send next declared task: " + proposed
+	if esc[0].Suggestion != want {
+		t.Errorf("suggestion = %q, want %q", esc[0].Suggestion, want)
+	}
+	if got := suggestionAction(&esc[0]); got != domain.ActionNextDeclaredTask {
+		t.Errorf("suggestion should round-trip to the symbolic action, got %q", got)
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Errorf("an escalated review must not send, sent %v", h.herdr.sentInputs())
+	}
+}
+
+func TestDeclaredTaskReviewCorrectionLearnsSymbolic(t *testing.T) {
+	// Confirming an escalated task review must learn the SYMBOLIC action too —
+	// the operator agreed with "send the next declared task", not with this
+	// task's text. This is the second half of the leak: the suggestion carries
+	// the real text, and the confirm flow round-trips it back to the sentinel.
+	taskFile := writeReviewTaskFile(t, "- [ ] refactor the parser\n")
+	cfg := fmt.Sprintf("[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 95\ntimeout_seconds = 5\n\n[[task_sources]]\nagent = \"agent-corr\"\npath = %q\n", taskFile)
+	h := newHarness(t, cfg)
+	h.herdr.setPane("All tests pass. Task is complete.\n")
+	h.llm.configured = true
+	h.llm.consult = reviewConsult(h, domain.ActionSendProposed, 40)
+
+	ctx := context.Background()
+	if _, err := h.raw.EnsureAgentName(ctx, "agent-corr"); err != nil {
+		t.Fatal(err)
+	}
+	h.push("agent-corr", "idle")
+	var esc []domain.AuditRecord
+	waitFor(t, 5*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+
+	// The operator confirms via the same round-trip the front-ends use.
+	action := frontendSuggestedAction(esc[0])
+	if action != domain.ActionNextDeclaredTask {
+		t.Fatalf("confirm resolves suggestion to %q, want %q", action, domain.ActionNextDeclaredTask)
+	}
+	if _, err := h.raw.InsertCorrection(ctx, domain.CorrectionRecord{
+		AuditID: esc[0].ID, CorrectedAction: action, Author: "operator", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := control.Nudge(ctx, h.ctlPath, control.KindReload); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, 3*time.Second, func() bool {
+		st, _ := h.raw.GetSignature(ctx, esc[0].Signature)
+		return st != nil && st.ConsecutiveConfirmations >= 1
+	})
+	decs, _ := h.raw.DecisionsForSignature(ctx, esc[0].Signature, 10)
+	if len(decs) == 0 || decs[0].ChosenAction != domain.ActionNextDeclaredTask {
+		t.Fatalf("confirmed review must learn the symbolic action: %+v", decs)
+	}
+	if decs[0].Source != domain.SourceOperator {
+		t.Errorf("learned source = %q, want %q", decs[0].Source, domain.SourceOperator)
+	}
+	// The suggestion round-trips exactly, so this reads as a confirmation of
+	// what was suggested rather than a correction away from it.
+	if decs[0].IsCorrection {
+		t.Errorf("confirming the suggested action must not record a correction: %+v", decs[0])
+	}
+}
+
+func TestLLMApprovalStillLearnsLiteralAction(t *testing.T) {
+	// The symbolic rewrite is scoped to task reviews. An ordinary approval
+	// consult shares the same RecordDecision call and must keep learning what
+	// the LLM actually answered.
+	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n"
+	h := newHarness(t, cfg)
+	h.herdr.setPane(approvalPane)
+	h.llm.configured = true
+	h.llm.consult = reviewConsult(h, "y", 90)
+
+	h.push("agent-appr", "blocked")
+	waitFor(t, 5*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	rec := onlyDecision(t, h)
+	if rec.ChosenAction != "y" {
+		t.Errorf("an approval must still learn the literal answer, got %q", rec.ChosenAction)
+	}
+}
+
+func TestLLMSendProposedSentinelOutsideTaskReviewEscalates(t *testing.T) {
+	// The sentinel is only expandable on a task review carrying a proposed
+	// task. Submitted anywhere else it has no meaning, so it must escalate
+	// rather than reach the pane as literal text.
+	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n"
+	h := newHarness(t, cfg)
+	h.herdr.setPane("Do you want to proceed?\n1. Yes\n2. No\n")
+	h.llm.configured = true
+	h.llm.consult = reviewConsult(h, domain.ActionSendProposed, 90)
+
+	ctx := context.Background()
+	h.push("agent-stray", "blocked")
+	var esc []domain.AuditRecord
+	waitFor(t, 5*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	for _, sent := range h.herdr.sentInputs() {
+		if strings.Contains(sent, domain.ActionSendProposed) {
+			t.Errorf("the raw sentinel must never reach the pane, sent %q", sent)
+		}
+	}
+	// The defining property: escalate with NO suggestion. Routing this through
+	// reject() instead would surface "LLM suggested: @next_task:declared" as
+	// confirmable, and a confirm --send would type the sentinel into the pane —
+	// while this test's send assertion above still passed.
+	if esc[0].Suggestion != "" {
+		t.Errorf("an unexpandable sentinel must not be surfaced as confirmable, suggestion = %q", esc[0].Suggestion)
+	}
+	if !strings.Contains(esc[0].Rationale, string(domain.ReasonLLMNoSubmit)) {
+		t.Errorf("want an %s escalation, got rationale %q", domain.ReasonLLMNoSubmit, esc[0].Rationale)
 	}
 }
 

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -1025,12 +1025,7 @@ func SuggestedAction(audit *domain.AuditRecord) string {
 	if strings.HasPrefix(sug, domain.SuggestTaskPrefix) {
 		return domain.SuggestGenerateTask
 	}
-	for _, p := range []string{"respond: ", "choose: ", "answer series: ", "on error: ", "LLM suggested: "} {
-		if len(sug) > len(p) && sug[:len(p)] == p {
-			sug = sug[len(p):]
-			break
-		}
-	}
+	sug = stripSourcePrefix(sug)
 	for _, p := range []string{"send next declared task: ", "send inferred next task: "} {
 		if len(sug) > len(p) && sug[:len(p)] == p {
 			if p == "send next declared task: " {
@@ -1047,13 +1042,31 @@ func SuggestedAction(audit *domain.AuditRecord) string {
 	return sug
 }
 
+// stripSourcePrefix removes the leading "who suggested this and how" label from
+// an escalation suggestion, leaving the action-bearing remainder. The
+// task-send prefixes are deliberately NOT here: they can ride behind
+// "LLM suggested: ", so both layers must be peeled in order.
+func stripSourcePrefix(sug string) string {
+	for _, p := range []string{"respond: ", "choose: ", "answer series: ", "on error: ", "LLM suggested: "} {
+		if len(sug) > len(p) && sug[:len(p)] == p {
+			return sug[len(p):]
+		}
+	}
+	return sug
+}
+
 // materializeForSend converts symbolic learned actions into the concrete
-// suggestion text when the operator asks to send.
+// suggestion text when the operator asks to send. It peels the source prefix
+// first, exactly as SuggestedAction does: an LLM task review suggests
+// "LLM suggested: send next declared task: <text>", and matching the task-send
+// prefix against the unpeeled string would miss, returning the raw
+// "@next_task:declared" sentinel — which Resolve would then type into the pane.
 func materializeForSend(action string, audit *domain.AuditRecord) string {
 	if action == domain.ActionNextDeclaredTask || action == domain.ActionNextInferredTask {
+		sug := stripSourcePrefix(audit.Suggestion)
 		for _, p := range []string{"send next declared task: ", "send inferred next task: "} {
-			if len(audit.Suggestion) > len(p) && audit.Suggestion[:len(p)] == p {
-				return audit.Suggestion[len(p):]
+			if len(sug) > len(p) && sug[:len(p)] == p {
+				return sug[len(p):]
 			}
 		}
 	}

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -474,31 +474,47 @@ func TestResolveFailedSendLeavesUnsent(t *testing.T) {
 
 func TestConfirmSendsRenderedDeclaredTaskPrompt(t *testing.T) {
 	// The confirm path must deliver the exact rendered prompt carried in the
-	// "send next declared task: " suggestion (the SuggestedAction /
-	// materializeForSend contract), while recording the symbolic action.
-	app, st := testApp(t)
-	fake := &fakeHerdr{}
-	app.Herdr = fake
-	ctx := context.Background()
-
+	// suggestion (the SuggestedAction / materializeForSend contract), while
+	// recording the symbolic action. An LLM task review wraps that suggestion in
+	// "LLM suggested: ", so both layers must be peeled — matching the task-send
+	// prefix against the unpeeled string would miss and type the raw
+	// "@next_task:declared" sentinel into the agent's pane.
 	prompt := domain.DeclaredTask{Task: "step two", Path: "/docs/tasks.md"}.Prompt()
-	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
-		AgentID: "w1:p1", SituationType: domain.SituationIdle, Trigger: "t",
-		Action: "escalated", Status: "escalated",
-		Suggestion: "send next declared task: " + prompt, CreatedAt: time.Now(),
-	})
-	if err := app.Confirm(ctx, id, true); err != nil {
-		t.Fatal(err)
-	}
-	corr, _ := st.UnprocessedCorrections(ctx)
-	if len(corr) != 1 || corr[0].CorrectedAction != domain.ActionNextDeclaredTask {
-		t.Errorf("confirm should record the symbolic declared-task action: %+v", corr)
-	}
-	if len(fake.inputs) != 1 || fake.inputs[0] != prompt {
-		t.Errorf("delivered %v, want the rendered prompt %q", fake.inputs, prompt)
-	}
-	if len(fake.panes) != 1 || fake.panes[0] != "w1:p1" {
-		t.Errorf("delivered to %v, want the audit's agent pane", fake.panes)
+	for _, tc := range []struct {
+		name       string
+		suggestion string
+		want       string
+	}{
+		{"declared", "send next declared task: " + prompt, domain.ActionNextDeclaredTask},
+		{"inferred", "send inferred next task: " + prompt, domain.ActionNextInferredTask},
+		{"llm-reviewed declared", "LLM suggested: send next declared task: " + prompt, domain.ActionNextDeclaredTask},
+		{"llm-reviewed inferred", "LLM suggested: send inferred next task: " + prompt, domain.ActionNextInferredTask},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app, st := testApp(t)
+			fake := &fakeHerdr{}
+			app.Herdr = fake
+			ctx := context.Background()
+
+			id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+				AgentID: "w1:p1", SituationType: domain.SituationIdle, Trigger: "t",
+				Action: "escalated", Status: "escalated",
+				Suggestion: tc.suggestion, CreatedAt: time.Now(),
+			})
+			if err := app.Confirm(ctx, id, true); err != nil {
+				t.Fatal(err)
+			}
+			corr, _ := st.UnprocessedCorrections(ctx)
+			if len(corr) != 1 || corr[0].CorrectedAction != tc.want {
+				t.Errorf("confirm should record the symbolic action %q: %+v", tc.want, corr)
+			}
+			if len(fake.inputs) != 1 || fake.inputs[0] != prompt {
+				t.Errorf("delivered %v, want the rendered prompt %q", fake.inputs, prompt)
+			}
+			if len(fake.panes) != 1 || fake.panes[0] != "w1:p1" {
+				t.Errorf("delivered to %v, want the audit's agent pane", fake.panes)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## The bug

Auto-sent tasks learn the **entire task text** as the rule's action instead of the symbolic `@next_task:declared`. Visible in a live `hap signatures list`:

```
idle:81169fc4021…  top="@next_task:declared"                      ← correct (rule path)
idle:734a5a8da7b…  top="Your next task is 3. Enhance the TUI…"    ← bug  (LLM task-review path)
idle:aa2083670ab…  top="Your next task is Add a maximum number…"  ← bug
```

Idle situations are meant to learn symbolically so one rule generalizes across every task in a checklist; the literal prompt is materialized at send time by `domain.materialize` (intent stated in `decide.go:8-12`). The rule path does this correctly via `learnedAction`. The **LLM task-review path does not**.

## Root cause

`handleLLMOutcome` expanded the send-proposed sentinel **in place**:

```go
llmDec.Action = res.request.ProposedTask   // sentinel destroyed here
```

The expansion is correct and must stay — the safety re-gates have to scan the real instruction, never a sentinel. The bug is that one field then serves **three roles** needing different values. Two leaked the literal text:

1. **Learning** — `RecordDecision` recorded `llmDec.Action` → full text (`source=llm`).
2. **Escalation suggestion** — `reject()` set `"LLM suggested: " + <full text>`; on confirm, `SuggestedAction` found no task-send prefix and returned the literal → `CorrectedAction` → `applyCorrection` learned full text (`source=operator`).
3. **Send text + safety gates** — correctly needs the expanded text.

## Why it matters

`domain.Confidence` buckets by the raw `ChosenAction` string. Every task has different text, so each lands in its own bucket and the signature never agrees with itself. Worse: repeated `@noop` records form **one** bucket and can win the plurality — and `resolveSituation` checks `@noop` **before** the declared task, so the rule resolves to "do nothing" and permanently stands the agent down.

Note this does **not** change LLM consult volume: the task review is gated before `Decide()` is reached, so for `llm_review=true` sources the LLM decides every send regardless of graduation.

## The fix

Keep the expansion where it is and carry the symbolic action alongside — the same split the rule path already makes via `delivery{sendText, input, learned}`. A review learns `@next_task:declared` whatever it sends (verbatim, edited, or a different pending item); the pane always receives the real text. The audit row deliberately keeps the real text — it is the human record of what was sent.

Also in scope:
- **`materializeForSend`** matched the task-send prefix only at the *start* of the suggestion. The new `"LLM suggested: send next declared task: …"` form defeated that match and fell through to the raw sentinel, which `Resolve` would type **into the agent's pane** on `confirm --send`. Both call sites now share one `stripSourcePrefix` helper.
- Guards a stray sentinel submitted outside a task review (previously reached the pane as literal text), escalating without a suggestion so it can never be confirmed into the pane.

## Verification

- Full suite green (22 packages, `-tags "vectors cpu"`); gofmt/vet/golangci-lint clean.
- Every new test **fails on the un-fixed code** with the bug's exact signature — including the confirm-send trap delivering the literal `@next_task:declared`.
- Integration suite against real herdr passes, incl. `TestRealConfirmDeliversMenuDigit`.
- **Live-tested against a real agent.** Semantic matching mapped the test onto a signature that already carried the old records, so both are directly comparable:

  | when | daemon | learned |
  |---|---|---|
  | 07-16 08:38–08:39 | old | `"Your next task is reply with exactly the word kiwi…"` ×5 |
  | 07-17 00:38 | fixed | `@next_task:declared` ×3 |

  The pane received the real instruction and the agent acted on it.

## Follow-ups (not in this PR)

- Existing polluted rules aren't repaired by the code fix. Four idle rules carry literal task text; all are still `shadow 1/3` (none graduated, none acting). Delete with `hap signatures delete` once this ships — doing it earlier just lets the current daemon rewrite them.
- `CLAUDE.md`'s `go test -tags integration ./test/integration/ -v` is stale: `internal/match` needs the `vectors` tag for bleve's `AddKNNWithFilter`. The working form is `-tags "integration vectors cpu"`.

https://claude.ai/code/session_01LxMdSdreijPgYXN62Yvebi