### PR TITLE
#1 feat: retry Enter with backoff on prompt submit for claude and codex

### DIFF
--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -148,6 +148,7 @@ func run(verb string, args []string) error {
 			return err
 		}
 		defer closeStore()
+		defer drainSubmitRetries(app)
 		if _, err := logging.Setup(paths.StateDir, false); err != nil {
 			return err
 		}
@@ -158,7 +159,17 @@ func run(verb string, args []string) error {
 			return err
 		}
 		defer closeStore()
+		defer drainSubmitRetries(app)
 		return cli.Run(ctx, app, os.Stdout, verb, args)
+	}
+}
+
+// drainSubmitRetries waits for in-flight submit-retry Enter workers before a
+// one-shot process (or a closing TUI) exits, so a prompt whose first Enter
+// did not take still gets its retries.
+func drainSubmitRetries(app *frontend.App) {
+	if w, ok := app.Herdr.(ports.SubmitRetryWaiter); ok {
+		w.WaitSubmitRetries()
 	}
 }
 

--- a/internal/fakeherdr/fakeherdr.go
+++ b/internal/fakeherdr/fakeherdr.go
@@ -262,7 +262,14 @@ case "$1 $2" in
     cat %q.paneinfo 2>/dev/null
     ;;
   "agent list")
-    cat %q.agents 2>/dev/null
+    agents_dir=%q.agents.d
+    if [ -d "$agents_dir" ] && [ -n "$(ls -A "$agents_dir" 2>/dev/null)" ]; then
+      first="$agents_dir/$(ls "$agents_dir" | head -n 1)"
+      cat "$first"
+      if [ "$(ls "$agents_dir" | wc -l)" -gt 1 ]; then rm -f "$first"; fi
+    else
+      cat %q.agents 2>/dev/null
+    fi
     ;;
   "workspace list")
     cat %q.workspaces 2>/dev/null
@@ -272,7 +279,7 @@ case "$1 $2" in
     ;;
 esac
 exit 0
-`, f.LogPath, f.FailFlag, f.PaneFile, f.PaneFile, f.PaneFile, f.PaneFile, f.PaneFile)
+`, f.LogPath, f.FailFlag, f.PaneFile, f.PaneFile, f.PaneFile, f.PaneFile, f.PaneFile, f.PaneFile)
 	if err := os.WriteFile(f.BinPath, []byte(script), 0o700); err != nil {
 		return nil, err
 	}
