### PR TITLE
#1 fix: dedup pending escalations by normalized content, not exact string

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -754,36 +754,53 @@ func (d *Daemon) hasOpenEscalation(ctx context.Context, agentID string) bool {
 	return false
 }
 
-// duplicatePendingEscalation reports whether the captured situation exactly
-// matches an escalation the user has not yet handled. It is the content-level
-// sibling of hasOpenEscalation (which is pane/agent-level and used by the
-// reconcile sweep): finer, so a genuinely new situation on a pane that already
-// has an open escalation still gets processed. The pane excerpt is truncated
-// exactly as escalate() stores it so the comparison lines up.
+// duplicatePendingEscalation reports whether the captured situation repeats an
+// escalation the operator has not yet handled — so re-raising it would ask the
+// same question twice. Herdr re-delivers an attention event for one agent after
+// a delay (the agent flips done->idle when the operator reads the pane), and
+// the exact-string check it replaces missed those re-fires because the pane's
+// volatile chrome (a spinner tick, an elapsed/countdown counter) had moved on.
+//
+// The key is agent + agent type + the NORMALIZED pane content
+// (domain.NormalizeForDedup elides that chrome). The agent status is
+// deliberately excluded — it is the field that legitimately CHANGES between the
+// duplicates — and so are trigger() (which embeds it) and situation_type (which
+// the classifier DERIVES from it). See domain.DuplicatesPendingEscalation.
+//
+// It runs only where escalations are raised (escalate() and the
+// pane-read-failure path), NOT before the decision core: the rate guard, retry
+// ceiling, and shadow-mode learning all work by re-processing repeated
+// identical events, so suppressing those would bypass a safety control.
+//
+// It is the content-level sibling of hasOpenEscalation (which is
+// pane/agent-level and used by the reconcile sweep): finer, so a genuinely new
+// situation on a pane that already has an open escalation still gets processed.
+// The pane excerpt is truncated exactly as the write paths store it so the
+// comparison lines up.
 //
 // Fails OPEN (returns false) on a store error — the opposite of
 // hasOpenEscalation. Dropping a real event silently is worse than
-// re-processing one, so on doubt the event proceeds to escalate/act rather
-// than being ignored (the "never a silent drop" architecture rule).
+// re-processing one, so on doubt the event proceeds to escalate rather than
+// being ignored (the "never a silent drop" architecture rule).
 func (d *Daemon) duplicatePendingEscalation(ctx context.Context, s domain.Situation) bool {
-	dup, err := d.opt.Store.DuplicatePendingEscalation(ctx, s.AgentID, s.AgentType,
-		s.Type, truncateTailRunes(s.Content, snapshotMaxRunes))
+	pending, err := d.opt.Store.PendingEscalationExcerpts(ctx, s.AgentID, s.AgentType)
 	if err != nil {
 		slog.Warn("duplicate-escalation check failed; processing event",
 			"agent", s.AgentID, "pane", s.PaneID, "error", err)
 		return false
 	}
-	return dup
+	return domain.DuplicatesPendingEscalation(s.Type,
+		truncateTailRunes(s.Content, snapshotMaxRunes), pending)
 }
 
