### PR TITLE
feat: answer Claude's remote-environment picker as a parked approval

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -26,7 +26,7 @@ if `hap` is already on `PATH`, use it directly.
 
 **situation types** — the plugin classifies agent states into four types:
 - `idle` — agent finished and is waiting for the next prompt
-- `approval` — agent is asking for permission (e.g. tool approval)
+- `approval` — agent is asking for permission (e.g. tool approval; also structural forms herdr reports as idle, like Codex's Plan approval and Claude's "Select remote environment" picker for remote sub-agents)
 - `choice` — agent presents a multiple-choice question
 - `error` — agent hit an error and is waiting for guidance
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,9 +218,11 @@ The **`herdr`** skill covers CLI usage; these are the hap-specific protocol fact
   blocked.** Herdr shows no blocked status while the modal stands (verified live 2026-07-17), so
   hap detects it structurally (`domain.ClaudeRemoteEnvForm`: title + `❯ N.` options + end-anchored
   "Enter to select · Esc to cancel" footer) and classifies it as a parked APPROVAL at idle/done —
-  same exception pattern as Codex's Plan approval. Its commit protocol is unverified, so all
-  paths answer it adaptively via `mcqdeliver.ClaudeRemoteEnv` (digit → verify caret → Enter),
-  failing closed when the learned label matches none of the offered environments.
+  same exception pattern as Codex's Plan approval. Verified live (2026-07-17): despite the
+  "Enter to select" footer, the digit alone COMMITS the selection (the picker closes, no Enter) —
+  but all paths still answer it adaptively via `mcqdeliver.ClaudeRemoteEnv` (digit → verify
+  caret → Enter only if still standing) in case a build ships the caret binding, failing closed
+  when the learned label matches none of the offered environments.
 - **`pane read --source recent` is a consuming delta**, not the screen: after one read (e.g. the
   daemon's classification read) it can return just the cursor line. To recover a standing menu at
   confirm time, read `--source visible` (`herdr.CLI.ReadPaneVisible` / `ports.VisiblePaneReader`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,13 @@ The **`herdr`** skill covers CLI usage; these are the hap-specific protocol fact
   forms: nothing is answered and the agent stays blocked. Never plan a whole keystroke series up
   front — `internal/mcqdeliver` presses the digit, re-reads, and only presses Enter if the answer
   did not commit (and refuses if the caret never reached the chosen option).
+- **Claude's "Select remote environment" picker (remote sub-agent launch) reports IDLE, not
+  blocked.** Herdr shows no blocked status while the modal stands (verified live 2026-07-17), so
+  hap detects it structurally (`domain.ClaudeRemoteEnvForm`: title + `❯ N.` options + end-anchored
+  "Enter to select · Esc to cancel" footer) and classifies it as a parked APPROVAL at idle/done —
+  same exception pattern as Codex's Plan approval. Its commit protocol is unverified, so all
+  paths answer it adaptively via `mcqdeliver.ClaudeRemoteEnv` (digit → verify caret → Enter),
+  failing closed when the learned label matches none of the offered environments.
 - **`pane read --source recent` is a consuming delta**, not the screen: after one read (e.g. the
   daemon's classification read) it can return just the cursor line. To recover a standing menu at
   confirm time, read `--source visible` (`herdr.CLI.ReadPaneVisible` / `ports.VisiblePaneReader`).

--- a/internal/classify/classify.go
+++ b/internal/classify/classify.go
@@ -133,6 +133,10 @@ func (c *Classifier) Classify(agentType, agentStatus, pane string) domain.Situat
 	s := domain.Situation{AgentType: agentType, Content: pane, Type: domain.SituationUnclassifiable}
 	codexPlanApproval := strings.EqualFold(agentType, "codex") && domain.CodexPlanApprovalForm(pane)
 	codexRateLimit := strings.EqualFold(agentType, "codex") && domain.CodexRateLimitForm(pane)
+	claudeRemoteEnv := false
+	if strings.EqualFold(agentType, "claude") {
+		_, claudeRemoteEnv = domain.ClaudeRemoteEnvForm(pane)
+	}
 
 	// Approval and choice are normally BLOCKED situations (constitution
 	// taxonomy): their content rules are gated on herdr reporting the agent
@@ -156,6 +160,13 @@ func (c *Classifier) Classify(agentType, agentStatus, pane string) domain.Situat
 		// permission sentence. Detect it at the approval rule's position so
 		// approval retains priority over numbered-choice parsing.
 		if !matched && r.situation == domain.SituationApproval && codexPlanApproval {
+			matched = true
+		}
+		// Claude's "Select remote environment" picker (remote sub-agent
+		// launch) is likewise a structural approval: its footer also matches
+		// the single-question MCQ shape, so detecting it here keeps approval's
+		// priority over the choice-position ParseMCQForm hook.
+		if !matched && r.situation == domain.SituationApproval && claudeRemoteEnv {
 			matched = true
 		}
 		// Agent MCQ selection prompts render structurally, not as a plain
@@ -186,7 +197,12 @@ func (c *Classifier) Classify(agentType, agentStatus, pane string) domain.Situat
 		// non-structural approval and choice matches.
 		codexPlanParked := r.situation == domain.SituationApproval && codexPlanApproval &&
 			(agentStatus == "idle" || agentStatus == "done")
-		if (r.situation == domain.SituationApproval || r.situation == domain.SituationChoice) && !blocked && !codexPlanParked {
+		// Herdr likewise reports Claude's standing remote-environment picker
+		// as idle (verified live 2026-07-17). Same reasoning, same statuses:
+		// working stays excluded.
+		claudeRemoteEnvParked := r.situation == domain.SituationApproval && claudeRemoteEnv &&
+			(agentStatus == "idle" || agentStatus == "done")
+		if (r.situation == domain.SituationApproval || r.situation == domain.SituationChoice) && !blocked && !codexPlanParked && !claudeRemoteEnvParked {
 			continue
 		}
 		s.Type = r.situation
@@ -241,6 +257,17 @@ func enrich(s *domain.Situation) {
 			s.TabCount = form.AnswerCount
 		}
 	case domain.SituationApproval:
+		if strings.EqualFold(s.AgentType, "claude") {
+			if form, ok := domain.ClaudeRemoteEnvForm(s.Content); ok {
+				// Stable across projects and environment lists, so equivalent
+				// pickers share one signature; the env labels are the learned
+				// ACTION, not the key. Delivery re-maps the learned label onto
+				// the live option set and fails closed when it is absent.
+				s.PermissionVerb = "select remote environment"
+				s.Options = append(s.Options, form.OptionLabels()...)
+				return
+			}
+		}
 		if strings.EqualFold(s.AgentType, "codex") && domain.CodexPlanApprovalForm(s.Content) {
 			// Stable across the plan body and the volatile "Context: N% used"
 			// description, so equivalent Plan approvals share a signature.

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -19,10 +19,11 @@ func TestGoldenTranscripts(t *testing.T) {
 	c := New(nil)
 
 	statusFor := map[string]string{
-		"idle_finished.txt":          "idle",
-		"codex_idle.txt":             "idle",
-		"approval_codex_plan.txt":    "idle",
-		"error_codex_rate_limit.txt": "idle",
+		"idle_finished.txt":              "idle",
+		"codex_idle.txt":                 "idle",
+		"approval_codex_plan.txt":        "idle",
+		"error_codex_rate_limit.txt":     "idle",
+		"approval_claude_remote_env.txt": "idle",
 	}
 	agentTypeFor := map[string]string{
 		"approval_codex_plan.txt":     "codex",
@@ -472,6 +473,46 @@ func TestCodexPlanModeApprovalClassifiesApprovalAtParkedStatuses(t *testing.T) {
 	}
 	if s := c.Classify("claude", "idle", string(data)); s.Type == domain.SituationApproval {
 		t.Fatal("Codex Plan approval structure must remain scoped to codex")
+	}
+}
+
+func TestClaudeRemoteEnvClassifiesApprovalAtParkedStatuses(t *testing.T) {
+	// Claude's "Select remote environment" picker (remote sub-agent launch)
+	// stands while Herdr reports the pane idle, so it is a parked structural
+	// approval — like Codex's Plan approval — at blocked/idle/done, never at
+	// working, and scoped strictly to agent_type claude.
+	c := New(nil)
+	data, err := os.ReadFile(filepath.Join("testdata", "transcripts", "approval_claude_remote_env.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, status := range []string{"blocked", "idle", "done"} {
+		s := c.Classify("claude", status, string(data))
+		if s.Type != domain.SituationApproval {
+			t.Fatalf("remote-env picker at %s = %v, want approval", status, s.Type)
+		}
+		if s.PermissionVerb != "select remote environment" {
+			t.Errorf("remote-env picker verb = %q", s.PermissionVerb)
+		}
+		if len(s.Options) != 4 {
+			t.Fatalf("remote-env picker options = %d (%v), want 4", len(s.Options), s.Options)
+		}
+		// The default environment's ✔ marker is UI state, not part of the
+		// label; a rule learned from the clean label must match either way.
+		if s.Options[0] != "herdr-auto-pilot (env_01F41H1jxkGrT2zj55CqE4WQ)" {
+			t.Errorf("remote-env picker option 1 = %q, want the ✔ stripped", s.Options[0])
+		}
+	}
+	if s := c.Classify("claude", "working", string(data)); s.Type == domain.SituationApproval {
+		t.Fatal("working claude pane must not classify the remote-env picker as approval")
+	}
+	if s := c.Classify("codex", "idle", string(data)); s.Type == domain.SituationApproval {
+		t.Fatal("remote-env picker structure must remain scoped to claude")
+	}
+	// Its footer also matches the single-question MCQ shape; approval must
+	// keep priority over choice at blocked status too.
+	if s := c.Classify("claude", "blocked", string(data)); s.Type == domain.SituationChoice {
+		t.Fatal("remote-env picker must classify approval, not choice")
 	}
 }
 

--- a/internal/classify/testdata/classifications.golden
+++ b/internal/classify/testdata/classifications.golden
@@ -1,4 +1,5 @@
 approval_claude_plan.txt status=blocked type=approval verb=proceed options=4
+approval_claude_remote_env.txt status=idle type=approval verb=select options=4
 approval_codex_plan.txt status=idle type=approval verb=implement options=3
 approval_permission.txt status=blocked type=approval verb=proceed options=3
 approval_yn.txt status=blocked type=approval verb= options=0

--- a/internal/classify/testdata/transcripts/approval_claude_remote_env.txt
+++ b/internal/classify/testdata/transcripts/approval_claude_remote_env.txt
@@ -1,0 +1,14 @@
+● Build, gofmt, and vet are all clean. Now running the full test suite and a code review in parallel via subagents:
+
+● 2 background agents launched (↓ to manage)
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+   Select remote environment
+
+   Configure environments at: https://claude.ai/code
+
+   ❯ 1. herdr-auto-pilot (env_01F41H1jxkGrT2zj55CqE4WQ) ✔
+     2. myspec-monorepo (env_01CASfztpZp7mYRJPK41sGvK)
+     3. Full-access (env_011CUW5BKtc4vkq5q1uSp7MY)
+     4. Default (env_011CUKn5Aj1q6ujg5PFvEhTE)
+
+   Enter to select · Esc to cancel

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1136,7 +1136,7 @@ func (d *Daemon) act(ctx context.Context, s domain.Situation, sig domain.Signatu
 		return
 	}
 
-	// Claude's "Select remote environment" picker has an unverified commit
+	// Claude's "Select remote environment" picker commits per a per-build
 	// protocol (the digit may only move the caret), so answer it adaptively
 	// via verified keystrokes. Without the keystroke capability this FAILS
 	// CLOSED to escalation: the plain text send below would type the literal
@@ -2740,7 +2740,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 	}
 	// Claude's remote-environment picker takes the adaptive keystroke
 	// deliverer for the same reason as the act path: its commit protocol is
-	// unverified, so a blind digit + Enter send could no-op or double-commit.
+	// per-build, so a blind digit + Enter send could no-op or double-commit.
 	// The freshness gate above only proves SOME picker is standing (the
 	// approval salient is verb-only); the deliverer's live label→digit
 	// mapping is what rejects a swapped environment list. Without keystroke

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1136,6 +1136,29 @@ func (d *Daemon) act(ctx context.Context, s domain.Situation, sig domain.Signatu
 		return
 	}
 
+	// Claude's "Select remote environment" picker has an unverified commit
+	// protocol (the digit may only move the caret), so answer it adaptively
+	// via verified keystrokes. Without the keystroke capability this FAILS
+	// CLOSED to escalation: the plain text send below would type the literal
+	// label + Enter, and under the caret binding Enter commits whatever
+	// option the caret rests on — a rule learned on another project's
+	// environment list must never launch the wrong cloud environment.
+	if s.Type == domain.SituationApproval && strings.EqualFold(s.AgentType, "claude") {
+		if _, isRemoteEnv := domain.ClaudeRemoteEnvForm(s.Content); isRemoteEnv {
+			ks, ok := d.opt.Herdr.(ports.KeystrokeSender)
+			if !ok {
+				d.escalate(ctx, s, sig, domain.Decision{
+					Action: domain.ActionEscalate, Reason: domain.ReasonHerdrUnreachable,
+					Rationale:  "keystrokes unavailable; the remote-environment picker needs verified keystrokes",
+					Confidence: dec.Confidence, Suggestion: "respond: " + dec.Input,
+				}, tr, now)
+				return
+			}
+			d.deliverRemoteEnv(ctx, ks, s, sig, dec, tr, now)
+			return
+		}
+	}
+
 	// Numbered menus (Claude approvals/choices) accept the option's digit,
 	// not the label text; deliver the keystroke the menu expects. Free-text
 	// situations deliver the literal reply. s.Content is the classification
@@ -2714,6 +2737,31 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		d.deliverSeriesLLM(ctx, ks, s, res.sig, tr, llmDec, groups,
 			computedConf, &llmConf, now)
 		return
+	}
+	// Claude's remote-environment picker takes the adaptive keystroke
+	// deliverer for the same reason as the act path: its commit protocol is
+	// unverified, so a blind digit + Enter send could no-op or double-commit.
+	// The freshness gate above only proves SOME picker is standing (the
+	// approval salient is verb-only); the deliverer's live label→digit
+	// mapping is what rejects a swapped environment list. Without keystroke
+	// support this fails closed to escalation, like the multi-tab branch —
+	// the generic send below could commit whatever the caret rests on.
+	if s.Type == domain.SituationApproval && strings.EqualFold(s.AgentType, "claude") {
+		if _, isRemoteEnv := domain.ClaudeRemoteEnvForm(pane); isRemoteEnv {
+			ks, ok := d.opt.Herdr.(ports.KeystrokeSender)
+			if !ok {
+				reject(domain.ReasonHerdrUnreachable,
+					"herdr adapter cannot send keystrokes; the remote-environment picker needs them")
+				return
+			}
+			if !d.acquirePane(s.AgentID) {
+				reject(domain.ReasonRateLimited,
+					"another pane interaction is in flight for this agent; not delivering concurrently")
+				return
+			}
+			d.deliverRemoteEnvLLM(ctx, ks, s, res.sig, tr, llmDec, computedConf, &llmConf, now)
+			return
+		}
 	}
 	executed := d.withAgentAutomation(ctx, s, res.sig, tr, llmDec.Action,
 		computedConf, &llmConf, llmDec.CapturedOutput, now, func() {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3599,3 +3599,177 @@ func TestSignatureSnapshotRecordedOnFirstSighting(t *testing.T) {
 		t.Errorf("later sighting must not overwrite the original snapshot")
 	}
 }
+
+// --- Claude "Select remote environment" picker (remote sub-agent launch) ---
+
+// remoteEnvPane is a live capture shape: Herdr reports the pane IDLE while
+// this modal stands, so it classifies via the parked-approval exception.
+const remoteEnvPane = `● 2 background agents launched (↓ to manage)
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+   Select remote environment
+
+   Configure environments at: https://claude.ai/code
+
+   ❯ 1. herdr-auto-pilot (env_01F41H1jxkGrT2zj55CqE4WQ) ✔
+     2. myspec-monorepo (env_01CASfztpZp7mYRJPK41sGvK)
+     3. Full-access (env_011CUW5BKtc4vkq5q1uSp7MY)
+     4. Default (env_011CUKn5Aj1q6ujg5PFvEhTE)
+
+   Enter to select · Esc to cancel
+`
+
+// remoteEnvPaneCaret3 is the same picker after a "3" keystroke under the
+// caret-only binding (digit moves ❯, Enter commits).
+const remoteEnvPaneCaret3 = `   Select remote environment
+
+   Configure environments at: https://claude.ai/code
+
+     1. herdr-auto-pilot (env_01F41H1jxkGrT2zj55CqE4WQ) ✔
+     2. myspec-monorepo (env_01CASfztpZp7mYRJPK41sGvK)
+   ❯ 3. Full-access (env_011CUW5BKtc4vkq5q1uSp7MY)
+     4. Default (env_011CUKn5Aj1q6ujg5PFvEhTE)
+
+   Enter to select · Esc to cancel
+`
+
+const remoteEnvClosedPane = "● Environment selected. Launching remote agent…\n"
+
+// The headline regression: the picker at IDLE status must classify as an
+// approval and raise an escalation — before this support it classified idle
+// and was dismissed as over_masked, leaving the agent silently blocked.
+func TestRemoteEnvPickerAtIdleEscalatesAsApproval(t *testing.T) {
+	h := newHarness(t, "")
+	h.herdr.setPane(remoteEnvPane)
+
+	h.push("agent-env", "idle")
+
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(context.Background())
+		return len(esc) == 1
+	})
+	esc, _ := h.raw.PendingEscalations(context.Background())
+	if esc[0].SituationType != domain.SituationApproval {
+		t.Fatalf("situation = %s, want approval", esc[0].SituationType)
+	}
+	if !strings.HasPrefix(esc[0].Signature, "approval:") {
+		t.Errorf("signature = %q, want an approval signature", esc[0].Signature)
+	}
+	if strings.Contains(esc[0].Rationale, "over_masked") {
+		t.Errorf("picker must not be dismissed as over_masked: %+v", esc[0])
+	}
+	if len(h.herdr.sentInputs()) != 0 || len(h.herdr.keysSent()) != 0 {
+		t.Fatal("a first sighting must escalate, not answer")
+	}
+}
+
+// A graduated rule answers the picker adaptively via verified keystrokes —
+// here the caret-only binding: the digit moves ❯, Enter commits. The learned
+// LABEL is what history stores; the live digit is derived per delivery.
+func TestAutoActDeliversRemoteEnvSelectionAdaptively(t *testing.T) {
+	h := newHarness(t, "")
+	h.herdr.setPane(remoteEnvPane)
+	h.seedAutonomous(remoteEnvPane, domain.SituationApproval, "Full-access (env_011CUW5BKtc4vkq5q1uSp7MY)")
+	h.herdr.mu.Lock()
+	h.herdr.keyScript = []string{"3", "enter"}
+	h.herdr.keyScriptFrames = []string{remoteEnvPaneCaret3, remoteEnvClosedPane}
+	h.herdr.mu.Unlock()
+
+	h.push("agent-env-auto", "idle")
+
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.keysSent()) == 2 })
+	if got := strings.Join(h.herdr.keysSent(), ","); got != "3,enter" {
+		t.Errorf("keys = %q, want \"3,enter\"", got)
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Errorf("the picker must be answered with keystrokes, not a text send: %v", h.herdr.sentInputs())
+	}
+	audits, err := h.raw.AuditLog(context.Background(), 10)
+	if err != nil || len(audits) == 0 {
+		t.Fatalf("audit log: %v %v", audits, err)
+	}
+	if audits[0].Status != "auto" || !strings.HasPrefix(audits[0].Input, "Full-access") {
+		t.Errorf("audit record mismatch: %+v", audits[0])
+	}
+}
+
+// The cross-project backstop end to end: the picker's approval signature is
+// global (verb-only), so a rule learned on another project's environment list
+// resolves here — and its label matches nothing on the live menu. Delivery
+// must refuse before any keystroke and flip the audit to escalated.
+func TestAutoActRemoteEnvUnknownLabelEscalates(t *testing.T) {
+	h := newHarness(t, "")
+	h.herdr.setPane(remoteEnvPane)
+	h.seedAutonomous(remoteEnvPane, domain.SituationApproval, "other-project (env_01ZZZZZZZZZZZZZZZZZZZZZZZZ)")
+
+	h.push("agent-env-x", "idle")
+
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := h.raw.AuditLog(context.Background(), 10)
+		return len(audits) > 0 && audits[0].Status == "escalated"
+	})
+	if got := h.herdr.keysSent(); len(got) != 0 {
+		t.Fatalf("no keystroke may be sent for an unmappable label, got %v", got)
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Fatal("no text may be sent for an unmappable label")
+	}
+}
+
+// The LLM promotion path answers the picker through the same adaptive
+// deliverer — here the digit-commits binding (no Enter needed).
+func TestLLMPromotionDeliversRemoteEnvSelection(t *testing.T) {
+	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n"
+	h := newHarness(t, cfg)
+	h.herdr.setPane(remoteEnvPane)
+	h.herdr.mu.Lock()
+	h.herdr.keyScript = []string{"2"}
+	h.herdr.keyScriptFrames = []string{remoteEnvClosedPane}
+	h.herdr.mu.Unlock()
+	h.llm.configured = true
+	h.llm.consult = func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+		id, _ := h.raw.InsertLLMDecision(ctx, domain.LLMDecision{
+			RequestID: req.RequestID, Signature: req.Signature,
+			SituationType: req.SituationType, AgentType: req.AgentType,
+			Action: "myspec-monorepo (env_01CASfztpZp7mYRJPK41sGvK)", Rationale: "project default",
+			ConfidentScore: 90, Status: "pending", CreatedAt: time.Now(),
+		})
+		return &domain.LLMDecision{ID: id, RequestID: req.RequestID,
+			Action:    "myspec-monorepo (env_01CASfztpZp7mYRJPK41sGvK)",
+			Rationale: "project default", ConfidentScore: 90, Status: "pending"}, nil
+	}
+
+	h.push("agent-env-llm", "idle")
+
+	waitFor(t, 5*time.Second, func() bool { return len(h.herdr.keysSent()) == 1 })
+	if got := h.herdr.keysSent()[0]; got != "2" {
+		t.Errorf("key = %q, want the live menu digit \"2\"", got)
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Errorf("the picker must be answered with keystrokes, not a text send: %v", h.herdr.sentInputs())
+	}
+}
+
+// A keystroke-less adapter must fail CLOSED on the picker: the plain text
+// send would type the literal label + Enter, and under the caret binding
+// Enter commits whatever option the caret rests on — so the daemon escalates
+// instead of falling through.
+func TestAutoActRemoteEnvWithoutKeystrokesEscalates(t *testing.T) {
+	h := newHarnessWrapped(t, "", func(f *fakeHerdr) ports.HerdrPort {
+		return inspectorlessHerdr{f}
+	})
+	h.herdr.setPane(remoteEnvPane)
+	h.seedAutonomous(remoteEnvPane, domain.SituationApproval, "Full-access (env_011CUW5BKtc4vkq5q1uSp7MY)")
+
+	h.push("agent-env-nokeys", "idle")
+
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(context.Background())
+		return len(esc) == 1
+	})
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Fatalf("no text may be sent without verified keystrokes, sent %v", h.herdr.sentInputs())
+	}
+	if len(h.herdr.keysSent()) != 0 {
+		t.Fatalf("no keystroke path exists on this adapter, sent %v", h.herdr.keysSent())
+	}
+}

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -499,6 +499,157 @@ func (d *Daemon) deliverSeriesLLM(ctx context.Context, ks ports.KeystrokeSender,
 	}()
 }
 