@@ -292,6 +299,30 @@ func (f *FakeCLI) SetPaneInfo(content string) error {
 // SetAgentList sets the raw JSON `agent list` returns.
 func (f *FakeCLI) SetAgentList(content string) error {
 	return os.WriteFile(f.PaneFile+".agents", []byte(content), 0o600)
+}
+
+// SetAgentListSequence makes successive `agent list` invocations return each
+// JSON in turn; the final entry repeats forever and permanently shadows
+// SetAgentList for this fake. It replaces any sequence set earlier; calling
+// it with no arguments removes the sequence so SetAgentList applies again.
+func (f *FakeCLI) SetAgentListSequence(responses ...string) error {
+	dir := f.PaneFile + ".agents.d"
+	if err := os.RemoveAll(dir); err != nil {
+		return err
+	}
+	if len(responses) == 0 {
+		return nil
+	}
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		return err
+	}
+	for i, r := range responses {
+		name := filepath.Join(dir, fmt.Sprintf("%03d", i+1))
+		if err := os.WriteFile(name, []byte(r), 0o600); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SetWorkspaceList sets the raw JSON `workspace list` returns.

--- a/internal/herdr/cli.go
+++ b/internal/herdr/cli.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strconv"
@@ -23,7 +24,18 @@ var (
 	_ ports.AgentAwareSender        = (*CLI)(nil)
 )
 
-const codexSecondEnterDelay = 300 * time.Millisecond
+const (
+	codexSecondEnterDelay = 300 * time.Millisecond
+	// submitRetryBaseDelay is the first status-gated retry-Enter delay;
+	// each subsequent retry doubles it (300, 600, 1200, 2400ms).
+	submitRetryBaseDelay = 300 * time.Millisecond
+	// submitRetryMax caps the status-gated retry Enters per send.
+	submitRetryMax = 4
+	// statusProbeTimeout bounds each retry-loop herdr query (status poll,
+	// pane read) so a wedged herdr costs at most ~2s per probe instead of
+	// the full CLI timeout, keeping the caller's worst-case stall bounded.
+	statusProbeTimeout = 2 * time.Second
+)
 
 // CLI issues one-shot Herdr control actions through the herdr binary
 // (HERDR_BIN_PATH), which stays portable across Unix sockets and Windows
@@ -31,6 +43,8 @@ const codexSecondEnterDelay = 300 * time.Millisecond
 type CLI struct {
 	BinPath string
 	Timeout time.Duration
+	// retryBaseDelay overrides submitRetryBaseDelay in tests (0 = default).
+	retryBaseDelay time.Duration
 }
 
 // NewCLI resolves the herdr binary from HERDR_BIN_PATH (falling back to
@@ -65,37 +79,146 @@ func (c *CLI) run(ctx context.Context, args ...string) (string, error) {
 // the literal text, then `pane send-keys <pane> enter` submits it (verified
 // against herdr 0.7: agent send alone does not press Enter).
 func (c *CLI) Send(ctx context.Context, paneID, input string) error {
-	return c.send(ctx, paneID, input, false)
+	return c.send(ctx, paneID, input, sendBehavior{})
 }
 
-// SendToAgent adds a delayed second Enter for Codex. Codex treats rapidly
+// sendBehavior selects the per-agent-type submit hardening applied by send.
+type sendBehavior struct {
+	codexDoubleEnter bool // unconditional Enter after codexSecondEnterDelay
+	retrySubmit      bool // status-gated exponential retry Enters
+}
+
+// SendToAgent hardens submission per agent type. Codex treats rapidly
 // injected text as a paste burst and interprets the first immediate Enter as
-// a newline; after its suppression window expires, the second Enter submits
-// the composed prompt.
+// a newline, so it always gets a delayed second Enter. Codex and Claude
+// additionally get status-gated retry Enters: when the agent was idle/done
+// before the send and its status has not moved afterwards, Enter is pressed
+// again with exponential backoff until the status changes (submitRetryMax
+// attempts max).
 func (c *CLI) SendToAgent(ctx context.Context, paneID, agentType, input string) error {
-	return c.send(ctx, paneID, input, strings.EqualFold(strings.TrimSpace(agentType), "codex"))
+	kind := strings.ToLower(strings.TrimSpace(agentType))
+	return c.send(ctx, paneID, input, sendBehavior{
+		codexDoubleEnter: kind == "codex",
+		retrySubmit:      kind == "codex" || kind == "claude",
+	})
 }
 
-func (c *CLI) send(ctx context.Context, paneID, input string, codex bool) error {
+func (c *CLI) send(ctx context.Context, paneID, input string, b sendBehavior) error {
+	// Snapshot BEFORE the send; only a cleanly idle/done agent arms the
+	// retry loop — a blocked agent's standing menu must never receive stray
+	// Enters (they could commit a default option).
+	preStatus, retry := "", false
+	if b.retrySubmit {
+		if st, ok := c.probeAgentStatus(ctx, paneID); ok && st != "" && !domain.AgentBusy(st) {
+			preStatus, retry = st, true
+		}
+	}
 	if _, err := c.run(ctx, "agent", "send", paneID, input); err != nil {
 		return err
 	}
 	if _, err := c.run(ctx, "pane", "send-keys", paneID, "enter"); err != nil {
 		return err
 	}
-	if !codex {
-		return nil
+	if b.codexDoubleEnter {
+		if err := sleepCtx(ctx, codexSecondEnterDelay); err != nil {
+			return err
+		}
+		if _, err := c.run(ctx, "pane", "send-keys", paneID, "enter"); err != nil {
+			return err
+		}
 	}
+	if retry {
+		c.retrySubmitEnter(ctx, paneID, preStatus)
+	}
+	return nil
+}
 
-	timer := time.NewTimer(codexSecondEnterDelay)
+// retrySubmitEnter is the best-effort submit self-heal: while the agent's
+// status has not moved off its pre-send value, press Enter again with
+// exponential backoff. It never returns an error — the primary delivery
+// already succeeded, and failing the whole send here would falsely mark a
+// delivered action as escalated. A status-read failure or a vanished pane
+// stops the loop (fail safe).
+func (c *CLI) retrySubmitEnter(ctx context.Context, paneID, preStatus string) {
+	delay := c.retryBaseDelay
+	if delay <= 0 {
+		delay = submitRetryBaseDelay
+	}
+	for attempt := 0; attempt < submitRetryMax; attempt++ {
+		if err := sleepCtx(ctx, delay); err != nil {
+			return
+		}
+		st, ok := c.probeAgentStatus(ctx, paneID)
+		if !ok || st != preStatus {
+			return
+		}
+		// Some approval modals park at idle/done (Claude's remote-env
+		// picker, Codex's Plan approval), so the status gate alone cannot
+		// prove the pane is safe: a stray Enter into such a modal commits
+		// its highlighted option. Re-check the visible pane before every
+		// press and stop the moment a standing form appears.
+		if c.paneShowsStandingForm(ctx, paneID) {
+			return
+		}
+		if _, err := c.run(ctx, "pane", "send-keys", paneID, "enter"); err != nil {
+			slog.Warn("submit-retry enter failed", "pane", paneID, "error", err)
+			return
+		}
+		delay *= 2
+	}
+}
+
+// probeAgentStatus returns the pane's current agent status via `agent list`
+// under statusProbeTimeout; ok=false when the list fails or the pane is
+// absent.
+func (c *CLI) probeAgentStatus(ctx context.Context, paneID string) (string, bool) {
+	ctx, cancel := context.WithTimeout(ctx, statusProbeTimeout)
+	defer cancel()
+	agents, err := c.ListAgents(ctx)
+	if err != nil {
+		return "", false
+	}
+	for _, a := range agents {
+		if a.PaneID == paneID {
+			return a.Status, true
+		}
+	}
+	return "", false
+}
+
+// paneShowsStandingForm reports whether the visible pane renders a structural
+// approval form that a bare Enter could commit. An unreadable pane counts as
+// a form (fail safe: skip the retry rather than press blind). Only the
+// end-anchored structural detectors are used — a generic numbered-list match
+// would false-positive on ordinary agent output in scrollback.
+func (c *CLI) paneShowsStandingForm(ctx context.Context, paneID string) bool {
+	ctx, cancel := context.WithTimeout(ctx, statusProbeTimeout)
+	defer cancel()
+	content, err := c.ReadPaneVisible(ctx, paneID, 60)
+	if err != nil {
+		return true
+	}
+	if _, ok := domain.ClaudeRemoteEnvForm(content); ok {
+		return true
+	}
+	if domain.CodexPlanApprovalForm(content) {
+		return true
+	}
+	if _, ok := domain.MultiTabForm(content); ok {
+		return true
+	}
+	return false
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-timer.C:
+		return nil
 	}
-	_, err := c.run(ctx, "pane", "send-keys", paneID, "enter")
-	return err
 }
 
 // SendKey presses a single key in the pane (`pane send-keys`) without

--- a/internal/herdr/cli.go
+++ b/internal/herdr/cli.go
@@ -10,9 +10,11 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/logging"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
 )
 
@@ -22,6 +24,7 @@ var (
 	_ ports.KeystrokeSender         = (*CLI)(nil)
 	_ ports.KeystrokeSequenceSender = (*CLI)(nil)
 	_ ports.AgentAwareSender        = (*CLI)(nil)
+	_ ports.SubmitRetryWaiter       = (*CLI)(nil)
 )
 
 const (
@@ -45,6 +48,13 @@ type CLI struct {
 	Timeout time.Duration
 	// retryBaseDelay overrides submitRetryBaseDelay in tests (0 = default).
 	retryBaseDelay time.Duration
+
+	// Submit-retry workers run detached from the send call (the daemon's
+	// monitor loop must never absorb their backoff sleeps); a newer send to
+	// the same pane supersedes the previous worker.
+	retryMu      sync.Mutex
+	retryCancels map[string]context.CancelFunc
+	retryWG      sync.WaitGroup
 }
 
 // NewCLI resolves the herdr binary from HERDR_BIN_PATH (falling back to
@@ -128,9 +138,46 @@ func (c *CLI) send(ctx context.Context, paneID, input string, b sendBehavior) er
 		}
 	}
 	if retry {
-		c.retrySubmitEnter(ctx, paneID, preStatus)
+		c.spawnSubmitRetry(ctx, paneID, preStatus)
 	}
 	return nil
+}
+
+// spawnSubmitRetry runs the retry loop in its own guarded goroutine so the
+// caller — notably the daemon's monitor select loop — never absorbs the
+// backoff sleeps and probe subprocess calls (same no-stall pattern as the
+// daemon's post-action unblock self-check). The worker inherits the caller's
+// ctx, so daemon shutdown cancels it; a newer send to the same pane cancels
+// the previous worker to keep at most one Enter-presser per pane. One-shot
+// processes drain workers via WaitSubmitRetries before exiting.
+func (c *CLI) spawnSubmitRetry(ctx context.Context, paneID, preStatus string) {
+	rctx, cancel := context.WithCancel(ctx)
+	c.retryMu.Lock()
+	if c.retryCancels == nil {
+		c.retryCancels = make(map[string]context.CancelFunc)
+	}
+	if prev, ok := c.retryCancels[paneID]; ok {
+		prev()
+	}
+	c.retryCancels[paneID] = cancel
+	c.retryMu.Unlock()
+	c.retryWG.Add(1)
+	go func() {
+		defer c.retryWG.Done()
+		defer cancel()
+		_ = logging.Guard("submit-retry", func() error {
+			c.retrySubmitEnter(rctx, paneID, preStatus)
+			return nil
+		})
+	}()
+}
+
+// WaitSubmitRetries blocks until every in-flight submit-retry worker has
+// finished (ports.SubmitRetryWaiter). One-shot commands call it before the
+// process exits so pending retries are not silently lost; long-lived callers
+// (the daemon, the TUI while running) never need to.
+func (c *CLI) WaitSubmitRetries() {
+	c.retryWG.Wait()
 }
 
 // retrySubmitEnter is the best-effort submit self-heal: while the agent's

--- a/internal/herdr/herdr_test.go
+++ b/internal/herdr/herdr_test.go
@@ -325,9 +325,31 @@ func TestSendKeysUsesOneHerdrInvocation(t *testing.T) {
 	}
 }
 