-// ignoreDuplicate audits a no-op for an event whose situation already has an
-// identical pending escalation awaiting the operator. Shared by escalate() and
+// ignoreDuplicate audits a no-op for an event whose situation already has a
+// matching pending escalation awaiting the operator. Shared by escalate() and
 // the pane-read-failure path so both routes record duplicates the same way.
 func (d *Daemon) ignoreDuplicate(ctx context.Context, s domain.Situation,
 	tr domain.AgentTransition, now time.Time) {
 	d.audit(ctx, domain.AuditRecord{
 		AgentID: s.AgentID, AgentType: s.AgentType, Trigger: trigger(tr),
-		SituationType: s.Type, Action: "ignored", Status: "ignored",
+		SituationType: s.Type, Action: "ignored", Status: domain.AuditStatusIgnored,
 		Rationale:   "duplicated event",
 		PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes),
 		CreatedAt:   now,
@@ -814,8 +831,9 @@ func (d *Daemon) handleAttention(ctx context.Context, tr domain.AgentTransition)
 		// This escalation bypasses escalate() (no pane to classify), so apply
 		// the same dedup here: a persistent outage delivers the same blocked
 		// event repeatedly and must not pile up identical pending rows. The
-		// unreadable pane has no excerpt, so the key collapses to agent + type
-		// + unclassifiable — exactly matching the row this path writes.
+		// unreadable pane has no excerpt, so the empty-content fallback in
+		// domain.DuplicatesPendingEscalation keys on the situation type, which
+		// keeps this from matching a pending escalation of a different kind.
 		failed := domain.Situation{
 			AgentID: tr.AgentID, AgentType: tr.AgentType, PaneID: tr.PaneID,
 			Type: domain.SituationUnclassifiable,
@@ -1351,16 +1369,16 @@ func (d *Daemon) deliverNoop(ctx context.Context, s domain.Situation, sig domain
 func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.SignatureResult,
 	dec domain.Decision, tr domain.AgentTransition, now time.Time) {
 
-	// Dedup: if this exact situation is already awaiting the user in the
-	// pending-escalation queue (same agent + type + situation type + pane
-	// content), re-raising it would just be a duplicate ask. Ignore the event
-	// (no ops) and record why. Gating here rather than before decideAndAct
-	// means only a would-be duplicate ESCALATION is suppressed — a situation
-	// that can now auto-answer (e.g. after a kill-switch resume) still acts.
-	// escalate() is where almost every escalation is born, so this also caps
-	// escalation storms from the async LLM/rewrite/taskgen rejection paths.
-	// (The one escalation that bypasses escalate() — the pane-read-failure
-	// path in handleAttention — is dedup'd there directly.)
+	// Dedup: if this situation is already awaiting the user in the
+	// pending-escalation queue, re-raising it would just be a duplicate ask.
+	// Ignore the event (no ops) and record why. Gating here rather than before
+	// decideAndAct means only a would-be duplicate ESCALATION is suppressed — a
+	// situation that can now auto-answer (e.g. after a kill-switch resume) still
+	// acts, and the rate guard / retry ceiling still see every repeated
+	// identical event. escalate() is where almost every escalation is born, so
+	// this also caps escalation storms from the async LLM/rewrite/taskgen
+	// rejection paths. (The one escalation that bypasses escalate() — the
+	// pane-read-failure path in handleAttention — is dedup'd there directly.)
 	if d.duplicatePendingEscalation(ctx, s) {
 		d.ignoreDuplicate(ctx, s, tr, now)
 		return
@@ -2716,8 +2734,8 @@ func (d *Daemon) applyLLMRetry(ctx context.Context, r domain.LLMRetry) bool {
 	// The retry is now accepted: its consult is not competing with an
 	// in-flight one and its agent still has a live pane. Retire the source
 	// escalation before scheduling the recapture. This removes the stale
-	// failure from the pending list and prevents duplicatePendingEscalation
-	// from mistaking the explicitly requested retry for a duplicate of itself.
+	// failure from the pending list and prevents the duplicate check from
+	// mistaking the explicitly requested retry for a duplicate of itself.
 	// A retry failure writes a fresh retryable escalation; a successful LLM
 	// result writes a fresh llm_retry escalation for operator review.
 	retired, err := d.opt.Store.RetireEscalationForRetry(ctx, r.AuditID)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -394,6 +394,7 @@ type failingStore struct {
 	mu          sync.Mutex
 	failAudit   bool
 	failPending bool
+	failDedup   bool
 }
 
 func (f *failingStore) setFailAudit(v bool) {
@@ -406,6 +407,12 @@ func (f *failingStore) setFailPending(v bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.failPending = v
+}
+
+func (f *failingStore) setFailDedup(v bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failDedup = v
 }
 
 func (f *failingStore) AppendAudit(ctx context.Context, a domain.AuditRecord) (int64, error) {
@@ -426,6 +433,16 @@ func (f *failingStore) HasPendingLLMConsult(ctx context.Context, agentID string)
 		return false, errors.New("induced pending-check failure")
 	}
 	return f.StorePort.HasPendingLLMConsult(ctx, agentID)
+}
+
+func (f *failingStore) PendingEscalationExcerpts(ctx context.Context, agentID, agentType string) ([]domain.PendingEscalation, error) {
+	f.mu.Lock()
+	fail := f.failDedup
+	f.mu.Unlock()
+	if fail {
+		return nil, errors.New("induced dedup-check failure")
+	}
+	return f.StorePort.PendingEscalationExcerpts(ctx, agentID, agentType)
 }
 
 // --- harness ---
@@ -1150,6 +1167,62 @@ func TestPipelineShadowModeEscalatesWithSuggestion(t *testing.T) {
 // otherApprovalPane is a distinct approval (different command → different
 // classified content/signature) used to prove content-level dedup.
 const otherApprovalPane = "Bash(npm install)\n\nDo you want to proceed?\n❯ 1. Yes\n  2. No, and tell the agent what to do differently\n"
+
+// chromedApproval renders the approval with a leading spinner/status line that
+// ticks a timer between captures — the volatile agent-TUI chrome that
+// NormalizeForDedup elides so two captures of one standing screen read equal.
+func chromedApproval(seconds int) string {
+	return fmt.Sprintf("✻ Baking… (%ds · esc to interrupt)\n%s", seconds, approvalPane)
+}
+
+// TestPipelineDedupAbsorbsChromeJitter is the headline improvement over the
+// old exact-match dedup: an escalation is raised, then herdr re-delivers the
+// same screen (as idle, when the operator reads the pane) with only the
+// spinner's elapsed counter ticked. The old exact `pane_excerpt = ?` check
+// missed that re-fire and raised a duplicate ask; the normalized check catches
+// it — one pending escalation, one ignored row.
+func TestPipelineDedupAbsorbsChromeJitter(t *testing.T) {
+	h := newHarness(t, "")
+	ctx := context.Background()
+	h.herdr.setPane(chromedApproval(12))
+
+	// No learned rule → the approval escalates.
+	h.push("agent-dup", "blocked")
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+
+	// Same screen re-delivered as idle with the timer ticked: the pane content
+	// differs only in the chrome line, and the re-classification to idle must
+	// not matter (situation_type is excluded from the key).
+	h.herdr.setPane(chromedApproval(14))
+	h.push("agent-dup", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(ignoredRows(t, h)) == 1 })
+
+	if esc, _ := h.raw.PendingEscalations(ctx); len(esc) != 1 {
+		t.Fatalf("chrome-jittered re-delivery raised a duplicate ask: got %d, want 1", len(esc))
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Fatal("duplicate escalation must not send input")
+	}
+}
+
+// TestPipelineDedupFailsOpen: a store error in the duplicate-ask check must not
+// drop a real event ("never a silent drop") — it is processed instead.
+func TestPipelineDedupFailsOpen(t *testing.T) {
+	h := newHarness(t, "")
+	ctx := context.Background()
+	h.herdr.setPane(approvalPane)
+	h.store.(*failingStore).setFailDedup(true)
+
+	h.push("agent-dup", "blocked")
+	// The event still escalates despite the dedup query failing.
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+}
 
 // ignoredRows returns every audit row the daemon marked as an ignored
 // duplicate event.

--- a/internal/domain/dedup.go
+++ b/internal/domain/dedup.go
@@ -1,0 +1,137 @@
+package domain
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Herdr re-delivers an attention event for the same agent after a delay: the
+// agent flips done->idle when the operator reads the pane, and the event fires
+// again carrying the same screen. Re-raising an escalation for it would ask the
+// operator the same question twice. This file holds the pure half of the
+// duplicate-ask check: what counts as "the same screen again".
+
+// Volatile agent-TUI chrome (FR-003). These lines repaint on a timer and carry
+// no decision content, so two captures of one standing screen differ only
+// here. Each pattern is justified by an observed render:
+//
+//	✻ Waiting for API response · will retry in 2m 2s · check your network
+//	✽ Thinking… (12s · ↑ 1.2k tokens · esc to interrupt)
+//
+// The elision is deliberately LINE-scoped rather than token-scoped. Masking
+// individual tokens is what makes MaskVolatile unusable here (see
+// NormalizeForDedup): a token masker that eats "2s" also eats the "5s" in
+// `Bash(sleep 5s)`. A whole chrome LINE can be dropped safely because nothing
+// in it is ever the question being asked.
+var (
+	// dedupSpinnerLineRE matches a spinner/status header by its leading glyph.
+	// Only the star frames the agent TUIs use EXCLUSIVELY for the animated
+	// working line are listed — they cycle (✽ ✻ ✶ ✳ ✢) between captures of one
+	// motionless screen. Deliberately NOT included: ● (Claude's SETTLED
+	// assistant-message bullet — a stable content line, e.g. "● All tests
+	// pass."), and · / * (which also begin separators and markdown bullets).
+	// Eliding those would risk collapsing two genuinely different escalations,
+	// silently dropping a real operator ask.
+	dedupSpinnerLineRE = regexp.MustCompile(`^[✽✻✶✳✢]\s`)
+	// dedupChromeMarkers are substrings that mark a line as agent chrome
+	// carrying a live counter (elapsed time, countdown, token usage). These
+	// catch the volatile status/retry lines regardless of their current glyph.
+	dedupChromeMarkers = []string{"esc to interrupt", "will retry in"}
+	// dedupWhitespaceRE collapses whitespace runs so a repaint that shifts
+	// padding or re-wraps a line still reads as the same screen.
+	dedupWhitespaceRE = regexp.MustCompile(`\s+`)
+)
+
+// dedupChromePlaceholder replaces an elided chrome line. A placeholder rather
+// than a deletion so a screen that GAINS or LOSES a chrome line is still
+// recognizably different.
+const dedupChromePlaceholder = "<chrome>"
+
+// NormalizeForDedup canonicalizes captured pane content for the duplicate
+// check: elide volatile agent-TUI chrome lines, then collapse whitespace runs.
+//
+// It deliberately does NOT use MaskVolatile, and that is the whole design.
+// MaskVolatile is the LEARNING primitive: it replaces <path>/<num>/<hash> so
+// paraphrases of one situation collapse onto a single signature. Those are
+// exactly the tokens that distinguish two consecutive but DIFFERENT questions
+// from one agent — verified: "Bash(rm -rf /tmp/foo)" and "Bash(rm -rf
+// /tmp/bar)" both mask to "Bash(rm -rf <path>)". Because herdr's pane read is
+// a consuming delta (--source recent), a second capture may carry no
+// scrollback to tell them apart, so masking here would silently swallow a real
+// question and strand the agent — the "never a silent drop" rule.
+//
+// Dedup asks "is this the same screen again?", not "is this the same KIND of
+// screen?". So paths, commands and numbers are left untouched and only chrome
+// that provably repaints on its own is elided. An unrecognized jitter source
+// therefore fails SAFE: the captures compare unequal and the event is
+// processed, exactly as it is today.
+func NormalizeForDedup(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, ln := range lines {
+		if isDedupChromeLine(strings.TrimSpace(ln)) {
+			lines[i] = dedupChromePlaceholder
+		}
+	}
+	return strings.TrimSpace(dedupWhitespaceRE.ReplaceAllString(strings.Join(lines, "\n"), " "))
+}
+
+// isDedupChromeLine reports whether a trimmed line is volatile agent chrome.
+func isDedupChromeLine(trimmed string) bool {
+	if trimmed == "" {
+		return false
+	}
+	if dedupSpinnerLineRE.MatchString(trimmed) {
+		return true
+	}
+	for _, m := range dedupChromeMarkers {
+		if strings.Contains(trimmed, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// PendingEscalation is one escalation still awaiting the operator, narrowed to
+// the fields the duplicate-ask check may look at. Narrowed on purpose: it omits
+// the agent status (and AuditRecord.Trigger, which embeds it as "agent-status:
+// idle") so a caller cannot key on the field that legitimately CHANGES between
+// the duplicates.
+type PendingEscalation struct {
+	SituationType SituationType
+	PaneExcerpt   string
+}
+
+// DuplicatesPendingEscalation reports whether a fresh capture repeats an
+// escalation already awaiting the operator — so re-raising it would just ask
+// the same question twice. `pending` must be pre-scoped to one agent + agent
+// type (the store does this).
+//
+// The key is agent + agent type + the normalized pane content. Neither the
+// agent status nor the situation type participates:
+//   - agent_status is exactly what changes between the duplicates (done->idle
+//     when the operator reads the pane); AuditRecord.Trigger embeds it, which
+//     is why PendingEscalation omits it.
+//   - situation_type is DERIVED from the status (Classifier.Classify gates the
+//     approval/choice rules on herdr reporting "blocked"), so one standing
+//     screen re-fired as idle reclassifies. Keying on it would miss the very
+//     re-fire this exists to catch.
+//
+// The one exception is empty content: with no content to compare, the type is
+// the only identity left, so an empty-excerpt escalation must also match on
+// type. This keeps the herdr-unreachable path (which has no pane to read, and
+// legitimately keys on "") from matching an empty-excerpt escalation of a
+// different kind.
+func DuplicatesPendingEscalation(sitType SituationType, excerpt string, pending []PendingEscalation) bool {
+	key := NormalizeForDedup(excerpt)
+	for _, p := range pending {
+		if NormalizeForDedup(p.PaneExcerpt) != key {
+			continue
+		}
+		// No content to discriminate on: fall back to the situation type.
+		if key == "" && p.SituationType != sitType {
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/internal/domain/dedup_test.go
+++ b/internal/domain/dedup_test.go
@@ -1,0 +1,139 @@
+package domain
+
+import "testing"
+
+func TestNormalizeForDedup(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"trims and collapses whitespace", "  a   b\t c \n", "a b c"},
+		{"collapses newlines", "line one\nline two", "line one line two"},
+		{"empty stays empty", "   \n\t ", ""},
+		{
+			"elides claude api-retry countdown",
+			"✻ Waiting for API response · will retry in 2m 2s · check your network\nAllow bash?",
+			"<chrome> Allow bash?",
+		},
+		{
+			"countdown tick reads identical",
+			"✻ Waiting for API response · will retry in 2m 0s · check your network\nAllow bash?",
+			"<chrome> Allow bash?",
+		},
+		{
+			"elides elapsed/token spinner line",
+			"✽ Thinking… (12s · ↑ 1.2k tokens · esc to interrupt)\nEdit main.go?",
+			"<chrome> Edit main.go?",
+		},
+		{
+			"different question is NOT collapsed",
+			"Bash(rm -rf /tmp/foo)?",
+			"Bash(rm -rf /tmp/foo)?",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeForDedup(tc.in); got != tc.want {
+				t.Errorf("NormalizeForDedup(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The decisive property: two DIFFERENT commands/paths must never normalize
+// equal (the MaskVolatile trap this design exists to avoid).
+func TestNormalizeForDedupKeepsDistinctContentDistinct(t *testing.T) {
+	pairs := [][2]string{
+		{"Bash(rm -rf /tmp/foo)?", "Bash(rm -rf /tmp/bar)?"},
+		{"Edit /a/b.go?", "Edit /a/c.go?"},
+		{"Delete 3 files?", "Delete 4 files?"},
+		// ● is Claude's SETTLED assistant-message bullet — real content, not a
+		// spinner frame. Two escalations distinguished only by a ●-led line must
+		// stay distinct (regression: the glyph was once wrongly elided).
+		{"● I'll delete the staging bucket.\nProceed?", "● I'll delete the prod bucket.\nProceed?"},
+		{"* run tests\nProceed?", "* run lint\nProceed?"},
+	}
+	for _, p := range pairs {
+		if NormalizeForDedup(p[0]) == NormalizeForDedup(p[1]) {
+			t.Errorf("distinct content collapsed: %q vs %q", p[0], p[1])
+		}
+	}
+}
+
+// Timer/spinner jitter on one standing screen must normalize equal.
+func TestNormalizeForDedupAbsorbsChromeJitter(t *testing.T) {
+	pairs := [][2]string{
+		{
+			"✻ Waiting for API response · will retry in 2m 2s · check your network\nAllow bash(ls)?",
+			"✻ Waiting for API response · will retry in 1m 58s · check your network\nAllow bash(ls)?",
+		},
+		{
+			"✽ Thinking… (12s · esc to interrupt)\nEdit main.go?",
+			"✳ Thinking… (14s · esc to interrupt)\nEdit main.go?",
+		},
+	}
+	for _, p := range pairs {
+		if NormalizeForDedup(p[0]) != NormalizeForDedup(p[1]) {
+			t.Errorf("chrome jitter not absorbed:\n a=%q -> %q\n b=%q -> %q",
+				p[0], NormalizeForDedup(p[0]), p[1], NormalizeForDedup(p[1]))
+		}
+	}
+}
+
+func pend(sit SituationType, excerpt string) PendingEscalation {
+	return PendingEscalation{SituationType: sit, PaneExcerpt: excerpt}
+}
+
+func TestDuplicatesPendingEscalation(t *testing.T) {
+	const x = "Allow bash(ls)?"
+	tests := []struct {
+		name    string
+		sit     SituationType
+		excerpt string
+		pending []PendingEscalation
+		want    bool
+	}{
+		{"no pending escalations", SituationApproval, x, nil, false},
+		{"exact repeat of a pending escalation", SituationApproval, x,
+			[]PendingEscalation{pend(SituationApproval, x)}, true},
+		{
+			// The headline case: herdr re-fires with a flipped status, so the
+			// re-classified situation_type differs — must still dedup.
+			"same content, different situation_type still duplicates",
+			SituationIdle, x,
+			[]PendingEscalation{pend(SituationApproval, x)}, true,
+		},
+		{"whitespace/repaint jitter", SituationApproval, "a  b\nc",
+			[]PendingEscalation{pend(SituationApproval, "a b c")}, true},
+		{
+			"different question same shape is NOT a duplicate",
+			SituationApproval, "Edit /a/b.go?",
+			[]PendingEscalation{pend(SituationApproval, "Edit /a/c.go?")}, false,
+		},
+		{"first match among several wins", SituationApproval, x,
+			[]PendingEscalation{pend(SituationApproval, "something else"), pend(SituationApproval, x)}, true},
+		{
+			// Empty content: the read-failure path keys on "" and must match an
+			// empty-excerpt pending escalation of the same type.
+			"empty excerpt matches on situation type",
+			SituationUnclassifiable, "",
+			[]PendingEscalation{pend(SituationUnclassifiable, "")}, true,
+		},
+		{
+			// ...but not an empty-excerpt escalation of a DIFFERENT type.
+			"empty excerpt does not match a different empty type",
+			SituationUnclassifiable, "",
+			[]PendingEscalation{pend(SituationApproval, "")}, false,
+		},
+		{"empty candidate vs real content", SituationApproval, x,
+			[]PendingEscalation{pend(SituationApproval, "")}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DuplicatesPendingEscalation(tc.sit, tc.excerpt, tc.pending); got != tc.want {
+				t.Errorf("DuplicatesPendingEscalation = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -275,6 +275,16 @@ const (
 	RationaleOperatorCorrected = "operator corrected"
 )
 
+// audit_log Status literals shared across packages.
+const (
+	// AuditStatusIgnored: a duplicate event the daemon dropped as a repeat of a
+	// pending escalation.
+	AuditStatusIgnored = "ignored"
+	// AuditStatusDeliveryFailed: a delivered action left the agent still
+	// blocked (verifyunblock's diagnostic).
+	AuditStatusDeliveryFailed = "delivery_failed"
+)
+
 // AgentStats are lifetime per-agent counters derived from audit_log, keyed by
 // the herdr pane id. A rename preserves them (same pane id); a restart yields
 // a new pane id and thus a fresh, empty set.

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -274,11 +274,11 @@ type ReadStore interface {
 	// CountPendingEscalations counts pending escalations without fetching
 	// the (pane-excerpt-heavy) rows.
 	CountPendingEscalations(ctx context.Context) (int64, error)
-	// DuplicatePendingEscalation reports whether an unresolved escalation
-	// already exists for the same agent + agent type + situation type +
-	// exact pane excerpt — the daemon's live-event dedup key.
-	DuplicatePendingEscalation(ctx context.Context, agentID, agentType string,
-		sitType domain.SituationType, paneExcerpt string) (bool, error)
+	// PendingEscalationExcerpts returns the pane excerpts of every escalation
+	// still awaiting the operator for this agent + agent type (any age) — the
+	// candidate set for the daemon's duplicate-ask check. The excerpt
+	// comparison itself lives in domain.DuplicatesPendingEscalation.
+	PendingEscalationExcerpts(ctx context.Context, agentID, agentType string) ([]domain.PendingEscalation, error)
 	UnprocessedCorrections(ctx context.Context) ([]domain.CorrectionRecord, error)
 	// UnprocessedLLMRetries returns queued LLM-retry requests in order.
 	UnprocessedLLMRetries(ctx context.Context) ([]domain.LLMRetry, error)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1125,14 +1125,32 @@ func (s *Store) PendingEscalations(ctx context.Context) ([]domain.AuditRecord, e
 	return s.scanAudits(rows)
 }
 
-// PendingEscalationExcerpts returns the pane excerpts of every escalation still
-// awaiting the operator for this agent + agent type, regardless of age — the
-// candidate set for the daemon's duplicate-ask check. It is NOT scoped by
-// situation_type: that field is DERIVED from the agent status (the classifier
-// gates the approval/choice rules on herdr reporting "blocked"), so one
-// standing screen re-fired as idle reclassifies, and scoping by it would miss
-// the very re-delivery this dedups. The excerpt comparison, which is the real
-// key, happens in domain.DuplicatesPendingEscalation.
+// PendingEscalationDedupLimit bounds how many pending escalations the daemon
+// pulls per duplicate-ask check. The check runs on the synchronous event loop
+// and normalizes each returned excerpt (up to snapshotMaxRunes) in Go, so the
+// fetch is capped to keep that work constant regardless of how large an agent's
+// unresolved-escalation backlog grows (NFR-001/NFR-002). Correctness holds in
+// practice: an agent shows one screen at a time and the dedup itself stops
+// identical escalations from stacking, so a re-delivery always matches a RECENT
+// escalation — well inside this newest-first window. The limit is generous
+// (~100× a realistic agent's pending count); should it ever be exceeded, the
+// worst case is one redundant operator ask, never a silent drop.
+const PendingEscalationDedupLimit = 128
+
+// PendingEscalationExcerpts returns the pane excerpts of the most recent pending
+// escalations awaiting the operator for this agent + agent type (newest first,
+// capped at PendingEscalationDedupLimit) — the candidate set for the daemon's
+// duplicate-ask check. It is NOT scoped by situation_type: that field is DERIVED
+// from the agent status (the classifier gates the approval/choice rules on herdr
+// reporting "blocked"), so one standing screen re-fired as idle reclassifies,
+// and scoping by it would miss the very re-delivery this dedups. The excerpt
+// comparison, which is the real key, happens in
+// domain.DuplicatesPendingEscalation.
+//
+// The status='escalated' filter is served by idx_audit_status, and pending
+// escalations are globally few (the dedup prevents identical ones from
+// stacking), so the scan stays bounded; the LIMIT additionally caps the Go-side
+// normalization.
 //
 // Escalations with an unprocessed LLM retry are excluded: the retry explicitly
 // asks to re-evaluate this exact content, so its source row must not suppress
@@ -1143,8 +1161,8 @@ func (s *Store) PendingEscalationExcerpts(ctx context.Context, agentID, agentTyp
 			WHERE a.status = 'escalated' AND a.agent_id = ? AND a.agent_type = ?
 			  AND NOT EXISTS (SELECT 1 FROM llm_retries r
 					WHERE r.audit_id = a.id AND r.processed = 0)
-			ORDER BY a.id DESC`,
-		agentID, agentType)
+			ORDER BY a.id DESC LIMIT ?`,
+		agentID, agentType, PendingEscalationDedupLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1125,30 +1125,41 @@ func (s *Store) PendingEscalations(ctx context.Context) ([]domain.AuditRecord, e
 	return s.scanAudits(rows)
 }
 
-// DuplicatePendingEscalation reports whether an unresolved escalation already
-// exists for the same agent + agent type + situation type + exact pane content.
-// It backs the daemon's live-event dedup: a fresh transition whose captured
-// situation matches an escalation still awaiting the user is a duplicate and is
-// ignored. Escalations with an unprocessed LLM retry are excluded: the retry
-// explicitly asks to re-evaluate the same content, so its source row must not
-// suppress that recapture. Once accepted, the daemon retires the source row
-// before marking the queued retry processed. Cheaper than PendingEscalations —
-// it never materializes the (pane-excerpt-heavy) rows. The caller must pass the
-// pane excerpt already truncated the same way escalate() stores it, so the
-// comparison lines up.
-func (s *Store) DuplicatePendingEscalation(ctx context.Context, agentID, agentType string,
-	sitType domain.SituationType, paneExcerpt string) (bool, error) {
-	var exists int
-	err := s.db.QueryRowContext(ctx,
-		`SELECT EXISTS(SELECT 1 FROM audit_log a WHERE a.status = 'escalated'
-			AND a.agent_id = ? AND a.agent_type = ? AND a.situation_type = ? AND a.pane_excerpt = ?
-			AND NOT EXISTS (SELECT 1 FROM llm_retries r
-				WHERE r.audit_id = a.id AND r.processed = 0))`,
-		agentID, agentType, string(sitType), paneExcerpt).Scan(&exists)
+// PendingEscalationExcerpts returns the pane excerpts of every escalation still
+// awaiting the operator for this agent + agent type, regardless of age — the
+// candidate set for the daemon's duplicate-ask check. It is NOT scoped by
+// situation_type: that field is DERIVED from the agent status (the classifier
+// gates the approval/choice rules on herdr reporting "blocked"), so one
+// standing screen re-fired as idle reclassifies, and scoping by it would miss
+// the very re-delivery this dedups. The excerpt comparison, which is the real
+// key, happens in domain.DuplicatesPendingEscalation.
+//
+// Escalations with an unprocessed LLM retry are excluded: the retry explicitly
+// asks to re-evaluate this exact content, so its source row must not suppress
+// the recapture (mirrors the pre-existing dedup query).
+func (s *Store) PendingEscalationExcerpts(ctx context.Context, agentID, agentType string) ([]domain.PendingEscalation, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT situation_type, pane_excerpt FROM audit_log a
+			WHERE a.status = 'escalated' AND a.agent_id = ? AND a.agent_type = ?
+			  AND NOT EXISTS (SELECT 1 FROM llm_retries r
+					WHERE r.audit_id = a.id AND r.processed = 0)
+			ORDER BY a.id DESC`,
+		agentID, agentType)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	return exists != 0, nil
+	defer rows.Close()
+	var out []domain.PendingEscalation
+	for rows.Next() {
+		var sit, excerpt string
+		if err := rows.Scan(&sit, &excerpt); err != nil {
+			return nil, err
+		}
+		out = append(out, domain.PendingEscalation{
+			SituationType: domain.SituationType(sit), PaneExcerpt: excerpt,
+		})
+	}
+	return out, rows.Err()
 }
 
 // UnprocessedCorrections returns corrections the daemon has not consumed.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -443,6 +443,51 @@ func TestPendingEscalationExcerpts(t *testing.T) {
 	}
 }
 
+// TestPendingEscalationExcerptsBounded pins the hot-path bound: the
+// duplicate-ask check runs on the daemon's synchronous event loop, so a large
+// unresolved-escalation backlog for one agent must not make the fetch (and the
+// Go-side normalization the daemon does over it) grow without limit. Seed more
+// than the cap and assert the query returns at most PendingEscalationDedupLimit
+// rows, newest first (so a re-delivery of a recent screen is still covered).
+func TestPendingEscalationExcerptsBounded(t *testing.T) {
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	total := PendingEscalationDedupLimit + 25
+	for i := 0; i < total; i++ {
+		if _, err := s.AppendAudit(ctx, domain.AuditRecord{
+			AgentID: "agent-1", AgentType: "claude", Trigger: "x",
+			SituationType: domain.SituationApproval, Action: "escalated", Status: "escalated",
+			PaneExcerpt: fmt.Sprintf("pending screen %d", i),
+			CreatedAt:   now.Add(time.Duration(i) * time.Millisecond),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := s.PendingEscalationExcerpts(ctx, "agent-1", "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != PendingEscalationDedupLimit {
+		t.Fatalf("fetch not bounded: got %d rows, want %d", len(got), PendingEscalationDedupLimit)
+	}
+	// Newest-first: the most recently seeded screen is present, so a re-delivery
+	// of the agent's current (recent) screen still dedups.
+	newest := fmt.Sprintf("pending screen %d", total-1)
+	found := false
+	for _, p := range got {
+		if p.PaneExcerpt == newest {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("newest pending escalation %q missing from the bounded window", newest)
+	}
+}
+
 func TestRetireEscalationForRetry(t *testing.T) {
 	s, _ := openTestStore(t)
 	ctx := context.Background()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -369,64 +369,77 @@ func TestPendingEscalations(t *testing.T) {
 	}
 }
 
-func TestDuplicatePendingEscalation(t *testing.T) {
+func TestPendingEscalationExcerpts(t *testing.T) {
 	s, _ := openTestStore(t)
 	ctx := context.Background()
-	rec := domain.AuditRecord{
-		AgentID: "agent-1", AgentType: "claude", Trigger: "x",
-		SituationType: domain.SituationChoice, Action: "escalated",
-		Status: "escalated", PaneExcerpt: "pick a package manager: 1. pnpm 2. npm",
-		CreatedAt: time.Now(),
-	}
-	id, err := s.AppendAudit(ctx, rec)
-	if err != nil {
-		t.Fatal(err)
-	}
+	now := time.Now()
 
-	dup := func(r domain.AuditRecord) bool {
-		got, err := s.DuplicatePendingEscalation(ctx, r.AgentID, r.AgentType, r.SituationType, r.PaneExcerpt)
+	var pendingID int64
+	seed := func(agentID, agentType string, sit domain.SituationType, status, excerpt string, at time.Time) int64 {
+		id, err := s.AppendAudit(ctx, domain.AuditRecord{
+			AgentID: agentID, AgentType: agentType, Trigger: "x",
+			SituationType: sit, Action: status, Status: status,
+			PaneExcerpt: excerpt, CreatedAt: at,
+		})
 		if err != nil {
-			t.Fatalf("DuplicatePendingEscalation: %v", err)
+			t.Fatal(err)
 		}
-		return got
+		return id
 	}
 
-	if !dup(rec) {
-		t.Error("identical escalated row should match")
+	// A pending escalation, however old, is a candidate (unbounded in time).
+	pendingID = seed("agent-1", "claude", domain.SituationApproval, "escalated", "allow bash?", now.Add(-10*time.Minute))
+	// A different situation_type escalation for the same agent is ALSO returned
+	// (the query is deliberately not type-scoped).
+	seed("agent-1", "claude", domain.SituationError, "escalated", "some error", now.Add(-20*time.Second))
+	// Non-escalated rows are never candidates.
+	seed("agent-1", "claude", domain.SituationIdle, "auto", "an auto send", now)
+	seed("agent-1", "claude", domain.SituationApproval, "resolved", "a resolved ask", now)
+	seed("agent-1", "claude", domain.SituationApproval, "dismissed", "a dismissed ask", now)
+	// A different agent / agent_type is out of scope.
+	seed("agent-2", "claude", domain.SituationApproval, "escalated", "other agent", now)
+	seed("agent-1", "codex", domain.SituationApproval, "escalated", "other type", now)
+
+	excerpts := func() map[string]bool {
+		got, err := s.PendingEscalationExcerpts(ctx, "agent-1", "claude")
+		if err != nil {
+			t.Fatalf("PendingEscalationExcerpts: %v", err)
+		}
+		m := map[string]bool{}
+		for _, p := range got {
+			m[p.PaneExcerpt] = true
+		}
+		return m
 	}
-	// An explicitly queued LLM retry must be allowed to re-evaluate identical
-	// pane content instead of deduplicating against its own source escalation.
-	retryID, err := s.InsertLLMRetry(ctx, id, time.Now())
+
+	got := excerpts()
+	for _, w := range []string{"allow bash?", "some error"} {
+		if !got[w] {
+			t.Errorf("expected pending escalation %q, got %v", w, got)
+		}
+	}
+	for _, unwanted := range []string{
+		"an auto send", "a resolved ask", "a dismissed ask", "other agent", "other type",
+	} {
+		if got[unwanted] {
+			t.Errorf("did not expect candidate %q", unwanted)
+		}
+	}
+
+	// An explicitly queued LLM retry excludes its source escalation, so it
+	// cannot dedup against its own recapture; a processed retry restores it.
+	retryID, err := s.InsertLLMRetry(ctx, pendingID, now)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if dup(rec) {
-		t.Error("escalation queued for LLM retry should be excluded from deduplication")
+	if excerpts()["allow bash?"] {
+		t.Error("escalation queued for LLM retry should be excluded")
 	}
 	if err := s.MarkLLMRetryProcessed(ctx, retryID); err != nil {
 		t.Fatal(err)
 	}
-	if !dup(rec) {
-		t.Error("a processed retry without retirement should restore normal deduplication")
-	}
-	// Any field differing breaks the match.
-	for name, mut := range map[string]func(domain.AuditRecord) domain.AuditRecord{
-		"agent_id":     func(r domain.AuditRecord) domain.AuditRecord { r.AgentID = "agent-2"; return r },
-		"agent_type":   func(r domain.AuditRecord) domain.AuditRecord { r.AgentType = "codex"; return r },
-		"situation":    func(r domain.AuditRecord) domain.AuditRecord { r.SituationType = domain.SituationIdle; return r },
-		"pane_excerpt": func(r domain.AuditRecord) domain.AuditRecord { r.PaneExcerpt = "something else"; return r },
-	} {
-		if dup(mut(rec)) {
-			t.Errorf("differing %s should not match", name)
-		}
-	}
-
-	// A non-escalated (resolved/dismissed) row is not a pending duplicate.
-	if err := s.UpdateAuditStatus(ctx, id, "resolved"); err != nil {
-		t.Fatal(err)
-	}
-	if dup(rec) {
-		t.Error("resolved escalation should not count as a pending duplicate")
+	if !excerpts()["allow bash?"] {
+		t.Error("a processed retry should restore the candidate")
 	}
 }
 

--- a/internal/verifyunblock/verifyunblock.go
+++ b/internal/verifyunblock/verifyunblock.go
@@ -30,7 +30,7 @@ import (
 // agent still blocked. It is distinct from the decision-audit statuses
 // ("auto"/"escalated"/"resolved"/"dismissed") so it shows plainly in
 // `hap audit` without matching the pending-escalation filters.
-const StatusFailed = "delivery_failed"
+const StatusFailed = domain.AuditStatusDeliveryFailed
 
 // reasonStillBlocked prefixes the failure Rationale (mirrors the daemon's
 // bracketed reason convention).


### PR DESCRIPTION
## Problem

Herdr re-delivers an attention event for the same agent after a delay — the agent flips `done`→`idle` when the operator reads the pane, re-firing the same screen. The pending-escalation dedup used an **exact** `pane_excerpt` match keyed on `situation_type`, so it missed those re-fires:

- the pane's volatile chrome had ticked between captures (a spinner glyph, or an elapsed/countdown counter — e.g. the real `✻ Waiting for API response · will retry in 2m 2s` line, which becomes `2m 0s` two seconds later);
- a `done`→`idle` re-delivery **reclassifies** the same screen to a different `situation_type` (the classifier gates approval/choice on herdr reporting `blocked`).

Result: the operator gets asked the same question twice.

## Change

Match on **normalized content** instead of an exact string, keyed on agent + agent type + content (`situation_type` dropped as status-derived; `agent_status` was never in the key):

- `domain.NormalizeForDedup` elides only the volatile agent-TUI status lines — identified by their live-counter markers (`esc to interrupt`, `will retry in`) or a spinner-**exclusive** star glyph (`✽✻✶✳✢`) — and collapses whitespace. It deliberately does **not** use `MaskVolatile`, whose `<path>`/`<num>` masking would collapse two genuinely different questions (`rm -rf /tmp/foo` vs `/tmp/bar` → same string). The `●` message bullet and markdown bullets are real content and are never elided.
- Empty-content fallback keys on `situation_type` for the pane-read-failure path.
- `Store.DuplicatePendingEscalation` (bool, exact SQL) → `PendingEscalationExcerpts` (returns the agent's pending escalations for a Go-side compare). Fails **open** on a store error, per "never a silent drop".

## Safety scoping

The check stays where escalations are raised (`escalate()`, the pre-LLM-review branch, and the pane-read-failure path) and **never runs before the decision core**. The runaway guard, retry ceiling, and shadow-mode learning all work by re-processing repeated identical events, so gating them would bypass a safety control. (An earlier draft that gated in `decideAndAct` broke 8 daemon tests for exactly this reason.)

## Testing

- New: `TestNormalizeForDedup*` (incl. distinct-content and `●`/`*`-bullet regressions), `TestDuplicatesPendingEscalation`, `TestPendingEscalationExcerpts`, `TestPipelineDedupAbsorbsChromeJitter`, `TestPipelineDedupFailsOpen`.
- Full touched-package suites pass (`domain`, `store`, `config`, `daemon`, `verifyunblock`, `frontend`), including the 8 previously-regressed daemon safety/learning tests.
- `go build`, `go vet`, `gofmt`, `golangci-lint` — all clean.
- Code-reviewed; the one finding (the `●` glyph in the spinner set) is fixed and covered by a regression test.