+// deliverRemoteEnv answers Claude's standing "Select remote environment"
+// picker autonomously: audit-first (FR-024), then — off the main loop, the
+// verify-commit keystrokes take seconds — the adaptive mcqdeliver protocol.
+// The deliverer re-reads the live pane itself and fails closed when the
+// picker is gone or the learned label matches none of the offered
+// environments (its approval signature is global, so a rule learned on
+// another project's environment list can resolve here). Failures flip the
+// audit to escalated; a delivery is never retried blind. Note the
+// post-delivery unblock check may be a no-op for this shape — Herdr reports
+// the standing picker as idle — which is acceptable because the deliverer
+// already verified the picker left the screen.
+func (d *Daemon) deliverRemoteEnv(ctx context.Context, ks ports.KeystrokeSender,
+	s domain.Situation, sig domain.SignatureResult, dec domain.Decision,
+	tr domain.AgentTransition, now time.Time) {
+
+	if !d.acquirePane(s.AgentID) {
+		d.escalate(ctx, s, sig, domain.Decision{
+			Action: domain.ActionEscalate, Reason: domain.ReasonRateLimited, Rationale: "pane busy",
+			Confidence: dec.Confidence, Suggestion: "respond: " + dec.Input,
+		}, tr, now)
+		return
+	}
+
+	go func() {
+		defer d.releasePane(s.AgentID)
+		logging.Guard("remote-env-delivery", func() error {
+			d.withAgentAutomation(ctx, s, sig, tr, dec.Input, dec.Confidence, nil, "", now, func() {
+				auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
+					AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: trigger(tr),
+					SituationType: s.Type, Action: domain.AuditActionAutoPrefix + dec.Input, Input: dec.Input,
+					Confidence: dec.Confidence, Rationale: dec.Rationale,
+					Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
+				})
+				if err != nil {
+					slog.Error("audit write failed; blocking autonomous action (FR-024)", "error", err)
+					d.notify(ctx, "Herd Auto Prompter: persistence failure",
+						"An automated action was blocked because its audit record could not be written.")
+					return
+				}
+				if err := d.sendRemoteEnvSelection(ctx, ks, s.PaneID, dec.Input); err != nil {
+					slog.Error("remote-env selection delivery failed", "pane", s.PaneID, "error", err)
+					d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
+					d.notify(ctx, "Herd Auto Prompter: action delivery failed",
+						fmt.Sprintf("Agent %s: the remote environment selection could not be delivered (%v); please review the picker.", s.AgentID, err))
+					return
+				}
+				d.mu.Lock()
+				d.lastAutoSend[s.AgentID] = now
+				d.mu.Unlock()
+				if _, err := d.opt.Store.RecordDecision(ctx, domain.DecisionRecord{
+					Signature: sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
+					ChosenAction: dec.Input, Source: dec.Source, Confidence: dec.Confidence, CreatedAt: now,
+				}); err != nil {
+					slog.Error("decision record write failed", "error", err)
+				}
+				if rate, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
+					updated := domain.RegisterAutoPrompt(*rate, now)
+					updated.AgentID = s.AgentID
+					if err := d.opt.Store.UpdateAgentRate(ctx, updated); err != nil {
+						slog.Error("agent rate update failed", "error", err)
+					}
+				}
+				slog.Info("remote environment selection delivered",
+					"agent", s.AgentID, "confidence", dec.Confidence, "audit_id", auditID)
+				d.scheduleUnblockCheck(verifyunblock.Params{
+					PaneID: s.PaneID, AgentID: s.AgentID, AgentType: s.AgentType,
+					Signature: sig.Signature, Input: dec.Input, Excerpt: s.Content, SituationType: s.Type,
+				})
+			})
+			return nil
+		})
+	}()
+}
+
+// deliverRemoteEnvLLM is the promotion-path twin of deliverRemoteEnv (same
+// relationship as deliverSeries / deliverSeriesLLM). Callers hold the pane
+// claim (acquirePane) before invoking it.
+func (d *Daemon) deliverRemoteEnvLLM(ctx context.Context, ks ports.KeystrokeSender,
+	s domain.Situation, sig domain.SignatureResult, tr domain.AgentTransition,
+	llmDec *domain.LLMDecision, confidence float64, llmConfidence *int, now time.Time) {
+
+	go func() {
+		defer d.releasePane(s.AgentID)
+		logging.Guard("remote-env-delivery-llm", func() error {
+			executed := d.withAgentAutomation(ctx, s, sig, tr, llmDec.Action,
+				confidence, llmConfidence, llmDec.CapturedOutput, now, func() {
+					auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
+						AgentID: s.AgentID, AgentType: s.AgentType, Signature: sig.Signature, Trigger: "llm-fallback",
+						SituationType: s.Type, Action: domain.AuditActionAutoPrefix + llmDec.Action, Input: llmDec.Action,
+						Confidence: confidence, LLMConfidence: llmConfidence,
+						Rationale: "LLM: " + llmDec.Rationale, LLMOutput: llmDec.CapturedOutput,
+						Status: "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes), CreatedAt: now,
+					})
+					if err != nil {
+						slog.Error("audit write failed; blocking LLM action (FR-024)", "error", err)
+						d.notify(ctx, "Herd Auto Prompter: persistence failure",
+							"An LLM-derived action was blocked because its audit record could not be written.")
+						return
+					}
+					if err := d.sendRemoteEnvSelection(ctx, ks, s.PaneID, llmDec.Action); err != nil {
+						slog.Error("LLM remote-env selection delivery failed", "pane", s.PaneID, "error", err)
+						d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
+						d.notify(ctx, "Herd Auto Prompter: action delivery failed", err.Error())
+						return
+					}
+					if err := d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "accepted"); err != nil {
+						slog.Error("llm decision status update failed", "error", err)
+					}
+					if _, err := d.opt.Store.RecordDecision(ctx, domain.DecisionRecord{
+						Signature: sig.Signature, SituationType: s.Type, AgentType: s.AgentType,
+						ChosenAction: llmDec.Action, Source: domain.SourceLLM, CreatedAt: now,
+					}); err != nil {
+						slog.Error("decision record write failed", "error", err)
+					}
+					if rate, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
+						updated := domain.RegisterAutoPrompt(*rate, now)
+						updated.AgentID = s.AgentID
+						if err := d.opt.Store.UpdateAgentRate(ctx, updated); err != nil {
+							slog.Error("agent rate update failed", "error", err)
+						}
+					}
+					d.mu.Lock()
+					d.lastAutoSend[s.AgentID] = now
+					d.mu.Unlock()
+					slog.Info("LLM remote environment selection promoted and delivered", "agent", s.AgentID)
+					d.scheduleUnblockCheck(verifyunblock.Params{
+						PaneID: s.PaneID, AgentID: s.AgentID, AgentType: s.AgentType,
+						Signature: sig.Signature, Input: llmDec.Action, Excerpt: s.Content, SituationType: s.Type,
+					})
+				})
+			if !executed {
+				d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "rejected")
+			}
+			return nil
+		})
+	}()
+}
+
+// sendRemoteEnvSelection answers the standing remote-environment picker via
+// the shared mcqdeliver protocol, which verifies every keystroke landed.
+func (d *Daemon) sendRemoteEnvSelection(ctx context.Context, ks ports.KeystrokeSender,
+	paneID, chosen string) error {
+	return mcqdeliver.ClaudeRemoteEnv(ctx, mcqdeliver.Config{
+		Keys:      ks,
+		Read:      d.readVisible,
+		PaneID:    paneID,
+		ReadLines: d.opt.PaneReadLines,
+		KeyDelay:  sweepKeyDelay,
+	}, chosen)
+}
+
 // sendTabSelections resets the form to its first question (fixed Left-arrow
 // burst — a human may have tabbed around since capture), then answers each tab
 // in order via the shared mcqdeliver protocol, which verifies every keystroke