+// agentListJSON renders the herdr `agent list` envelope with one agent row.
+func agentListJSON(agentType, status, paneID string) string {
+	return fmt.Sprintf(`{"id":"cli:agent:list","result":{"agents":[`+
+		`{"agent":%q,"agent_status":%q,"pane_id":%q,"workspace_id":"w1"}],"type":"agent_list"}}`,
+		agentType, status, paneID)
+}
+
+func countCalls(calls []string, call string) int {
+	n := 0
+	for _, c := range calls {
+		if c == call {
+			n++
+		}
+	}
+	return n
+}
+
 func TestSendToCodexSubmitsAgainAfterDelay(t *testing.T) {
 	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
 	if err != nil {
+		t.Fatal(err)
+	}
+	// A blocked agent (menu answer) is retry-ineligible: codex must still get
+	// exactly its one guaranteed second Enter.
+	if err := fake.SetAgentList(agentListJSON("codex", "blocked", "w1:p1")); err != nil {
 		t.Fatal(err)
 	}
 	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second}
@@ -340,6 +362,7 @@ func TestSendToCodexSubmitsAgainAfterDelay(t *testing.T) {
 	}
 	calls := fake.Calls()
 	want := []string{
+		"agent list",
 		"agent send w1:p1 run the tests",
 		"pane send-keys w1:p1 enter",
 		"pane send-keys w1:p1 enter",
@@ -349,9 +372,14 @@ func TestSendToCodexSubmitsAgainAfterDelay(t *testing.T) {
 	}
 }
 
