### PR TITLE
#1 feat: add hap task start op and remind agents to mark tasks in-progress

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -468,6 +468,7 @@ hap task backend-dev list                 # all items, with status + number
 hap task backend-dev list --status pending  # or: done | all (default all)
 hap task backend-dev get 3                 # show one item
 hap task backend-dev add "wire up retries" # append a new unchecked item
+hap task backend-dev start 2               # mark item 2 in-progress ([-])
 hap task backend-dev done 2                # tick item 2 off ([x])
 hap task backend-dev undone 2              # re-open item 2 ([ ])
 hap task backend-dev update 2 "new text"   # edit text, keep status
@@ -526,7 +527,7 @@ agent to manage its list through the `hap task` CLI with its own name pre-filled
 in every command (and a `--path` fallback for sources that aren't name-addressable):
 
 ```
-Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks: `hap task {agent_name} list` to view them and `hap task {agent_name} done <n>` to mark one complete as you go (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`).
+Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks: `hap task {agent_name} list` to view them, `hap task {agent_name} start <n>` to mark one in-progress when you begin working on it, and `hap task {agent_name} done <n>` to mark it complete as you go (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`).
 ```
 
 - `{next_task_content}` — the text of the next unchecked item (or `"none"` when the list is complete)

--- a/README.md
+++ b/README.md
@@ -405,9 +405,11 @@ error = "#ff5f5f"
 # the agent to manage its list through the hap CLI with its own name pre-filled
 # (and a --path fallback for sources that aren't name-addressable):
 #   "Your next task is {next_task_content}. Prefer the hap CLI to manage your
-#    tasks: `hap task {agent_name} list` to view them and `hap task {agent_name}
-#    done <n>` to mark one complete as you go (if that name isn't recognized,
-#    use `--path {task_list_path}` in place of `{agent_name}`)."
+#    tasks: `hap task {agent_name} list` to view them, `hap task {agent_name}
+#    start <n>` to mark one in-progress when you begin working on it, and
+#    `hap task {agent_name} done <n>` to mark it complete as you go (if that
+#    name isn't recognized, use `--path {task_list_path}` in place of
+#    `{agent_name}`)."
 # When every item is checked off, the templated prompt is never sent: the
 # plugin escalates a confirmable @noop suggestion ("No more pending tasks")
 # instead — unless BOTH llm.task_generate_command and

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -69,7 +69,8 @@ Configure:
   rules [list|add <regex>|remove <index>]      never-auto patterns
   task-source [add] [--agent A] [--workspace W] [--template T] <checklist.md> | list | remove <index>
   task [<agent> | --path F] list [--status all|pending|done] | get <n> | add <text>
-                        | done <n> | undone <n> | update <n> <text> | remove <n>
+                        | start <n> | done <n> | undone <n> | update <n> <text>
+                        | remove <n> | send <n> [--yes]
                         CRUD the checklist items in an agent's task list
   clear-data --yes      reset learned history + audit data
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -947,7 +947,7 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 // position among all items in the file; every mutating op re-prints the
 // renumbered list so the caller always sees fresh numbers.
 func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
-	usage := "usage: task [<agent> | --path <file>] list [--status all|pending|done] | get <n> | add <text> | done <n> | undone <n> | update <n> <text> | remove <n> | send <n> [--yes]"
+	usage := "usage: task [<agent> | --path <file>] list [--status all|pending|done] | get <n> | add <text> | start <n> | done <n> | undone <n> | update <n> <text> | remove <n> | send <n> [--yes]"
 	agent, path, args, err := taskTarget(args)
 	if err != nil {
 		return err
@@ -985,6 +985,8 @@ func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) 
 		fmt.Fprintf(out, "added task #%d\n", idx)
 		printTaskList(out, items, "all")
 		return nil
+	case "start", "wip":
+		return taskStart(app, out, agent, path, rest)
 	case "done", "check":
 		return taskToggle(app, out, agent, path, rest, true)
 	case "undone", "uncheck", "reopen":
@@ -1191,6 +1193,22 @@ func taskToggle(app *frontend.App, out io.Writer, agent, path string, rest []str
 		state = "pending"
 	}
 	fmt.Fprintf(out, "task #%d marked %s\n", idx, state)
+	printTaskList(out, items, "all")
+	return nil
+}
+
+// taskStart marks item n with the [-] in-progress marker — the op the default
+// next-task template tells an agent to run when it begins working a task.
+func taskStart(app *frontend.App, out io.Writer, agent, path string, rest []string) error {
+	idx, err := taskIndexArg(rest)
+	if err != nil {
+		return err
+	}
+	items, err := app.MarkTaskInProgress(agent, path, idx)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "task #%d marked in-progress\n", idx)
 	printTaskList(out, items, "all")
 	return nil
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1001,6 +1001,65 @@ func TestTaskCRUDByPath(t *testing.T) {
 	}
 }
 
