### PR TITLE
feat: add per-agent automation lifecycle controls

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -83,7 +83,8 @@ last kill event:     resumed by operator at 2026-07-11T21:49:30+08:00
 
 ## list agents
 
-see all monitored agents with their short names, pane ids, types, and statuses:
+see all monitored agents with their short names, pane ids, types, statuses,
+and automation state:
 
 ```bash
 hap agents
@@ -91,9 +92,9 @@ hap agents
 
 output:
 ```
-brave-otter  w6:p1   claude   idle
-cool-fox     w6:p3   claude   working
-swift-hawk   w8:p1   codex    done
+brave-otter  w6:p1   claude   idle      enabled
+cool-fox     w6:p3   claude   working   disabled
+swift-hawk   w8:p1   codex    done      enabled
 ```
 
 ## rename an agent
@@ -103,6 +104,20 @@ give an agent a friendly name (used by task sources and for readability):
 ```bash
 hap rename brave-otter backend-dev
 ```
+
+disable or enable automation for one agent without removing it from the
+Agents list:
+
+```bash
+hap disable backend-dev
+hap enable backend-dev
+```
+
+in the TUI Agents tab, `x` disables the selected agent after a `Y/n`
+confirmation and `e` enables it. disabled agents show `DISABLED`. autonomous
+actions are suppressed and audited as `denied` with `[agent_disabled]`;
+escalations are immediately audited as `dismissed` with the same rationale and
+never enter the pending queue.
 
 ## manage escalations
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ LLM/agent CLI. Autonomous actions must clear the applicable confidence and
 safety gates; uncertain ones escalate to you. Everything it does is audited
 and correctable.
 
+> [!IMPORTANT]
+> **Agent compatibility:** Herd Auto Prompter is developed and extensively
+> tested against **Claude Code** (`claude`) and the **OpenAI Codex CLI**
+> (`codex`). These are the primary supported coding-agent types.
+>
+> Other coding agents are best-effort and have not received the same level of
+> integration and regression testing. Their status events, prompts, menus, and
+> terminal UI formats may differ, so agents such as **OpenCode** (`opencode`),
+> **Antigravity CLI** (`agy`), and other types may be misclassified or may not
+> work reliably. Keep shadow mode and conservative confidence thresholds in
+> place while evaluating an additional agent type, and review its audit trail
+> before allowing autonomous actions.
+
 - **Learned rules, not guesses** — every action taken from a learned rule
   traces back to your confirmed decisions. Explicit task sources and the
   opt-in LLM helper are separate, clearly audited paths.
@@ -445,13 +458,21 @@ and the source entry itself — can be managed. Use the name in task-source
 selectors, and rename agents to whatever fits your workflow:
 
 ```sh
-hap agents                      # short name, pane id, type, status
+hap agents                      # short name, pane id, type, status, automation
 hap rename brave-otter backend-dev