--- a/internal/domain/clauderemoteenv.go
+++ b/internal/domain/clauderemoteenv.go
@@ -1,0 +1,90 @@
+package domain
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Claude Code's remote sub-agent launcher renders a "Select remote
+// environment" picker: a title line, an optional "Configure environments
+// at: …" hint, `❯ N. label (env_id)` options (the account default carries a
+// trailing ✔), and an "Enter to select · Esc to cancel" footer. Herdr
+// reports the pane IDLE while this modal stands (verified live 2026-07-17),
+// so — like Codex's Plan approval — the structural form itself must be
+// strong enough to prove Claude is awaiting an approval. Requiring the
+// title, the footer at the true end of the capture, and at least two
+// numbered options in between keeps a narrated or stale copy in scrollback
+// from becoming a live permission prompt.
+var (
+	claudeRemoteEnvTitleRE = regexp.MustCompile(`(?im)^\s*Select remote environment\s*$`)
+	// End-of-text anchor (\s*\z): a live modal sits at the true bottom of
+	// the capture (verified: nothing renders below the footer). If a future
+	// Claude build draws anything under it, relax this to "footer within the
+	// last few lines".
+	claudeRemoteEnvFooterRE = regexp.MustCompile(`(?im)^\s*Enter to select\s*·\s*Esc to cancel\s*\z`)
+	// The account-default environment carries a trailing check marker; strip
+	// it so learned labels stay stable whether or not the marker is present.
+	remoteEnvCheckSuffixRE = regexp.MustCompile(`\s*✔\s*$`)
+)
+
+// RemoteEnvForm is the parsed live state of Claude Code's "Select remote
+// environment" picker.
+type RemoteEnvForm struct {
+	Region         string           // title→footer slice of the pane (live form only)
+	Options        []NumberedOption // labels with the trailing ✔ marker stripped
+	SelectedOption string           // digit under the ❯ caret ("" when absent)
+}
+
+// ClaudeRemoteEnvForm reports whether pane shows the live picker and parses
+// it. It deliberately recognizes only this Claude-specific form; callers
+// must additionally gate on agent_type == "claude". The classifier treats a
+// standing picker as a parked APPROVAL at idle/done status (launching a
+// remote agent spawns a paid cloud environment, so `working` stays excluded
+// until live evidence shows Herdr reporting it — extend the parked statuses
+// in classify.Classify if that happens).
+func ClaudeRemoteEnvForm(pane string) (RemoteEnvForm, bool) {
+	titles := claudeRemoteEnvTitleRE.FindAllStringIndex(pane, -1)
+	footer := claudeRemoteEnvFooterRE.FindStringIndex(pane)
+	if len(titles) == 0 || footer == nil {
+		return RemoteEnvForm{}, false
+	}
+	// Last title occurrence is the live render (a consuming "recent" read can
+	// carry earlier renders above the current one).
+	title := titles[len(titles)-1]
+	if footer[0] <= title[0] {
+		return RemoteEnvForm{}, false
+	}
+	region := pane[title[0]:footer[1]]
+	opts := ParseNumberedOptions(region)
+	if len(opts) < 2 {
+		return RemoteEnvForm{}, false
+	}
+	form := RemoteEnvForm{Region: region, Options: make([]NumberedOption, 0, len(opts))}
+	for _, o := range opts {
+		o.Label = strings.TrimSpace(remoteEnvCheckSuffixRE.ReplaceAllString(o.Label, ""))
+		if o.Label == "" {
+			return RemoteEnvForm{}, false
+		}
+		form.Options = append(form.Options, o)
+	}
+	if m := mcqTabCaretRE.FindStringSubmatch(region); m != nil {
+		form.SelectedOption = m[1]
+	}
+	return form, true
+}
+
+// TrimRemoteEnvCheck strips the picker's trailing ✔ marker from a label, so
+// a reply recorded from the raw render still matches the normalized options.
+func TrimRemoteEnvCheck(label string) string {
+	return strings.TrimSpace(remoteEnvCheckSuffixRE.ReplaceAllString(label, ""))
+}
+
+// OptionLabels returns the ✔-stripped option labels in display order (the
+// classifier's option set for the enriched approval situation).
+func (f RemoteEnvForm) OptionLabels() []string {
+	labels := make([]string, 0, len(f.Options))
+	for _, o := range f.Options {
+		labels = append(labels, o.Label)
+	}
+	return labels
+}

