### PR TITLE
#1 fix: dedup re-fired escalations across recap chrome and head-shifted windows

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -770,10 +770,15 @@ func (d *Daemon) hasOpenEscalation(ctx context.Context, agentID string) bool {
 // volatile chrome (a spinner tick, an elapsed/countdown counter) had moved on.
 //
 // The key is agent + agent type + the NORMALIZED pane content
-// (domain.NormalizeForDedup elides that chrome). The agent status is
-// deliberately excluded — it is the field that legitimately CHANGES between the
-// duplicates — and so are trigger() (which embeds it) and situation_type (which
-// the classifier DERIVES from it). See domain.DuplicatesPendingEscalation.
+// (domain.NormalizeForDedup elides that chrome, and deletes Claude's ※-led
+// recap/tip blocks, which appear on their own on a settled screen). The agent
+// status is deliberately excluded — it is the field that legitimately CHANGES
+// between the duplicates — and so are trigger() (which embeds it) and
+// situation_type (which the classifier DERIVES from it). A capture whose
+// tail-anchored window merely shifted (an appearing note block pushed old
+// text off the head) is also recognized, via a suffix compare gated on both
+// captures filling at least half of snapshotMaxRunes. See
+// domain.DuplicatesPendingEscalation.
 //
 // It runs only where escalations are raised (escalate() and the
 // pane-read-failure path), NOT before the decision core: the rate guard, retry
@@ -798,7 +803,7 @@ func (d *Daemon) duplicatePendingEscalation(ctx context.Context, s domain.Situat
 		return false
 	}
 	return domain.DuplicatesPendingEscalation(s.Type,
-		truncateTailRunes(s.Content, snapshotMaxRunes), pending)
+		truncateTailRunes(s.Content, snapshotMaxRunes), snapshotMaxRunes, pending)
 }
 
 // ignoreDuplicate audits a no-op for an event whose situation already has a

