### PR TITLE
#1 feat: rewrite failure sends original as-is; add @rewrite:nochange and @noop sentinels

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -346,7 +346,7 @@ edits made through `hap config set` / `set-threshold` apply live — the command
 | `llm.auto_act_confidence_threshold` | 999 (never) | min LLM self-reported confidence (0-100) to auto-act on a consult decision; below it (or no score) the situation escalates with reason `[llm_low_confidence]`. 999 is unreachable = never auto-act |
 | `llm.pane_excerpt_chars` | 5000 | pane excerpt size in characters for LLM consult/rewrite context |
 | `llm.rewrite_timeout_seconds` | 60 | timeout for rewrite calls |
-| `llm.rewrite_fallback_template` | `You must act based on the following: {original_text}` | wraps original text when rewrite fails (placeholders: `{original_text}`, `{agent_name}`) |
+| `llm.rewrite_fallback_template` | `{original_text}` (original sent as-is) | optional wrapper around the original when the rewrite fails (placeholders: `{original_text}`, `{agent_name}`) |
 | `llm.command` | (unset) | argv template for the consult fallback CLI (see llm fallback config) |
 | `llm.command_start` | (unset) | argv template for the FIRST consult per agent; empty inherits `llm.command` (opt-in) |
 | `llm.rewrite_command` | (unset) | argv template for the one-shot rewrite CLI (see llm rewrite) |