--- a/internal/domain/clauderemoteenv.go
+++ b/internal/domain/clauderemoteenv.go
@@ -44,13 +44,17 @@ type RemoteEnvForm struct {
 // in classify.Classify if that happens).
 func ClaudeRemoteEnvForm(pane string) (RemoteEnvForm, bool) {
 	titles := claudeRemoteEnvTitleRE.FindAllStringIndex(pane, -1)
-	footer := claudeRemoteEnvFooterRE.FindStringIndex(pane)
-	if len(titles) == 0 || footer == nil {
+	footers := claudeRemoteEnvFooterRE.FindAllStringIndex(pane, -1)
+	if len(titles) == 0 || len(footers) == 0 {
 		return RemoteEnvForm{}, false
 	}
-	// Last title occurrence is the live render (a consuming "recent" read can
-	// carry earlier renders above the current one).
+	// Last title and last footer are the live render (a consuming "recent"
+	// read can carry earlier complete renders above the current one). The \z
+	// anchor already makes an earlier render's footer unmatchable, but pair
+	// last-with-last anyway so relaxing the anchor can never re-pair the live
+	// title with a stale footer.
 	title := titles[len(titles)-1]
+	footer := footers[len(footers)-1]
 	if footer[0] <= title[0] {
 		return RemoteEnvForm{}, false
 	}

--- a/internal/domain/clauderemoteenv_test.go
+++ b/internal/domain/clauderemoteenv_test.go
@@ -95,6 +95,22 @@ func TestClaudeRemoteEnvFormLastTitleWins(t *testing.T) {
 	}
 }
 
+func TestClaudeRemoteEnvFormTwoCompleteRendersParsesLive(t *testing.T) {
+	// A capture holding TWO complete renders (an earlier one WITH its footer,
+	// then the live one) must pair the live title with the live footer — a
+	// first-footer pairing would reject the live frame and reintroduce the
+	// silent-block failure this detector exists to fix. The earlier render's
+	// options differ so the assertion proves which render was parsed.
+	earlier := strings.ReplaceAll(remoteEnvPicker, "herdr-auto-pilot", "old-project")
+	form, ok := ClaudeRemoteEnvForm(earlier + "\n● narration between renders\n\n" + remoteEnvPicker)
+	if !ok {
+		t.Fatal("capture with two complete renders must parse as the live form")
+	}
+	if len(form.Options) != 4 || !strings.HasPrefix(form.Options[0].Label, "herdr-auto-pilot") {
+		t.Fatalf("parsed the wrong render: %+v", form.Options)
+	}
+}
+
 func TestClaudeRemoteEnvApprovalSignaturePassesOverMaskGuard(t *testing.T) {
 	// The enriched approval situation must produce a stable, unmasked salient
 	// so the decision core never dismisses the picker as over_masked (the

--- a/internal/domain/clauderemoteenv_test.go
+++ b/internal/domain/clauderemoteenv_test.go
@@ -1,0 +1,116 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+const remoteEnvPicker = `● 2 background agents launched (↓ to manage)
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+   Select remote environment
+
+   Configure environments at: https://claude.ai/code
+
+   ❯ 1. herdr-auto-pilot (env_01F41H1jxkGrT2zj55CqE4WQ) ✔
+     2. myspec-monorepo (env_01CASfztpZp7mYRJPK41sGvK)
+     3. Full-access (env_011CUW5BKtc4vkq5q1uSp7MY)
+     4. Default (env_011CUKn5Aj1q6ujg5PFvEhTE)
+
+   Enter to select · Esc to cancel
+`
+
+func TestClaudeRemoteEnvFormParsesLivePicker(t *testing.T) {
+	form, ok := ClaudeRemoteEnvForm(remoteEnvPicker)
+	if !ok {
+		t.Fatal("live picker must parse")
+	}
+	if len(form.Options) != 4 {
+		t.Fatalf("options = %d (%v), want 4", len(form.Options), form.Options)
+	}
+	// The default entry's trailing ✔ is UI state, not part of the label.
+	if form.Options[0].Label != "herdr-auto-pilot (env_01F41H1jxkGrT2zj55CqE4WQ)" {
+		t.Errorf("option 1 label = %q, want ✔ stripped", form.Options[0].Label)
+	}
+	if form.Options[3] != (NumberedOption{Number: "4", Label: "Default (env_011CUKn5Aj1q6ujg5PFvEhTE)"}) {
+		t.Errorf("option 4 = %+v", form.Options[3])
+	}
+	if form.SelectedOption != "1" {
+		t.Errorf("caret = %q, want 1", form.SelectedOption)
+	}
+	if labels := form.OptionLabels(); len(labels) != 4 || labels[2] != "Full-access (env_011CUW5BKtc4vkq5q1uSp7MY)" {
+		t.Errorf("OptionLabels = %v", labels)
+	}
+}
+
+func TestClaudeRemoteEnvFormRejectsNonLiveShapes(t *testing.T) {
+	live := remoteEnvPicker
+	cases := []struct {
+		name string
+		pane string
+	}{
+		{"empty", ""},
+		{"missing title", strings.Replace(live, "Select remote environment", "Pick something", 1)},
+		{"missing footer", strings.Replace(live, "Enter to select · Esc to cancel", "", 1)},
+		// A stale copy in scrollback with narration below the footer is not a
+		// standing modal (footer is end-anchored).
+		{"narration after footer", live + "\n● Environment selected, launching agent…\n"},
+		// Footer occurring before the title (e.g. an older picker's footer in
+		// scrollback above a narrated title) is not a live form either.
+		{"footer before title", "   Enter to select · Esc to cancel\n   Select remote environment\n"},
+		{"too few options", "   Select remote environment\n\n   ❯ 1. only-env (env_01AAAAAAAAAAAAAAAAAAAAAAAA)\n\n   Enter to select · Esc to cancel\n"},
+	}
+	for _, tc := range cases {
+		if _, ok := ClaudeRemoteEnvForm(tc.pane); ok {
+			t.Errorf("%s: must not parse as a live picker", tc.name)
+		}
+	}
+}
+
+func TestClaudeRemoteEnvFormScopesOptionsToRegion(t *testing.T) {
+	// A numbered list in scrollback above the picker must not leak into the
+	// option set — options come from the title→footer region only.
+	pane := "Here is what I changed:\n1. Fixed the parser\n2. Added a test\n\n" + remoteEnvPicker
+	form, ok := ClaudeRemoteEnvForm(pane)
+	if !ok {
+		t.Fatal("picker with scrollback above must still parse")
+	}
+	if len(form.Options) != 4 {
+		t.Fatalf("options = %d (%v), want the 4 picker entries only", len(form.Options), form.Options)
+	}
+	if strings.Contains(strings.Join(form.OptionLabels(), "|"), "Fixed the parser") {
+		t.Errorf("scrollback list leaked into options: %v", form.Options)
+	}
+}
+
+func TestClaudeRemoteEnvFormLastTitleWins(t *testing.T) {
+	// A consuming "recent" read can carry an earlier render above the live
+	// one; the last title occurrence is the live form.
+	stale := strings.Replace(remoteEnvPicker, "Enter to select · Esc to cancel", "", 1)
+	form, ok := ClaudeRemoteEnvForm(stale + "\n" + remoteEnvPicker)
+	if !ok {
+		t.Fatal("repeated render must parse")
+	}
+	if len(form.Options) != 4 {
+		t.Fatalf("options = %d, want 4 (from the last render only)", len(form.Options))
+	}
+}
+
+func TestClaudeRemoteEnvApprovalSignaturePassesOverMaskGuard(t *testing.T) {
+	// The enriched approval situation must produce a stable, unmasked salient
+	// so the decision core never dismisses the picker as over_masked (the
+	// original failure: classified idle, raw trailing-window salient tripped
+	// the guard).
+	s := Situation{
+		AgentType:      "claude",
+		Type:           SituationApproval,
+		Content:        remoteEnvPicker,
+		PermissionVerb: "select remote environment",
+	}
+	sig := ComputeSignature(s)
+	if sig.Verdict != GuardOK {
+		t.Fatalf("verdict = %v, want %v (salient %q)", sig.Verdict, GuardOK, sig.Salient)
+	}
+	if sig.Salient != "permission:select remote environment" {
+		t.Errorf("salient = %q", sig.Salient)
+	}
+}

--- a/internal/domain/menu.go
+++ b/internal/domain/menu.go
@@ -91,7 +91,13 @@ func OptionLabels(content string) []string {
 // matches no option: free-text prompts (a typed reply, an error-retry
 // command) must be delivered literally, so callers send chosen unchanged.
 func MenuKeystroke(content, chosen string) (string, bool) {
-	opts := ParseNumberedOptions(content)
+	return MenuKeystrokeFrom(ParseNumberedOptions(content), chosen)
+}
+
+// MenuKeystrokeFrom is MenuKeystroke over an already-parsed option set, for
+// callers whose options carry normalized labels the raw pane does not (e.g.
+// the remote-environment picker strips the ✔ marker from the default entry).
+func MenuKeystrokeFrom(opts []NumberedOption, chosen string) (string, bool) {
 	if len(opts) == 0 {
 		return chosen, false
 	}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -795,7 +795,7 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 			markSent()
 			return a.nudge(ctx, control.KindReload)
 		}
-		// Claude's remote-environment picker commits per an unverified
+		// Claude's remote-environment picker commits per a per-build
 		// protocol (the digit may only move the caret), so a standing picker
 		// is answered via the adaptive keystroke deliverer. A keystroke-less
 		// adapter falls through to the plain digit + Enter send below ONLY

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -795,6 +795,35 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 			markSent()
 			return a.nudge(ctx, control.KindReload)
 		}
+		// Claude's remote-environment picker commits per an unverified
+		// protocol (the digit may only move the caret), so a standing picker
+		// is answered via the adaptive keystroke deliverer. A keystroke-less
+		// adapter falls through to the plain digit + Enter send below ONLY
+		// when the reply maps to a live option — an unmappable label would be
+		// typed literally and its Enter could commit whatever option the
+		// caret rests on (launching the wrong cloud environment), so that
+		// case fails closed even on an operator's explicit confirm.
+		if rerr == nil && audit.SituationType == domain.SituationApproval &&
+			strings.EqualFold(audit.AgentType, "claude") {
+			if form, isRemoteEnv := domain.ClaudeRemoteEnvForm(pane); isRemoteEnv {
+				if ks, ok := a.Herdr.(ports.KeystrokeSender); ok {
+					if err := mcqdeliver.ClaudeRemoteEnv(ctx, mcqdeliver.Config{
+						Keys:      ks,
+						Read:      a.readVisiblePane,
+						PaneID:    audit.AgentID,
+						ReadLines: menuReadLines,
+						KeyDelay:  seriesKeyDelay,
+					}, outbound); err != nil {
+						return fmt.Errorf("correction recorded, but %w", err)
+					}
+					markSent()
+					return a.nudge(ctx, control.KindReload)
+				}
+				if _, mapped := domain.MenuKeystrokeFrom(form.Options, domain.TrimRemoteEnvCheck(outbound)); !mapped {
+					return fmt.Errorf("correction recorded, but %q matches none of the offered environments and this herdr adapter cannot send verified keystrokes", outbound)
+				}
+			}
+		}
 		if rerr == nil {
 			outbound = domain.DeliverKeystroke(audit.SituationType, audit.AgentType, pane, outbound)
 		}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -797,15 +797,27 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 		}
 		// Claude's remote-environment picker commits per a per-build
 		// protocol (the digit may only move the caret), so a standing picker
-		// is answered via the adaptive keystroke deliverer. A keystroke-less
-		// adapter falls through to the plain digit + Enter send below ONLY
-		// when the reply maps to a live option — an unmappable label would be
-		// typed literally and its Enter could commit whatever option the
-		// caret rests on (launching the wrong cloud environment), so that
-		// case fails closed even on an operator's explicit confirm.
-		if rerr == nil && audit.SituationType == domain.SituationApproval &&
-			strings.EqualFold(audit.AgentType, "claude") {
-			if form, isRemoteEnv := domain.ClaudeRemoteEnvForm(pane); isRemoteEnv {
+		// is answered via the adaptive keystroke deliverer. The situation is
+		// identified from the audit's own pane capture as well as the live
+		// read: a failed or stale read must REFUSE, never fall through to the
+		// literal-label send below — its trailing Enter could commit whatever
+		// option the caret rests on and launch the wrong cloud environment. A
+		// keystroke-less adapter falls through ONLY when the reply maps to a
+		// live option digit (safe under both bindings).
+		if audit.SituationType == domain.SituationApproval && strings.EqualFold(audit.AgentType, "claude") {
+			_, wasRemoteEnv := domain.ClaudeRemoteEnvForm(audit.PaneExcerpt)
+			var form domain.RemoteEnvForm
+			live := false
+			if rerr == nil {
+				form, live = domain.ClaudeRemoteEnvForm(pane)
+			}
+			if wasRemoteEnv || live {
+				if rerr != nil {
+					return fmt.Errorf("correction recorded, but the pane could not be read to answer the remote environment picker: %w", rerr)
+				}
+				if !live {
+					return fmt.Errorf("correction recorded, but the pane no longer shows the remote environment picker")
+				}
 				if ks, ok := a.Herdr.(ports.KeystrokeSender); ok {
 					if err := mcqdeliver.ClaudeRemoteEnv(ctx, mcqdeliver.Config{
 						Keys:      ks,

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -3211,3 +3211,137 @@ func TestRemoveTaskSourceKeepsChecklistFile(t *testing.T) {
 		t.Errorf("checklist file must be untouched, got %q", data)
 	}
 }
+
+// --- Claude "Select remote environment" picker ---
+
+const frontRemoteEnvPane = `   Select remote environment
+
+   Configure environments at: https://claude.ai/code
+
+   ❯ 1. herdr-auto-pilot (env_01F41H1jxkGrT2zj55CqE4WQ) ✔
+     2. myspec-monorepo (env_01CASfztpZp7mYRJPK41sGvK)
+     3. Full-access (env_011CUW5BKtc4vkq5q1uSp7MY)
+     4. Default (env_011CUKn5Aj1q6ujg5PFvEhTE)
+
+   Enter to select · Esc to cancel
+`
+
+const frontRemoteEnvPaneCaret4 = `   Select remote environment
+
+   Configure environments at: https://claude.ai/code
+
+     1. herdr-auto-pilot (env_01F41H1jxkGrT2zj55CqE4WQ) ✔
+     2. myspec-monorepo (env_01CASfztpZp7mYRJPK41sGvK)
+     3. Full-access (env_011CUW5BKtc4vkq5q1uSp7MY)
+   ❯ 4. Default (env_011CUKn5Aj1q6ujg5PFvEhTE)
+
+   Enter to select · Esc to cancel
+`
+
+// Confirming a remote-environment escalation on a keystroke-capable adapter
+// must answer the standing picker adaptively (digit → verify → Enter), never
+// a text send, and mark the correction sent only after the picker commits.
+func TestConfirmDeliversRemoteEnvSelectionAdaptively(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeKeyHerdr{
+		fakeHerdr:       fakeHerdr{pane: frontRemoteEnvPane},
+		keyScript:       []string{"4", "enter"},
+		keyScriptFrames: []string{frontRemoteEnvPaneCaret4, "● Launching remote agent…\n"},
+	}
+	app.Herdr = fake
+	ctx := context.Background()
+
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:p1", AgentType: "claude", SituationType: domain.SituationApproval,
+		Trigger: "t", Action: "escalated", Status: "escalated",
+		Suggestion: "LLM suggested: Default (env_011CUKn5Aj1q6ujg5PFvEhTE)", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(fake.keys, ","); got != "4,enter" {
+		t.Errorf("keys = %q, want \"4,enter\"", got)
+	}
+	if len(fake.inputs) != 0 {
+		t.Errorf("the picker must be answered with keystrokes, not a text send: %v", fake.inputs)
+	}
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 1 || !corr[0].Sent {
+		t.Errorf("correction should be recorded and marked sent: %+v", corr)
+	}
+}
+
+// A failed adaptive delivery (the picker refuses the label) keeps the
+// correction recorded but NOT sent, and surfaces the error to the operator.
+func TestConfirmRemoteEnvUnknownLabelKeepsCorrectionUnsent(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeKeyHerdr{fakeHerdr: fakeHerdr{pane: frontRemoteEnvPane}}
+	app.Herdr = fake
+	ctx := context.Background()
+
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:p1", AgentType: "claude", SituationType: domain.SituationApproval,
+		Trigger: "t", Action: "escalated", Status: "escalated",
+		Suggestion: "LLM suggested: other-project (env_01ZZZZZZZZZZZZZZZZZZZZZZZZ)", CreatedAt: time.Now(),
+	})
+	err := app.Confirm(ctx, id, true)
+	if err == nil || !strings.Contains(err.Error(), "correction recorded") {
+		t.Fatalf("err = %v, want a correction-recorded delivery failure", err)
+	}
+	if len(fake.keys) != 0 {
+		t.Errorf("no keystroke may be sent for an unmappable label, got %v", fake.keys)
+	}
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 1 || corr[0].Sent {
+		t.Errorf("correction should be recorded but unsent: %+v", corr)
+	}
+}
+
+// A keystroke-less adapter must fall back to the plain digit text send rather
+// than failing the operator's explicit confirm.
+func TestConfirmRemoteEnvKeystrokelessFallsBackToTextSend(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeHerdr{pane: frontRemoteEnvPane}
+	app.Herdr = fake
+	ctx := context.Background()
+
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:p1", AgentType: "claude", SituationType: domain.SituationApproval,
+		Trigger: "t", Action: "escalated", Status: "escalated",
+		Suggestion: "LLM suggested: Default (env_011CUKn5Aj1q6ujg5PFvEhTE)", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.inputs) != 1 || fake.inputs[0] != "4" {
+		t.Errorf("delivered %v, want the mapped menu digit [\"4\"]", fake.inputs)
+	}
+}
+
+// A keystroke-less adapter with an UNMAPPABLE label must fail closed even on
+// an operator's explicit confirm: the plain text send would type the literal
+// label + Enter, and under the caret binding Enter commits whatever option
+// the caret rests on. Only a mappable label may fall through to a digit send.
+func TestConfirmRemoteEnvKeystrokelessUnknownLabelFailsClosed(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeHerdr{pane: frontRemoteEnvPane}
+	app.Herdr = fake
+	ctx := context.Background()
+
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:p1", AgentType: "claude", SituationType: domain.SituationApproval,
+		Trigger: "t", Action: "escalated", Status: "escalated",
+		Suggestion: "LLM suggested: other-project (env_01ZZZZZZZZZZZZZZZZZZZZZZZZ)", CreatedAt: time.Now(),
+	})
+	err := app.Confirm(ctx, id, true)
+	if err == nil || !strings.Contains(err.Error(), "none of the offered environments") {
+		t.Fatalf("err = %v, want an unmappable-label refusal", err)
+	}
+	if len(fake.inputs) != 0 {
+		t.Errorf("nothing may be sent for an unmappable label, sent %v", fake.inputs)
+	}
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 1 || corr[0].Sent {
+		t.Errorf("correction should be recorded but unsent: %+v", corr)
+	}
+}

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -3345,3 +3345,57 @@ func TestConfirmRemoteEnvKeystrokelessUnknownLabelFailsClosed(t *testing.T) {
 		t.Errorf("correction should be recorded but unsent: %+v", corr)
 	}
 }
+
+// A read failure on a remote-environment approval must REFUSE, never fall
+// through to the literal-label text send — its trailing Enter could commit
+// whatever option the caret rests on. The situation is identified from the
+// audit's own pane capture, so the refusal works exactly when the live pane
+// is unreadable.
+func TestConfirmRemoteEnvReadFailureFailsClosed(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeKeyHerdr{fakeHerdr: fakeHerdr{readErr: errAny}}
+	app.Herdr = fake
+	ctx := context.Background()
+
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:p1", AgentType: "claude", SituationType: domain.SituationApproval,
+		Trigger: "t", Action: "escalated", Status: "escalated",
+		Suggestion:  "LLM suggested: Default (env_011CUKn5Aj1q6ujg5PFvEhTE)",
+		PaneExcerpt: frontRemoteEnvPane, CreatedAt: time.Now(),
+	})
+	err := app.Confirm(ctx, id, true)
+	if err == nil || !strings.Contains(err.Error(), "could not be read") {
+		t.Fatalf("err = %v, want a read-failure refusal", err)
+	}
+	if len(fake.inputs) != 0 || len(fake.keys) != 0 {
+		t.Errorf("nothing may be sent when the pane is unreadable: inputs=%v keys=%v", fake.inputs, fake.keys)
+	}
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 1 || corr[0].Sent {
+		t.Errorf("correction should be recorded but unsent: %+v", corr)
+	}
+}
+
+// The picker no longer standing (already answered, or the pane moved on) must
+// refuse too — identified via the audit capture, so the literal label is
+// never typed into whatever replaced the picker.
+func TestConfirmRemoteEnvGonePickerFailsClosed(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeKeyHerdr{fakeHerdr: fakeHerdr{pane: "● Environment selected. Launching remote agent…\n"}}
+	app.Herdr = fake
+	ctx := context.Background()
+
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:p1", AgentType: "claude", SituationType: domain.SituationApproval,
+		Trigger: "t", Action: "escalated", Status: "escalated",
+		Suggestion:  "LLM suggested: Default (env_011CUKn5Aj1q6ujg5PFvEhTE)",
+		PaneExcerpt: frontRemoteEnvPane, CreatedAt: time.Now(),
+	})
+	err := app.Confirm(ctx, id, true)
+	if err == nil || !strings.Contains(err.Error(), "no longer shows") {
+		t.Fatalf("err = %v, want a picker-gone refusal", err)
+	}
+	if len(fake.inputs) != 0 || len(fake.keys) != 0 {
+		t.Errorf("nothing may be sent when the picker is gone: inputs=%v keys=%v", fake.inputs, fake.keys)
+	}
+}