--- a/internal/domain/dedup.go
+++ b/internal/domain/dedup.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 // Herdr re-delivers an attention event for the same agent after a delay: the
@@ -47,8 +48,55 @@ var (
 // recognizably different.
 const dedupChromePlaceholder = "<chrome>"
 
+// Claude-injected note lines — the "※ recap: …" session summary (terminated by
+// its "(disable recaps in /config)" line) and the rotating "※ Tip: …" hints.
+// Unlike spinner lines, these APPEAR on their own on an otherwise motionless
+// screen (the recap renders after the agent settles — verified live
+// 2026-07-17, escalations #816/#817), so they are DELETED rather than replaced
+// with dedupChromePlaceholder: a placeholder would keep "screen without recap"
+// and "same screen with recap" unequal, which is the exact duplicate this
+// elision exists to absorb.
+//
+// The trigger is anchored to the two observed note shapes, NOT the bare ※
+// glyph: pasted or quoted content can begin with ※ (it is a common note marker
+// in Japanese text), and deleting an unrecognized ※ line could collapse two
+// genuinely different screens — a silent drop of a real question. An
+// unrecognized ※ line is kept, so it fails safe (the captures compare unequal
+// and the event escalates, exactly as before this elision existed).
+const (
+	dedupNoteGlyph       = "※"
+	dedupRecapTerminator = "(disable recaps in /config)"
+	// dedupRecapMaxLines bounds the terminator look-ahead: a real recap wraps
+	// onto at most a handful of physical lines before its terminator.
+	dedupRecapMaxLines = 8
+)
+
+// dedupNoteLine classifies a trimmed line as a note marker: 0 = not a note,
+// 1 = a single-line note ("※ Tip: …"), 2 = a recap marker ("※ recap: …",
+// whose wrapped continuation lines may be deleted through the terminator).
+func dedupNoteLine(trimmed string) int {
+	rest, ok := strings.CutPrefix(trimmed, dedupNoteGlyph)
+	if !ok {
+		return 0
+	}
+	rest = strings.ToLower(strings.TrimSpace(rest))
+	switch {
+	case strings.HasPrefix(rest, "recap:"):
+		return 2
+	case strings.HasPrefix(rest, "tip:"):
+		return 1
+	}
+	return 0
+}
+
 // NormalizeForDedup canonicalizes captured pane content for the duplicate
-// check: elide volatile agent-TUI chrome lines, then collapse whitespace runs.
+// check: delete Claude's ※-led recap/tip note lines (they appear on their own
+// on a settled screen — see dedupNoteLine), elide volatile agent-TUI chrome
+// lines, then collapse whitespace runs. A recap's wrapped continuation lines
+// are deleted only when its "(disable recaps in /config)" terminator is found
+// within the same non-blank run — without the terminator only the marker line
+// is deleted, so plain text adjacent to a recap marker can never be mistaken
+// for its continuation.
 //
 // It deliberately does NOT use MaskVolatile, and that is the whole design.
 // MaskVolatile is the LEARNING primitive: it replaces <path>/<num>/<hash> so
@@ -67,12 +115,45 @@ const dedupChromePlaceholder = "<chrome>"
 // processed, exactly as it is today.
 func NormalizeForDedup(s string) string {
 	lines := strings.Split(s, "\n")
-	for i, ln := range lines {
-		if isDedupChromeLine(strings.TrimSpace(ln)) {
-			lines[i] = dedupChromePlaceholder
+	kept := make([]string, 0, len(lines))
+	for i := 0; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		switch dedupNoteLine(trimmed) {
+		case 1: // single-line note: delete just this line
+			continue
+		case 2: // recap: delete through the terminator if it is in reach
+			if end, ok := recapBlockEnd(lines, i); ok {
+				i = end
+			}
+			continue
+		}
+		if isDedupChromeLine(trimmed) {
+			kept = append(kept, dedupChromePlaceholder)
+			continue
+		}
+		kept = append(kept, lines[i])
+	}
+	return strings.TrimSpace(dedupWhitespaceRE.ReplaceAllString(strings.Join(kept, "\n"), " "))
+}
+
+// recapBlockEnd looks ahead from a recap marker line for the recap's
+// terminator within the same non-blank run (a wrapped recap is consecutive
+// non-blank lines; Claude separates blocks with blank lines), bounded by
+// dedupRecapMaxLines. It returns the terminator's index when found. When the
+// terminator is out of reach — cut off by the truncation window, or the ※ line
+// was not really a recap — it reports false and the caller deletes only the
+// marker line, so real content adjacent to the marker is never swallowed.
+func recapBlockEnd(lines []string, start int) (int, bool) {
+	for j := start + 1; j < len(lines) && j <= start+dedupRecapMaxLines; j++ {
+		trimmed := strings.TrimSpace(lines[j])
+		if trimmed == "" {
+			return 0, false
+		}
+		if strings.Contains(trimmed, dedupRecapTerminator) {
+			return j, true
 		}
 	}
-	return strings.TrimSpace(dedupWhitespaceRE.ReplaceAllString(strings.Join(lines, "\n"), " "))
+	return 0, false
 }
 
 // isDedupChromeLine reports whether a trimmed line is volatile agent chrome.
@@ -121,17 +202,95 @@ type PendingEscalation struct {
 // type. This keeps the herdr-unreachable path (which has no pane to read, and
 // legitimately keys on "") from matching an empty-excerpt escalation of a
 // different kind.
-func DuplicatesPendingEscalation(sitType SituationType, excerpt string, pending []PendingEscalation) bool {
+//
+// Beyond the exact compare, a tail-window-shift tolerant compare absorbs the
+// second way one standing screen re-captures differently: excerpts are the
+// TRAILING snapshotCap runes of the pane, so anything the agent TUI appends
+// drags older text off the window's head. The tail match then succeeds when
+// the appended material is itself deleted by normalization (the ※ note
+// blocks) — the two captures differ only in how much scrollback the head
+// retains, and, first line dropped (it may be cut mid-line by the
+// truncation), one normalized capture is the exact tail of the other: the
+// same screen with less head context. Appended material that SURVIVES
+// normalization keeps the tails unequal and the event escalates — the safe
+// direction. A genuinely NEW
+// question can never satisfy this: terminal content only appends at the
+// bottom, so new output lands between the old content and the prompt and
+// breaks the tail match.
+//
+// snapshotCap is the tail-truncation cap (in runes) the CALLER applied to both
+// the fresh excerpt and the stored pending excerpts. The suffix compare only
+// runs when both captures fill at least HALF of it. A capture that large is a
+// tail window of a longer transcript — herdr's pane read is itself a
+// tail-anchored window, so a capture can be head-shifted, its first line cut
+// mid-line, WITHOUT hitting the daemon's rune cap (verified: the #816/#817
+// excerpts measured 3930/3901 runes against the 4000 cap). A small capture,
+// by contrast, is a complete pane whose first line is real, possibly the only
+// discriminating content: two approvals for different commands share every
+// menu line below the first — dropping it would collapse them, a silent drop
+// of a real question. A cap of 0 or less disables the suffix compare
+// entirely. See suffixDuplicate for the degenerate-length guard.
+func DuplicatesPendingEscalation(sitType SituationType, excerpt string, snapshotCap int, pending []PendingEscalation) bool {
 	key := NormalizeForDedup(excerpt)
+	freshWindowed := snapshotCap > 0 && utf8.RuneCountInString(excerpt)*2 >= snapshotCap
+	suffixKey := NormalizeForDedup(dropFirstLine(excerpt))
 	for _, p := range pending {
-		if NormalizeForDedup(p.PaneExcerpt) != key {
-			continue
+		if NormalizeForDedup(p.PaneExcerpt) == key {
+			// No content to discriminate on: fall back to the situation type.
+			if key == "" && p.SituationType != sitType {
+				continue
+			}
+			return true
 		}
-		// No content to discriminate on: fall back to the situation type.
-		if key == "" && p.SituationType != sitType {
-			continue
+		if freshWindowed && utf8.RuneCountInString(p.PaneExcerpt)*2 >= snapshotCap &&
+			suffixDuplicate(suffixKey, NormalizeForDedup(dropFirstLine(p.PaneExcerpt))) {
+			return true
 		}
-		return true
 	}
 	return false
+}
+
+// dropFirstLine removes the first line of a tail-windowed capture: both the
+// daemon's rune truncation and herdr's own pane read cut at the tail, so the
+// window's first line is often a partial line (or a chrome line whose leading
+// glyph was cut off, which would then normalize differently in the two
+// captures). Callers only use this on captures large enough to be tail
+// windows — a small capture's first line is real content. A capture with no
+// newline is entirely that unreliable first line, so it yields "" —
+// single-line excerpts are served by the exact compare alone.
+func dropFirstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[i+1:]
+	}
+	return ""
+}
+
+// suffixDuplicate reports whether one normalized, first-line-dropped capture
+// is the exact tail of the other — the same screen with a head-shifted
+// truncation window.
+//
+// The length ratio guards the degenerate match: the last few hundred
+// normalized runes of any capture of one pane are near-constant chrome
+// (separator rules, the prompt box, the status bar), so a very short capture —
+// a cleared pane, a just-started agent — would tail-match ANY later screen of
+// that pane and silently drop a real question. Requiring the shorter capture
+// to hold at least two thirds of the longer's content means a match must agree
+// on the question region too, not just the trailing chrome. Two thirds leaves
+// room for what legitimately shrinks a re-capture of a full window: the
+// deleted note block plus head-line jitter is hundreds of runes against the
+// 4000-rune snapshot cap. The ratio is measured in runes, matching the unit
+// the snapshot cap and this reasoning are stated in (TUI glyphs are 3 bytes
+// each, so byte lengths would over-weight glyph-dense regions).
+func suffixDuplicate(a, b string) bool {
+	shorter, longer := a, b
+	// Byte len is fine for ORDERING (a suffix is never byte-longer than its
+	// container); only the ratio below needs runes.
+	if len(shorter) > len(longer) {
+		shorter, longer = longer, shorter
+	}
+	if shorter == "" ||
+		utf8.RuneCountInString(shorter)*3 < utf8.RuneCountInString(longer)*2 {
+		return false
+	}
+	return strings.HasSuffix(longer, shorter)
 }

--- a/internal/domain/dedup.go
+++ b/internal/domain/dedup.go
@@ -224,12 +224,20 @@ type PendingEscalation struct {
 // tail window of a longer transcript — herdr's pane read is itself a
 // tail-anchored window, so a capture can be head-shifted, its first line cut
 // mid-line, WITHOUT hitting the daemon's rune cap (verified: the #816/#817
-// excerpts measured 3930/3901 runes against the 4000 cap). A small capture,
-// by contrast, is a complete pane whose first line is real, possibly the only
-// discriminating content: two approvals for different commands share every
-// menu line below the first — dropping it would collapse them, a silent drop
-// of a real question. A cap of 0 or less disables the suffix compare
-// entirely. See suffixDuplicate for the degenerate-length guard.
+// excerpts measured 3930/3901 runes against the 4000 cap; NO observable
+// provenance says whether a capture's head was cut, so size is the available
+// proxy). A small capture, by contrast, is a complete pane whose first line
+// is real, possibly the only discriminating content: two approvals for
+// different commands share every menu line below the first — dropping it
+// would collapse them, a silent drop of a real question. A cap of 0 or less
+// disables the suffix compare entirely.
+//
+// Because a complete pane can also exceed half the cap, size alone is not
+// trusted with the first line: firstLineExplained additionally requires the
+// dropped line to be a cut fragment of content the OTHER capture retains,
+// which is what a genuinely head-shifted window looks like and what two
+// first-line-discriminated questions never do. See suffixDuplicate for the
+// degenerate-length guard.
 func DuplicatesPendingEscalation(sitType SituationType, excerpt string, snapshotCap int, pending []PendingEscalation) bool {
 	key := NormalizeForDedup(excerpt)
 	freshWindowed := snapshotCap > 0 && utf8.RuneCountInString(excerpt)*2 >= snapshotCap
@@ -243,11 +251,36 @@ func DuplicatesPendingEscalation(sitType SituationType, excerpt string, snapshot
 			return true
 		}
 		if freshWindowed && utf8.RuneCountInString(p.PaneExcerpt)*2 >= snapshotCap &&
+			firstLineExplained(excerpt, p.PaneExcerpt) &&
 			suffixDuplicate(suffixKey, NormalizeForDedup(dropFirstLine(p.PaneExcerpt))) {
 			return true
 		}
 	}
 	return false
+}
+
+// firstLineExplained reports whether either capture's first line — the line
+// dropFirstLine discards before the suffix compare — is explainable as a cut
+// fragment of content the OTHER capture retains. Two tail windows onto one
+// screen always satisfy this: the more-shifted window's first line is a
+// fragment of a line the less-shifted window still holds (even two different
+// mid-line cuts of the same line satisfy it, the shorter fragment being a
+// substring of the longer). Two different questions whose only difference IS
+// their first line — a complete pane's command line above an identical menu —
+// satisfy neither direction, so the suffix compare never sees them. A
+// mutated-in-place first line (a chrome counter that ticked at the window
+// head) fails both directions and escalates: fail open, exactly the pre-fix
+// behavior.
+func firstLineExplained(a, b string) bool {
+	return firstLineIn(a, b) || firstLineIn(b, a)
+}
+
+// firstLineIn reports whether src's trimmed first line appears in other. A
+// blank first line is trivially explained — dropping it discards nothing.
+func firstLineIn(src, other string) bool {
+	first, _, _ := strings.Cut(src, "\n")
+	first = strings.TrimSpace(first)
+	return first == "" || strings.Contains(other, first)
 }
 
 // dropFirstLine removes the first line of a tail-windowed capture: both the

--- a/internal/domain/dedup_test.go
+++ b/internal/domain/dedup_test.go
@@ -1,6 +1,9 @@
 package domain
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestNormalizeForDedup(t *testing.T) {
 	tests := []struct {
@@ -31,6 +34,64 @@ func TestNormalizeForDedup(t *testing.T) {
 			"Bash(rm -rf /tmp/foo)?",
 			"Bash(rm -rf /tmp/foo)?",
 		},
+		{
+			// Deleted, not <chrome>-replaced: the recap APPEARS between two
+			// captures of one settled screen, so a placeholder would keep the
+			// pair unequal (regression: escalations #816/#817, 2026-07-17).
+			"claude recap block is deleted",
+			"● Done — PR open.\n\n※ recap: I did the thing.\n  (disable recaps in /config)\n\n❯",
+			"● Done — PR open. ❯",
+		},
+		{
+			"wrapped recap continuation lines are deleted with it",
+			"● Done.\n\n※ recap: a long summary that the pane\nwrapped onto a second line.\n  (disable recaps in /config)\n\n❯",
+			"● Done. ❯",
+		},
+		{
+			"claude tip line is deleted",
+			"※ Tip: use /memory to edit memory\n\nAllow bash?",
+			"Allow bash?",
+		},
+		{
+			// Without the terminator in reach the ※ line was either cut by the
+			// truncation window or is not really a recap — only the marker
+			// line is deleted, so adjacent real content is never swallowed.
+			"recap marker without terminator deletes only itself",
+			"※ recap: stuff\nquestion A\n\n❯",
+			"question A ❯",
+		},
+		{
+			"recap marker as last line is deleted",
+			"Allow bash?\n※ recap: cut off by the window",
+			"Allow bash?",
+		},
+		{
+			"tip as last line is deleted",
+			"Allow bash?\n※ Tip: use /memory",
+			"Allow bash?",
+		},
+		{
+			// Only the two observed note shapes trigger deletion — a bare ※
+			// (a common note marker in pasted text) is real content.
+			"unrecognized ※ line is kept",
+			"※ important: see the manual\nAllow bash?",
+			"※ important: see the manual Allow bash?",
+		},
+		{
+			// A blank line ends the look-ahead even when a terminator exists
+			// further down: the content past the blank belongs to another
+			// block and must survive.
+			"recap terminator past a blank line does not extend the block",
+			"※ recap: x\n\nreal question\n(disable recaps in /config)\n❯",
+			"real question (disable recaps in /config) ❯",
+		},
+		{
+			// The look-ahead is bounded: a terminator more than
+			// dedupRecapMaxLines away never extends the deletion.
+			"recap terminator beyond the look-ahead bound is not reached",
+			"※ recap: long\nl1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\n(disable recaps in /config)\n\nAllow?",
+			"l1 l2 l3 l4 l5 l6 l7 l8 l9 (disable recaps in /config) Allow?",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -53,6 +114,18 @@ func TestNormalizeForDedupKeepsDistinctContentDistinct(t *testing.T) {
 		// stay distinct (regression: the glyph was once wrongly elided).
 		{"● I'll delete the staging bucket.\nProceed?", "● I'll delete the prod bucket.\nProceed?"},
 		{"* run tests\nProceed?", "* run lint\nProceed?"},
+		// A bare ※ line is NOT a recognized note shape — deleting it (and
+		// worse, a consume-until-blank of what follows) would collapse these.
+		{"※foo\nquestion A", "※foo\nquestion B"},
+		// A recap marker with no terminator in reach must not swallow the
+		// adjacent real content that distinguishes these.
+		{"※ recap: x\nquestion A\n\n❯", "※ recap: x\nquestion B\n\n❯"},
+		// ...and a terminator past a blank line must not pull the question
+		// between them into the deleted block.
+		{
+			"※ recap: x\n\nquestion A\n(disable recaps in /config)",
+			"※ recap: x\n\nquestion B\n(disable recaps in /config)",
+		},
 	}
 	for _, p := range pairs {
 		if NormalizeForDedup(p[0]) == NormalizeForDedup(p[1]) {
@@ -87,53 +160,151 @@ func pend(sit SituationType, excerpt string) PendingEscalation {
 
 func TestDuplicatesPendingEscalation(t *testing.T) {
 	const x = "Allow bash(ls)?"
+	// realCap mirrors the daemon's snapshotMaxRunes: fixtures below are far
+	// shorter, so with this cap the suffix compare stays disabled and a case
+	// exercises the exact compare alone.
+	const realCap = 4000
+	// Multi-line screens for the suffix-compare cases. Both fill more than
+	// half of smallCap runes, so passing smallCap marks them as tail windows.
+	const (
+		pendingScreen = "● Build, vet, and\nlint are clean.\n\n● Tests pass.\n\n● Done — PR open.\n\n❯ \nstatus bar"
+		freshRecap    = "lint are clean.\n\n● Tests pass.\n\n● Done — PR open.\n\n※ recap: I did the thing, tests pass, PR open.\n  (disable recaps in /config)\n\n❯ \nstatus bar"
+		freshAppended = "lint are clean.\n\n● Tests pass.\n\n● Done — PR open.\n\n● Actually one test is flaky, investigating.\n\n❯ \nstatus bar"
+		smallCap      = 75
+	)
 	tests := []struct {
 		name    string
 		sit     SituationType
 		excerpt string
+		cap     int
 		pending []PendingEscalation
 		want    bool
 	}{
-		{"no pending escalations", SituationApproval, x, nil, false},
-		{"exact repeat of a pending escalation", SituationApproval, x,
+		{"no pending escalations", SituationApproval, x, realCap, nil, false},
+		{"exact repeat of a pending escalation", SituationApproval, x, realCap,
 			[]PendingEscalation{pend(SituationApproval, x)}, true},
 		{
 			// The headline case: herdr re-fires with a flipped status, so the
 			// re-classified situation_type differs — must still dedup.
 			"same content, different situation_type still duplicates",
-			SituationIdle, x,
+			SituationIdle, x, realCap,
 			[]PendingEscalation{pend(SituationApproval, x)}, true,
 		},
-		{"whitespace/repaint jitter", SituationApproval, "a  b\nc",
+		{"whitespace/repaint jitter", SituationApproval, "a  b\nc", realCap,
 			[]PendingEscalation{pend(SituationApproval, "a b c")}, true},
 		{
 			"different question same shape is NOT a duplicate",
-			SituationApproval, "Edit /a/b.go?",
+			SituationApproval, "Edit /a/b.go?", realCap,
 			[]PendingEscalation{pend(SituationApproval, "Edit /a/c.go?")}, false,
 		},
-		{"first match among several wins", SituationApproval, x,
+		{"first match among several wins", SituationApproval, x, realCap,
 			[]PendingEscalation{pend(SituationApproval, "something else"), pend(SituationApproval, x)}, true},
 		{
 			// Empty content: the read-failure path keys on "" and must match an
 			// empty-excerpt pending escalation of the same type.
 			"empty excerpt matches on situation type",
-			SituationUnclassifiable, "",
+			SituationUnclassifiable, "", realCap,
 			[]PendingEscalation{pend(SituationUnclassifiable, "")}, true,
 		},
 		{
 			// ...but not an empty-excerpt escalation of a DIFFERENT type.
 			"empty excerpt does not match a different empty type",
-			SituationUnclassifiable, "",
+			SituationUnclassifiable, "", realCap,
 			[]PendingEscalation{pend(SituationApproval, "")}, false,
 		},
-		{"empty candidate vs real content", SituationApproval, x,
+		{"empty candidate vs real content", SituationApproval, x, realCap,
 			[]PendingEscalation{pend(SituationApproval, "")}, false},
+		{
+			// A settled screen re-captured after the recap rendered: the recap
+			// is elided and the head-shifted window is absorbed by the suffix
+			// compare (regression: escalations #816/#817, 2026-07-17).
+			"recap arrival plus head-shifted window still duplicates",
+			SituationIdle, freshRecap, smallCap,
+			[]PendingEscalation{pend(SituationIdle, pendingScreen)}, true,
+		},
+		{
+			// New output between the old content and the prompt is a NEW
+			// situation: terminal content appends at the bottom, so it breaks
+			// the tail match by construction.
+			"appended real output is NOT a duplicate",
+			SituationIdle, freshAppended, smallCap,
+			[]PendingEscalation{pend(SituationIdle, pendingScreen)}, false,
+		},
+		{
+			// Small complete-pane captures (under half the cap) never enter
+			// the suffix compare: their first line is real content, and here
+			// it is the ONLY discriminating content (regression:
+			// TestPipelineIgnoresDuplicateEvent — two approvals for different
+			// commands share every menu line).
+			"different first-line command on small panes is NOT a duplicate",
+			SituationApproval,
+			"Bash(npm install)\n\nDo you want to proceed?\n❯ 1. Yes\n  2. No, and tell the agent what to do differently\n",
+			realCap,
+			[]PendingEscalation{pend(SituationApproval,
+				"Bash(go test ./...)\n\nDo you want to proceed?\n❯ 1. Yes\n  2. No, and tell the agent what to do differently\n")},
+			false,
+		},
+		{
+			// ...but on tail-windowed captures the first line is a cut
+			// fragment of scrollback, not content: two windows identical
+			// below it are the same standing screen.
+			"tail windows differing only in the cut first line duplicate",
+			SituationIdle,
+			"ted mid-line by truncation\n\n● Tests pass.\n\n● Done — PR open.\n\n❯ \nstatus bar",
+			70,
+			[]PendingEscalation{pend(SituationIdle,
+				"cut differently, same tail\n\n● Tests pass.\n\n● Done — PR open.\n\n❯ \nstatus bar")},
+			true,
+		},
+		{
+			// The trailing few hundred runes of any capture of one pane are
+			// near-constant chrome (prompt box, status bar), so a much shorter
+			// capture must not tail-match a long one: the length-ratio guard
+			// refuses before the question region is even compared.
+			"short chrome-tail capture does not match a long screen",
+			SituationIdle, "first line cut\n❯ \nstatus bar", 25,
+			[]PendingEscalation{pend(SituationIdle,
+				"● A long transcript.\n\n● With a real question buried in it — proceed?\n\n● More content to make it long.\n\n❯ \nstatus bar")},
+			false,
+		},
+		{
+			// A single-line excerpt has no reliable content once its (possibly
+			// truncation-cut) first line is dropped, so the suffix compare
+			// never fires — exact compare only.
+			"single-line excerpts are exact-match only",
+			SituationApproval, "proceed with the deploy?", 10,
+			[]PendingEscalation{pend(SituationApproval, "y/n: proceed with the deploy?")}, false,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := DuplicatesPendingEscalation(tc.sit, tc.excerpt, tc.pending); got != tc.want {
+			if got := DuplicatesPendingEscalation(tc.sit, tc.excerpt, tc.cap, tc.pending); got != tc.want {
 				t.Errorf("DuplicatesPendingEscalation = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// suffixDuplicate's length-ratio guard, pinned at its exact boundary so a
+// future "tweak the constant" change trips a test instead of silently widening
+// the match. The ratio is measured in runes.
+func TestSuffixDuplicateRatioBoundary(t *testing.T) {
+	// longer: 30 runes; at ratio 2/3 the shorter needs >= 20 runes.
+	longer := "aaaaaaaaaa" + "bbbbbbbbbb" + "cccccccccc"
+	atBoundary := longer[10:]    // 20 runes, exact tail
+	belowBoundary := longer[11:] // 19 runes, exact tail
+	if !suffixDuplicate(atBoundary, longer) {
+		t.Errorf("a 2/3-length exact tail must match")
+	}
+	if suffixDuplicate(belowBoundary, longer) {
+		t.Errorf("a below-2/3-length tail must be refused")
+	}
+	// Rune counting, not bytes: 3-byte glyphs must not skew the ratio.
+	glyphLonger := strings.Repeat("●", 30)
+	if !suffixDuplicate(strings.Repeat("●", 20), glyphLonger) {
+		t.Errorf("a 2/3-rune-length glyph tail must match")
+	}
+	if suffixDuplicate(strings.Repeat("●", 19), glyphLonger) {
+		t.Errorf("a below-2/3-rune-length glyph tail must be refused")
 	}
 }

--- a/internal/domain/dedup_test.go
+++ b/internal/domain/dedup_test.go
@@ -247,22 +247,40 @@ func TestDuplicatesPendingEscalation(t *testing.T) {
 		{
 			// ...but on tail-windowed captures the first line is a cut
 			// fragment of scrollback, not content: two windows identical
-			// below it are the same standing screen.
+			// below it are the same standing screen. The fresh window is
+			// shifted further, so its first line is a fragment of the
+			// pending capture's first line (firstLineExplained holds).
 			"tail windows differing only in the cut first line duplicate",
 			SituationIdle,
-			"ted mid-line by truncation\n\n● Tests pass.\n\n● Done — PR open.\n\n❯ \nstatus bar",
+			"mid-line by truncation\n\n● Tests pass.\n\n● Done — PR open.\n\n❯ \nstatus bar",
 			70,
 			[]PendingEscalation{pend(SituationIdle,
-				"cut differently, same tail\n\n● Tests pass.\n\n● Done — PR open.\n\n❯ \nstatus bar")},
+				"some content cut mid-line by truncation\n\n● Tests pass.\n\n● Done — PR open.\n\n❯ \nstatus bar")},
 			true,
+		},
+		{
+			// PR #153 review (charliecreates): a COMPLETE pane can also
+			// exceed half the cap, so size alone must not admit two
+			// questions whose only difference is their first command line —
+			// neither first line appears in the other capture, so
+			// firstLineExplained refuses before any suffix is compared.
+			"complete pane above half-cap with discriminating first line is NOT a duplicate",
+			SituationApproval,
+			"Bash(npm install)\n\nlots of identical build output here\n\nDo you want to proceed?\n❯ 1. Yes\n  2. No\n",
+			100,
+			[]PendingEscalation{pend(SituationApproval,
+				"Bash(go test ./...)\n\nlots of identical build output here\n\nDo you want to proceed?\n❯ 1. Yes\n  2. No\n")},
+			false,
 		},
 		{
 			// The trailing few hundred runes of any capture of one pane are
 			// near-constant chrome (prompt box, status bar), so a much shorter
 			// capture must not tail-match a long one: the length-ratio guard
-			// refuses before the question region is even compared.
+			// refuses before the question region is even compared. The first
+			// line is a fragment of the pending capture (firstLineExplained
+			// holds), so the ratio guard is what refuses here.
 			"short chrome-tail capture does not match a long screen",
-			SituationIdle, "first line cut\n❯ \nstatus bar", 25,
+			SituationIdle, "buried in it — proceed?\n❯ \nstatus bar", 25,
 			[]PendingEscalation{pend(SituationIdle,
 				"● A long transcript.\n\n● With a real question buried in it — proceed?\n\n● More content to make it long.\n\n❯ \nstatus bar")},
 			false,


### PR DESCRIPTION
## Problem

Escalations #816 and #817 — one settled Claude screen, re-fired by herdr's done→idle flip — both landed in the pending queue. The duplicate-ask check compared them unequal for two reasons:

1. Claude rendered its `※ recap: …` summary block between the two captures, and the normalizer treated it as real content.
2. Pane captures are tail-anchored windows (both herdr's pane read and the daemon's 4000-rune snapshot cap), so the recap's arrival shifted older text off the head of the second capture — an exact-equality compare then misses even after chrome elision.

## Fix

**Recap/tip elision** (`NormalizeForDedup`): Claude's note lines are now deleted — not `<chrome>`-placeholdered, since the block *appears* between captures. The trigger is anchored to the two observed shapes (`※ recap:` / `※ Tip:`), never the bare `※` glyph; a recap's wrapped continuation lines are deleted only when the `(disable recaps in /config)` terminator is found within an 8-line non-blank look-ahead. Anything unrecognized is kept, failing toward escalation.

**Guarded suffix compare** (`DuplicatesPendingEscalation`, new `snapshotCap` parameter): with each capture's possibly-cut first line dropped, one normalized capture being the exact tail of the other is the same screen with less head context. Gates, each verified by a dedicated test:

- engages only when **both** raw excerpts fill ≥ half the snapshot cap (a small complete pane's first line is real, possibly the only discriminating content — two approvals differing only in the command line must never collapse; caught live by `TestPipelineIgnoresDuplicateEvent`);
- a 2/3 rune-length ratio refuses degenerate matches on the near-constant trailing chrome (prompt box/status bar);
- appended real output lands between old content and the prompt, breaking the tail match by construction — false positives fail toward escalating, per the "never a silent drop" rule.

## Verification

- Replayed the real #816/#817 stored excerpts through the new code: now duplicates; unrelated content and the small-pane different-command case still escalate.
- Full unit suite green (all packages), including the two prior failure modes as regression tests.
- Integration suite against real herdr: 5 pass, 3 expected skips.
- gofmt / vet / golangci-lint clean; two subagent code-review rounds applied (note-shape anchoring, half-cap gate, rune-ratio, boundary tests).

https://claude.ai/code/session_0162qGzBfdPGLgrbUfV8osks