+// TestTaskStartMarksInProgress covers the `task start` op the default
+// next-task template steers agents to run when they begin a task: it writes
+// the [-] in-progress marker (the same one the send path's reserveTask uses).
+func TestTaskStartMarksInProgress(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] first\n- [ ] second\n")
+
+	out, err := run(t, app, "task", "--path", path, "start", "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "task #2 marked in-progress") {
+		t.Errorf("start must report the item as in-progress, got:\n%s", out)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "- [ ] first\n- [-] second\n"
+	if string(data) != want {
+		t.Errorf("file after start:\n got %q\nwant %q", string(data), want)
+	}
+
+	// wip is an alias for start.
+	if _, err := run(t, app, "task", "--path", path, "wip", "1"); err != nil {
+		t.Fatal(err)
+	}
+	data, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "- [-] first\n- [-] second\n"; string(data) != want {
+		t.Errorf("file after wip:\n got %q\nwant %q", string(data), want)
+	}
+
+	// start on a done item re-opens it as in-progress (marker rewritten
+	// unconditionally, like done/undone).
+	if _, err := run(t, app, "task", "--path", path, "done", "1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run(t, app, "task", "--path", path, "start", "1"); err != nil {
+		t.Fatal(err)
+	}
+	data, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "- [-] first\n- [-] second\n"; string(data) != want {
+		t.Errorf("file after re-opening a done item:\n got %q\nwant %q", string(data), want)
+	}
+
+	if _, err := run(t, app, "task", "--path", path, "start", "99"); err == nil {
+		t.Error("out-of-range start must error")
+	}
+	if _, err := run(t, app, "task", "--path", path, "start"); err == nil {
+		t.Error("start without a task number must error")
+	}
+}
+
 func TestTaskByAgentResolvesSource(t *testing.T) {
 	app, _ := testApp(t)
 	path := writeTaskFile(t, "- [ ] alpha\n- [ ] beta\n")

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -26,11 +26,15 @@ var inProgressItemRE = regexp.MustCompile(`^\s*(?:[-*+]\s+)?\[-\]\s*(.+)$`)
 //
 // The default steers the agent to manage its list through the `hap task` CLI
 // with the agent's own name pre-filled in every command (so `hap task
-// {agent_name} done <n>` resolves this exact source). It also spells out the
-// `--path {task_list_path}` form so a source that isn't name-addressable (one
-// scoped by agent type, pane id, workspace, or "any") is still manageable —
-// `hap task {agent_name}` errors on those, and the path form always works.
-const DefaultNextTaskTemplate = "Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks: `hap task {agent_name} list` to view them and `hap task {agent_name} done <n>` to mark one complete as you go (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`)."
+// {agent_name} done <n>` resolves this exact source), covering the full task
+// lifecycle: `start <n>` marks a task [-] in-progress the moment the agent
+// begins it (the daemon's auto-send leaves the item [ ], so without this
+// nothing records that the task is being worked), and `done <n>` ticks it
+// off. It also spells out the `--path {task_list_path}` form so a source that
+// isn't name-addressable (one scoped by agent type, pane id, workspace, or
+// "any") is still manageable — `hap task {agent_name}` errors on those, and
+// the path form always works.
+const DefaultNextTaskTemplate = "Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks: `hap task {agent_name} list` to view them, `hap task {agent_name} start <n>` to mark one in-progress when you begin working on it, and `hap task {agent_name} done <n>` to mark it complete as you go (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`)."
 
 // NoTaskContent is the {next_task_content} value when a declared list has
 // no unchecked item left: the templated prompt is still delivered so the

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -90,12 +90,12 @@ func TestDeclaredTaskPrompt(t *testing.T) {
 		{
 			name: "default template crafts CLI commands with the agent name and a --path fallback",
 			task: DeclaredTask{Task: "add validation", Path: "/docs/tasks.md", AgentName: "brave-otter"},
-			want: "Your next task is add validation. Prefer the hap CLI to manage your tasks: `hap task brave-otter list` to view them and `hap task brave-otter done <n>` to mark one complete as you go (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`).",
+			want: "Your next task is add validation. Prefer the hap CLI to manage your tasks: `hap task brave-otter list` to view them, `hap task brave-otter start <n>` to mark one in-progress when you begin working on it, and `hap task brave-otter done <n>` to mark it complete as you go (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`).",
 		},
 		{
 			name: "completed list uses none",
 			task: DeclaredTask{Task: NoTaskContent, Path: "/docs/tasks.md", AgentName: "brave-otter"},
-			want: "Your next task is none. Prefer the hap CLI to manage your tasks: `hap task brave-otter list` to view them and `hap task brave-otter done <n>` to mark one complete as you go (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`).",
+			want: "Your next task is none. Prefer the hap CLI to manage your tasks: `hap task brave-otter list` to view them, `hap task brave-otter start <n>` to mark one in-progress when you begin working on it, and `hap task brave-otter done <n>` to mark it complete as you go (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`).",
 		},
 		{
 			name: "custom template",

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -2209,6 +2209,22 @@ func (a *App) SetTaskDone(agent, path string, index int, done bool, expectText .
 	}))
 }
 