+hap disable backend-dev         # stop automation for only this agent
+hap enable backend-dev          # allow automation again
 hap task-source --agent backend-dev ./docs/backend-tasks.md
 hap task-source --agent backend-dev --template 'Do this next: {next_task_content} (full list: {task_list_path})' ./docs/backend-tasks.md
 ```
 
-(Or in the TUI: select the agent and press `n`.)
+(Or in the TUI: select the agent and press `n` to rename it, `x` to disable
+it behind a `Y/n` confirmation, or `e` to enable it again. A disabled live
+agent remains in the list with `DISABLED` in its status column. HAP never
+performs autonomous pane actions for it: would-be actions are audited as
+`denied` with rationale `[agent_disabled]`, while would-be escalations are
+written directly as `dismissed` with the same tag and never enter the pending
+queue.)
 
 ### The Tasks tab
 
@@ -971,6 +992,11 @@ Invariants:
   trigger, situation, action or escalation reason, confidence, rationale, and
   (for LLM decisions) captured output. `audit` / the *Audit* tab shows it;
   corrections keep their lineage to the original decision.
+- Escalations whose target is no longer present in an authoritative Herdr
+  agent snapshot are written directly as `dismissed` with `[agent_not_live]`.
+  Disabled agents use `[agent_disabled]`; their suppressed autonomous actions
+  are written as `denied`. These lifecycle outcomes remain visible without
+  notifying the operator or creating a stale pending escalation.
 - `clear-data --yes` resets all learned history and audit data (it never
   leaves your machine in the first place).
 

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -44,10 +44,12 @@ Core:
 
 Operate:
   status                automation state, pending escalations, agents
-  agents                list monitored agents (short name, id, type, status)
+  agents                list agents (short name, id, type, status, automation)
   capture <agent>       re-run the normal capture pipeline for a live
                         blocked/idle/done agent (name or pane id)
   rename <agent> <name> give an agent a short name (used by task sources)
+  disable <agent>       disable autonomous actions for one agent
+  enable <agent>        re-enable autonomous actions for one agent
   escalations [prune [minutes]]  list pending escalations; prune dismisses
                         those older than N minutes (default 360)
   confirm <id> [--send]         confirm an escalation's suggested action

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -77,6 +77,10 @@ func Run(ctx context.Context, app *frontend.App, out io.Writer, verb string, arg
 		return task(ctx, app, out, args)
 	case "rename":
 		return rename(ctx, app, out, args)
+	case "disable":
+		return setAgentDisabled(ctx, app, out, args, true)
+	case "enable":
+		return setAgentDisabled(ctx, app, out, args, false)
 	case "signatures", "sigs":
 		return signatures(ctx, app, out, args)
 	case "clear-data":
@@ -427,6 +431,24 @@ func rename(ctx context.Context, app *frontend.App, out io.Writer, args []string
 	return nil
 }
 
+func setAgentDisabled(ctx context.Context, app *frontend.App, out io.Writer,
+	args []string, disabled bool) error {
+	verb := "enable"
+	state := "enabled"
+	if disabled {
+		verb = "disable"
+		state = "disabled"
+	}
+	if len(args) != 1 || strings.TrimSpace(args[0]) == "" {
+		return fmt.Errorf("usage: %s <agent-name-or-pane-id>", verb)
+	}
+	if err := app.SetAgentDisabled(ctx, args[0], disabled); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "agent %q %s\n", args[0], state)
+	return nil
+}
+
 func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 	st, err := app.GetStatus(ctx)
 	if err != nil {
@@ -530,7 +552,12 @@ func agents(ctx context.Context, app *frontend.App, out io.Writer) error {
 		if name == "" {
 			name = "-"
 		}
-		fmt.Fprintf(out, "%s\t%s\t%s\t%s\n", name, a.AgentID, a.AgentType, a.Status)
+		automation := "enabled"
+		if st.AgentDisabled(a.AgentID) {
+			automation = "disabled"
+		}
+		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\n",
+			name, a.AgentID, a.AgentType, a.Status, automation)
 	}
 	return nil
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -112,6 +112,40 @@ func TestCaptureCLI(t *testing.T) {
 	}
 }
 
+func TestDisableEnableAgentCLI(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	if err := st.AssignAgentName(ctx, "pane-live", "vivid-falcon"); err != nil {
+		t.Fatal(err)
+	}
+	app.Herdr = &captureHerdr{agents: []domain.AgentTransition{{
+		AgentID: "pane-live", PaneID: "pane-live", AgentType: "codex", Status: "idle",
+	}}}
+
+	out, err := run(t, app, "disable", "vivid-falcon")
+	if err != nil || !strings.Contains(out, "disabled") {
+		t.Fatalf("disable output=%q err=%v", out, err)
+	}
+	if disabled, _ := st.AgentDisabled(ctx, "pane-live"); !disabled {
+		t.Fatal("disable command did not persist state")
+	}
+	out, err = run(t, app, "agents")
+	if err != nil || !strings.Contains(out, "\tdisabled\n") {
+		t.Fatalf("agents must show disabled indicator, output=%q err=%v", out, err)
+	}
+
+	out, err = run(t, app, "enable", "pane-live")
+	if err != nil || !strings.Contains(out, "enabled") {
+		t.Fatalf("enable output=%q err=%v", out, err)
+	}
+	if disabled, _ := st.AgentDisabled(ctx, "pane-live"); disabled {
+		t.Fatal("enable command did not clear state")
+	}
+	if _, err := run(t, app, "disable", "not-an-agent"); err == nil {
+		t.Fatal("unknown disable target must fail")
+	}
+}
+
 func TestStatusShowsDaemonLine(t *testing.T) {
 	app, _ := testApp(t)
 

--- a/internal/daemon/agent_lifecycle_e2e_test.go
+++ b/internal/daemon/agent_lifecycle_e2e_test.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+type restartableDaemon struct {
+	store  *store.Store
+	events *fakeEvents
+	cancel context.CancelFunc
+	done   chan error
+}
+
+func startRestartableDaemon(t *testing.T, dbPath, configPath string,
+	herdr *fakeHerdr) *restartableDaemon {
+	t.Helper()
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := &fakeEvents{ch: make(chan domain.AgentTransition, 16)}
+	d, err := New(Options{
+		ConfigPath: configPath,
+		Store:      st,
+		Herdr:      herdr,
+		Events:     events,
+		Notify:     herdr,
+		LLM:        &fakeLLM{},
+	})
+	if err != nil {
+		_ = st.Close()
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	run := &restartableDaemon{
+		store: st, events: events, cancel: cancel, done: make(chan error, 1),
+	}
+	go func() { run.done <- d.Run(ctx) }()
+	return run
+}
+
+func (d *restartableDaemon) stop(t *testing.T) {
+	t.Helper()
+	d.cancel()
+	select {
+	case err := <-d.done:
+		if err != nil {
+			t.Fatalf("daemon shutdown: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("daemon did not stop within timeout")
+	}
+	if err := d.store.Close(); err != nil {
+		t.Fatalf("close daemon store: %v", err)
+	}
+}
+
+func seedLifecycleAutoApproval(t *testing.T, st *store.Store) {
+	t.Helper()
+	s := classifierForTest().Classify("claude", "blocked", approvalPane)
+	if s.Type != domain.SituationApproval {
+		t.Fatalf("fixture classifies as %v, want approval", s.Type)
+	}
+	sig := domain.ComputeSignature(s)
+	ctx := context.Background()
+	for i := 0; i < 8; i++ {
+		if _, err := st.RecordDecision(ctx, domain.DecisionRecord{
+			Signature: sig.Signature, SituationType: s.Type, AgentType: "claude",
+			ChosenAction: "1", Source: domain.SourceOperator,
+			CreatedAt: time.Now().Add(-time.Duration(8-i) * time.Minute),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := st.UpsertSignature(ctx, domain.SignatureState{
+		Signature: sig.Signature, SituationType: s.Type, AgentType: "claude",
+		Mode: domain.ModeAutonomous, ConsecutiveConfirmations: 8,
+		CachedConfidence: 1, UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAgentDisableLifecycleSurvivesDaemonRestartEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(tinyCaptureDelay), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(dir, "hap.db")
+	const agentID = "agent-restart-disabled"
+	live := func(status string) []domain.AgentTransition {
+		return []domain.AgentTransition{{
+			AgentID: agentID, PaneID: agentID, AgentType: "claude", Status: status,
+		}}
+	}
+
+	herdr := &fakeHerdr{}
+	herdr.setPane(approvalPane)
+	herdr.setAgents(live("working"))
+
+	first := startRestartableDaemon(t, dbPath, configPath, herdr)
+	seedLifecycleAutoApproval(t, first.store)
+	app := &frontend.App{Store: first.store, Herdr: herdr, Author: "e2e"}
+	if err := app.SetAgentDisabled(context.Background(), agentID, true); err != nil {
+		t.Fatalf("disable live agent: %v", err)
+	}
+	first.stop(t)
+
+	// Restart HAP over the same state while the agent is blocked. Startup
+	// reconciliation must preserve the disabled state and deny the otherwise
+	// autonomous approval without sending or surfacing an escalation.
+	herdr.setAgents(live("blocked"))
+	second := startRestartableDaemon(t, dbPath, configPath, herdr)
+	defer second.stop(t)
+	ctx := context.Background()
+	if disabled, err := second.store.AgentDisabled(ctx, agentID); err != nil || !disabled {
+		t.Fatalf("disabled state after restart = %v, err=%v; want true", disabled, err)
+	}
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := second.store.AuditLog(ctx, 10)
+		return len(audits) == 1 && audits[0].Status == "denied"
+	})
+	if sent := herdr.sentInputs(); len(sent) != 0 {
+		t.Fatalf("disabled agent received pane input after restart: %v", sent)
+	}
+	if pending, err := second.store.PendingEscalations(ctx); err != nil || len(pending) != 0 {
+		t.Fatalf("disabled agent pending escalations after restart = %+v, err=%v", pending, err)
+	}
+	audits, _ := second.store.AuditLog(ctx, 10)
+	if got := audits[0]; got.Action != domain.AuditActionDenied || got.Rationale != "[agent_disabled]" {
+		t.Fatalf("disabled restart audit = %+v, want denied/[agent_disabled]", got)
+	}
+
+	// Re-enable through the same frontend API, then model a new working→blocked
+	// episode. The persisted lifecycle state clears and normal automation resumes.
+	app = &frontend.App{Store: second.store, Herdr: herdr, Author: "e2e"}
+	if err := app.SetAgentDisabled(ctx, agentID, false); err != nil {
+		t.Fatalf("re-enable agent: %v", err)
+	}
+	if disabled, err := second.store.AgentDisabled(ctx, agentID); err != nil || disabled {
+		t.Fatalf("disabled state after enable = %v, err=%v; want false", disabled, err)
+	}
+	herdr.setAgents(live("working"))
+	second.events.ch <- live("working")[0]
+	herdr.setAgents(live("blocked"))
+	second.events.ch <- live("blocked")[0]
+	waitFor(t, 3*time.Second, func() bool { return len(herdr.sentInputs()) == 1 })
+	if got := herdr.sentInputs()[0]; got != "1" {
+		t.Fatalf("post-enable autonomous input = %q, want %q", got, "1")
+	}
+	if pending, err := second.store.PendingEscalations(ctx); err != nil || len(pending) != 0 {
+		t.Fatalf("post-enable pending escalations = %+v, err=%v", pending, err)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2582,24 +2582,6 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		}
 	}
 
-	// The operator may disable the agent while a consult is running. Let all
-	// rejection paths above raise their normal (auto-dismissed) escalation,
-	// but stop a promotable action here before any audit-as-auto or pane send.
-	if disabled, err := d.opt.Store.AgentDisabled(ctx, s.AgentID); err != nil {
-		reject(domain.ReasonPersistenceFailed, "disabled-state read after LLM consult: "+err.Error())
-		return
-	} else if disabled {
-		d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "rejected")
-		var llmConf *int
-		if llmDec.ConfidentScore >= 0 {
-			llmConf = &llmDec.ConfidentScore
-		}
-		d.auditAgentDisabled(ctx, s, res.sig, tr, llmDec.Action,
-			domain.Confidence(history, cfg.Learning.ConfirmationWeight).Score,
-			llmConf, llmDec.CapturedOutput, now)
-		return
-	}
-
 	// Both scores land on the auto-acted audit row: the computed 0-1 agreement
 	// over this signature's history AND the LLM's self-reported 0-100 (>= 0
 	// here — a lower score would have escalated at the gate above).
@@ -2611,43 +2593,52 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		// staleness re-read is skipped on purpose: it exists solely to
 		// prevent stale *injections*, a stale noop is harmless, and
 		// rejecting it would recreate the very escalation noise the noop
-		// resolves. Audit-before-act still applies (FR-024).
-		if _, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
-			AgentID: s.AgentID, AgentType: s.AgentType, Signature: res.sig.Signature, Trigger: "llm-fallback",
-			SituationType: s.Type, Action: "noop", Input: "",
-			Confidence: computedConf, LLMConfidence: &llmConf,
-			Rationale: "LLM: " + llmDec.Rationale, LLMOutput: llmDec.CapturedOutput,
-			Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
-		}); err != nil {
-			slog.Error("audit write failed; blocking LLM noop (FR-024)", "error", err)
-			d.notify(ctx, "Herd Auto Prompter: persistence failure",
-				"An LLM-derived no-op was blocked because its audit record could not be written.")
-			return
-		}
-		if err := d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "accepted"); err != nil {
-			slog.Error("llm decision status update failed", "error", err)
-		}
-		if _, err := d.opt.Store.RecordDecision(ctx, domain.DecisionRecord{
-			Signature: res.sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
-			ChosenAction: domain.ActionNoop, Source: domain.SourceLLM, CreatedAt: now,
-		}); err != nil {
-			slog.Error("decision record write failed", "error", err)
-		}
-		// The runaway counter still advances (D3): a self-flapping agent
-		// must not consult-and-noop silently forever. lastAutoSend stays
-		// untouched (nothing was sent); lastAutoNoop is stamped so a
-		// self-resuming flap does not reset that counter.
-		if rate2, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
-			updated := domain.RegisterAutoPrompt(*rate2, now)
-			updated.AgentID = s.AgentID
-			if err := d.opt.Store.UpdateAgentRate(ctx, updated); err != nil {
-				slog.Error("agent rate update failed", "error", err)
+		// resolves. Audit-before-act still applies (FR-024), and the final
+		// lifecycle barrier prevents learning or rate advancement after disable.
+		executed := d.withAgentAutomation(ctx, s, res.sig, tr, "",
+			computedConf, &llmConf, llmDec.CapturedOutput, now, func() {
+				if _, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
+					AgentID: s.AgentID, AgentType: s.AgentType, Signature: res.sig.Signature, Trigger: "llm-fallback",
+					SituationType: s.Type, Action: "noop", Input: "",
+					Confidence: computedConf, LLMConfidence: &llmConf,
+					Rationale: "LLM: " + llmDec.Rationale, LLMOutput: llmDec.CapturedOutput,
+					Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
+				}); err != nil {
+					slog.Error("audit write failed; blocking LLM noop (FR-024)", "error", err)
+					d.notify(ctx, "Herd Auto Prompter: persistence failure",
+						"An LLM-derived no-op was blocked because its audit record could not be written.")
+					return
+				}
+				if err := d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "accepted"); err != nil {
+					slog.Error("llm decision status update failed", "error", err)
+				}
+				if _, err := d.opt.Store.RecordDecision(ctx, domain.DecisionRecord{
+					Signature: res.sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
+					ChosenAction: domain.ActionNoop, Source: domain.SourceLLM, CreatedAt: now,
+				}); err != nil {
+					slog.Error("decision record write failed", "error", err)
+				}
+				// The runaway counter still advances (D3): a self-flapping agent
+				// must not consult-and-noop silently forever. lastAutoSend stays
+				// untouched (nothing was sent); lastAutoNoop is stamped so a
+				// self-resuming flap does not reset that counter.
+				if rate2, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
+					updated := domain.RegisterAutoPrompt(*rate2, now)
+					updated.AgentID = s.AgentID
+					if err := d.opt.Store.UpdateAgentRate(ctx, updated); err != nil {
+						slog.Error("agent rate update failed", "error", err)
+					}
+				}
+				d.mu.Lock()
+				d.lastAutoNoop[s.AgentID] = now
+				d.mu.Unlock()
+				slog.Info("LLM noop accepted: no reply sent", "agent", s.AgentID)
+			})
+		if !executed {
+			if err := d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "rejected"); err != nil {
+				slog.Error("llm decision status update failed", "error", err)
 			}
 		}
-		d.mu.Lock()
-		d.lastAutoNoop[s.AgentID] = now
-		d.mu.Unlock()
-		slog.Info("LLM noop accepted: no reply sent", "agent", s.AgentID)
 		return
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1215,17 +1215,15 @@ type delivery struct {
 // and counter writes.
 func (d *Daemon) deliverAutonomous(ctx context.Context, s domain.Situation, sig domain.SignatureResult,
 	dec domain.Decision, tr domain.AgentTransition, del delivery, now time.Time) {
-	if disabled, err := d.opt.Store.AgentDisabled(ctx, s.AgentID); err != nil {
-		d.escalate(ctx, s, sig, domain.Decision{
-			Action: domain.ActionEscalate, Reason: domain.ReasonPersistenceFailed,
-			Rationale: "disabled-state read before send: " + err.Error(),
-		}, tr, now)
-		return
-	} else if disabled {
-		d.auditAgentDisabled(ctx, s, sig, tr, del.input, dec.Confidence, nil, del.llmOutput, now)
-		return
-	}
+	d.withAgentAutomation(ctx, s, sig, tr, del.input, dec.Confidence, nil, del.llmOutput, now,
+		func() { d.deliverAutonomousClaimed(ctx, s, sig, dec, tr, del, now) })
+}
 
+// deliverAutonomousClaimed runs while the cross-process per-agent lifecycle
+// barrier is held, so SetAgentDisabled cannot commit between audit and send.
+func (d *Daemon) deliverAutonomousClaimed(ctx context.Context, s domain.Situation,
+	sig domain.SignatureResult, dec domain.Decision, tr domain.AgentTransition,
+	del delivery, now time.Time) {
 	auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
 		SituationType: s.Type, Action: domain.AuditActionAutoPrefix + del.input, Input: del.input,
@@ -1345,17 +1343,12 @@ func (d *Daemon) scheduleUnblockCheck(p verifyunblock.Params) {
 // human interaction and reset that counter.
 func (d *Daemon) deliverNoop(ctx context.Context, s domain.Situation, sig domain.SignatureResult,
 	dec domain.Decision, tr domain.AgentTransition, now time.Time) {
-	if disabled, err := d.opt.Store.AgentDisabled(ctx, s.AgentID); err != nil {
-		d.escalate(ctx, s, sig, domain.Decision{
-			Action: domain.ActionEscalate, Reason: domain.ReasonPersistenceFailed,
-			Rationale: "disabled-state read before noop: " + err.Error(),
-		}, tr, now)
-		return
-	} else if disabled {
-		d.auditAgentDisabled(ctx, s, sig, tr, "", dec.Confidence, nil, "", now)
-		return
-	}
+	d.withAgentAutomation(ctx, s, sig, tr, "", dec.Confidence, nil, "", now,
+		func() { d.deliverNoopClaimed(ctx, s, sig, dec, tr, now) })
+}
 
+func (d *Daemon) deliverNoopClaimed(ctx context.Context, s domain.Situation,
+	sig domain.SignatureResult, dec domain.Decision, tr domain.AgentTransition, now time.Time) {
 	auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
 		SituationType: s.Type, Action: "noop", Input: "",
@@ -1530,6 +1523,29 @@ func (d *Daemon) auditAgentDisabled(ctx context.Context, s domain.Situation,
 	})
 	slog.Info("autonomous action denied: agent disabled",
 		"agent", s.AgentID, "situation", s.Type, "input", input)
+}
+
+// withAgentAutomation is the daemon side of the persistent disable barrier.
+// The store coordinates this callback with SetAgentDisabled across processes;
+// all audit/send/learn/rate work in fn therefore happens wholly before a
+// disable commits, or is denied wholly after it.
+func (d *Daemon) withAgentAutomation(ctx context.Context, s domain.Situation,
+	sig domain.SignatureResult, tr domain.AgentTransition, input string,
+	confidence float64, llmConfidence *int, llmOutput string, now time.Time,
+	fn func()) bool {
+	disabled, err := d.opt.Store.WithAgentAutomation(ctx, s.AgentID, fn)
+	if err != nil {
+		d.escalate(ctx, s, sig, domain.Decision{
+			Action: domain.ActionEscalate, Reason: domain.ReasonPersistenceFailed,
+			Rationale: "agent lifecycle barrier: " + err.Error(),
+		}, tr, now)
+		return false
+	}
+	if disabled {
+		d.auditAgentDisabled(ctx, s, sig, tr, input, confidence, llmConfidence, llmOutput, now)
+		return false
+	}
+	return true
 }
 
 // consultLLM assembles the consult context, stages the request, and
@@ -2686,20 +2702,6 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		}
 	}
 
-	// Promote: audit-before-act guard applies here too (FR-024).
-	auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
-		AgentID: s.AgentID, AgentType: s.AgentType, Signature: res.sig.Signature, Trigger: "llm-fallback",
-		SituationType: s.Type, Action: domain.AuditActionAutoPrefix + llmDec.Action, Input: llmDec.Action,
-		Confidence: computedConf, LLMConfidence: &llmConf,
-		Rationale: "LLM: " + llmDec.Rationale, LLMOutput: llmDec.CapturedOutput,
-		Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
-	})
-	if err != nil {
-		slog.Error("audit write failed; blocking LLM action (FR-024)", "error", err)
-		d.notify(ctx, "Herd Auto Prompter: persistence failure",
-			"An LLM-derived action was blocked because its audit record could not be written.")
-		return
-	}
 	// Same numbered-menu mapping as the learned act path: deliver the digit
 	// for approval/choice, the literal reply otherwise. Multi-tab forms take
 	// the validated digit series, one keystroke per tab — off the main loop
@@ -2708,47 +2710,64 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 	if s.Type == domain.SituationChoice && s.EffectiveAnswerCount() > 1 {
 		ks, ok := d.opt.Herdr.(ports.KeystrokeSender)
 		if !ok {
-			d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
-			d.notify(ctx, "Herd Auto Prompter: action delivery failed",
+			reject(domain.ReasonHerdrUnreachable,
 				"herdr adapter cannot send keystrokes; multi-tab answer needs them")
 			return
 		}
 		if !d.acquirePane(s.AgentID) {
-			d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
-			d.notify(ctx, "Herd Auto Prompter: action delivery failed",
+			reject(domain.ReasonRateLimited,
 				"another pane interaction is in flight for this agent; not delivering concurrently")
 			return
 		}
 		groups, _ := domain.ParseTabSelections(llmDec.Action)
-		d.deliverSeriesLLM(ctx, ks, s, res.sig.Signature, llmDec, groups, auditID, now)
+		d.deliverSeriesLLM(ctx, ks, s, res.sig, tr, llmDec, groups,
+			computedConf, &llmConf, now)
 		return
 	}
-	if err := ports.SendToAgent(ctx, d.opt.Herdr, s.PaneID, s.AgentType,
-		domain.DeliverKeystroke(s.Type, s.AgentType, pane, llmDec.Action)); err != nil {
-		d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
-		d.notify(ctx, "Herd Auto Prompter: action delivery failed", err.Error())
-		return
+	executed := d.withAgentAutomation(ctx, s, res.sig, tr, llmDec.Action,
+		computedConf, &llmConf, llmDec.CapturedOutput, now, func() {
+			auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
+				AgentID: s.AgentID, AgentType: s.AgentType, Signature: res.sig.Signature, Trigger: "llm-fallback",
+				SituationType: s.Type, Action: domain.AuditActionAutoPrefix + llmDec.Action, Input: llmDec.Action,
+				Confidence: computedConf, LLMConfidence: &llmConf,
+				Rationale: "LLM: " + llmDec.Rationale, LLMOutput: llmDec.CapturedOutput,
+				Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
+			})
+			if err != nil {
+				slog.Error("audit write failed; blocking LLM action (FR-024)", "error", err)
+				d.notify(ctx, "Herd Auto Prompter: persistence failure",
+					"An LLM-derived action was blocked because its audit record could not be written.")
+				return
+			}
+			if err := ports.SendToAgent(ctx, d.opt.Herdr, s.PaneID, s.AgentType,
+				domain.DeliverKeystroke(s.Type, s.AgentType, pane, llmDec.Action)); err != nil {
+				d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
+				d.notify(ctx, "Herd Auto Prompter: action delivery failed", err.Error())
+				return
+			}
+			d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "accepted")
+			d.opt.Store.RecordDecision(ctx, domain.DecisionRecord{
+				Signature: res.sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
+				ChosenAction: d.llmLearnedAction(llmDec, taskReviewSend),
+				Source:       domain.SourceLLM, CreatedAt: now,
+			})
+			if rate2, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
+				updated := domain.RegisterAutoPrompt(*rate2, now)
+				updated.AgentID = s.AgentID
+				d.opt.Store.UpdateAgentRate(ctx, updated)
+			}
+			d.mu.Lock()
+			d.lastAutoSend[s.AgentID] = now
+			d.mu.Unlock()
+			slog.Info("LLM decision promoted and delivered", "agent", s.AgentID, "action", llmDec.Action)
+			d.scheduleUnblockCheck(verifyunblock.Params{
+				PaneID: s.PaneID, AgentID: s.AgentID, AgentType: s.AgentType,
+				Signature: res.sig.Signature, Input: llmDec.Action, Excerpt: s.Content, SituationType: s.Type,
+			})
+		})
+	if !executed {
+		d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "rejected")
 	}
-	d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "accepted")
-	d.opt.Store.RecordDecision(ctx, domain.DecisionRecord{
-		Signature: res.sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
-		ChosenAction: d.llmLearnedAction(llmDec, taskReviewSend),
-		Source:       domain.SourceLLM, CreatedAt: now,
-	})
-	if rate2, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
-		updated := domain.RegisterAutoPrompt(*rate2, now)
-		updated.AgentID = s.AgentID
-		d.opt.Store.UpdateAgentRate(ctx, updated)
-	}
-	d.mu.Lock()
-	d.lastAutoSend[s.AgentID] = now
-	d.mu.Unlock()
-	slog.Info("LLM decision promoted and delivered", "agent", s.AgentID, "action", llmDec.Action)
-
-	d.scheduleUnblockCheck(verifyunblock.Params{
-		PaneID: s.PaneID, AgentID: s.AgentID, AgentType: s.AgentType,
-		Signature: res.sig.Signature, Input: llmDec.Action, Excerpt: s.Content, SituationType: s.Type,
-	})
 }
 
 // processCorrections consumes front-end-written correction records and

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -828,29 +828,18 @@ func (d *Daemon) handleAttention(ctx context.Context, tr domain.AgentTransition)
 		// Herdr unreachable / pane read failure: no automated action, log,
 		// notify (FR-023); the subscriber's backoff handles reconnection.
 		slog.Warn("pane read failed; taking no action", "pane", tr.PaneID, "error", err)
-		// This escalation bypasses escalate() (no pane to classify), so apply
-		// the same dedup here: a persistent outage delivers the same blocked
-		// event repeatedly and must not pile up identical pending rows. The
-		// unreadable pane has no excerpt, so the empty-content fallback in
-		// domain.DuplicatesPendingEscalation keys on the situation type, which
-		// keeps this from matching a pending escalation of a different kind.
+		// Route even this unclassifiable failure through escalate() so its
+		// lifecycle auto-dismiss and dedup rules are identical to every other
+		// escalation. The unreadable pane has no excerpt, so the normalized
+		// dedup's empty-content fallback keys on the situation type.
 		failed := domain.Situation{
 			AgentID: tr.AgentID, AgentType: tr.AgentType, PaneID: tr.PaneID,
 			Type: domain.SituationUnclassifiable,
 		}
-		if d.duplicatePendingEscalation(ctx, failed) {
-			d.ignoreDuplicate(ctx, failed, tr, now)
-			return
-		}
-		d.audit(ctx, domain.AuditRecord{
-			AgentID: tr.AgentID, AgentType: tr.AgentType, Trigger: trigger(tr),
-			SituationType: domain.SituationUnclassifiable,
-			Action:        domain.AuditActionEscalated,
-			// Bracketed like every escalate()-built rationale, so the one
-			// path that bypasses escalate() renders identically.
-			Rationale: "[" + string(domain.ReasonHerdrUnreachable) + "]",
-			Status:    "escalated", CreatedAt: now,
-		})
+		d.escalate(ctx, failed, domain.SignatureResult{}, domain.Decision{
+			Action: domain.ActionEscalate, Reason: domain.ReasonHerdrUnreachable,
+			Rationale: err.Error(),
+		}, tr, now)
 		return
 	}
 
@@ -932,6 +921,15 @@ func (d *Daemon) decideAndAct(ctx context.Context, situation domain.Situation,
 		}, tr, now)
 		return
 	}
+	disabled, err := d.opt.Store.AgentDisabled(ctx, situation.AgentID)
+	if err != nil {
+		slog.Error("disabled-state read failed; escalating", "error", err)
+		d.escalate(ctx, situation, sig, domain.Decision{
+			Action: domain.ActionEscalate, Reason: domain.ReasonPersistenceFailed,
+			Rationale: "disabled-state read: " + err.Error(),
+		}, tr, now)
+		return
+	}
 
 	// Both the never-auto match and the suspected-irreversible heuristic scan
 	// only the actionable region (pending dialog + outbound task text), not the
@@ -962,7 +960,7 @@ func (d *Daemon) decideAndAct(ctx context.Context, situation domain.Situation,
 	// suspected-irreversible) escalate normally instead of spending a consult.
 	if situation.Type == domain.SituationIdle && declared != nil &&
 		declared.Task != domain.NoTaskContent && declared.LLMReview &&
-		!killActive && !allowMatched && !suspected &&
+		!disabled && !killActive && !allowMatched && !suspected &&
 		d.llmPort() != nil && d.llmPort().Configured() {
 		// A matching escalation already awaiting the operator (e.g. a prior
 		// decline of this same task) means the situation is handled: don't
@@ -1004,6 +1002,15 @@ func (d *Daemon) decideAndAct(ctx context.Context, situation domain.Situation,
 	}
 
 	decision := domain.Decide(in)
+	if disabled {
+		if decision.Action == domain.ActionEscalate {
+			d.escalate(ctx, situation, sig, decision, tr, now)
+		} else {
+			d.auditAgentDisabled(ctx, situation, sig, tr, decision.Input,
+				decision.Confidence, nil, "", now)
+		}
+		return
+	}
 
 	// Any newer decision for this agent owns the pane: an in-flight rewrite
 	// for a DIFFERENT situation must never deliver behind it. A same-
@@ -1208,6 +1215,16 @@ type delivery struct {
 // and counter writes.
 func (d *Daemon) deliverAutonomous(ctx context.Context, s domain.Situation, sig domain.SignatureResult,
 	dec domain.Decision, tr domain.AgentTransition, del delivery, now time.Time) {
+	if disabled, err := d.opt.Store.AgentDisabled(ctx, s.AgentID); err != nil {
+		d.escalate(ctx, s, sig, domain.Decision{
+			Action: domain.ActionEscalate, Reason: domain.ReasonPersistenceFailed,
+			Rationale: "disabled-state read before send: " + err.Error(),
+		}, tr, now)
+		return
+	} else if disabled {
+		d.auditAgentDisabled(ctx, s, sig, tr, del.input, dec.Confidence, nil, del.llmOutput, now)
+		return
+	}
 
 	auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
@@ -1328,6 +1345,16 @@ func (d *Daemon) scheduleUnblockCheck(p verifyunblock.Params) {
 // human interaction and reset that counter.
 func (d *Daemon) deliverNoop(ctx context.Context, s domain.Situation, sig domain.SignatureResult,
 	dec domain.Decision, tr domain.AgentTransition, now time.Time) {
+	if disabled, err := d.opt.Store.AgentDisabled(ctx, s.AgentID); err != nil {
+		d.escalate(ctx, s, sig, domain.Decision{
+			Action: domain.ActionEscalate, Reason: domain.ReasonPersistenceFailed,
+			Rationale: "disabled-state read before noop: " + err.Error(),
+		}, tr, now)
+		return
+	} else if disabled {
+		d.auditAgentDisabled(ctx, s, sig, tr, "", dec.Confidence, nil, "", now)
+		return
+	}
 
 	auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
@@ -1368,18 +1395,20 @@ func (d *Daemon) deliverNoop(ctx context.Context, s domain.Situation, sig domain
 // escalate records and surfaces an escalation: no input is sent (FR-018).
 func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.SignatureResult,
 	dec domain.Decision, tr domain.AgentTransition, now time.Time) {
+	autoDismissReason := d.escalationAutoDismissReason(ctx, s.AgentID)
 
-	// Dedup: if this situation is already awaiting the user in the
+	// Dedup: if this normalized situation is already awaiting the user in the
 	// pending-escalation queue, re-raising it would just be a duplicate ask.
 	// Ignore the event (no ops) and record why. Gating here rather than before
 	// decideAndAct means only a would-be duplicate ESCALATION is suppressed — a
 	// situation that can now auto-answer (e.g. after a kill-switch resume) still
-	// acts, and the rate guard / retry ceiling still see every repeated
-	// identical event. escalate() is where almost every escalation is born, so
-	// this also caps escalation storms from the async LLM/rewrite/taskgen
-	// rejection paths. (The one escalation that bypasses escalate() — the
-	// pane-read-failure path in handleAttention — is dedup'd there directly.)
-	if d.duplicatePendingEscalation(ctx, s) {
+	// acts, and the rate guard / retry ceiling still see every repeated event.
+	// escalate() is where almost every escalation is born, so this also caps
+	// escalation storms from the async LLM/rewrite/taskgen rejection paths.
+	// A proven-gone/disabled agent still gets an audit row below, so the
+	// automatic dismissal remains visible in history. Do not let an older
+	// pending row turn that lifecycle decision into an opaque "duplicate".
+	if autoDismissReason == "" && d.duplicatePendingEscalation(ctx, s) {
 		d.ignoreDuplicate(ctx, s, tr, now)
 		return
 	}
@@ -1407,6 +1436,21 @@ func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.Si
 		EmbedError:  sig.Match.EmbedError,
 		CreatedAt:   now,
 	}
+	if autoDismissReason != "" {
+		// Store the would-be escalation directly as dismissed. This is atomic
+		// from the front-end's perspective (it can never flash in the pending
+		// queue), while Action="escalated" plus Status="dismissed" preserves
+		// the same append-only audit shape as an operator dismissal.
+		rec.Status = "dismissed"
+		rec.Rationale += " [" + autoDismissReason + "]"
+		if _, err := d.opt.Store.AppendAudit(ctx, rec); err != nil {
+			slog.Error("audit write failed for auto-dismissed escalation", "error", err)
+			return
+		}
+		slog.Info("escalation auto-dismissed: agent unavailable",
+			"agent", s.AgentID, "situation", s.Type, "reason", autoDismissReason)
+		return
+	}
 	if _, err := d.opt.Store.AppendAudit(ctx, rec); err != nil {
 		slog.Error("audit write failed for escalation", "error", err)
 	}
@@ -1433,6 +1477,59 @@ func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.Si
 	slog.Info("escalated", "agent", s.AgentID, "situation", s.Type,
 		"reason", dec.Reason, "suggestion", dec.Suggestion,
 		"version", buildinfo.Version)
+}
+
+const (
+	autoDismissAgentNotLive  = "agent_not_live"
+	autoDismissAgentDisabled = "agent_disabled"
+)
+
+// escalationAutoDismissReason returns a non-empty audit tag only when Herdr
+// authoritatively reports that an escalation's target cannot receive operator
+// attention: a successful live-agent snapshot omits it, or reports it disabled.
+// List failures are inconclusive and deliberately keep the escalation visible.
+func (d *Daemon) escalationAutoDismissReason(ctx context.Context, agentID string) string {
+	if disabled, err := d.opt.Store.AgentDisabled(ctx, agentID); err == nil && disabled {
+		return autoDismissAgentDisabled
+	} else if err != nil {
+		slog.Warn("disabled-state read failed while raising escalation",
+			"agent", agentID, "error", err)
+	}
+	if agentID == "" || d.opt.Herdr == nil {
+		return ""
+	}
+	agents, err := d.opt.Herdr.ListAgents(ctx)
+	if err != nil {
+		return ""
+	}
+	for _, agent := range agents {
+		if agent.AgentID != agentID {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(agent.Status), "disabled") {
+			return autoDismissAgentDisabled
+		}
+		return ""
+	}
+	return autoDismissAgentNotLive
+}
+
+// auditAgentDisabled records the autonomous action that would have happened,
+// without sending, learning, or advancing the rate counter. The exact
+// rationale tag is intentionally stable for audit consumers.
+func (d *Daemon) auditAgentDisabled(ctx context.Context, s domain.Situation,
+	sig domain.SignatureResult, tr domain.AgentTransition, input string,
+	confidence float64, llmConfidence *int, llmOutput string, now time.Time) {
+	d.audit(ctx, domain.AuditRecord{
+		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature,
+		Trigger: trigger(tr), SituationType: s.Type,
+		Action: domain.AuditActionDenied, Input: input, Confidence: confidence,
+		LLMConfidence: llmConfidence, LLMOutput: llmOutput,
+		Rationale: "[agent_disabled]", Status: "denied",
+		PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
+	})
+	slog.Info("autonomous action denied: agent disabled",
+		"agent", s.AgentID, "situation", s.Type, "input", input)
 }
 
 // consultLLM assembles the consult context, stages the request, and
@@ -1789,6 +1886,11 @@ func (d *Daemon) agentNotCleanlyIdle(ctx context.Context, agentID string) bool {
 	}
 	for _, a := range agents {
 		if a.AgentID == agentID {
+			// Disabled is an unavailable lifecycle state, not merely a busy
+			// agent. Let escalate() create the required dismissed audit row.
+			if strings.EqualFold(strings.TrimSpace(a.Status), "disabled") {
+				return false
+			}
 			return domain.AgentBusy(a.Status)
 		}
 	}
@@ -2068,6 +2170,17 @@ func (d *Daemon) handleRewriteOutcome(ctx context.Context, res rewriteOutcome) {
 
 	cfg, allow, cls := d.snapshot()
 	now := d.opt.Clock.Now()
+	if disabled, err := d.opt.Store.AgentDisabled(ctx, s.AgentID); err == nil && disabled {
+		d.auditAgentDisabled(ctx, s, res.sig, res.tr, res.dec.Input,
+			res.dec.Confidence, nil, res.rewritten, now)
+		return
+	} else if err != nil {
+		d.escalate(ctx, s, res.sig, domain.Decision{
+			Action: domain.ActionEscalate, Reason: domain.ReasonPersistenceFailed,
+			Rationale: "disabled-state read after rewrite: " + err.Error(),
+		}, res.tr, now)
+		return
+	}
 
 	escalateWith := func(reason domain.EscalateReason, why string) {
 		d.escalate(ctx, s, res.sig, domain.Decision{
@@ -2451,6 +2564,24 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 			reject(domain.ReasonVarianceGuard, "LLM contradicts history")
 			return
 		}
+	}
+
+	// The operator may disable the agent while a consult is running. Let all
+	// rejection paths above raise their normal (auto-dismissed) escalation,
+	// but stop a promotable action here before any audit-as-auto or pane send.
+	if disabled, err := d.opt.Store.AgentDisabled(ctx, s.AgentID); err != nil {
+		reject(domain.ReasonPersistenceFailed, "disabled-state read after LLM consult: "+err.Error())
+		return
+	} else if disabled {
+		d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "rejected")
+		var llmConf *int
+		if llmDec.ConfidentScore >= 0 {
+			llmConf = &llmDec.ConfidentScore
+		}
+		d.auditAgentDisabled(ctx, s, res.sig, tr, llmDec.Action,
+			domain.Confidence(history, cfg.Learning.ConfirmationWeight).Score,
+			llmConf, llmDec.CapturedOutput, now)
+		return
 	}
 
 	// Both scores land on the auto-acted audit row: the computed 0-1 agreement

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1011,6 +1011,14 @@ func TestConfirmDrivenShadowToAutoPromotion(t *testing.T) {
 	const graduationN = 3
 	h := newHarness(t, fmt.Sprintf("[learning]\ngraduation_n = %d\n", graduationN))
 	h.herdr.setPane(approvalPane)
+	// Confirmation nudges reload, whose reconcile pass re-drives live parked
+	// agents. This test injects each blocked event explicitly and is about the
+	// learning transition, not reconciliation, so keep the authoritative live
+	// snapshot working to prevent a background re-drive racing the next loop.
+	h.herdr.setAgents([]domain.AgentTransition{{
+		AgentID: "agent-promote", PaneID: "agent-promote",
+		AgentType: "claude", Status: "working",
+	}})
 	ctx := context.Background()
 
 	// The learned action is the option LABEL "Yes" (approvalPane offers

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -72,6 +72,8 @@ type fakeHerdr struct {
 	// resolving the pane.
 	agents          []domain.AgentTransition
 	listAgentsCalls int
+	agentsPinned    bool
+	failListAgents  bool
 }
 
 func (f *fakeHerdr) Send(ctx context.Context, paneID, input string) error {
@@ -239,6 +241,9 @@ func (f *fakeHerdr) ListAgents(ctx context.Context) ([]domain.AgentTransition, e
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.listAgentsCalls++
+	if f.failListAgents {
+		return nil, errors.New("induced agent-list failure")
+	}
 	return append([]domain.AgentTransition(nil), f.agents...), nil
 }
 
@@ -246,6 +251,31 @@ func (f *fakeHerdr) setAgents(agents []domain.AgentTransition) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.agents = agents
+	f.agentsPinned = true
+}
+
+func (f *fakeHerdr) setFailListAgents(fail bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failListAgents = fail
+}
+
+// observeTransition keeps the fake's live snapshot aligned with pushed Herdr
+// events. Tests that call setAgents pin an explicit later snapshot (for example,
+// "working" after a blocked event), which must not be overwritten here.
+func (f *fakeHerdr) observeTransition(tr domain.AgentTransition) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.agentsPinned {
+		return
+	}
+	for i := range f.agents {
+		if f.agents[i].AgentID == tr.AgentID {
+			f.agents[i] = tr
+			return
+		}
+	}
+	f.agents = append(f.agents, tr)
 }
 
 func (f *fakeHerdr) listAgentsCallCount() int {
@@ -587,10 +617,12 @@ func (h *harness) push(agentID, status string) {
 }
 
 func (h *harness) pushIn(agentID, workspaceID, status string) {
-	h.events.ch <- domain.AgentTransition{
+	tr := domain.AgentTransition{
 		AgentID: agentID, PaneID: agentID, WorkspaceID: workspaceID,
 		AgentType: "claude", Status: status,
 	}
+	h.herdr.observeTransition(tr)
+	h.events.ch <- tr
 }
 
 // seedAutonomous trains a signature to autonomous mode with a consistent
@@ -1290,6 +1322,94 @@ func TestPipelineIgnoresDuplicateEvent(t *testing.T) {
 	}
 }
 
+func TestEscalationAutoDismissesUnavailableAgentWithAudit(t *testing.T) {
+	tests := []struct {
+		name          string
+		agents        []domain.AgentTransition
+		failList      bool
+		storeDisabled bool
+		wantStatus    string
+		wantTag       string
+		wantPending   int
+		wantNotified  bool
+	}{
+		{
+			name: "agent no longer live", wantStatus: "dismissed",
+			wantTag: "[agent_not_live]", wantPending: 0,
+		},
+		{
+			name:       "agent disabled",
+			agents:     []domain.AgentTransition{{AgentID: "agent-target", Status: " disabled "}},
+			wantStatus: "dismissed", wantTag: "[agent_disabled]", wantPending: 0,
+		},
+		{
+			name: "agent disabled in HAP", storeDisabled: true,
+			agents:     []domain.AgentTransition{{AgentID: "agent-target", Status: "idle"}},
+			wantStatus: "dismissed", wantTag: "[agent_disabled]", wantPending: 0,
+		},
+		{
+			name:       "agent live",
+			agents:     []domain.AgentTransition{{AgentID: "agent-target", Status: "idle"}},
+			wantStatus: "escalated", wantPending: 1, wantNotified: true,
+		},
+		{
+			name:     "agent list unavailable is inconclusive",
+			failList: true, wantStatus: "escalated", wantPending: 1, wantNotified: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newHarness(t, "")
+			h.herdr.setAgents(tt.agents)
+			h.herdr.setFailListAgents(tt.failList)
+			ctx := context.Background()
+			if tt.storeDisabled {
+				if _, err := h.raw.EnsureAgentName(ctx, "agent-target"); err != nil {
+					t.Fatal(err)
+				}
+				if err := h.raw.SetAgentDisabled(ctx, "agent-target", true); err != nil {
+					t.Fatal(err)
+				}
+			}
+			s := domain.Situation{
+				AgentID: "agent-target", PaneID: "agent-target", AgentType: "claude",
+				Type: domain.SituationApproval, Status: "blocked", Content: approvalPane,
+			}
+			h.daemon.escalate(ctx, s, domain.ComputeSignature(s), domain.Decision{
+				Action: domain.ActionEscalate, Reason: domain.ReasonNoHistory,
+			}, domain.AgentTransition{
+				AgentID: s.AgentID, PaneID: s.PaneID, AgentType: s.AgentType, Status: s.Status,
+			}, time.Now())
+
+			audits, err := h.raw.AuditLog(ctx, 10)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(audits) != 1 {
+				t.Fatalf("audit rows = %d, want 1: %+v", len(audits), audits)
+			}
+			if audits[0].Action != domain.AuditActionEscalated || audits[0].Status != tt.wantStatus {
+				t.Errorf("audit action/status = %q/%q, want %q/%q",
+					audits[0].Action, audits[0].Status, domain.AuditActionEscalated, tt.wantStatus)
+			}
+			if tt.wantTag != "" && !strings.Contains(audits[0].Rationale, tt.wantTag) {
+				t.Errorf("audit rationale = %q, want tag %q", audits[0].Rationale, tt.wantTag)
+			}
+			pending, err := h.raw.PendingEscalations(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(pending) != tt.wantPending {
+				t.Errorf("pending escalations = %d, want %d", len(pending), tt.wantPending)
+			}
+			if notified := len(h.herdr.notified()) > 0; notified != tt.wantNotified {
+				t.Errorf("notification present = %v, want %v", notified, tt.wantNotified)
+			}
+		})
+	}
+}
+
 // TestReconcileEscalatesAlreadyParkedAgent covers #49: an agent already
 // blocked at subscribe time (never delivered as a pane.agent_status_changed
 // transition) is surfaced by reconcileAttention through the normal
@@ -1638,9 +1758,8 @@ func TestPaneReadFailureTakesNoAction(t *testing.T) {
 
 func TestPaneReadFailureDedupsDuplicateEvents(t *testing.T) {
 	// A persistent Herdr/pane-read outage delivers the same blocked event
-	// repeatedly. That escalation path bypasses escalate() (there is no pane
-	// to classify), so it must dedup inline — an outage must not pile up one
-	// identical pending escalation per event.
+	// repeatedly. The unreadable-pane escalation still has to enforce the same
+	// content-level dedup rule even though there is no pane content to classify.
 	h := newHarness(t, "")
 	h.herdr.failRead = true
 	ctx := context.Background()
@@ -2164,6 +2283,71 @@ func TestIdleTaskGenDropsStaleSuggestion(t *testing.T) {
 	}
 	if len(h.herdr.sentInputs()) != 0 {
 		t.Errorf("nothing may be sent for a dropped suggestion, got %v", h.herdr.sentInputs())
+	}
+}
+
+func TestIdleTaskGenAutoDismissesWhenAgentExits(t *testing.T) {
+	// Regression for an LLM generation that outlives its Codex process: Herdr
+	// successfully reports that the originating agent is gone, so the outcome
+	// must remain in Audit as dismissed and never enter the pending queue.
+	var h *harness
+	h, tg := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+		h.herdr.setAgents(nil)
+		return "Implement the next repository task", nil
+	})
+	h.herdr.setPane("Task is complete.\n")
+
+	ctx := context.Background()
+	h.push("agent-exited", "idle")
+	waitFor(t, 3*time.Second, func() bool {
+		pending, _ := h.raw.HasPendingLLMConsult(ctx, "agent-exited")
+		return !pending && len(tg.genCalls()) == 1
+	})
+
+	if pending, _ := h.raw.PendingEscalations(ctx); len(pending) != 0 {
+		t.Fatalf("exited agent left %d pending escalation(s), want 0", len(pending))
+	}
+	audits, err := h.raw.AuditLog(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(audits) != 1 || audits[0].Status != "dismissed" {
+		t.Fatalf("task-generation audit = %+v, want one dismissed row", audits)
+	}
+	if !strings.Contains(audits[0].Rationale, "[agent_not_live]") {
+		t.Errorf("dismissed audit rationale = %q, missing lifecycle reason", audits[0].Rationale)
+	}
+	if got := len(h.herdr.notified()); got != 0 {
+		t.Errorf("auto-dismissed escalation raised %d notification(s), want 0", got)
+	}
+}
+
+func TestDisabledAgentDeniesAutonomousAction(t *testing.T) {
+	h := newHarness(t, "[learning]\ngraduation_n = 3\n")
+	h.herdr.setPane(approvalPane)
+	h.seedAutonomous(approvalPane, domain.SituationApproval, "Yes")
+	ctx := context.Background()
+	if _, err := h.raw.EnsureAgentName(ctx, "agent-disabled"); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.raw.SetAgentDisabled(ctx, "agent-disabled", true); err != nil {
+		t.Fatal(err)
+	}
+
+	h.push("agent-disabled", "blocked")
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := h.raw.AuditLog(ctx, 10)
+		return len(audits) == 1
+	})
+	audits, _ := h.raw.AuditLog(ctx, 10)
+	if got := audits[0]; got.Action != domain.AuditActionDenied || got.Status != "denied" || got.Rationale != "[agent_disabled]" {
+		t.Fatalf("disabled action audit = %+v, want denied/[agent_disabled]", got)
+	}
+	if sent := h.herdr.sentInputs(); len(sent) != 0 {
+		t.Fatalf("disabled agent received autonomous input: %v", sent)
+	}
+	if pending, _ := h.raw.PendingEscalations(ctx); len(pending) != 0 {
+		t.Fatalf("disabled autonomous decision left pending escalations: %+v", pending)
 	}
 }
 
@@ -2772,6 +2956,10 @@ func TestRetryLLMOutcomeNeverAutoActs(t *testing.T) {
 	}
 	t.Cleanup(func() { raw.Close() })
 	fh := &fakeHerdr{}
+	fh.setAgents([]domain.AgentTransition{{
+		AgentID: "agent-retry-boundary", PaneID: "pane-retry-boundary",
+		AgentType: "claude", Status: "blocked",
+	}})
 	d, err := New(Options{ConfigPath: cfgPath, Store: raw, Herdr: fh, LLM: &fakeLLM{}})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -427,6 +427,27 @@ type failingStore struct {
 	failDedup   bool
 }
 
+// pausingAutomationStore lets a test stop immediately before the real
+// cross-process lifecycle claim, so an operator disable can deterministically
+// win the race and prove the delivery path rechecks under the barrier.
+type pausingAutomationStore struct {
+	ports.StorePort
+	reached chan struct{}
+	resume  chan struct{}
+	once    sync.Once
+}
+
+func (s *pausingAutomationStore) WithAgentAutomation(ctx context.Context,
+	agentID string, fn func()) (bool, error) {
+	s.once.Do(func() { close(s.reached) })
+	select {
+	case <-s.resume:
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+	return s.StorePort.WithAgentAutomation(ctx, agentID, fn)
+}
+
 func (f *failingStore) setFailAudit(v bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -782,6 +803,48 @@ func TestLLMPromotionDeliversMenuDigitForLabel(t *testing.T) {
 	waitFor(t, 5*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
 	if got := h.herdr.sentInputs()[0]; got != "1" {
 		t.Errorf("promoted LLM label \"Yes\" delivered as %q, want digit \"1\"", got)
+	}
+}
+
+func TestLLMPromotionDeniedWhenDisableWinsFinalBarrier(t *testing.T) {
+	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n"
+	h := newHarness(t, cfg)
+	h.herdr.setPane(approvalPane)
+	h.llm.configured = true
+	h.llm.consult = func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+		id, _ := h.raw.InsertLLMDecision(ctx, domain.LLMDecision{
+			RequestID: req.RequestID, Signature: req.Signature,
+			SituationType: req.SituationType, AgentType: req.AgentType,
+			Action: "Yes", Rationale: "approve", ConfidentScore: 80,
+			Status: "pending", CreatedAt: time.Now(),
+		})
+		return &domain.LLMDecision{ID: id, RequestID: req.RequestID, Action: "Yes",
+			Rationale: "approve", ConfidentScore: 80, Status: "pending"}, nil
+	}
+	gate := &pausingAutomationStore{
+		StorePort: h.store, reached: make(chan struct{}), resume: make(chan struct{}),
+	}
+	h.daemon.opt.Store = gate
+	h.push("agent-llm-disabled", "blocked")
+	select {
+	case <-gate.reached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("LLM promotion did not reach its final lifecycle barrier")
+	}
+	if err := h.raw.SetAgentDisabled(context.Background(), "agent-llm-disabled", true); err != nil {
+		t.Fatal(err)
+	}
+	close(gate.resume)
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := h.raw.AuditLog(context.Background(), 10)
+		return len(audits) == 1 && audits[0].Status == "denied"
+	})
+	if sent := h.herdr.sentInputs(); len(sent) != 0 {
+		t.Fatalf("LLM promotion crossed disable barrier: %v", sent)
+	}
+	audits, _ := h.raw.AuditLog(context.Background(), 10)
+	if audits[0].Action != domain.AuditActionDenied || audits[0].Rationale != "[agent_disabled]" {
+		t.Fatalf("LLM denied audit = %+v", audits[0])
 	}
 }
 
@@ -1852,7 +1915,13 @@ func TestRunawayGuardPausesAgent(t *testing.T) {
 	})
 
 	// Confirming the escalation is a human-initiated send: it delivers the
-	// retained action and resumes this agent's automation.
+	// retained action and resumes this agent's automation. Confirmation also
+	// reloads the daemon, so pin the authoritative post-send snapshot to working;
+	// otherwise reconciliation can re-drive the intentionally stale blocked
+	// event and immediately pause the agent again.
+	h.herdr.setAgents([]domain.AgentTransition{{
+		AgentID: "agent-8", PaneID: "agent-8", AgentType: "claude", Status: "working",
+	}})
 	app := frontend.App{Store: h.raw, Herdr: h.herdr, ControlPath: h.ctlPath, Author: "test"}
 	if err := app.Confirm(context.Background(), escalation.ID, true); err != nil {
 		t.Fatal(err)
@@ -2338,11 +2407,21 @@ func TestDisabledAgentDeniesAutonomousAction(t *testing.T) {
 	if _, err := h.raw.EnsureAgentName(ctx, "agent-disabled"); err != nil {
 		t.Fatal(err)
 	}
+	gate := &pausingAutomationStore{
+		StorePort: h.store, reached: make(chan struct{}), resume: make(chan struct{}),
+	}
+	h.daemon.opt.Store = gate
+
+	h.push("agent-disabled", "blocked")
+	select {
+	case <-gate.reached:
+	case <-time.After(3 * time.Second):
+		t.Fatal("autonomous delivery did not reach its final lifecycle barrier")
+	}
 	if err := h.raw.SetAgentDisabled(ctx, "agent-disabled", true); err != nil {
 		t.Fatal(err)
 	}
-
-	h.push("agent-disabled", "blocked")
+	close(gate.resume)
 	waitFor(t, 3*time.Second, func() bool {
 		audits, _ := h.raw.AuditLog(ctx, 10)
 		return len(audits) == 1

--- a/internal/daemon/noop_test.go
+++ b/internal/daemon/noop_test.go
@@ -100,6 +100,55 @@ func TestLLMNoopPromotionRecordsWithoutSend(t *testing.T) {
 	}
 }
 
+func TestLLMNoopDeniedWhenDisableWinsFinalBarrier(t *testing.T) {
+	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n"
+	h := newHarness(t, cfg)
+	h.herdr.setPane(approvalPane)
+	h.llm.configured = true
+	h.llm.consult = func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+		id, _ := h.raw.InsertLLMDecision(ctx, domain.LLMDecision{
+			RequestID: req.RequestID, Signature: req.Signature,
+			SituationType: req.SituationType, AgentType: req.AgentType,
+			Action: "@noop", Rationale: "no reply needed", ConfidentScore: 80,
+			Status: "pending", CreatedAt: time.Now(),
+		})
+		return &domain.LLMDecision{ID: id, RequestID: req.RequestID, Action: "@noop",
+			Rationale: "no reply needed", ConfidentScore: 80, Status: "pending"}, nil
+	}
+	gate := &pausingAutomationStore{
+		StorePort: h.store, reached: make(chan struct{}), resume: make(chan struct{}),
+	}
+	h.daemon.opt.Store = gate
+	h.push("agent-llmnoop-disabled", "blocked")
+	select {
+	case <-gate.reached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("LLM noop did not reach its final lifecycle barrier")
+	}
+	ctx := context.Background()
+	if err := h.raw.SetAgentDisabled(ctx, "agent-llmnoop-disabled", true); err != nil {
+		t.Fatal(err)
+	}
+	close(gate.resume)
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := h.raw.AuditLog(ctx, 10)
+		return len(audits) == 1 && audits[0].Status == "denied"
+	})
+
+	audits, _ := h.raw.AuditLog(ctx, 10)
+	if audits[0].Action != domain.AuditActionDenied || audits[0].Rationale != "[agent_disabled]" {
+		t.Fatalf("LLM noop denied audit = %+v", audits[0])
+	}
+	decs, _ := h.raw.DecisionsForSignature(ctx, audits[0].Signature, 10)
+	if len(decs) != 0 {
+		t.Fatalf("disabled LLM noop was learned: %+v", decs)
+	}
+	rate, err := h.raw.GetAgentRate(ctx, "agent-llmnoop-disabled")
+	if err != nil || rate.ConsecutiveAuto != 0 {
+		t.Fatalf("disabled LLM noop advanced rate: rate=%+v err=%v", rate, err)
+	}
+}
+
 // Below the confidence threshold (default 999 = never), an LLM @noop surfaces
 // as a human-readable suggestion; confirming it records the @noop as a
 // learning event (end-to-end: accepted noop escalation becomes learned history).

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -38,6 +38,10 @@ const sweepResetKeys = domain.MCQResetKeys
 // single-frame situation proceeds to decideAndAct, which escalates with the
 // proper reason.
 func (d *Daemon) sweepAllowed(ctx context.Context, s domain.Situation) bool {
+	disabled, err := d.opt.Store.AgentDisabled(ctx, s.AgentID)
+	if err != nil || disabled {
+		return false
+	}
 	kill, err := d.opt.Store.LatestKillEvent(ctx)
 	if err != nil || domain.KillStateActive(kill) {
 		return false
@@ -343,6 +347,13 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 			Action: domain.ActionEscalate, Reason: reason, Rationale: why,
 			Confidence: dec.Confidence, Suggestion: "answer series: " + dec.Input,
 		}, tr, now)
+	}
+	if disabled, err := d.opt.Store.AgentDisabled(ctx, s.AgentID); err != nil {
+		escalateWith(domain.ReasonPersistenceFailed, "disabled-state read before series: "+err.Error())
+		return
+	} else if disabled {
+		d.auditAgentDisabled(ctx, s, sig, tr, dec.Input, dec.Confidence, nil, "", now)
+		return
 	}
 
 	ks, ok := d.opt.Herdr.(ports.KeystrokeSender)

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -348,14 +348,6 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 			Confidence: dec.Confidence, Suggestion: "answer series: " + dec.Input,
 		}, tr, now)
 	}
-	if disabled, err := d.opt.Store.AgentDisabled(ctx, s.AgentID); err != nil {
-		escalateWith(domain.ReasonPersistenceFailed, "disabled-state read before series: "+err.Error())
-		return
-	} else if disabled {
-		d.auditAgentDisabled(ctx, s, sig, tr, dec.Input, dec.Confidence, nil, "", now)
-		return
-	}
-
 	ks, ok := d.opt.Herdr.(ports.KeystrokeSender)
 	if !ok {
 		escalateWith(domain.ReasonHerdrUnreachable, "keystrokes unavailable")
@@ -377,111 +369,131 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 		return
 	}
 
-	auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
-		AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
-		SituationType: s.Type, Action: "auto:" + dec.Input, Input: dec.Input,
-		Confidence: dec.Confidence, Rationale: dec.Rationale,
-		Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
-	})
-	if err != nil {
-		d.releasePane(s.AgentID)
-		slog.Error("audit write failed; blocking autonomous action (FR-024)", "error", err)
-		d.notify(ctx, "Herd Auto Prompter: persistence failure",
-			"An automated action was blocked because its audit record could not be written.")
-		return
-	}
-
 	go func() {
 		defer d.releasePane(s.AgentID)
 		logging.Guard("series-delivery", func() error {
-			if err := d.reverifyMultiSelect(ctx, ks, s); err != nil {
-				slog.Warn("multi-select baseline moved before delivery; refusing", "pane", s.PaneID, "error", err)
-				d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
-				d.notify(ctx, "Herd Auto Prompter: action delivery skipped",
-					fmt.Sprintf("Agent %s: the multi-select form changed before the answer could be delivered (%v); please review it.", s.AgentID, err))
-				return nil
-			}
-			if err := d.sendTabSelections(ctx, ks, s, groups); err != nil {
-				slog.Error("answer series delivery failed", "pane", s.PaneID, "error", err)
-				d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
-				d.notify(ctx, "Herd Auto Prompter: action delivery failed",
-					fmt.Sprintf("Agent %s: multi-tab answer series failed mid-delivery (%v); please review the form.", s.AgentID, err))
-				return nil
-			}
-			d.mu.Lock()
-			d.lastAutoSend[s.AgentID] = now
-			d.mu.Unlock()
-			if _, err := d.opt.Store.RecordDecision(ctx, domain.DecisionRecord{
-				Signature: sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
-				ChosenAction: dec.Input, Source: dec.Source, Confidence: dec.Confidence, CreatedAt: now,
-			}); err != nil {
-				slog.Error("decision record write failed", "error", err)
-			}
-			if rate, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
-				updated := domain.RegisterAutoPrompt(*rate, now)
-				updated.AgentID = s.AgentID
-				if err := d.opt.Store.UpdateAgentRate(ctx, updated); err != nil {
-					slog.Error("agent rate update failed", "error", err)
+			d.withAgentAutomation(ctx, s, sig, tr, dec.Input, dec.Confidence, nil, "", now, func() {
+				auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
+					AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
+					SituationType: s.Type, Action: "auto:" + dec.Input, Input: dec.Input,
+					Confidence: dec.Confidence, Rationale: dec.Rationale,
+					Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
+				})
+				if err != nil {
+					slog.Error("audit write failed; blocking autonomous action (FR-024)", "error", err)
+					d.notify(ctx, "Herd Auto Prompter: persistence failure",
+						"An automated action was blocked because its audit record could not be written.")
+					return
 				}
-			}
-			slog.Info("multi-tab answer series delivered",
-				"agent", s.AgentID, "answers", answerCount, "confidence", dec.Confidence, "audit_id", auditID)
-			d.scheduleUnblockCheck(verifyunblock.Params{
-				PaneID: s.PaneID, AgentID: s.AgentID, AgentType: s.AgentType,
-				Signature: sig.Signature, Input: dec.Input, Excerpt: s.Content, SituationType: s.Type,
+				if err := d.reverifyMultiSelect(ctx, ks, s); err != nil {
+					slog.Warn("multi-select baseline moved before delivery; refusing", "pane", s.PaneID, "error", err)
+					d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
+					d.notify(ctx, "Herd Auto Prompter: action delivery skipped",
+						fmt.Sprintf("Agent %s: the multi-select form changed before the answer could be delivered (%v); please review it.", s.AgentID, err))
+					return
+				}
+				if err := d.sendTabSelections(ctx, ks, s, groups); err != nil {
+					slog.Error("answer series delivery failed", "pane", s.PaneID, "error", err)
+					d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
+					d.notify(ctx, "Herd Auto Prompter: action delivery failed",
+						fmt.Sprintf("Agent %s: multi-tab answer series failed mid-delivery (%v); please review the form.", s.AgentID, err))
+					return
+				}
+				d.mu.Lock()
+				d.lastAutoSend[s.AgentID] = now
+				d.mu.Unlock()
+				if _, err := d.opt.Store.RecordDecision(ctx, domain.DecisionRecord{
+					Signature: sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
+					ChosenAction: dec.Input, Source: dec.Source, Confidence: dec.Confidence, CreatedAt: now,
+				}); err != nil {
+					slog.Error("decision record write failed", "error", err)
+				}
+				if rate, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
+					updated := domain.RegisterAutoPrompt(*rate, now)
+					updated.AgentID = s.AgentID
+					if err := d.opt.Store.UpdateAgentRate(ctx, updated); err != nil {
+						slog.Error("agent rate update failed", "error", err)
+					}
+				}
+				slog.Info("multi-tab answer series delivered",
+					"agent", s.AgentID, "answers", answerCount, "confidence", dec.Confidence, "audit_id", auditID)
+				d.scheduleUnblockCheck(verifyunblock.Params{
+					PaneID: s.PaneID, AgentID: s.AgentID, AgentType: s.AgentType,
+					Signature: sig.Signature, Input: dec.Input, Excerpt: s.Content, SituationType: s.Type,
+				})
 			})
 			return nil
 		})
 	}()
 }
 
-// deliverSeriesLLM is the promotion-path twin of deliverSeries: the audit
-// row is already committed by the caller (FR-024); the keystrokes and the
-// accept/learn/rate writes run off the main loop.
+// deliverSeriesLLM is the promotion-path twin of deliverSeries. Its final
+// disabled check, audit, keystrokes, and accept/learn/rate writes run under the
+// same cross-process lifecycle barrier, off the main loop.
 func (d *Daemon) deliverSeriesLLM(ctx context.Context, ks ports.KeystrokeSender,
-	s domain.Situation, sigKey string, llmDec *domain.LLMDecision, groups [][]string,
-	auditID int64, now time.Time) {
+	s domain.Situation, sig domain.SignatureResult, tr domain.AgentTransition,
+	llmDec *domain.LLMDecision, groups [][]string, confidence float64,
+	llmConfidence *int, now time.Time) {
 
 	go func() {
 		defer d.releasePane(s.AgentID)
 		logging.Guard("series-delivery-llm", func() error {
-			if err := d.reverifyMultiSelect(ctx, ks, s); err != nil {
-				slog.Warn("multi-select baseline moved before LLM delivery; refusing", "pane", s.PaneID, "error", err)
-				d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
-				d.notify(ctx, "Herd Auto Prompter: action delivery skipped",
-					fmt.Sprintf("Agent %s: the multi-select form changed before the answer could be delivered (%v); please review it.", s.AgentID, err))
-				return nil
+			executed := d.withAgentAutomation(ctx, s, sig, tr, llmDec.Action,
+				confidence, llmConfidence, llmDec.CapturedOutput, now, func() {
+					auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
+						AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: "llm-fallback",
+						SituationType: s.Type, Action: domain.AuditActionAutoPrefix + llmDec.Action, Input: llmDec.Action,
+						Confidence: confidence, LLMConfidence: llmConfidence,
+						Rationale: "LLM: " + llmDec.Rationale, LLMOutput: llmDec.CapturedOutput,
+						Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
+					})
+					if err != nil {
+						slog.Error("audit write failed; blocking LLM action (FR-024)", "error", err)
+						d.notify(ctx, "Herd Auto Prompter: persistence failure",
+							"An LLM-derived action was blocked because its audit record could not be written.")
+						return
+					}
+					if err := d.reverifyMultiSelect(ctx, ks, s); err != nil {
+						slog.Warn("multi-select baseline moved before LLM delivery; refusing", "pane", s.PaneID, "error", err)
+						d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
+						d.notify(ctx, "Herd Auto Prompter: action delivery skipped",
+							fmt.Sprintf("Agent %s: the multi-select form changed before the answer could be delivered (%v); please review it.", s.AgentID, err))
+						return
+					}
+					if err := d.sendTabSelections(ctx, ks, s, groups); err != nil {
+						slog.Error("LLM answer series delivery failed", "pane", s.PaneID, "error", err)
+						d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
+						d.notify(ctx, "Herd Auto Prompter: action delivery failed", err.Error())
+						return
+					}
+					if err := d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "accepted"); err != nil {
+						slog.Error("llm decision status update failed", "error", err)
+					}
+					if _, err := d.opt.Store.RecordDecision(ctx, domain.DecisionRecord{
+						Signature: sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
+						ChosenAction: llmDec.Action, Source: domain.SourceLLM, CreatedAt: now,
+					}); err != nil {
+						slog.Error("decision record write failed", "error", err)
+					}
+					if rate, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
+						updated := domain.RegisterAutoPrompt(*rate, now)
+						updated.AgentID = s.AgentID
+						if err := d.opt.Store.UpdateAgentRate(ctx, updated); err != nil {
+							slog.Error("agent rate update failed", "error", err)
+						}
+					}
+					d.mu.Lock()
+					d.lastAutoSend[s.AgentID] = now
+					d.mu.Unlock()
+					slog.Info("LLM answer series promoted and delivered", "agent", s.AgentID, "answers", s.EffectiveAnswerCount())
+					d.scheduleUnblockCheck(verifyunblock.Params{
+						PaneID: s.PaneID, AgentID: s.AgentID, AgentType: s.AgentType,
+						Signature: sig.Signature, Input: llmDec.Action, Excerpt: s.Content, SituationType: s.Type,
+					})
+				})
+			if !executed {
+				d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "rejected")
 			}
-			if err := d.sendTabSelections(ctx, ks, s, groups); err != nil {
-				slog.Error("LLM answer series delivery failed", "pane", s.PaneID, "error", err)
-				d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
-				d.notify(ctx, "Herd Auto Prompter: action delivery failed", err.Error())
-				return nil
-			}
-			if err := d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "accepted"); err != nil {
-				slog.Error("llm decision status update failed", "error", err)
-			}
-			if _, err := d.opt.Store.RecordDecision(ctx, domain.DecisionRecord{
-				Signature: sigKey, SituationType: s.Type, AgentType: s.AgentType,
-				ChosenAction: llmDec.Action, Source: domain.SourceLLM, CreatedAt: now,
-			}); err != nil {
-				slog.Error("decision record write failed", "error", err)
-			}
-			if rate, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
-				updated := domain.RegisterAutoPrompt(*rate, now)
-				updated.AgentID = s.AgentID
-				if err := d.opt.Store.UpdateAgentRate(ctx, updated); err != nil {
-					slog.Error("agent rate update failed", "error", err)
-				}
-			}
-			d.mu.Lock()
-			d.lastAutoSend[s.AgentID] = now
-			d.mu.Unlock()
-			slog.Info("LLM answer series promoted and delivered", "agent", s.AgentID, "answers", s.EffectiveAnswerCount())
-			d.scheduleUnblockCheck(verifyunblock.Params{
-				PaneID: s.PaneID, AgentID: s.AgentID, AgentType: s.AgentType,
-				Signature: sigKey, Input: llmDec.Action, Excerpt: s.Content, SituationType: s.Type,
-			})
 			return nil
 		})
 	}()

--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -84,10 +84,12 @@ func TestCodexBlockedMCQEscalatesAsAggregatedChoice(t *testing.T) {
 		codexQuestionFrame(2, 2, 2, "1", false),
 	}
 	h.herdr.setFrames(frames)
-	h.events.ch <- domain.AgentTransition{
+	tr := domain.AgentTransition{
 		AgentID: "agent-codex-escalation", PaneID: "agent-codex-escalation",
 		AgentType: "codex", Status: "blocked",
 	}
+	h.herdr.observeTransition(tr)
+	h.events.ch <- tr
 	ctx := context.Background()
 	waitFor(t, 10*time.Second, func() bool {
 		esc, _ := h.raw.PendingEscalations(ctx)

--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -523,6 +523,49 @@ func TestLLMMultiTabConsultAndSeriesPromotion(t *testing.T) {
 	}
 }
 
+func TestLLMMultiTabSeriesDeniedWhenDisableWinsFinalBarrier(t *testing.T) {
+	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n"
+	h := newHarness(t, cfg)
+	h.herdr.setFrames(mcqFrames)
+	h.llm.configured = true
+	h.llm.consult = func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+		id, _ := h.raw.InsertLLMDecision(ctx, domain.LLMDecision{
+			RequestID: req.RequestID, Signature: req.Signature,
+			SituationType: req.SituationType, AgentType: req.AgentType,
+			Action: "1 2 1", Rationale: "defaults", ConfidentScore: 80,
+			Status: "pending", CreatedAt: time.Now(),
+		})
+		return &domain.LLMDecision{ID: id, RequestID: req.RequestID, Action: "1 2 1",
+			Rationale: "defaults", ConfidentScore: 80, Status: "pending"}, nil
+	}
+	gate := &pausingAutomationStore{
+		StorePort: h.store, reached: make(chan struct{}), resume: make(chan struct{}),
+	}
+	h.daemon.opt.Store = gate
+	h.push("agent-mcqllm-disabled", "blocked")
+	select {
+	case <-gate.reached:
+	case <-time.After(10 * time.Second):
+		t.Fatal("LLM series did not reach its final lifecycle barrier")
+	}
+	if err := h.raw.SetAgentDisabled(context.Background(), "agent-mcqllm-disabled", true); err != nil {
+		t.Fatal(err)
+	}
+	keysBefore := len(h.herdr.keysSent())
+	close(gate.resume)
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := h.raw.AuditLog(context.Background(), 10)
+		return len(audits) == 1 && audits[0].Status == "denied"
+	})
+	if keysAfter := len(h.herdr.keysSent()); keysAfter != keysBefore {
+		t.Fatalf("LLM series sent %d keystroke(s) after disable won barrier", keysAfter-keysBefore)
+	}
+	audits, _ := h.raw.AuditLog(context.Background(), 10)
+	if audits[0].Action != domain.AuditActionDenied || audits[0].Rationale != "[agent_disabled]" {
+		t.Fatalf("LLM series denied audit = %+v", audits[0])
+	}
+}
+
 // A DIFFERENT form with the same tab count showing at promotion time must
 // reject the series: consults take minutes and forms can be replaced.
 func TestLLMMultiTabDifferentFormRejected(t *testing.T) {

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -262,6 +262,9 @@ type DecisionRecord struct {
 const (
 	// AuditActionEscalated is the audit_log action for an escalation.
 	AuditActionEscalated = "escalated"
+	// AuditActionDenied records an autonomous action suppressed by an
+	// operator-owned guard such as a disabled agent.
+	AuditActionDenied = "denied"
 	// AuditActionAutoPrefix prefixes the action of an autonomous send
 	// ("auto:" + the delivered input); a noop uses "noop", not this prefix.
 	AuditActionAutoPrefix = "auto:"

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -323,6 +323,9 @@ type Status struct {
 	AgentsKnown bool
 	// AgentNames maps agent/pane ids to their short names.
 	AgentNames map[string]string
+	// DisabledAgents contains agent/pane ids whose HAP automation has been
+	// disabled by the operator. They remain visible in MonitoredAgents.
+	DisabledAgents map[string]bool
 	// AgentStats maps agent/pane ids to their lifetime counters (auto-sends,
 	// escalations, operator confirmations/corrections, first-seen). Nil when
 	// the stats query failed; a missing key means a live agent with no stats
@@ -384,6 +387,9 @@ func (a *App) GetStatus(ctx context.Context) (Status, error) {
 	if names, err := a.Store.AgentNames(ctx); err == nil {
 		st.AgentNames = names
 	}
+	if disabled, err := a.Store.DisabledAgents(ctx); err == nil {
+		st.DisabledAgents = disabled
+	}
 	// Best-effort, like AgentNames: a stats-query error just leaves it nil.
 	if stats, err := a.Store.AgentStats(ctx); err == nil {
 		st.AgentStats = stats
@@ -419,6 +425,9 @@ func (a *App) GetStatus(ctx context.Context) (Status, error) {
 
 // AgentName returns the short name for an agent id ("" when unnamed).
 func (st Status) AgentName(agentID string) string { return st.AgentNames[agentID] }
+
+// AgentDisabled reports the persistent operator-owned automation state.
+func (st Status) AgentDisabled(agentID string) bool { return st.DisabledAgents[agentID] }
 
 // StatsFor returns the lifetime counters for an agent id (a zero-valued
 // AgentStats when none are recorded).
@@ -570,6 +579,33 @@ func (a *App) RenameAgent(ctx context.Context, target, newName string) error {
 				err = a.Store.AssignAgentName(ctx, agent.AgentID, newName)
 				break
 			}
+		}
+	}
+	if err != nil {
+		return err
+	}
+	return a.nudge(ctx, control.KindReload)
+}
+
+// SetAgentDisabled changes whether HAP may perform autonomous work for an
+// agent. A currently live but not-yet-named agent is named first so its state
+// remains visible and addressable after it exits.
+func (a *App) SetAgentDisabled(ctx context.Context, target string, disabled bool) error {
+	err := a.Store.SetAgentDisabled(ctx, target, disabled)
+	if errors.Is(err, ports.ErrUnknownAgent) && a.Herdr != nil {
+		agents, listErr := a.Herdr.ListAgents(ctx)
+		if listErr != nil {
+			return fmt.Errorf("%w (and the live agent list is unavailable: %v)", err, listErr)
+		}
+		for _, agent := range agents {
+			if agent.AgentID != target && agent.PaneID != target {
+				continue
+			}
+			if _, nameErr := a.Store.EnsureAgentName(ctx, agent.AgentID); nameErr != nil {
+				return nameErr
+			}
+			err = a.Store.SetAgentDisabled(ctx, agent.AgentID, disabled)
+			break
 		}
 	}
 	if err != nil {

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -224,6 +224,8 @@ type FrontendStore interface {
 	// first sight. Front-ends use it to name live agents the daemon has
 	// not observed yet (insert-if-absent; renames stay operator-owned).
 	EnsureAgentName(ctx context.Context, agentID string) (string, error)
+	// SetAgentDisabled changes the persistent operator-owned automation state.
+	SetAgentDisabled(ctx context.Context, target string, disabled bool) error
 	// DeleteSignature removes one learned signature with its decision
 	// history and error-retry row, returning the decision count. The daemon
 	// may recreate the signature from an in-flight event; the recreated
@@ -291,6 +293,10 @@ type ReadStore interface {
 	LLMDecisionByRequest(ctx context.Context, requestID string) (*domain.LLMDecision, error)
 	// AgentNames returns every agent id → short name mapping.
 	AgentNames(ctx context.Context) (map[string]string, error)
+	// AgentDisabled reports whether automation is disabled for one agent id.
+	AgentDisabled(ctx context.Context, agentID string) (bool, error)
+	// DisabledAgents returns all disabled agent ids for operator-facing views.
+	DisabledAgents(ctx context.Context) (map[string]bool, error)
 	// AgentStats returns lifetime per-agent counters keyed by agent/pane id,
 	// including agents with zero recorded events (so their FirstSeen shows).
 	AgentStats(ctx context.Context) (map[string]domain.AgentStats, error)

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -163,6 +163,10 @@ type StorePort interface {
 // DaemonStore is the daemon-exclusive write surface plus shared reads.
 type DaemonStore interface {
 	ReadStore
+	// WithAgentAutomation serializes a final disabled-state check and an
+	// autonomous action against SetAgentDisabled across processes. It returns
+	// disabled=true without calling fn when the operator disabled the agent.
+	WithAgentAutomation(ctx context.Context, agentID string, fn func()) (disabled bool, err error)
 
 	UpsertSignature(ctx context.Context, s domain.SignatureState) error
 	RecordDecision(ctx context.Context, d domain.DecisionRecord) (int64, error)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -178,6 +178,7 @@ INSERT OR IGNORE INTO operator (id, label) VALUES ('operator', 'Operator');
 CREATE TABLE IF NOT EXISTS agent_names (
 	agent_id TEXT PRIMARY KEY,
 	name TEXT NOT NULL UNIQUE,
+	disabled INTEGER NOT NULL DEFAULT 0,
 	created_at INTEGER NOT NULL
 );
 CREATE TABLE IF NOT EXISTS signature_embeddings (
@@ -226,6 +227,9 @@ func (s *Store) migrate() error {
 		// Per-signature decision-id floor: decisions with id <= this are kept
 		// but excluded from confidence/graduation (stamped by an operator reset).
 		`ALTER TABLE signatures ADD COLUMN decision_floor_id INTEGER NOT NULL DEFAULT 0`,
+		// Operator-owned per-agent automation switch. Kept on agent_names so
+		// renames preserve it and disabled agents remain visible by name.
+		`ALTER TABLE agent_names ADD COLUMN disabled INTEGER NOT NULL DEFAULT 0`,
 	} {
 		if _, err := s.db.Exec(ddl); err != nil &&
 			!strings.Contains(err.Error(), "duplicate column name") {
@@ -1459,6 +1463,64 @@ func (s *Store) AgentNames(ctx context.Context) (map[string]string, error) {
 		names[id] = name
 	}
 	return names, rows.Err()
+}
+
+// SetAgentDisabled changes the operator-owned automation state for a known
+// agent. target may be its short name or pane/agent id. Unknown targets are
+// rejected rather than creating invisible state for a typo.
+func (s *Store) SetAgentDisabled(ctx context.Context, target string, disabled bool) error {
+	agentID, err := s.ResolveAgent(ctx, target)
+	if err != nil {
+		return err
+	}
+	value := 0
+	if disabled {
+		value = 1
+	}
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE agent_names SET disabled = ? WHERE agent_id = ?`, value, agentID)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("no agent known as %q: %w", target, ports.ErrUnknownAgent)
+	}
+	return nil
+}
+
+// AgentDisabled reports whether automation is disabled for an agent id.
+// Unnamed/unknown ids are enabled by default.
+func (s *Store) AgentDisabled(ctx context.Context, agentID string) (bool, error) {
+	var disabled int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT disabled FROM agent_names WHERE agent_id = ?`, agentID).Scan(&disabled)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return disabled != 0, err
+}
+
+// DisabledAgents returns the disabled agent ids for operator-facing views.
+func (s *Store) DisabledAgents(ctx context.Context) (map[string]bool, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT agent_id FROM agent_names WHERE disabled != 0`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	disabled := map[string]bool{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		disabled[id] = true
+	}
+	return disabled, rows.Err()
 }
 
 // AgentStats returns lifetime per-agent counters keyed by agent/pane id.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,14 +11,18 @@ package store
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
 	"net/url"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -30,7 +34,8 @@ import (
 
 // Store is the SQLite-backed implementation of ports.StorePort.
 type Store struct {
-	db *sql.DB
+	db           *sql.DB
+	agentLockDir string
 }
 
 // Open opens (creating if needed) the database at path with WAL mode and a
@@ -50,7 +55,7 @@ func Open(path string) (*Store, error) {
 	}
 	// SQLite serializes writers; a small pool avoids needless SQLITE_BUSY.
 	db.SetMaxOpenConns(2)
-	s := &Store{db: db}
+	s := &Store{db: db, agentLockDir: filepath.Join(filepath.Dir(path), "agent-automation-locks")}
 	if err := s.migrate(); err != nil {
 		db.Close()
 		return nil, err
@@ -1473,6 +1478,11 @@ func (s *Store) SetAgentDisabled(ctx context.Context, target string, disabled bo
 	if err != nil {
 		return err
 	}
+	unlock, err := s.lockAgentAutomation(ctx, agentID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	value := 0
 	if disabled {
 		value = 1
@@ -1490,6 +1500,56 @@ func (s *Store) SetAgentDisabled(ctx context.Context, target string, disabled bo
 		return fmt.Errorf("no agent known as %q: %w", target, ports.ErrUnknownAgent)
 	}
 	return nil
+}
+
+// WithAgentAutomation is the final cross-process lifecycle barrier around an
+// autonomous action. The file lock gives SetAgentDisabled and the daemon one
+// total order: either disable commits first and fn is skipped, or the action
+// completes before disable can commit and return to the operator.
+func (s *Store) WithAgentAutomation(ctx context.Context, agentID string,
+	fn func()) (bool, error) {
+	unlock, err := s.lockAgentAutomation(ctx, agentID)
+	if err != nil {
+		return false, err
+	}
+	defer unlock()
+	disabled, err := s.AgentDisabled(ctx, agentID)
+	if err != nil || disabled {
+		return disabled, err
+	}
+	fn()
+	return false, nil
+}
+
+func (s *Store) lockAgentAutomation(ctx context.Context, agentID string) (func(), error) {
+	if err := os.MkdirAll(s.agentLockDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create agent automation lock directory: %w", err)
+	}
+	sum := sha256.Sum256([]byte(agentID))
+	path := filepath.Join(s.agentLockDir, fmt.Sprintf("%x.lock", sum[:16]))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open agent automation lock: %w", err)
+	}
+	for {
+		err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return func() {
+				_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+				_ = f.Close()
+			}, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) {
+			_ = f.Close()
+			return nil, fmt.Errorf("lock agent automation: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			_ = f.Close()
+			return nil, ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
 }
 
 // AgentDisabled reports whether automation is disabled for an agent id.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -865,6 +865,42 @@ func TestAgentNames(t *testing.T) {
 	}
 }
 
+func TestAgentDisabledState(t *testing.T) {
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+	if err := s.AssignAgentName(ctx, "w1:p1", "builder"); err != nil {
+		t.Fatal(err)
+	}
+	if disabled, err := s.AgentDisabled(ctx, "w1:p1"); err != nil || disabled {
+		t.Fatalf("new agent disabled=%v err=%v, want enabled", disabled, err)
+	}
+	if err := s.SetAgentDisabled(ctx, "builder", true); err != nil {
+		t.Fatal(err)
+	}
+	if disabled, err := s.AgentDisabled(ctx, "w1:p1"); err != nil || !disabled {
+		t.Fatalf("disabled=%v err=%v, want true", disabled, err)
+	}
+	all, err := s.DisabledAgents(ctx)
+	if err != nil || !all["w1:p1"] {
+		t.Fatalf("disabled agents=%v err=%v", all, err)
+	}
+	if err := s.RenameAgent(ctx, "builder", "reviewer"); err != nil {
+		t.Fatal(err)
+	}
+	if disabled, _ := s.AgentDisabled(ctx, "w1:p1"); !disabled {
+		t.Error("rename must preserve disabled state")
+	}
+	if err := s.SetAgentDisabled(ctx, "reviewer", false); err != nil {
+		t.Fatal(err)
+	}
+	if disabled, _ := s.AgentDisabled(ctx, "w1:p1"); disabled {
+		t.Error("enable did not clear disabled state")
+	}
+	if err := s.SetAgentDisabled(ctx, "unknown", true); err == nil {
+		t.Error("unknown target must be rejected")
+	}
+}
+
 func TestClearLearnedData(t *testing.T) {
 	s, _ := openTestStore(t)
 	ctx := context.Background()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -898,6 +899,61 @@ func TestAgentDisabledState(t *testing.T) {
 	}
 	if err := s.SetAgentDisabled(ctx, "unknown", true); err == nil {
 		t.Error("unknown target must be rejected")
+	}
+}
+
+func TestAgentDisableIsBarrierForInFlightAutomation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "barrier.db")
+	actionStore, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer actionStore.Close()
+	operatorStore, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer operatorStore.Close()
+	ctx := context.Background()
+	if err := actionStore.AssignAgentName(ctx, "w1:p1", "builder"); err != nil {
+		t.Fatal(err)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	actionDone := make(chan error, 1)
+	go func() {
+		disabled, err := actionStore.WithAgentAutomation(ctx, "w1:p1", func() {
+			close(started)
+			<-release
+		})
+		if err == nil && disabled {
+			err = errors.New("enabled action was unexpectedly denied")
+		}
+		actionDone <- err
+	}()
+	<-started
+
+	disableDone := make(chan error, 1)
+	go func() { disableDone <- operatorStore.SetAgentDisabled(ctx, "builder", true) }()
+	select {
+	case err := <-disableDone:
+		t.Fatalf("disable crossed an in-flight automation barrier: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	if err := <-actionDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-disableDone; err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	disabled, err := actionStore.WithAgentAutomation(ctx, "w1:p1", func() { called = true })
+	if err != nil || !disabled || called {
+		t.Fatalf("post-disable action: disabled=%v called=%v err=%v", disabled, called, err)
 	}
 }
 

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -731,6 +731,38 @@ func TestAgentsListRendersStatColumns(t *testing.T) {
 	}
 }
 
+func TestAgentsDisabledIndicatorAndKeys(t *testing.T) {
+	m := Model{width: 120, height: 30}
+	upd, _ := m.Update(refreshMsg{status: frontend.Status{
+		MonitoredAgents: []domain.AgentTransition{{
+			AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "codex", Status: "idle",
+		}},
+		AgentNames:     map[string]string{"w1:p1": "quiet-orca"},
+		DisabledAgents: map[string]bool{"w1:p1": true},
+	}})
+	m = upd.(Model)
+	m.tab = tabAgents
+	if view := m.View(); !strings.Contains(view, "DISABLED") {
+		t.Fatalf("disabled agent needs a clear list indicator:\n%s", view)
+	}
+
+	// e is immediate (no confirmation); with no app attached this still proves
+	// the key dispatch reaches the enable action and returns its command.
+	upd, cmd := m.Update(pressKeyMsg("e"))
+	if cmd == nil {
+		t.Fatal("e on a disabled agent should issue an enable command")
+	}
+	m = upd.(Model)
+
+	// An enabled snapshot must require Y/n confirmation before x mutates it.
+	m.data.status.DisabledAgents = nil
+	upd, cmd = m.Update(pressKeyMsg("x"))
+	m = upd.(Model)
+	if cmd != nil || m.confirm == nil || !strings.Contains(m.confirm.label, "[Y/n]") {
+		t.Fatalf("x should open Y/n disable confirmation, cmd=%v confirm=%+v", cmd != nil, m.confirm)
+	}
+}
+
 func TestAgentsListRowsFitContentWidth(t *testing.T) {
 	// The Agents row is the widest list row (it grew with the TASK column). A
 	// row that wraps silently becomes two screen lines, breaking the

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -336,8 +336,12 @@ func (m Model) visibleAgents() []domain.AgentTransition {
 	}
 	var out []domain.AgentTransition
 	for _, a := range m.data.status.MonitoredAgents {
+		automation := "enabled"
+		if m.data.status.AgentDisabled(a.AgentID) {
+			automation = "disabled"
+		}
 		if m.matchesQuery(tabAgents, m.data.status.AgentName(a.AgentID),
-			agentLocation(a, m.data.status), a.AgentID, a.AgentType, a.Status) {
+			agentLocation(a, m.data.status), a.AgentID, a.AgentType, a.Status, automation) {
 			out = append(out, a)
 		}
 	}
@@ -857,6 +861,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m.correctByID(id, true)
 			}
 		case "e":
+			if a := m.detail.agent; a != nil {
+				m.detail = nil
+				return m.enableAgent(*a)
+			}
 			// On a task detail, e edits the snapshotted item (the prompt
 			// replaces the overlay; the expected-text guard still protects
 			// against the file changing since the snapshot).
@@ -865,6 +873,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m.editTaskRowPrompt(*r)
 			}
 		case "x", "delete":
+			if a := m.detail.agent; a != nil {
+				m.detail = nil
+				return m.disableAgentPrompt(*a)
+			}
 			if id := m.detail.confirmID; id != 0 {
 				m.detail = nil
 				return m.dismissByID(id)
@@ -1093,6 +1105,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "e":
 		switch m.tab {
+		case tabAgents:
+			return m.enableSelectedAgent()
 		case tabConfig:
 			return m.editSelectedRule()
 		case tabTasks:
@@ -1165,6 +1179,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "x", "delete":
 		switch m.tab {
+		case tabAgents:
+			return m.disableSelectedAgentPrompt()
 		case tabEscalations:
 			return m.deleteEscalations()
 		case tabTasks:
@@ -2102,6 +2118,58 @@ func (m Model) renameSelected() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m Model) disableSelectedAgentPrompt() (tea.Model, tea.Cmd) {
+	agents := m.visibleAgents()
+	if m.cursors[m.tab] >= len(agents) {
+		return m, nil
+	}
+	return m.disableAgentPrompt(agents[m.cursors[m.tab]])
+}
+
+func (m Model) disableAgentPrompt(agent domain.AgentTransition) (tea.Model, tea.Cmd) {
+	if m.data.status.AgentDisabled(agent.AgentID) {
+		m.message = "agent is already disabled"
+		return m, nil
+	}
+	app, agentID := m.app, agent.AgentID
+	name := orDash(m.data.status.AgentName(agentID))
+	m.confirm = &confirmation{
+		label: fmt.Sprintf("disable agent %s (%s)? [Y/n]", name, agentID),
+		onConfirm: func() tea.Cmd {
+			return m.do(fmt.Sprintf("agent %s disabled", name), func(ctx context.Context) error {
+				return app.SetAgentDisabled(ctx, agentID, true)
+			})
+		},
+		revalidate: func(current Model) (string, bool) {
+			if current.data.status.AgentDisabled(agentID) {
+				return "agent is already disabled", false
+			}
+			return "", true
+		},
+	}
+	return m, nil
+}
+
+func (m Model) enableSelectedAgent() (tea.Model, tea.Cmd) {
+	agents := m.visibleAgents()
+	if m.cursors[m.tab] >= len(agents) {
+		return m, nil
+	}
+	return m.enableAgent(agents[m.cursors[m.tab]])
+}
+
+func (m Model) enableAgent(agent domain.AgentTransition) (tea.Model, tea.Cmd) {
+	if !m.data.status.AgentDisabled(agent.AgentID) {
+		m.message = "agent is already enabled"
+		return m, nil
+	}
+	name := orDash(m.data.status.AgentName(agent.AgentID))
+	m.beginAction()
+	return m, m.do(fmt.Sprintf("agent %s enabled", name), func(ctx context.Context) error {
+		return m.app.SetAgentDisabled(ctx, agent.AgentID, false)
+	})
+}
+
 // focusAgent asks herdr to jump to the agent's exact pane (tab focus + zoom).
 func (m Model) focusAgent(a domain.AgentTransition) (tea.Model, tea.Cmd) {
 	if a.TabID == "" || a.PaneID == "" {
@@ -2498,7 +2566,11 @@ func (m Model) agentDetailLines(a domain.AgentTransition, w int) []string {
 		}))
 	lines = m.detailField(lines, w, "Pane", a.PaneID)
 	lines = m.detailField(lines, w, "Type", a.AgentType)
-	lines = m.detailField(lines, w, "Status", a.Status)
+	status := a.Status
+	if m.data.status.AgentDisabled(a.AgentID) {
+		status += " [DISABLED]"
+	}
+	lines = m.detailField(lines, w, "Status", status)
 	lines = m.detailField(lines, w, "Task source", m.agentTaskSources(a))
 	if !a.At.IsZero() {
 		lines = m.detailField(lines, w, "Last transition", a.At.Format(time.RFC3339))
@@ -3378,7 +3450,7 @@ func (m Model) helpLine() string {
 				preview + "  ↑/↓: scroll  tab: switch tab  " + closeKeys
 		}
 		if m.detail.agent != nil {
-			return "↑/↓: scroll  tab: switch tab  f: focus in herdr  t: see tasks" + preview + "  " + closeKeys
+			return "x: disable  e: enable  ↑/↓: scroll  tab: switch tab  f: focus in herdr  t: see tasks" + preview + "  " + closeKeys
 		}
 		if m.detail.task != nil {
 			return "enter/y: send to agent  e: edit  x: delete  f: focus in herdr  ↑/↓: scroll  tab: switch tab  " + closeKeys
@@ -3397,7 +3469,7 @@ func (m Model) helpLine() string {
 	}
 	switch m.tab {
 	case tabAgents:
-		return "v: details  n: rename agent  f: focus in herdr  t: see tasks  /: search  " + common
+		return "v: details  x: disable  e: enable  n: rename agent  f: focus in herdr  t: see tasks  /: search  " + common
 	case tabTasks:
 		return "enter/y: send to agent  v: details  a: add  e: edit  d: done/undone  x: delete (source on a header)  space: mark  f: focus in herdr  /: search  " + common
 	case tabEscalations:
@@ -3562,8 +3634,12 @@ func (m Model) renderAgents(b *strings.Builder) {
 		a := agents[i]
 		name := orDash(m.data.status.AgentName(a.AgentID))
 		s := m.data.status.StatsFor(a.AgentID)
+		status := a.Status
+		if m.data.status.AgentDisabled(a.AgentID) {
+			status = "DISABLED"
+		}
 		line := fmt.Sprintf(agentsRowFmt,
-			name, oneLine(agentLocation(a, m.data.status), 12), a.AgentType, a.Status,
+			name, oneLine(agentLocation(a, m.data.status), 12), a.AgentType, status,
 			oneLine(m.agentTaskCount(a), 7),
 			strconv.Itoa(s.Escalations), strconv.Itoa(s.AutoSends),
 			strconv.Itoa(s.Confirmed), strconv.Itoa(s.Corrections),


### PR DESCRIPTION
## Summary

- persist a per-agent automation-disabled state across refreshes and renames
- add `hap disable <agent>` / `hap enable <agent>` and Agents-tab `x` / `e` controls, with `Y/n` confirmation before disabling
- keep disabled live agents visible with a clear `DISABLED` indicator
- auto-dismiss escalations for disabled or authoritatively absent agents while retaining append-only audit records
- document Claude/Codex as the extensively tested agent types and other agent integrations as best-effort

## Lifecycle behavior

Disabling an agent stops autonomous pane actions without removing the agent from the Agents list. Disable and autonomous delivery share a cross-process, per-agent lifecycle barrier: if disable commits first, the action is denied; if a delivery already owns the barrier, disable waits for that delivery to finish before returning. This prevents a disable from committing between the final state check and a direct, scalar-LLM, or multi-tab send.

A would-be autonomous action for a disabled agent is recorded with action/status `denied` and the exact rationale `[agent_disabled]`; HAP does not send input, learn a decision, or advance the automation rate counter. A would-be escalation is written directly as `dismissed` with `[agent_disabled]`, so it never appears in the pending queue and does not notify the operator. Enabling the agent restores normal decision handling.

Escalations targeting an agent that is absent from a successful Herdr live-agent snapshot are similarly recorded as `dismissed` with `[agent_not_live]`. A Herdr list error remains inconclusive and leaves the escalation visible. This fixes stale async task-generation outcomes such as the escalation previously shown for the exited `mighty-orca` agent.

## Validation

- `go test -tags "vectors cpu" ./... -count=1 -timeout 15m`
- focused lifecycle tests under `go test -race` for store, direct delivery, scalar LLM promotion, LLM no-op promotion, and multi-tab LLM promotion
- cross-process store coverage proving disable waits behind in-flight automation and future automation is denied
- end-to-end restart coverage proving disabled state survives daemon shutdown/reopen, suppresses pane actions and pending escalations, and resumes automation after enable
- daemon coverage for unavailable/disabled escalation dismissal, audit tags, suppressed sends, delayed task-generation after agent exit, and disable-winning final-send races
- CLI coverage for disable/enable commands and list indicators
- TUI coverage for the disabled indicator, `x` confirmation, and `e` enable binding