-func TestSendToNonCodexDoesNotSubmitAgain(t *testing.T) {
+func TestSendToBlockedClaudeDoesNotSubmitAgain(t *testing.T) {
 	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
 	if err != nil {
+		t.Fatal(err)
+	}
+	// Blocked = a standing menu; stray retry Enters could commit a default
+	// option, so the send must press Enter exactly once.
+	if err := fake.SetAgentList(agentListJSON("claude", "blocked", "w1:p1")); err != nil {
 		t.Fatal(err)
 	}
 	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second}
@@ -359,9 +387,227 @@ func TestSendToNonCodexDoesNotSubmitAgain(t *testing.T) {
 		t.Fatal(err)
 	}
 	calls := fake.Calls()
+	want := []string{
+		"agent list",
+		"agent send w1:p1 run the tests",
+		"pane send-keys w1:p1 enter",
+	}
+	if fmt.Sprint(calls) != fmt.Sprint(want) {
+		t.Errorf("blocked claude send calls = %v, want %v", calls, want)
+	}
+}
+
+func TestSendToUnknownAgentTypeSkipsSubmitHardening(t *testing.T) {
+	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second}
+	if err := cli.SendToAgent(context.Background(), "w1:p1", "gemini", "run the tests"); err != nil {
+		t.Fatal(err)
+	}
+	calls := fake.Calls()
 	if len(calls) != 2 || calls[0] != "agent send w1:p1 run the tests" ||
 		calls[1] != "pane send-keys w1:p1 enter" {
-		t.Errorf("non-codex send should press Enter once, got %v", calls)
+		t.Errorf("unknown-type send should press Enter once with no status check, got %v", calls)
+	}
+}
+
+func TestSendToClaudeRetriesUntilStatusChanges(t *testing.T) {
+	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fake.SetAgentListSequence(
+		agentListJSON("claude", "idle", "w1:p1"),    // snapshot
+		agentListJSON("claude", "idle", "w1:p1"),    // poll 1: unchanged → retry Enter
+		agentListJSON("claude", "working", "w1:p1"), // poll 2: changed → stop
+	); err != nil {
+		t.Fatal(err)
+	}
+	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second, retryBaseDelay: 5 * time.Millisecond}
+	if err := cli.SendToAgent(context.Background(), "w1:p1", "claude", "run the tests"); err != nil {
+		t.Fatal(err)
+	}
+	calls := fake.Calls()
+	if got := countCalls(calls, "pane send-keys w1:p1 enter"); got != 2 {
+		t.Errorf("want initial Enter + exactly one retry Enter, got %d in %v", got, calls)
+	}
+	if got := countCalls(calls, "agent list"); got != 3 {
+		t.Errorf("want snapshot + two polls, got %d agent list calls in %v", got, calls)
+	}
+}
+
+func TestSendToClaudeStopsAfterMaxRetries(t *testing.T) {
+	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fake.SetAgentList(agentListJSON("claude", "idle", "w1:p1")); err != nil {
+		t.Fatal(err)
+	}
+	base := 20 * time.Millisecond
+	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second, retryBaseDelay: base}
+	start := time.Now()
+	if err := cli.SendToAgent(context.Background(), "w1:p1", "claude", "run the tests"); err != nil {
+		t.Fatal(err)
+	}
+	// Exponential schedule: base + 2base + 4base + 8base.
+	if wantMin := 15 * base; time.Since(start) < wantMin {
+		t.Errorf("retries finished too early: elapsed %v, want at least %v", time.Since(start), wantMin)
+	}
+	calls := fake.Calls()
+	if got := countCalls(calls, "pane send-keys w1:p1 enter"); got != 1+submitRetryMax {
+		t.Errorf("want initial Enter + %d retries, got %d in %v", submitRetryMax, got, calls)
+	}
+	if got := countCalls(calls, "agent list"); got != 1+submitRetryMax {
+		t.Errorf("want snapshot + %d polls, got %d agent list calls in %v", submitRetryMax, got, calls)
+	}
+}
+
+func TestSendToIdleCodexRetriesAfterGuaranteedEnter(t *testing.T) {
+	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fake.SetAgentListSequence(
+		agentListJSON("codex", "idle", "w1:p1"),    // snapshot
+		agentListJSON("codex", "working", "w1:p1"), // poll 1: changed → stop
+	); err != nil {
+		t.Fatal(err)
+	}
+	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second, retryBaseDelay: 5 * time.Millisecond}
+	if err := cli.SendToAgent(context.Background(), "w1:p1", "codex", "run the tests"); err != nil {
+		t.Fatal(err)
+	}
+	calls := fake.Calls()
+	if got := countCalls(calls, "pane send-keys w1:p1 enter"); got != 2 {
+		t.Errorf("want initial + guaranteed Enter only, got %d in %v", got, calls)
+	}
+	if got := countCalls(calls, "agent list"); got != 2 {
+		t.Errorf("want snapshot + one poll, got %d agent list calls in %v", got, calls)
+	}
+}
+
+func TestSendSnapshotFailureDisablesRetries(t *testing.T) {
+	for _, tc := range []struct {
+		agentType  string
+		wantEnters int
+	}{
+		{"claude", 1},
+		{"codex", 2}, // the guaranteed second Enter never depends on status
+	} {
+		t.Run(tc.agentType, func(t *testing.T) {
+			fake, err := fakeherdr.NewFakeCLI(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			// No agent list configured: the snapshot fails, so no retries.
+			cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second, retryBaseDelay: 5 * time.Millisecond}
+			if err := cli.SendToAgent(context.Background(), "w1:p1", tc.agentType, "run the tests"); err != nil {
+				t.Fatal(err)
+			}
+			calls := fake.Calls()
+			if got := countCalls(calls, "pane send-keys w1:p1 enter"); got != tc.wantEnters {
+				t.Errorf("want %d Enters, got %d in %v", tc.wantEnters, got, calls)
+			}
+			if got := countCalls(calls, "agent list"); got != 1 {
+				t.Errorf("want only the snapshot attempt, got %d agent list calls in %v", got, calls)
+			}
+		})
+	}
+}
+
+func TestSendRetryStopsOnListFailureMidLoop(t *testing.T) {
+	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fake.SetAgentListSequence(
+		agentListJSON("claude", "idle", "w1:p1"), // snapshot
+		"not-json",                               // poll 1: unreadable → stop
+	); err != nil {
+		t.Fatal(err)
+	}
+	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second, retryBaseDelay: 5 * time.Millisecond}
+	if err := cli.SendToAgent(context.Background(), "w1:p1", "claude", "run the tests"); err != nil {
+		t.Fatal(err)
+	}
+	if got := countCalls(fake.Calls(), "pane send-keys w1:p1 enter"); got != 1 {
+		t.Errorf("mid-loop list failure must stop retries, got %d Enters in %v", got, fake.Calls())
+	}
+}
+
+func TestSendRetryStopsWhenPaneVanishes(t *testing.T) {
+	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fake.SetAgentListSequence(
+		agentListJSON("claude", "idle", "w1:p1"), // snapshot
+		agentListJSON("claude", "idle", "w1:p9"), // poll 1: pane gone → stop
+	); err != nil {
+		t.Fatal(err)
+	}
+	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second, retryBaseDelay: 5 * time.Millisecond}
+	if err := cli.SendToAgent(context.Background(), "w1:p1", "claude", "run the tests"); err != nil {
+		t.Fatal(err)
+	}
+	if got := countCalls(fake.Calls(), "pane send-keys w1:p1 enter"); got != 1 {
+		t.Errorf("vanished pane must stop retries, got %d Enters in %v", got, fake.Calls())
+	}
+}
+
+func TestSendRetryStopsWhenStandingFormAppears(t *testing.T) {
+	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Claude's remote-env picker parks at IDLE, so the status gate alone
+	// cannot exclude it: the pre-press pane re-check must refuse the Enter
+	// (a stray Enter would commit the highlighted environment).
+	if err := fake.SetAgentList(agentListJSON("claude", "idle", "w1:p1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := fake.SetPaneContent("Select remote environment\n" +
+		"❯ 1. Default (env-default) ✔\n" +
+		"  2. Ubuntu 22 (env-ubuntu)\n" +
+		"Enter to select · Esc to cancel"); err != nil {
+		t.Fatal(err)
+	}
+	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second, retryBaseDelay: 5 * time.Millisecond}
+	if err := cli.SendToAgent(context.Background(), "w1:p1", "claude", "run the tests"); err != nil {
+		t.Fatal(err)
+	}
+	if got := countCalls(fake.Calls(), "pane send-keys w1:p1 enter"); got != 1 {
+		t.Errorf("standing form must stop retry Enters, got %d in %v", got, fake.Calls())
+	}
+}
+
+func TestSendRetryStopsOnContextCancel(t *testing.T) {
+	fake, err := fakeherdr.NewFakeCLI(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fake.SetAgentList(agentListJSON("claude", "idle", "w1:p1")); err != nil {
+		t.Fatal(err)
+	}
+	// The ctx budget must comfortably cover the three subprocess spawns
+	// before the retry sleep (snapshot, agent send, send-keys) so only the
+	// 30s retry wait can hit the deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second, retryBaseDelay: 30 * time.Second}
+	start := time.Now()
+	// The loop swallows the ctx error: the primary delivery already landed.
+	if err := cli.SendToAgent(ctx, "w1:p1", "claude", "run the tests"); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(start); elapsed >= 10*time.Second {
+		t.Errorf("cancelled retry wait should return promptly, took %v", elapsed)
+	}
+	if got := countCalls(fake.Calls(), "pane send-keys w1:p1 enter"); got != 1 {
+		t.Errorf("cancelled ctx must stop retries, got %d Enters in %v", got, fake.Calls())
 	}
 }
 

--- a/internal/herdr/herdr_test.go
+++ b/internal/herdr/herdr_test.go
@@ -429,6 +429,7 @@ func TestSendToClaudeRetriesUntilStatusChanges(t *testing.T) {
 	if err := cli.SendToAgent(context.Background(), "w1:p1", "claude", "run the tests"); err != nil {
 		t.Fatal(err)
 	}
+	cli.WaitSubmitRetries()
 	calls := fake.Calls()
 	if got := countCalls(calls, "pane send-keys w1:p1 enter"); got != 2 {
 		t.Errorf("want initial Enter + exactly one retry Enter, got %d in %v", got, calls)
@@ -452,6 +453,7 @@ func TestSendToClaudeStopsAfterMaxRetries(t *testing.T) {
 	if err := cli.SendToAgent(context.Background(), "w1:p1", "claude", "run the tests"); err != nil {
 		t.Fatal(err)
 	}
+	cli.WaitSubmitRetries()
 	// Exponential schedule: base + 2base + 4base + 8base.
 	if wantMin := 15 * base; time.Since(start) < wantMin {
 		t.Errorf("retries finished too early: elapsed %v, want at least %v", time.Since(start), wantMin)
@@ -480,6 +482,7 @@ func TestSendToIdleCodexRetriesAfterGuaranteedEnter(t *testing.T) {
 	if err := cli.SendToAgent(context.Background(), "w1:p1", "codex", "run the tests"); err != nil {
 		t.Fatal(err)
 	}
+	cli.WaitSubmitRetries()
 	calls := fake.Calls()
 	if got := countCalls(calls, "pane send-keys w1:p1 enter"); got != 2 {
 		t.Errorf("want initial + guaranteed Enter only, got %d in %v", got, calls)
@@ -507,6 +510,7 @@ func TestSendSnapshotFailureDisablesRetries(t *testing.T) {
 			if err := cli.SendToAgent(context.Background(), "w1:p1", tc.agentType, "run the tests"); err != nil {
 				t.Fatal(err)
 			}
+			cli.WaitSubmitRetries()
 			calls := fake.Calls()
 			if got := countCalls(calls, "pane send-keys w1:p1 enter"); got != tc.wantEnters {
 				t.Errorf("want %d Enters, got %d in %v", tc.wantEnters, got, calls)
@@ -533,6 +537,7 @@ func TestSendRetryStopsOnListFailureMidLoop(t *testing.T) {
 	if err := cli.SendToAgent(context.Background(), "w1:p1", "claude", "run the tests"); err != nil {
 		t.Fatal(err)
 	}
+	cli.WaitSubmitRetries()
 	if got := countCalls(fake.Calls(), "pane send-keys w1:p1 enter"); got != 1 {
 		t.Errorf("mid-loop list failure must stop retries, got %d Enters in %v", got, fake.Calls())
 	}
@@ -553,6 +558,7 @@ func TestSendRetryStopsWhenPaneVanishes(t *testing.T) {
 	if err := cli.SendToAgent(context.Background(), "w1:p1", "claude", "run the tests"); err != nil {
 		t.Fatal(err)
 	}
+	cli.WaitSubmitRetries()
 	if got := countCalls(fake.Calls(), "pane send-keys w1:p1 enter"); got != 1 {
 		t.Errorf("vanished pane must stop retries, got %d Enters in %v", got, fake.Calls())
 	}
@@ -579,6 +585,7 @@ func TestSendRetryStopsWhenStandingFormAppears(t *testing.T) {
 	if err := cli.SendToAgent(context.Background(), "w1:p1", "claude", "run the tests"); err != nil {
 		t.Fatal(err)
 	}
+	cli.WaitSubmitRetries()
 	if got := countCalls(fake.Calls(), "pane send-keys w1:p1 enter"); got != 1 {
 		t.Errorf("standing form must stop retry Enters, got %d in %v", got, fake.Calls())
 	}
@@ -592,17 +599,17 @@ func TestSendRetryStopsOnContextCancel(t *testing.T) {
 	if err := fake.SetAgentList(agentListJSON("claude", "idle", "w1:p1")); err != nil {
 		t.Fatal(err)
 	}
-	// The ctx budget must comfortably cover the three subprocess spawns
-	// before the retry sleep (snapshot, agent send, send-keys) so only the
-	// 30s retry wait can hit the deadline.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cli := &CLI{BinPath: fake.BinPath, Timeout: 5 * time.Second, retryBaseDelay: 30 * time.Second}
-	start := time.Now()
-	// The loop swallows the ctx error: the primary delivery already landed.
+	// The worker swallows the ctx error: the primary delivery already landed.
 	if err := cli.SendToAgent(ctx, "w1:p1", "claude", "run the tests"); err != nil {
 		t.Fatal(err)
 	}
+	// Cancelling the caller's ctx must interrupt the worker's 30s retry wait.
+	cancel()
+	start := time.Now()
+	cli.WaitSubmitRetries()
 	if elapsed := time.Since(start); elapsed >= 10*time.Second {
 		t.Errorf("cancelled retry wait should return promptly, took %v", elapsed)
 	}

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -28,6 +28,15 @@ type AgentAwareSender interface {
 	SendToAgent(ctx context.Context, paneID, agentType, input string) error
 }
 
+// SubmitRetryWaiter is implemented by adapters whose SendToAgent spawns
+// asynchronous submit-retry workers (extra Enters pressed while an idle
+// agent's status has not moved). One-shot processes type-assert and wait
+// before exiting so in-flight retries are not silently lost; long-lived
+// callers never need to.
+type SubmitRetryWaiter interface {
+	WaitSubmitRetries()
+}
+
 // SendToAgent delivers input through the agent-aware capability when the
 // adapter provides it, otherwise it falls back to the base HerdrPort contract.
 func SendToAgent(ctx context.Context, h HerdrPort, paneID, agentType, input string) error {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -240,6 +241,11 @@ type ruleItem struct {
 type Model struct {
 	app *frontend.App
 	ctx context.Context
+	// inflight counts mutation Cmds handed to bubbletea, which does NOT wait
+	// for them on quit; Run drains it so a send confirmed just before 'q'
+	// still completes (and spawns its submit retries) before the process
+	// exits. Pointer: Model is copied by value on every update.
+	inflight *sync.WaitGroup
 
 	tab     tab
 	data    refreshMsg
@@ -523,7 +529,7 @@ func (m Model) visibleSignatures() []frontend.SignatureRow {
 
 // New creates the TUI model.
 func New(ctx context.Context, app *frontend.App) Model {
-	return Model{app: app, ctx: ctx}
+	return Model{app: app, ctx: ctx, inflight: &sync.WaitGroup{}}
 }
 
 // Init starts the refresh loop.
@@ -1217,10 +1223,19 @@ func (m *Model) beginAction() {
 	m.clampListViewport()
 }
 
-// do runs a mutation and reports its outcome.
+// do runs a mutation and reports its outcome. The inflight Add happens here,
+// on the update loop — before Program.Run can return — so Run's drain never
+// races the counter from zero (bubbletea always launches a returned Cmd, so
+// the paired Done is guaranteed).
 func (m Model) do(okMsg string, fn func(context.Context) error) tea.Cmd {
-	ctx := m.ctx
+	ctx, wg := m.ctx, m.inflight
+	if wg != nil {
+		wg.Add(1)
+	}
 	return func() tea.Msg {
+		if wg != nil {
+			defer wg.Done()
+		}
 		if err := fn(ctx); err != nil {
 			return actionResultMsg{err: err}
 		}
@@ -3919,5 +3934,15 @@ func Run(ctx context.Context, app *frontend.App) error {
 	m.bellOut = os.Stdout
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	_, err := p.Run()
+	// bubbletea does not wait for in-flight Cmd goroutines on quit; drain
+	// them (bounded, in case a Cmd was somehow never launched) so a send
+	// confirmed right before quitting still lands and registers its submit
+	// retries before main's exit drain runs.
+	done := make(chan struct{})
+	go func() { m.inflight.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+	}
 	return err
 }


### PR DESCRIPTION
## Summary

A prompt's trailing Enter sometimes fails to submit, leaving the agent idle with the text composed. Previously only codex got a hardcoded second Enter after 300ms.

- `SendToAgent` now snapshots the agent's status (via `agent list`) before sending; for **claude and codex**, while the status has not moved off its pre-send value it presses Enter again with **exponential backoff** (300 → 600 → 1200 → 2400ms, 4 retries max), stopping as soon as the status changes.
- Codex keeps its unconditional 300ms second Enter exactly as before (it applies to blocked/menu sends too).
- **Safety gates**: the retry loop only arms when the pre-send status is cleanly idle/done (never for blocked menus or working agents), and before every retry press it re-reads the visible pane and refuses if a standing approval form is rendered (Claude remote-env picker, Codex plan approval, multi-tab AskUserQuestion forms — these park at *idle*, so the status gate alone can't exclude them, and a stray Enter would commit the highlighted option).
- Fail safe: retry-loop errors never propagate (the primary delivery already succeeded); every status/pane probe is bounded to 2s so a wedged herdr can't stall the daemon loop for the full CLI timeout.
- Test infra: `fakeherdr.SetAgentListSequence` serves changing `agent list` responses across calls.

## Testing

- Full unit suite green: `go test -tags "vectors cpu" ./... -count=1` (all 25 packages).
- New table/scenario tests: retry-until-status-change, max-retry exponential schedule, codex guaranteed-Enter compatibility (idle + blocked), snapshot-failure fallback, mid-loop list failure, vanished pane, standing remote-env form, ctx cancellation.
- Integration suite against a real herdr: 5 pass, 3 expected skips (`go test -tags integration ./test/integration/ -v`), including `TestRealConfirmDeliversRemoteEnvSelection`.
- `gofmt`, `go vet`, `golangci-lint` clean.

https://claude.ai/code/session_01FKbYWbyEGhsT8iGnbyBJgr