+// MarkTaskInProgress sets an item's checkbox to the [-] in-progress marker —
+// what an agent runs (`hap task <agent> start <n>`) when it begins working a
+// task, and the same marker the send path's reserveTask writes. Like
+// SetTaskDone it rewrites the marker unconditionally (starting a done item
+// re-opens it as in-progress). An optional expectText aborts (inside the file
+// lock) if the item's text no longer matches — see expectTaskText.
+func (a *App) MarkTaskInProgress(agent, path string, index int, expectText ...string) ([]domain.ChecklistItem, error) {
+	p, err := a.taskFilePath(agent, path)
+	if err != nil {
+		return nil, err
+	}
+	return mutateTaskFile(p, guardedMutation(index, expectText, func(content string) (string, error) {
+		return domain.MarkChecklistItemInProgress(content, index)
+	}))
+}
+
 // EditTask replaces an item's text (keeping its status) and returns the list.
 // Line breaks in the new text are stored as literal `\n` sequences — the item
 // stays one task on one line (see AddTask). An optional expectText aborts


### PR DESCRIPTION
## Summary
- New `hap task <agent|--path F> start <n>` op (alias `wip`) marks checklist item n with the `[-]` in-progress marker — the same marker the manual `task send` path's `reserveTask` writes. Backed by a new `App.MarkTaskInProgress` mirroring `SetTaskDone` (same file-lock + optional expect-text guard), calling the existing `domain.MarkChecklistItemInProgress`.
- `DefaultNextTaskTemplate` now reminds agents to run `start <n>` when they begin working a task (and keeps `list` / `done <n>`). The daemon's auto-send leaves a delivered item `[ ]`, so without this nothing recorded that a task was being worked.
- `start` on a done item re-opens it as `[-]` (marker rewritten unconditionally, like done/undone) — covered by a test.
- Docs: README template comment, hap skill op list + template; `hap` help text also gains the previously missing `send <n> [--yes]` op.

## Testing
- Full suite green: `go test -tags "vectors cpu" ./... -count=1` (all packages pass).
- New `TestTaskStartMarksInProgress` (CLI): file bytes for `[-]`, output line, `wip` alias, done→in-progress re-open, out-of-range and missing-arg errors.
- Updated golden template strings in `TestDeclaredTaskPrompt`.
- `gofmt`, `go vet`, `golangci-lint run --build-tags "vectors,cpu"`: clean.
- Live check: built `hap`, ran `task --path ./tasks.md start 2` → file shows `- [-] second`, out-of-range errors cleanly.

Patch release on merge — manifest version untouched.