@@ -677,11 +677,12 @@ when a learned rule resolves to literal free text (idle next-task prompt, error 
 [llm]
 rewrite_command = [
   "claude", "-p",
-  "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
+  "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text — or @rewrite:nochange if the instruction is already right as-is, or @noop if nothing should be sent at all.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
   "--model", "haiku",
 ]
 rewrite_timeout_seconds = 30
-rewrite_fallback_template = "You must act based on the following: {original_text}"
+# optional — on failure the original is sent as-is; set this only to wrap it:
+# rewrite_fallback_template = "You must act based on the following: {original_text}"
 ```
 
 ### rewrite placeholders
@@ -699,8 +700,10 @@ also available as env vars: `HAP_REWRITE_TEXT`, `HAP_SITUATION_TYPE`, `HAP_AGENT
 ### rewrite invariants
 
 - numbered-menu answers are never rewritten — a mapped digit reaches the menu untouched. only literal free text goes through the rewriter.
-- a rewrite failure never blocks the send: on error, timeout, or empty output the original text is delivered wrapped in `rewrite_fallback_template`.
-- safety controls still apply to the rewritten text: output matching the never-auto patterns or the irreversible heuristic is discarded in favor of the wrapped original.
+- a rewrite failure never blocks the send: on error, timeout, or empty output the original text is delivered as-is (or wrapped in `rewrite_fallback_template` when configured).
+- `@rewrite:nochange` output sends the original verbatim (bypassing any fallback template); all safety re-gates still run on it.
+- `@noop` output sends nothing at all — audited as a `noop` row, runaway counter still advances, nothing learned. only the exact `@`-prefixed sentinel counts; a bare `noop` is delivered literally.
+- safety controls still apply to the rewritten text: output matching the never-auto patterns or the irreversible heuristic is discarded in favor of the original.
 - learning is unaffected: decision history records the original learned action, never the rewritten text.
 
 ## resolved paths (diagnostics)

--- a/README.md
+++ b/README.md
@@ -920,12 +920,12 @@ text**.
 [llm]
 rewrite_command = [
   "claude", "-p",
-  "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
+  "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text — or @rewrite:nochange if the instruction is already right as-is, or @noop if nothing should be sent at all.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
   "--model", "haiku",
 ]
 rewrite_timeout_seconds = 30   # omitted: inherits timeout_seconds
-# Wraps the original when the rewrite fails (never blocks the send):
-rewrite_fallback_template = "You must act based on the following: {original_text}"
+# On rewrite failure the ORIGINAL text is sent as-is; set this only to wrap it:
+# rewrite_fallback_template = "You must act based on the following: {original_text}"
 # Optional: runs instead of rewrite_command on the agent's FIRST rewrite
 # (same first-interaction boundary as command_start, tracked independently;
 # empty inherits rewrite_command):
@@ -935,7 +935,8 @@ rewrite_fallback_template = "You must act based on the following: {original_text
 As with consult commands, a rewrite command that exits with an error in under
 one second is retried once with the other configured rewrite template
 (`rewrite_command` ↔ `rewrite_command_start`). Timeouts and clean empty or
-oversized output use the normal rewrite fallback instead of retrying.
+oversized output deliver the original as-is (or your
+`rewrite_fallback_template`) instead of retrying.
 
 Placeholders in `rewrite_command`: `{text}` (the literal reply a rule
 resolved to), `{situation_type}`, `{agent_type}`, `{agent_name}` (the
@@ -953,13 +954,22 @@ Invariants:
 - **Numbered-menu answers are never rewritten** — a mapped digit reaches
   the menu untouched. Only literal free text goes through the rewriter.
 - **A rewrite failure never blocks the send**: on error, timeout, or empty
-  output the original text is delivered wrapped in
+  output the original text is delivered exactly as it was. Set
   `rewrite_fallback_template` (`{original_text}`, `{agent_name}`
-  placeholders; empty or `{original_text}`-less templates fall back to the
-  built-in default).
+  placeholders) to wrap it instead; empty or `{original_text}`-less
+  templates fall back to the as-is default.
+- **`@rewrite:nochange` sends the original verbatim** — the rewrite CLI can
+  reply with just this sentinel to affirm the instruction, bypassing any
+  configured fallback template. All safety re-gates still run on the
+  original.
+- **`@noop` sends nothing at all** — the rewrite CLI judged that no reply is
+  better than this send. The veto is audited as a `noop` row and the runaway
+  counter still advances, but nothing is learned from it (the underlying
+  rule is untouched). Only the exact `@`-prefixed sentinel counts; a bare
+  `noop` is delivered as literal text.
 - **Safety controls still apply to the rewritten text**: output matching
   the never-auto patterns or the irreversible-operation heuristic is
-  discarded in favor of the wrapped original; if even that trips, the
+  discarded in favor of the original; if even that trips, the
   situation escalates instead of sending. Kill switch, rate guard, and a
   staleness re-check (the pane must still show the same situation) run
   again at delivery time.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,9 +129,10 @@ type LLM struct {
 	// RewriteTimeoutSeconds bounds one rewrite run; zero or omitted
 	// inherits timeout_seconds.
 	RewriteTimeoutSeconds int `toml:"rewrite_timeout_seconds"`
-	// RewriteFallbackTemplate wraps the original text when the rewrite
-	// fails (placeholders {original_text}, {agent_name}). Empty uses the
-	// built-in default; a rewrite failure never blocks the send.
+	// RewriteFallbackTemplate optionally wraps the original text when the
+	// rewrite fails (placeholders {original_text}, {agent_name}). Empty
+	// uses the built-in default, which sends the original as-is; a rewrite
+	// failure never blocks the send.
 	RewriteFallbackTemplate string `toml:"rewrite_fallback_template"`
 	// GenerateTaskCommand is the argv template for the one-shot task
 	// suggestion an idle agent gets when it has NO task source (no declared

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1408,6 +1408,51 @@ func (d *Daemon) deliverNoopClaimed(ctx context.Context, s domain.Situation,
 		"agent", s.AgentID, "situation", s.Type, "confidence", dec.Confidence, "audit_id", auditID)
 }
 
+// deliverRewriteNoop stands the daemon down after the rewrite CLI vetoed a
+// send ("@noop"): audit-first (FR-024), then the rate write — nothing is
+// sent. Unlike deliverNoop and the consult noop, NO decision is recorded:
+// this is a delivery-time contextual veto of an already-learned action, not
+// a decision about the signature — recorded @noop rows could win the
+// plurality and permanently stand the learned rule down (see the
+// llmLearnedAction warning) or trip the variance guard on later consults.
+// The runaway counter still advances (D3) and lastAutoNoop is stamped, so
+// a rewrite-noop loop eventually escalates instead of spinning silently.
+func (d *Daemon) deliverRewriteNoop(ctx context.Context, res rewriteOutcome, now time.Time) {
+	s := res.situation
+	d.withAgentAutomation(ctx, s, res.sig, res.tr, "", res.dec.Confidence, nil,
+		domain.ActionNoop, now, func() {
+			original := truncateRunes(res.dec.Input, 200)
+			auditID, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
+				AgentID: s.AgentID, AgentType: s.AgentType, Signature: res.sig.Signature,
+				Trigger: trigger(res.tr), SituationType: s.Type, Action: "noop", Input: "",
+				Confidence: res.dec.Confidence,
+				Rationale: fmt.Sprintf("%s; rewrite declined to send (@noop) (original: %q)",
+					res.dec.Rationale, original),
+				LLMOutput: domain.ActionNoop,
+				Status:    "auto", PaneExcerpt: truncateTailRunes(s.Content, snapshotMaxRunes),
+				CreatedAt: now,
+			})
+			if err != nil {
+				slog.Error("audit write failed; blocking rewrite noop (FR-024)", "error", err)
+				d.notify(ctx, "Herd Auto Prompter: persistence failure",
+					"A rewrite-declined no-op was blocked because its audit record could not be written.")
+				return
+			}
+			if rate, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
+				updated := domain.RegisterAutoPrompt(*rate, now)
+				updated.AgentID = s.AgentID
+				if err := d.opt.Store.UpdateAgentRate(ctx, updated); err != nil {
+					slog.Error("agent rate update failed", "error", err)
+				}
+			}
+			d.mu.Lock()
+			d.lastAutoNoop[s.AgentID] = now
+			d.mu.Unlock()
+			slog.Info("rewrite noop: no reply sent",
+				"agent", s.AgentID, "situation", s.Type, "audit_id", auditID)
+		})
+}
+
 // escalate records and surfaces an escalation: no input is sent (FR-018).
 func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.SignatureResult,
 	dec domain.Decision, tr domain.AgentTransition, now time.Time) {
@@ -2190,8 +2235,12 @@ func rewriteSuggestion(sitType domain.SituationType, learned, original string) s
 // handleRewriteOutcome finalizes an async outbound rewrite: the rewritten
 // text is re-gated through every safety control (the rewriter is an LLM
 // authoring outbound text — FR-015 applies) and delivered. A rewrite
-// failure degrades to the fallback-wrapped original rather than blocking
-// the send; only safety trips on that wrapped form escalate.
+// failure never blocks the send — it degrades to the original as-is (or
+// the configured rewrite_fallback_template); only safety trips on that
+// degraded form escalate. Two sentinels short-circuit the rewrite:
+// "@rewrite:nochange" sends the original verbatim (bypassing any fallback
+// template), and "@noop" sends nothing at all — the LLM judged that no
+// reply is better than this send.
 func (d *Daemon) handleRewriteOutcome(ctx context.Context, res rewriteOutcome) {
 	s := res.situation
 
@@ -2221,16 +2270,25 @@ func (d *Daemon) handleRewriteOutcome(ctx context.Context, res rewriteOutcome) {
 		return
 	}
 
+	isNoop := false
 	escalateWith := func(reason domain.EscalateReason, why string) {
+		suggestion := rewriteSuggestion(s.Type, res.learned, res.dec.Input)
+		if isNoop {
+			// The LLM advised silence — suggesting the original send would
+			// invert that. The suggestion text round-trips to @noop on a
+			// confirm (suggestionAction); raw "@noop" is never shown.
+			suggestion = domain.ActionNoopSuggestion
+		}
 		d.escalate(ctx, s, res.sig, domain.Decision{
 			Action: domain.ActionEscalate, Reason: reason, Rationale: why,
 			Confidence: res.dec.Confidence,
-			Suggestion: rewriteSuggestion(s.Type, res.learned, res.dec.Input),
+			Suggestion: suggestion,
 		}, res.tr, now)
 	}
 
 	// Final text: the rewrite, or — on any failure, including safety trips
-	// on the rewritten form — the fallback-wrapped original.
+	// on the rewritten form — the original via the fallback template
+	// (passthrough by default).
 	final := strings.TrimSpace(res.rewritten)
 	note := "rewritten by llm.rewrite_command"
 	llmOutput := ""
@@ -2244,6 +2302,15 @@ func (d *Daemon) handleRewriteOutcome(ctx context.Context, res rewriteOutcome) {
 		llmOutput = res.err.Error()
 	case final == "":
 		degrade("produced empty output")
+	case domain.IsRewriteNoop(final):
+		// Handled after the kill-switch check below: nothing will be sent.
+		isNoop = true
+	case domain.IsRewriteNoChange(final):
+		// The LLM affirmed the original — send it verbatim, bypassing even
+		// a custom fallback template (that frames failures, not agreements).
+		final = res.dec.Input
+		note = "rewrite affirmed original (@rewrite:nochange)"
+		llmOutput = domain.RewriteNoChange
 	default:
 		if hit, matched := allow.Match(s.AgentType, final); matched {
 			llmOutput = "discarded rewrite: " + truncateRunes(final, 500)
@@ -2261,6 +2328,28 @@ func (d *Daemon) handleRewriteOutcome(ctx context.Context, res rewriteOutcome) {
 	kill, err := d.opt.Store.LatestKillEvent(ctx)
 	if err != nil || domain.KillStateActive(kill) {
 		escalateWith(domain.ReasonDaemonPaused, "at rewrite")
+		return
+	}
+	if isNoop {
+		// The rewrite CLI vetoed the send ("@noop"): nothing goes to the
+		// pane. The rate guard still runs (D3 — a noop-forever loop must
+		// eventually hit the consecutive ceiling and surface to a human),
+		// but the never-auto screens and the staleness re-read are skipped:
+		// they vet outbound text and stale injections, and there is no send.
+		rate, err := d.opt.Store.GetAgentRate(ctx, s.AgentID)
+		if err != nil {
+			// Fail closed: an unreadable rate row must not skip the guard.
+			escalateWith(domain.ReasonPersistenceFailed, "rate read failed at rewrite: "+err.Error())
+			return
+		}
+		if ok, reason := domain.CheckRate(*rate, now, domain.RateLimits{
+			MaxConsecutive: cfg.Limits.MaxConsecutiveAutoPrompts,
+			MaxPerMinute:   cfg.Limits.MaxAutoPromptsPerMinute,
+		}); !ok {
+			escalateWith(reason, "at rewrite")
+			return
+		}
+		d.deliverRewriteNoop(ctx, res, now)
 		return
 	}
 	if hit, matched := allow.Match(s.AgentType, final); matched {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -607,6 +607,14 @@ func (d *Daemon) handleTransition(ctx context.Context, tr domain.AgentTransition
 		// that moved on (the consuming recent-delta still holds the old
 		// menu AND the answer) — activity supersedes it.
 		d.cancelCapture(tr.PaneID)
+		// Same for an in-flight rewrite: its situation no longer stands,
+		// whoever caused the resume. registerHumanInteraction below also
+		// cancels, but only when the resume counts as human — a self-flap
+		// within 10s of our own last auto action would otherwise leave the
+		// flight live, and a late "@noop" outcome (which skips the
+		// staleness re-read) would stamp audit/rate side effects for a
+		// pane that already moved on.
+		d.cancelRewriteExcept(tr.AgentID, "")
 		// Genuine progress ends the pane's parked episode: re-arm the
 		// subscribe-time reconcile so a fresh block/idle/done is surfaced (#49).
 		d.mu.Lock()
@@ -1072,7 +1080,7 @@ func (d *Daemon) cancelRewriteExcept(agentID, keepSig string) {
 	delete(d.rewriteInFlight, agentID)
 	d.mu.Unlock()
 	fl.cancel()
-	slog.Info("in-flight rewrite superseded by a newer decision", "agent", agentID)
+	slog.Info("in-flight rewrite superseded", "agent", agentID)
 }
 
 // readDecisionState gathers all store reads for one decision. The latest

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2320,6 +2320,9 @@ func (d *Daemon) handleRewriteOutcome(ctx context.Context, res rewriteOutcome) {
 		note = "rewrite affirmed original (@rewrite:nochange)"
 		llmOutput = domain.RewriteNoChange
 	default:
+		// The CLI's actual output always lands on the audit row (LLMOutput)
+		// — on a clean rewrite it is also the delivered text.
+		llmOutput = final
 		if hit, matched := allow.Match(s.AgentType, final); matched {
 			llmOutput = "discarded rewrite: " + truncateRunes(final, 500)
 			degrade("output matched never-auto " + hit.Diagnostic())

--- a/internal/daemon/rewrite_test.go
+++ b/internal/daemon/rewrite_test.go
@@ -110,9 +110,9 @@ func TestRewriteSkippedForMenuMappedApproval(t *testing.T) {
 	}
 }
 
-func TestRewriteFailureSendsFallbackWrappedOriginal(t *testing.T) {
+func TestRewriteFailureSendsOriginalAsIs(t *testing.T) {
 	// A rewrite failure never blocks the send — the original is delivered
-	// inside the default quoting template.
+	// exactly as it was, unwrapped (the default fallback is passthrough).
 	h, _, original := idleRewriteHarness(t, "agent-rw3", "",
 		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
 			return "", errors.New("induced rewrite failure")
@@ -120,9 +120,8 @@ func TestRewriteFailureSendsFallbackWrappedOriginal(t *testing.T) {
 
 	h.push("agent-rw3", "idle")
 	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
-	want := "You must act based on the following: " + original
-	if got := h.herdr.sentInputs()[0]; got != want {
-		t.Errorf("sent %q, want fallback-wrapped original %q", got, want)
+	if got := h.herdr.sentInputs()[0]; got != original {
+		t.Errorf("sent %q, want the original as-is %q", got, original)
 	}
 
 	audits, _ := h.raw.AuditLog(context.Background(), 10)
@@ -153,7 +152,7 @@ func TestRewriteCustomFallbackTemplate(t *testing.T) {
 func TestRewrittenTextTrippingNeverAutoFallsBack(t *testing.T) {
 	// SC-5/FR-015: the rewriter is an LLM authoring outbound text — output
 	// naming an irreversible operation is discarded and the safe original
-	// (wrapped) is delivered instead.
+	// is delivered as-is instead.
 	h, _, original := idleRewriteHarness(t, "agent-rw5", "",
 		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
 			return "sounds good, just force-push the branch afterwards", nil
@@ -161,9 +160,8 @@ func TestRewrittenTextTrippingNeverAutoFallsBack(t *testing.T) {
 
 	h.push("agent-rw5", "idle")
 	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
-	want := "You must act based on the following: " + original
-	if got := h.herdr.sentInputs()[0]; got != want {
-		t.Errorf("sent %q, want the dangerous rewrite discarded for %q", got, want)
+	if got := h.herdr.sentInputs()[0]; got != original {
+		t.Errorf("sent %q, want the dangerous rewrite discarded for the original %q", got, original)
 	}
 	audits, _ := h.raw.AuditLog(context.Background(), 10)
 	if len(audits) == 0 || !strings.Contains(audits[0].Rationale, "never-auto") {
@@ -431,5 +429,237 @@ func TestRewriteAuditFailureBlocksSend(t *testing.T) {
 	})
 	if got := h.herdr.sentInputs(); len(got) != 0 {
 		t.Errorf("audit failure must block the send (FR-024), sent %v", got)
+	}
+}
+
+func TestRewriteEmptyOutputSendsOriginal(t *testing.T) {
+	// Empty rewriter output (no adapter error) degrades to the original,
+	// delivered exactly as it was.
+	h, _, original := idleRewriteHarness(t, "agent-rw15", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			return "", nil
+		})
+
+	h.push("agent-rw15", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	if got := h.herdr.sentInputs()[0]; got != original {
+		t.Errorf("sent %q, want the original as-is %q", got, original)
+	}
+	audits, _ := h.raw.AuditLog(context.Background(), 10)
+	if len(audits) == 0 || !strings.Contains(audits[0].Rationale, "empty output") {
+		t.Errorf("audit rationale should note the empty rewrite: %+v", audits)
+	}
+}
+
+func TestRewriteNoChangeSendsOriginalVerbatim(t *testing.T) {
+	// "@rewrite:nochange" affirms the original: it is sent verbatim, even
+	// when a custom fallback template is configured — the template frames
+	// failures, not agreements.
+	extra := "[llm]\nrewrite_fallback_template = \"Operator rule says: {original_text}\"\n"
+	h, _, original := idleRewriteHarness(t, "agent-rw16", extra,
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			return "  @Rewrite:NoChange \n", nil
+		})
+
+	h.push("agent-rw16", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	if got := h.herdr.sentInputs()[0]; got != original {
+		t.Errorf("sent %q, want the original verbatim %q", got, original)
+	}
+	audits, _ := h.raw.AuditLog(context.Background(), 10)
+	if len(audits) == 0 || !strings.Contains(audits[0].Rationale, "@rewrite:nochange") {
+		t.Errorf("audit rationale should note the nochange sentinel: %+v", audits)
+	}
+	// Learning stays symbolic — the sentinel must not enter history.
+	if len(audits) > 0 {
+		decs, _ := h.raw.DecisionsForSignature(context.Background(), audits[0].Signature, 50)
+		if len(decs) == 0 || decs[0].ChosenAction != domain.ActionNextDeclaredTask {
+			t.Errorf("learned action drifted: %+v", decs)
+		}
+	}
+}
+
+func TestRewriteNoopSendsNothing(t *testing.T) {
+	// "@noop": the LLM vetoed the send. Nothing reaches the pane, a noop
+	// audit row lands, the runaway counter advances — and the learned rule
+	// is untouched (no @noop decision recorded, so the veto cannot stand
+	// the declared-task rule down permanently).
+	h, _, original := idleRewriteHarness(t, "agent-rw17", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			return "@noop", nil
+		})
+
+	h.push("agent-rw17", "idle")
+	// The rate write is the LAST persistence step in deliverRewriteNoop;
+	// waiting on it (not the audit, which lands first) avoids racing the
+	// delivery tail.
+	waitFor(t, 3*time.Second, func() bool {
+		rate, err := h.raw.GetAgentRate(context.Background(), "agent-rw17")
+		return err == nil && rate.ConsecutiveAuto == 1
+	})
+	if got := h.herdr.sentInputs(); len(got) != 0 {
+		t.Errorf("@noop must not send, sent %v", got)
+	}
+
+	audits, _ := h.raw.AuditLog(context.Background(), 10)
+	if len(audits) == 0 || audits[0].Status != "auto" || audits[0].Action != "noop" {
+		t.Fatalf("want a noop auto audit row first, got %+v", audits)
+	}
+	noop := audits[0]
+	if noop.Input != "" || noop.LLMOutput != domain.ActionNoop {
+		t.Errorf("noop audit row malformed: %+v", noop)
+	}
+	if !strings.Contains(noop.Rationale, "rewrite declined to send") ||
+		!strings.Contains(noop.Rationale, original[:20]) {
+		t.Errorf("noop rationale should carry the veto and the original: %q", noop.Rationale)
+	}
+
+	decs, err := h.raw.DecisionsForSignature(context.Background(), noop.Signature, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, dec := range decs {
+		if dec.ChosenAction == domain.ActionNoop {
+			t.Errorf("rewrite noop must not be recorded as a decision: %+v", dec)
+		}
+	}
+}
+
+func TestRewriteNoopRateGuardEscalates(t *testing.T) {
+	// A saturated runaway counter beats even a noop outcome: the situation
+	// escalates (suggesting "do nothing") instead of silently nooping —
+	// the operator must see a rate-limited agent, whatever the LLM said.
+	release := make(chan struct{})
+	h, fr, _ := idleRewriteHarness(t, "agent-rw22", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			<-release
+			return "@noop", nil
+		})
+
+	h.push("agent-rw22", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(fr.rewriteCalls()) == 1 })
+	h.raw.UpdateAgentRate(context.Background(), domain.AgentRate{
+		AgentID: "agent-rw22", ConsecutiveAuto: 1000, WindowStart: time.Now(), CountInWindow: 1000,
+	})
+	close(release)
+
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := h.raw.AuditLog(context.Background(), 10)
+		for _, a := range audits {
+			if a.Status == "escalated" && strings.Contains(a.Rationale, "[rate_limited]") {
+				return true
+			}
+		}
+		return false
+	})
+	if got := h.herdr.sentInputs(); len(got) != 0 {
+		t.Errorf("rate guard must block everything, sent %v", got)
+	}
+	audits, _ := h.raw.AuditLog(context.Background(), 10)
+	for _, a := range audits {
+		if a.Status == "escalated" && a.Suggestion != domain.ActionNoopSuggestion {
+			t.Errorf("escalation should suggest doing nothing, got %q", a.Suggestion)
+		}
+		if a.Status == "auto" {
+			t.Errorf("a rate-limited noop must not audit as auto: %+v", a)
+		}
+	}
+}
+
+func TestRewriteNoopSentinelSpellingExact(t *testing.T) {
+	// Case and surrounding whitespace are tolerated on the sentinel...
+	h, _, _ := idleRewriteHarness(t, "agent-rw18", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			return " @NoOp \n", nil
+		})
+	h.push("agent-rw18", "idle")
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := h.raw.AuditLog(context.Background(), 10)
+		return len(audits) > 0 && audits[0].Action == "noop"
+	})
+	if got := h.herdr.sentInputs(); len(got) != 0 {
+		t.Errorf("case-variant @noop must stand down, sent %v", got)
+	}
+
+	// ...but a bare "noop" is free text a rewrite could legitimately
+	// produce, so it is delivered literally.
+	h2, _, _ := idleRewriteHarness(t, "agent-rw19", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			return "noop", nil
+		})
+	h2.push("agent-rw19", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(h2.herdr.sentInputs()) == 1 })
+	if got := h2.herdr.sentInputs()[0]; got != "noop" {
+		t.Errorf("bare noop is not a sentinel; sent %q, want literal \"noop\"", got)
+	}
+}
+
+func TestRewriteNoopKillSwitchEscalates(t *testing.T) {
+	// A kill switch raised mid-flight still wins over a noop outcome, and
+	// the escalation suggests doing nothing — not sending the original the
+	// LLM just vetoed.
+	release := make(chan struct{})
+	h, fr, _ := idleRewriteHarness(t, "agent-rw20", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			<-release
+			return "@noop", nil
+		})
+
+	h.push("agent-rw20", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(fr.rewriteCalls()) == 1 })
+	h.raw.InsertKillEvent(context.Background(), domain.KillEvent{
+		State: "active", Scope: "global", Author: "test", CreatedAt: time.Now(),
+	})
+	close(release)
+
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := h.raw.AuditLog(context.Background(), 10)
+		for _, a := range audits {
+			if a.Status == "escalated" && strings.Contains(a.Rationale, "[daemon_paused]") {
+				return true
+			}
+		}
+		return false
+	})
+	if got := h.herdr.sentInputs(); len(got) != 0 {
+		t.Errorf("kill switch must block everything, sent %v", got)
+	}
+	audits, _ := h.raw.AuditLog(context.Background(), 10)
+	for _, a := range audits {
+		if a.Status == "escalated" && a.Suggestion != domain.ActionNoopSuggestion {
+			t.Errorf("escalation should suggest doing nothing, got %q", a.Suggestion)
+		}
+		if a.Status == "auto" {
+			t.Errorf("nothing may auto-run under the kill switch: %+v", a)
+		}
+	}
+}
+
+func TestRewriteNoopAuditFailureNotifies(t *testing.T) {
+	// FR-024 holds for the noop path too: no audit record, no state
+	// advance — and the operator is notified.
+	release := make(chan struct{})
+	h, fr, _ := idleRewriteHarness(t, "agent-rw21", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			<-release
+			return "@noop", nil
+		})
+
+	h.push("agent-rw21", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(fr.rewriteCalls()) == 1 })
+	h.store.(*failingStore).setFailAudit(true)
+	close(release)
+
+	waitFor(t, 3*time.Second, func() bool {
+		for _, n := range h.herdr.notified() {
+			if strings.Contains(n, "persistence failure") {
+				return true
+			}
+		}
+		return false
+	})
+	rate, err := h.raw.GetAgentRate(context.Background(), "agent-rw21")
+	if err != nil || rate.ConsecutiveAuto != 0 {
+		t.Errorf("blocked noop must not advance the runaway counter: %+v (%v)", rate, err)
 	}
 }

--- a/internal/daemon/rewrite_test.go
+++ b/internal/daemon/rewrite_test.go
@@ -75,6 +75,9 @@ func TestRewriteAppliedToIdleDeclaredTask(t *testing.T) {
 	if audits[0].Input != "REWRITTEN: please do step two" || audits[0].Status != "auto" {
 		t.Errorf("audit should carry the delivered text: %+v", audits[0])
 	}
+	if audits[0].LLMOutput != "REWRITTEN: please do step two" {
+		t.Errorf("audit LLMOutput should carry the CLI's actual output: %q", audits[0].LLMOutput)
+	}
 	if !strings.Contains(audits[0].Rationale, "rewritten by llm.rewrite_command") ||
 		!strings.Contains(audits[0].Rationale, "step two") {
 		t.Errorf("audit rationale should note the rewrite and the original: %q", audits[0].Rationale)

--- a/internal/daemon/rewrite_test.go
+++ b/internal/daemon/rewrite_test.go
@@ -635,6 +635,54 @@ func TestRewriteNoopKillSwitchEscalates(t *testing.T) {
 	}
 }
 
+func TestRewriteNoopDroppedWhenAgentResumes(t *testing.T) {
+	// The agent resumes working while the rewrite is in flight: the flight
+	// is cancelled on the transition, so a late "@noop" outcome — which
+	// deliberately skips the staleness re-read — must apply NO side
+	// effects: no noop audit row, no runaway-counter advance.
+	cancelled := make(chan struct{}, 1)
+	release := make(chan struct{})
+	h, fr, _ := idleRewriteHarness(t, "agent-rw23", "",
+		func(ctx context.Context, req domain.RewriteRequest) (string, error) {
+			select {
+			case <-ctx.Done():
+				cancelled <- struct{}{}
+				return "", ctx.Err()
+			case <-release:
+				return "@noop", nil
+			}
+		})
+
+	h.push("agent-rw23", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(fr.rewriteCalls()) == 1 })
+	h.push("agent-rw23", "working") // resume supersedes the flight
+
+	waitFor(t, 3*time.Second, func() bool {
+		select {
+		case <-cancelled:
+			return true
+		default:
+			return false
+		}
+	})
+	close(release)
+	time.Sleep(300 * time.Millisecond)
+
+	if got := h.herdr.sentInputs(); len(got) != 0 {
+		t.Errorf("a superseded flight must not send, sent %v", got)
+	}
+	audits, _ := h.raw.AuditLog(context.Background(), 10)
+	for _, a := range audits {
+		if a.Action == "noop" {
+			t.Errorf("stale noop must leave no audit row: %+v", a)
+		}
+	}
+	rate, err := h.raw.GetAgentRate(context.Background(), "agent-rw23")
+	if err != nil || rate.ConsecutiveAuto != 0 {
+		t.Errorf("stale noop must not advance the runaway counter: %+v (%v)", rate, err)
+	}
+}
+
 func TestRewriteNoopAuditFailureNotifies(t *testing.T) {
 	// FR-024 holds for the noop path too: no audit record, no state
 	// advance — and the operator is notified.

--- a/internal/domain/rewrite.go
+++ b/internal/domain/rewrite.go
@@ -24,17 +24,38 @@ type RewriteRequest struct {
 	First bool
 }
 
-// DefaultRewriteFallbackTemplate wraps the original text when the rewrite
-// CLI fails: the send must never be blocked by a rewrite failure, so the
-// already-safety-screened original is delivered inside a quoting frame.
-// Placeholders: {original_text}, {agent_name} (the agent's short name).
-const DefaultRewriteFallbackTemplate = "You must act based on the following: {original_text}"
+// DefaultRewriteFallbackTemplate is the failure-path template: the send must
+// never be blocked by a rewrite failure, so the already-safety-screened
+// original is delivered as-is by default. Set llm.rewrite_fallback_template
+// to opt into wrapping it (placeholders: {original_text}, {agent_name}).
+const DefaultRewriteFallbackTemplate = "{original_text}"
+
+// RewriteNoChange is the rewrite CLI's "the original is already right"
+// sentinel: the daemon sends the original text verbatim, bypassing any
+// configured fallback template. The companion "@noop" (ActionNoop) means
+// "send nothing at all".
+const RewriteNoChange = "@rewrite:nochange"
+
+// IsRewriteNoChange reports whether trimmed rewrite output is the
+// no-change sentinel (case-insensitive).
+func IsRewriteNoChange(s string) bool {
+	return strings.EqualFold(strings.TrimSpace(s), RewriteNoChange)
+}
+
+// IsRewriteNoop reports whether trimmed rewrite output is the noop sentinel
+// (case-insensitive). Unlike NormalizeNoopAction on the consult path, bare
+// spellings ("noop", "no_op", "no-op") are deliberately NOT accepted:
+// rewrite output is free text destined for a pane, and a bare "noop" could
+// be a legitimate rewritten reply — only the @ prefix marks LLM intent.
+func IsRewriteNoop(s string) bool {
+	return strings.EqualFold(strings.TrimSpace(s), ActionNoop)
+}
 
 // ApplyRewriteFallback renders the failure-path outbound text. An empty
 // template — or one missing the {original_text} placeholder, which would
-// silently drop the learned action — falls back to the default. A single
-// substitution pass means placeholder-like text inside the original is
-// never re-expanded. agentName fills {agent_name}.
+// silently drop the learned action — falls back to the default
+// (passthrough). A single substitution pass means placeholder-like text
+// inside the original is never re-expanded. agentName fills {agent_name}.
 func ApplyRewriteFallback(template, original, agentName string) string {
 	if !strings.Contains(template, "{original_text}") {
 		template = DefaultRewriteFallbackTemplate

--- a/internal/domain/rewrite_test.go
+++ b/internal/domain/rewrite_test.go
@@ -11,10 +11,10 @@ func TestApplyRewriteFallback(t *testing.T) {
 		want      string
 	}{
 		{
-			name:     "empty template uses default",
+			name:     "empty template uses default passthrough",
 			template: "",
 			original: "go test ./...",
-			want:     "You must act based on the following: go test ./...",
+			want:     "go test ./...",
 		},
 		{
 			name:     "custom template",
@@ -26,7 +26,7 @@ func TestApplyRewriteFallback(t *testing.T) {
 			name:     "template without placeholder falls back to default",
 			template: "just some words",
 			original: "go vet ./...",
-			want:     "You must act based on the following: go vet ./...",
+			want:     "go vet ./...",
 		},
 		{
 			name:     "placeholder in original not re-expanded",
@@ -38,7 +38,7 @@ func TestApplyRewriteFallback(t *testing.T) {
 			name:     "empty original still renders",
 			template: "",
 			original: "",
-			want:     "You must act based on the following: ",
+			want:     "",
 		},
 		{
 			name:      "agent_name substituted",
@@ -62,5 +62,47 @@ func TestApplyRewriteFallback(t *testing.T) {
 					tt.template, tt.original, tt.agentName, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIsRewriteNoChange(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"@rewrite:nochange", true},
+		{"@Rewrite:NoChange", true},
+		{"  @rewrite:nochange \n", true},
+		{"nochange", false},
+		{"@rewrite:nochange please", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsRewriteNoChange(tt.in); got != tt.want {
+			t.Errorf("IsRewriteNoChange(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestIsRewriteNoop(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"@noop", true},
+		{"@NoOp", true},
+		{" @noop \n", true},
+		// Bare spellings are free text a rewrite could legitimately
+		// produce — only the @ prefix marks sentinel intent.
+		{"noop", false},
+		{"no_op", false},
+		{"no-op", false},
+		{"do @noop now", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsRewriteNoop(tt.in); got != tt.want {
+			t.Errorf("IsRewriteNoop(%q) = %v, want %v", tt.in, got, tt.want)
+		}
 	}
 }

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1041,6 +1041,38 @@ func TestCapturedPanePreviewKeepsTail(t *testing.T) {
 	}
 }
 
+func TestAuditDetailShowsInputForDeliveredRow(t *testing.T) {
+	// A delivered auto row always carries the sent text: the detail view
+	// must render its Input section (empty fields are hidden, so this pins
+	// that Input is never empty-hidden on a delivered row — including a
+	// rewritten one, where Input and LLM output both carry real content).
+	m := testModel(t)
+	rec := domain.AuditRecord{
+		Status:    "auto",
+		Action:    "auto: REWRITTEN: please do step two",
+		Input:     "REWRITTEN: please do step two",
+		LLMOutput: "REWRITTEN: please do step two",
+		Rationale: "declared task; rewritten by llm.rewrite_command (original: \"step two\")",
+	}
+	got := strings.Join(m.auditDetailLines(rec, "", 80, auditDetailOptions{}), "\n")
+	for _, want := range []string{"Input", "REWRITTEN: please do step two", "LLM output"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("delivered auto row detail missing %q:\n%s", want, got)
+		}
+	}
+
+	// A noop row sends nothing — Input is genuinely empty and the section
+	// is hidden by design, not missing.
+	noop := domain.AuditRecord{
+		Status: "auto", Action: "noop", Input: "",
+		Rationale: "rewrite declined to send (@noop)",
+	}
+	got = strings.Join(m.auditDetailLines(noop, "", 80, auditDetailOptions{}), "\n")
+	if strings.Contains(got, "Input") {
+		t.Errorf("empty Input must stay hidden on a noop row:\n%s", got)
+	}
+}
+
 func TestEscalationCurrentSituationPreviewUsesTenLines(t *testing.T) {
 	m := testModel(t)
 	var pane strings.Builder

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -96,7 +96,7 @@ pane_excerpt_chars = 5000          # pane context included in the consult
 # stdout is the rewritten text.
 rewrite_command = [
   "claude", "--model", "haiku", "-p",
-  "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
+  "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text — or @rewrite:nochange if the instruction is already right as-is, or @noop if nothing should be sent at all.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
 ]
 
 # ── First-rewrite variant (optional) ──
@@ -107,17 +107,20 @@ rewrite_command = [
 # A sub-one-second error exit is retried once with the other rewrite template.
 # rewrite_command_start = [
 #   "claude", "--model", "haiku", "-p",
-#   "First rewrite for this agent. Rewrite this instruction given its screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
+#   "First rewrite for this agent. Rewrite this instruction given its screen. Reply with ONLY the rewritten text — or @rewrite:nochange if the instruction is already right as-is, or @noop if nothing should be sent at all.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
 # ]
 
 # ── Rewrite recipe — OpenAI Codex (commented; swap in to use codex) ──
 # rewrite_command = [
 #   "codex", "--model", "gpt-5.6-luna", "exec", "--skip-git-repo-check",
-#   "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
+#   "Rewrite this instruction for the coding agent given its current screen. Reply with ONLY the rewritten text — or @rewrite:nochange if the instruction is already right as-is, or @noop if nothing should be sent at all.\n\nInstruction: {text}\n\nScreen:\n{pane_excerpt}",
 # ]
 
 rewrite_timeout_seconds = 60       # omitted: inherits timeout_seconds
-rewrite_fallback_template = "You must act based on the following: {original_text}"
+# On rewrite failure/timeout/empty output the ORIGINAL text is sent as-is.
+# Set rewrite_fallback_template only to wrap it instead (placeholders:
+# {original_text}, {agent_name}).
+# rewrite_fallback_template = "You must act based on the following: {original_text}"
 
 # ── Idle task suggestion (optional) ──
 # When an agent goes idle with NO task source (no [[task_sources]] matches it


### PR DESCRIPTION
## Summary

Updates the LLM rewrite feature (`llm.rewrite_command`) so the original action is preserved — or suppressed — based on what the rewrite CLI returns:

- **Failure / timeout / empty output → the ORIGINAL text is sent as-is.** The default fallback template changed from `"You must act based on the following: {original_text}"` to plain `"{original_text}"`. Setting `llm.rewrite_fallback_template` still opts into custom wrapping. The sample config's active template line is now commented out so sample-seeded installs get the new default.
- **`@rewrite:nochange` → original sent verbatim**, bypassing even a custom fallback template (the LLM affirmed the instruction). All safety re-gates (kill switch, never-auto, irreversible, rate guard, staleness) still run on it.
- **`@noop` → nothing is sent.** The veto is audited as a `noop` row (FR-024 audit-before-act, inside the agent-lifecycle barrier), `lastAutoNoop` is stamped and the runaway counter advances (D3), but **no decision is recorded** — a delivery-time contextual veto must not shift the learned rule's history or trip the variance guard. Kill switch and rate guard still gate the noop path, and their escalations suggest "do nothing" (round-tripping to `@noop` on confirm) instead of the original the LLM just vetoed.
- Sentinels are trimmed + case-insensitive but **`@`-prefixed only**: a bare `noop` is legitimate free text and is delivered literally.
- Rewrite recipe prompts in README / sample config / hap skill now tell the CLI about both sentinels.

## Testing

- Full unit suite (`go test -tags "vectors cpu" ./... -count=1`): all 22 packages pass.
- New daemon tests: empty-output passthrough, nochange verbatim (with custom template configured), noop stand-down (audit row, no decision record, counter advance), exact-sentinel spelling, noop + kill switch, noop + rate guard, noop + audit failure (FR-024).
- `gofmt`, `go vet`, `golangci-lint` clean.
- Integration suite (`go test -tags "integration vectors cpu" ./test/integration/`): 5 pass, 3 expected skips (Claude-token and embed-model gated).

https://claude.ai/code/session_0162qGzBfdPGLgrbUfV8osks