--- a/internal/mcqdeliver/remoteenv.go
+++ b/internal/mcqdeliver/remoteenv.go
@@ -20,11 +20,12 @@ import (
 // another project's environment list must never commit whatever the caret
 // happens to rest on.
 //
-// The picker's commit protocol is unverified ("Enter to select" suggests the
-// digit only moves the caret, but Claude has shipped both bindings for
-// identically-footered forms), so delivery is ADAPTIVE like answerTab: press
-// the digit, re-read, and press Enter only if the picker is still standing
-// with the caret verified on the chosen option.
+// Verified live 2026-07-17: the current Claude build COMMITS on the digit
+// alone (the picker closes immediately; Enter is never needed), despite the
+// "Enter to select" footer. Claude has shipped both bindings for
+// identically-footered forms though, so delivery stays ADAPTIVE like
+// answerTab: press the digit, re-read, and press Enter only if the picker is
+// still standing with the caret verified on the chosen option.
 func ClaudeRemoteEnv(ctx context.Context, c Config, chosen string) error {
 	form, ok, err := c.remoteEnvState(ctx)
 	if err != nil {

--- a/internal/mcqdeliver/remoteenv.go
+++ b/internal/mcqdeliver/remoteenv.go
@@ -1,0 +1,80 @@
+// ClaudeRemoteEnv delivery: Claude Code's "Select remote environment"
+// picker (remote sub-agent launch) is a single standing modal, not a
+// multi-tab form, but it shares this package's adaptive verify-commit
+// discipline so the daemon and frontend paths cannot diverge on it.
+package mcqdeliver
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// ClaudeRemoteEnv answers Claude's standing "Select remote environment"
+// picker (remote sub-agent launch). chosen is the learned/confirmed reply —
+// an option label (✔-stripped) or a digit; it is mapped onto the LIVE menu's
+// option set and the delivery fails CLOSED when it maps to no offered option:
+// the picker's approval signature is global (verb-only), so a rule learned on
+// another project's environment list must never commit whatever the caret
+// happens to rest on.
+//
+// The picker's commit protocol is unverified ("Enter to select" suggests the
+// digit only moves the caret, but Claude has shipped both bindings for
+// identically-footered forms), so delivery is ADAPTIVE like answerTab: press
+// the digit, re-read, and press Enter only if the picker is still standing
+// with the caret verified on the chosen option.
+func ClaudeRemoteEnv(ctx context.Context, c Config, chosen string) error {
+	form, ok, err := c.remoteEnvState(ctx)
+	if err != nil {
+		return fmt.Errorf("remote-env pre-answer read: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("the pane is no longer showing the remote environment picker")
+	}
+	digit, ok := domain.MenuKeystrokeFrom(form.Options, domain.TrimRemoteEnvCheck(chosen))
+	if !ok {
+		return fmt.Errorf("%q matches none of the offered environments", chosen)
+	}
+
+	if err := c.Keys.SendKey(ctx, c.PaneID, digit); err != nil {
+		return fmt.Errorf("remote-env option %s: %w", digit, err)
+	}
+	time.Sleep(c.KeyDelay)
+
+	after, ok, err := c.remoteEnvState(ctx)
+	if err != nil {
+		return fmt.Errorf("remote-env post-option read: %w", err)
+	}
+	if !ok {
+		// Digit-commits protocol: the picker is gone, selection landed.
+		return nil
+	}
+	// Caret protocol: confirm the caret reached the intended option — Enter
+	// would commit whatever it rests on — and only then commit.
+	if after.SelectedOption != digit {
+		return fmt.Errorf("environment option %s was not selected (caret on %q)", digit, after.SelectedOption)
+	}
+	if err := c.Keys.SendKey(ctx, c.PaneID, "enter"); err != nil {
+		return fmt.Errorf("remote-env commit: %w", err)
+	}
+	time.Sleep(c.KeyDelay)
+
+	if _, ok, err := c.remoteEnvState(ctx); err != nil {
+		return fmt.Errorf("remote-env post-commit read: %w", err)
+	} else if ok {
+		return fmt.Errorf("the remote environment picker did not commit")
+	}
+	return nil
+}
+
+// remoteEnvState reads the pane and parses the live remote-environment picker.
+func (c Config) remoteEnvState(ctx context.Context) (domain.RemoteEnvForm, bool, error) {
+	pane, err := c.Read(ctx, c.PaneID, c.ReadLines)
+	if err != nil {
+		return domain.RemoteEnvForm{}, false, err
+	}
+	form, ok := domain.ClaudeRemoteEnvForm(pane)
+	return form, ok, nil
+}

--- a/internal/mcqdeliver/remoteenv_test.go
+++ b/internal/mcqdeliver/remoteenv_test.go
@@ -1,0 +1,264 @@
+package mcqdeliver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// fakeRemoteEnvMenu simulates Claude's standing "Select remote environment"
+// picker. Like fakeForm it renders the real on-screen shape so the production
+// domain parser is what reads it, and it supports both digit bindings because
+// the real picker's commit protocol is unverified.
+type fakeRemoteEnvMenu struct {
+	binding  digitBinding
+	labels   []string
+	caret    int // 1-based option under the caret
+	selected string
+	closed   bool
+	keys     []string
+	failKey  string
+	// stuck models a picker that ignores Enter, so the fail-closed guard for
+	// "did not commit" is reachable.
+	stuck bool
+}
+
+func newFakeRemoteEnvMenu(binding digitBinding) *fakeRemoteEnvMenu {
+	return &fakeRemoteEnvMenu{
+		binding: binding,
+		labels: []string{
+			"herdr-auto-pilot (env_01F41H1jxkGrT2zj55CqE4WQ) ✔",
+			"myspec-monorepo (env_01CASfztpZp7mYRJPK41sGvK)",
+			"Full-access (env_011CUW5BKtc4vkq5q1uSp7MY)",
+			"Default (env_011CUKn5Aj1q6ujg5PFvEhTE)",
+		},
+		caret: 1,
+	}
+}
+
+func (f *fakeRemoteEnvMenu) SendKey(_ context.Context, _, key string) error {
+	if key == f.failKey {
+		return errors.New("induced keystroke failure")
+	}
+	f.keys = append(f.keys, key)
+	if f.closed {
+		return nil // keys land in the composer once the picker is gone
+	}
+	switch key {
+	case "enter":
+		if !f.stuck {
+			f.selected = f.labels[f.caret-1]
+			f.closed = true
+		}
+	default:
+		d, err := strconv.Atoi(key)
+		if err != nil || d < 1 || d > len(f.labels) {
+			break
+		}
+		f.caret = d
+		if f.binding == digitCommits {
+			f.selected = f.labels[d-1]
+			f.closed = true
+		}
+	}
+	return nil
+}
+
+func (f *fakeRemoteEnvMenu) Read(_ context.Context, _ string, _ int) (string, error) {
+	if f.closed {
+		return "● Environment selected. Launching remote agent…\n", nil
+	}
+	var b strings.Builder
+	b.WriteString("   Select remote environment\n\n")
+	b.WriteString("   Configure environments at: https://claude.ai/code\n\n")
+	for i, label := range f.labels {
+		caret := " "
+		if f.caret == i+1 {
+			caret = "❯"
+		}
+		fmt.Fprintf(&b, "   %s %d. %s\n", caret, i+1, label)
+	}
+	b.WriteString("\n   Enter to select · Esc to cancel\n")
+	return b.String(), nil
+}
+
+func (f *fakeRemoteEnvMenu) config() Config {
+	return Config{Keys: f, Read: f.Read, PaneID: "w1:p1", ReadLines: 40, KeyDelay: 0}
+}
+
+// The picker's commit protocol is unverified, so delivery must land the
+// selection under BOTH real Claude bindings without knowing which is live.
+func TestClaudeRemoteEnvAnswersBothBindings(t *testing.T) {
+	tests := []struct {
+		name     string
+		binding  digitBinding
+		chosen   string
+		wantKeys []string
+		wantSel  string
+	}{
+		{
+			name:     "digit commits on its own",
+			binding:  digitCommits,
+			chosen:   "Full-access (env_011CUW5BKtc4vkq5q1uSp7MY)",
+			wantKeys: []string{"3"},
+			wantSel:  "Full-access (env_011CUW5BKtc4vkq5q1uSp7MY)",
+		},
+		{
+			name:     "digit only moves the caret, Enter commits",
+			binding:  digitMovesCaret,
+			chosen:   "Default (env_011CUKn5Aj1q6ujg5PFvEhTE)",
+			wantKeys: []string{"4", "enter"},
+			wantSel:  "Default (env_011CUKn5Aj1q6ujg5PFvEhTE)",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			menu := newFakeRemoteEnvMenu(tc.binding)
+			if err := ClaudeRemoteEnv(context.Background(), menu.config(), tc.chosen); err != nil {
+				t.Fatalf("ClaudeRemoteEnv returned error: %v", err)
+			}
+			if strings.Join(menu.keys, ",") != strings.Join(tc.wantKeys, ",") {
+				t.Errorf("keys sent = %v, want %v", menu.keys, tc.wantKeys)
+			}
+			if menu.selected != tc.wantSel {
+				t.Errorf("selected = %q, want %q", menu.selected, tc.wantSel)
+			}
+		})
+	}
+}
+
+// The default entry renders with a trailing ✔ but the learned label is clean;
+// both directions must resolve to the digit (the marker is UI state).
+func TestClaudeRemoteEnvResolvesCheckMarkedLabel(t *testing.T) {
+	for _, chosen := range []string{
+		"herdr-auto-pilot (env_01F41H1jxkGrT2zj55CqE4WQ)",
+		"herdr-auto-pilot (env_01F41H1jxkGrT2zj55CqE4WQ) ✔",
+		"1",
+	} {
+		menu := newFakeRemoteEnvMenu(digitMovesCaret)
+		if err := ClaudeRemoteEnv(context.Background(), menu.config(), chosen); err != nil {
+			t.Fatalf("chosen %q: %v", chosen, err)
+		}
+		if !strings.HasPrefix(menu.selected, "herdr-auto-pilot") {
+			t.Errorf("chosen %q selected %q", chosen, menu.selected)
+		}
+	}
+}
+
+// Selecting the option the caret already rests on (the ✔-marked default is
+// also option 1, where the caret starts) needs no special case under either
+// binding.
+func TestClaudeRemoteEnvSelectsOptionAlreadyUnderCaret(t *testing.T) {
+	for _, binding := range []digitBinding{digitCommits, digitMovesCaret} {
+		menu := newFakeRemoteEnvMenu(binding)
+		if err := ClaudeRemoteEnv(context.Background(), menu.config(), "1"); err != nil {
+			t.Fatalf("binding %v: %v", binding, err)
+		}
+		if !menu.closed || !strings.HasPrefix(menu.selected, "herdr-auto-pilot") {
+			t.Errorf("binding %v: closed=%v selected=%q", binding, menu.closed, menu.selected)
+		}
+	}
+}
+
+// The cross-project backstop: the picker's approval signature is global, so a
+// rule learned on another project's environment list can resolve here. When
+// its label matches none of the offered environments, delivery must refuse
+// BEFORE any keystroke — never commit whatever the caret rests on.
+func TestClaudeRemoteEnvRefusesUnknownLabelBeforeAnyKeystroke(t *testing.T) {
+	menu := newFakeRemoteEnvMenu(digitMovesCaret)
+	err := ClaudeRemoteEnv(context.Background(), menu.config(), "other-project (env_01ZZZZZZZZZZZZZZZZZZZZZZZZ)")
+	if err == nil {
+		t.Fatal("expected an error for a label absent from the live menu")
+	}
+	if !strings.Contains(err.Error(), "none of the offered environments") {
+		t.Errorf("error = %v, want it to name the unmatched label", err)
+	}
+	if len(menu.keys) != 0 {
+		t.Fatalf("no keystroke may be sent for an unmappable label, got %v", menu.keys)
+	}
+}
+
+// Fail closed when the digit neither commits nor moves the caret to the
+// chosen option: Enter must NOT be pressed.
+func TestClaudeRemoteEnvRefusesWhenCaretDidNotReachOption(t *testing.T) {
+	menu := newFakeRemoteEnvMenu(digitMovesCaret)
+	// keyDropper records digit keys without applying them, so the caret
+	// never reaches the chosen option.
+	cfg := menu.config()
+	cfg.Keys = keyDropper{menu: menu}
+	err := ClaudeRemoteEnv(context.Background(), cfg, "3")
+	if err == nil {
+		t.Fatal("expected an error when the caret never reached the chosen option")
+	}
+	if !strings.Contains(err.Error(), "was not selected") {
+		t.Errorf("error = %v, want it to name the unselected option", err)
+	}
+	for _, k := range menu.keys {
+		if k == "enter" {
+			t.Fatal("Enter must not be pressed once the caret is known to be wrong")
+		}
+	}
+	if menu.closed {
+		t.Error("nothing should have been committed")
+	}
+}
+
+// keyDropper records digit keys without applying them (a build that unbinds
+// digits) while still letting Enter through to the underlying menu.
+type keyDropper struct{ menu *fakeRemoteEnvMenu }
+
+func (k keyDropper) SendKey(ctx context.Context, pane, key string) error {
+	if key == "enter" {
+		return k.menu.SendKey(ctx, pane, key)
+	}
+	k.menu.keys = append(k.menu.keys, key)
+	return nil
+}
+
+// A picker that ignores Enter (or re-renders unchanged) must surface as a
+// failed commit, not report success.
+func TestClaudeRemoteEnvRefusesWhenPickerDoesNotCommit(t *testing.T) {
+	menu := newFakeRemoteEnvMenu(digitMovesCaret)
+	menu.stuck = true
+	err := ClaudeRemoteEnv(context.Background(), menu.config(), "2")
+	if err == nil || !strings.Contains(err.Error(), "did not commit") {
+		t.Fatalf("error = %v, want the stuck picker to surface", err)
+	}
+}
+
+// The picker being gone before delivery starts (already answered, or the
+// agent moved on) must fail closed instead of typing into whatever is there.
+func TestClaudeRemoteEnvRefusesWhenPickerGone(t *testing.T) {
+	menu := newFakeRemoteEnvMenu(digitCommits)
+	menu.closed = true
+	err := ClaudeRemoteEnv(context.Background(), menu.config(), "1")
+	if err == nil || !strings.Contains(err.Error(), "no longer showing") {
+		t.Fatalf("error = %v, want the missing picker to surface", err)
+	}
+	if len(menu.keys) != 0 {
+		t.Errorf("no keystroke may be sent when the picker is gone, got %v", menu.keys)
+	}
+}
+
+// Keystroke and read failures propagate.
+func TestClaudeRemoteEnvPropagatesFailures(t *testing.T) {
+	menu := newFakeRemoteEnvMenu(digitMovesCaret)
+	menu.failKey = "enter"
+	if err := ClaudeRemoteEnv(context.Background(), menu.config(), "2"); err == nil ||
+		!strings.Contains(err.Error(), "commit") {
+		t.Fatalf("error = %v, want the failing commit keystroke to surface", err)
+	}
+
+	menu = newFakeRemoteEnvMenu(digitCommits)
+	cfg := menu.config()
+	cfg.Read = func(context.Context, string, int) (string, error) {
+		return "", errors.New("induced read failure")
+	}
+	if err := ClaudeRemoteEnv(context.Background(), cfg, "1"); err == nil ||
+		!strings.Contains(err.Error(), "induced read failure") {
+		t.Fatalf("error = %v, want the induced read failure", err)
+	}
+}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -194,6 +194,127 @@ func TestRealConfirmDeliversMenuDigit(t *testing.T) {
 	t.Fatal("confirm did not drive the menu selection (send did not land)")
 }
 
+// startRemoteEnvAgent spawns a scratch agent that renders Claude's "Select
+// remote environment" picker in the CARET binding (a digit moves ❯, Enter
+// commits — the stricter of the two possible protocols) and returns its pane
+// id. The committed environment label is written to markerPath.
+func startRemoteEnvAgent(t *testing.T, markerPath string) string {
+	t.Helper()
+	script := filepath.Join(t.TempDir(), "remote_env.sh")
+	body := `#!/bin/bash
+caret=1
+render() {
+  printf '\033[2J\033[H'
+  echo '   Select remote environment'
+  echo
+  echo '   Configure environments at: https://claude.ai/code'
+  echo
+  for i in 1 2 3 4; do
+    mark='  '; [ "$i" -eq "$caret" ] && mark='❯ '
+    suffix=''; [ "$i" -eq 1 ] && suffix=' ✔'
+    echo "   ${mark}${i}. Env-${i} (env_0${i}ABCDEFGHIJKLMNOPQRSTUVWX)${suffix}"
+  done
+  echo
+  echo '   Enter to select · Esc to cancel'
+}
+render
+while IFS= read -r -s -n1 key; do
+  case "$key" in
+    [1-4]) caret=$key; render ;;
+    '') echo "Env-${caret}" > 'MARKER'; printf '\033[2J\033[H'; echo 'Environment selected.'; break ;;
+  esac
+done
+sleep 60
+`
+	body = strings.ReplaceAll(body, "MARKER", markerPath)
+	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	out := runHerdr(t, "agent", "start", "hapitest", "--cwd", "/tmp", "--no-focus",
+		"--", "bash", script)
+	var resp struct {
+		Result struct {
+			Agent struct {
+				PaneID string `json:"pane_id"`
+			} `json:"agent"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("parse agent start output: %v (%s)", err, out)
+	}
+	pane := resp.Result.Agent.PaneID
+	if pane == "" {
+		t.Fatalf("no pane id in agent start output: %s", out)
+	}
+	t.Cleanup(func() { tryHerdr("pane", "close", pane) })
+	return pane
+}
+
+// TestRealConfirmDeliversRemoteEnvSelection drives the remote-environment
+// picker end to end against a real herdr: an operator confirming the learned
+// environment LABEL must land the selection via the adaptive keystroke
+// deliverer (digit moves the caret, Enter commits) — a plain text send would
+// leave the picker standing.
+func TestRealConfirmDeliversRemoteEnvSelection(t *testing.T) {
+	requireHerdr(t)
+	cli := herdr.NewCLI()
+	marker := filepath.Join(t.TempDir(), "picked")
+	pane := startRemoteEnvAgent(t, marker)
+
+	// Wait for the picker to render; fail loudly if it never does — falling
+	// through would produce a far less diagnosable Confirm error (or even a
+	// stray text send into the pane).
+	rendered := false
+	lastRead := ""
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		if content, err := cli.ReadPaneVisible(context.Background(), pane, 20); err == nil {
+			lastRead = content
+			if _, ok := domain.ClaudeRemoteEnvForm(content); ok {
+				rendered = true
+				break
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if !rendered {
+		t.Fatalf("picker never rendered; last read %q", lastRead)
+	}
+
+	st, err := store.Open(filepath.Join(t.TempDir(), "hap.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	app := &frontend.App{Store: st, Herdr: cli, Author: "itest"}
+
+	ctx := context.Background()
+	id, err := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: pane, AgentType: "claude", SituationType: domain.SituationApproval,
+		Trigger: "t", Action: "escalated", Status: "escalated",
+		Suggestion: "LLM suggested: Env-3 (env_03ABCDEFGHIJKLMNOPQRSTUVWX)", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if b, err := os.ReadFile(marker); err == nil {
+			if got := strings.TrimSpace(string(b)); got == "Env-3" {
+				return // caret reached option 3 and Enter committed it
+			} else {
+				t.Fatalf("picker committed %q, want Env-3", got)
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatal("confirm did not commit the environment selection")
+}
+
 // claudeModel is the model alias the real-claude cases run with; haiku keeps
 // responses fast. Override with HAP_ITEST_CLAUDE_MODEL.
 func claudeModel() string {


### PR DESCRIPTION
## Problem

Claude Code's **"Select remote environment" picker** — shown when an agent asks approval to launch a remote (cloud) sub-agent — stands while herdr reports the pane **idle**, not blocked. hap's classifier gates approval/choice on blocked status, so the pane classified as `idle`, its raw trailing-window salient tripped the over-mask guard, and the event was dismissed (`[over_masked]`) — leaving the agent silently blocked forever. Observed live on a real pane (audit #782).

## Solution

- **Detection** (`internal/domain/clauderemoteenv.go`): structural parser keyed on the title line, `❯ N. label (env_…)` options scoped to the title→footer region, and the end-anchored `Enter to select · Esc to cancel` footer (a live modal sits at the true bottom of the capture; stale scrollback copies are rejected). The default entry's trailing `✔` is stripped from labels.
- **Classification** (`internal/classify`): the form matches at the approval rule position (winning over the single-question MCQ choice hook that its footer also matches), with a parked-status exception at idle/done mirroring `codexPlanParked`. `enrich` sets the stable verb `select remote environment` (salient passes the over-mask guard, one global signature across projects) plus the 4 option labels.
- **Delivery** (`internal/mcqdeliver.ClaudeRemoteEnv`): the picker's commit protocol is unverified (the footer suggests digit-moves-caret + Enter-commits, but Claude has shipped both bindings for identically-footered forms), so delivery is adaptive: press the digit → re-read → press Enter only if the picker is standing with the caret verifiably on the chosen option → verify it committed. Shared by all three paths (daemon act, LLM promotion, frontend confirm) so they can't diverge.
- **Fail closed**: the approval signature is global, so a rule learned on another project's environment list can resolve here — delivery refuses before any keystroke when the learned label maps to no live option, and keystroke-less adapters escalate (or, on an operator confirm, only fall through to a plain digit send when the label maps) instead of typing a literal label whose Enter could commit whatever the caret rests on.

All existing safety gates (kill switch, never-auto, rate guard, variance, graduation/shadow, LLM confidence threshold) apply unchanged; audit-first ordering (FR-024) and pane-claim pairing mirror `deliverSeries`.

## Tests

- Golden fixture from the live capture (`status=idle type=approval verb=select options=4`)
- Classifier: parked statuses (blocked/idle/done → approval; working → no; codex-scoped → no; approval beats choice)
- Domain: parse/reject table (stale copies, scrollback lists, ✔ stripping, caret), over-mask-guard signature pin
- mcqdeliver: both digit bindings, caret-verification refusals, unmappable-label refusal before any keystroke, stuck/gone picker
- Daemon: idle-status escalation regression (the headline bug), adaptive autonomous delivery, unmappable-label escalation, keystroke-less escalation, LLM promotion delivery
- Frontend: adaptive confirm, unsent-on-failure, keystroke-less mappable fallback + unmappable fail-closed
- Integration (`-tags integration`, real herdr): `TestRealConfirmDeliversRemoteEnvSelection` drives a scripted caret-protocol picker end to end — passes locally

Full suite (`go test -tags "vectors cpu" ./... -count=1`), vet, gofmt, and golangci-lint all clean; reviewed by a code-review agent and all findings addressed.