### PR TITLE
#155 fix: fold normalized option set into approval signatures

### DIFF
--- a/docs/specs/herd-auto-prompter/requirements.md
+++ b/docs/specs/herd-auto-prompter/requirements.md
@@ -44,7 +44,7 @@ The plugin SHALL classify each attention-requiring transition into exactly one o
 **FR-003 — Situation signature generation.**
 For each classified situation, the plugin SHALL derive a stable situation signature usable for matching against historical decisions.
 The signature SHALL:
-- Retain the **situation type**, the **agent type**, and the **salient decision content** — the normalized option set (for multiple-choice) or the permission verb/action (for approval/permission).
+- Retain the **situation type**, the **agent type**, and the **salient decision content** — the normalized option set (for multiple-choice) or the permission verb/action **plus** the normalized option set (for approval/permission; the remote-environment picker is exempt from option folding — its environment labels are the learned action, not the key). Folding options into approvals keeps very different screens that share a verb (a plan approval and a command approval both phrased "…to proceed?") from colliding into one learned rule.
 - **Mask volatile tokens** before hashing — absolute paths, hashes, line numbers, timestamps, UUIDs, and similar variable spans are replaced with typed placeholders so equivalent prompts collapse to one signature.
 - Be **scoped per agent type**, so one agent type's learned habits do not leak into another's signatures.
 *Acceptance:* Two prompts differing only in volatile tokens (paths, hashes, timestamps) produce the same signature; prompts differing in situation type, option set, permission verb, or agent type produce different signatures.

--- a/docs/specs/herd-auto-prompter/solution.md
+++ b/docs/specs/herd-auto-prompter/solution.md
@@ -162,7 +162,7 @@ sequenceDiagram
 ### Signature Normalizer (pure domain)
 
 **Responsibilities.** Produce a stable signature (FR-003) and apply guards (FR-003a).
-**Key Components.** Volatile-token masker (paths, hashes, line numbers, timestamps, UUIDs → typed placeholders), salient-content extractor (option set / permission verb), per-agent-type scoping, hasher; variance guard and over-masking floor.
+**Key Components.** Volatile-token masker (paths, hashes, line numbers, timestamps, UUIDs → typed placeholders), salient-content extractor (option set / permission verb + option set for approvals, remote-env picker exempt), per-agent-type scoping, hasher; variance guard and over-masking floor.
 **Key Interfaces.** `Signature(situation) -> (sig, guardVerdict)`.
 **Data Models.** Consumes classified situation; produces signature string.
 **Dependencies.** None external (pure).

--- a/internal/classify/classify.go
+++ b/internal/classify/classify.go
@@ -263,7 +263,7 @@ func enrich(s *domain.Situation) {
 				// pickers share one signature; the env labels are the learned
 				// ACTION, not the key. Delivery re-maps the learned label onto
 				// the live option set and fails closed when it is absent.
-				s.PermissionVerb = "select remote environment"
+				s.PermissionVerb = domain.PermissionVerbSelectRemoteEnv
 				s.Options = append(s.Options, form.OptionLabels()...)
 				return
 			}

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -82,6 +82,36 @@ func TestGoldenTranscripts(t *testing.T) {
 	}
 }
 
+// TestApprovalSignaturesDoNotCollideAcrossScreens is the end-to-end
+// regression for issue #155: a Claude plan-approval screen and a Bash command
+// approval both extract verb "proceed", but their option sets differ, so
+// their signatures must differ — a "Yes" rule learned on one must never
+// auto-fire on the other.
+func TestApprovalSignaturesDoNotCollideAcrossScreens(t *testing.T) {
+	c := New(nil)
+	sigFor := func(name string) domain.SignatureResult {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join("testdata", "transcripts", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := c.Classify("claude", "blocked", string(data))
+		if s.Type != domain.SituationApproval {
+			t.Fatalf("%s classified %v, want approval", name, s.Type)
+		}
+		sig := domain.ComputeSignature(s)
+		if sig.Verdict != domain.GuardOK {
+			t.Fatalf("%s verdict = %v, want ok (salient %q)", name, sig.Verdict, sig.Salient)
+		}
+		return sig
+	}
+	plan := sigFor("approval_claude_plan.txt")
+	perm := sigFor("approval_permission.txt")
+	if plan.Signature == perm.Signature {
+		t.Errorf("plan approval and permission approval share a signature (salient %q)", plan.Salient)
+	}
+}
+
 func TestUnclassifiableFailsSafe(t *testing.T) {
 	c := New(nil)
 	s := c.Classify("claude", "blocked", "completely novel pane content with no known shape")

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1267,8 +1267,10 @@ func TestPipelineShadowModeEscalatesWithSuggestion(t *testing.T) {
 	}
 }
 
-// otherApprovalPane is a distinct approval (different command → different
-// classified content/signature) used to prove content-level dedup.
+// otherApprovalPane is a distinct approval used to prove content-level dedup.
+// Its verb and option labels match approvalPane's, so the two share a
+// SIGNATURE (issue #155 folds options, not the command line, into approval
+// salients) — dedup must distinguish them by pane content, not signature.
 const otherApprovalPane = "Bash(npm install)\n\nDo you want to proceed?\n❯ 1. Yes\n  2. No, and tell the agent what to do differently\n"
 
 // chromedApproval renders the approval with a leading spinner/status line that

--- a/internal/daemon/semantic.go
+++ b/internal/daemon/semantic.go
@@ -113,7 +113,8 @@ func (d *Daemon) resolveSignature(ctx context.Context, cfg config.Config,
 			slog.Warn("embed failed; trying text match", "error", err)
 		default:
 			vec = v
-			hit, ok, err := d.matcher.MatchVector(ctx, vec, scope)
+			accept := func(h match.Hit) bool { return remapAllowed(s, sig, h) }
+			hit, ok, err := d.matcher.MatchVector(ctx, vec, scope, accept)
 			if err != nil {
 				slog.Warn("vector match failed; trying text match", "error", err)
 			} else if ok && hit.Score >= cfg.Embedding.SimilarityThreshold {
@@ -128,7 +129,8 @@ func (d *Daemon) resolveSignature(ctx context.Context, cfg config.Config,
 	}
 
 	if vec == nil { // no embedding this round: BM25 text fallback
-		hit, ok, err := d.matcher.MatchText(ctx, sig.Salient, scope)
+		accept := func(h match.Hit) bool { return remapAllowed(s, sig, h) }
+		hit, ok, err := d.matcher.MatchText(ctx, sig.Salient, scope, accept)
 		if err != nil {
 			slog.Warn("text match failed; using hash key", "error", err)
 			return sig
@@ -164,6 +166,27 @@ func (d *Daemon) resolveSignature(ctx context.Context, cfg config.Config,
 		slog.Warn("indexing signature embedding failed", "signature", sig.Raw, "error", err)
 	}
 	return sig
+}
+
+// remapAllowed is resolveSignature's accept filter for match candidates.
+// Approvals require compatible option sets between the fresh salient and the
+// candidate's stored salient (domain.ApprovalRemapCompatible) — issue #155:
+// similarity score alone can bridge two very different approval screens that
+// share a verb, e.g. a plan approval and a Bash approval both phrased "…to
+// proceed?". The matcher skips vetoed candidates (up to its top-K) and, when
+// none is acceptable, resolveSignature mints a fresh key and persists the
+// new identity, so the situation escalates rather than inheriting another
+// screen's learned rule. Other situation types pass.
+func remapAllowed(s domain.Situation, sig domain.SignatureResult, hit match.Hit) bool {
+	if s.Type != domain.SituationApproval {
+		return true
+	}
+	if !domain.ApprovalRemapCompatible(sig.Salient, hit.Salient) {
+		slog.Info("approval remap vetoed: option sets incompatible",
+			"candidate", hit.Signature, "raw", sig.Raw)
+		return false
+	}
+	return true
 }
 
 // embedderPort returns the current embedder (rebuilt on reload when the

--- a/internal/daemon/semantic_test.go
+++ b/internal/daemon/semantic_test.go
@@ -119,10 +119,12 @@ func approvalSituation(verb string) domain.Situation {
 }
 
 func TestResolveSignatureMintsThenRemapsSemantically(t *testing.T) {
+	// Keys are the exact salient texts the new-format approvals produce
+	// (options-less approvals still carry the "| options:" segment).
 	emb := &fakeEmbedder{vectors: map[string][]float32{
-		"permission:edit the config file":   {1, 0, 0, 0},
-		"permission:modify the config file": {0.99, 0.14, 0, 0}, // cos ≈ 0.99
-		"permission:delete the database":    {0, 1, 0, 0},
+		"permission:edit the config file | options:":   {1, 0, 0, 0},
+		"permission:modify the config file | options:": {0.99, 0.14, 0, 0}, // cos ≈ 0.99
+		"permission:delete the database | options:":    {0, 1, 0, 0},
 	}}
 	d := semanticHarness(t, emb, "")
 	ctx := context.Background()
@@ -212,7 +214,7 @@ func TestResolveSignatureExactHitSkipsEmbedding(t *testing.T) {
 
 func TestResolveSignatureBM25FallbackOnEmbedFailure(t *testing.T) {
 	emb := &fakeEmbedder{vectors: map[string][]float32{
-		"permission:write the deployment manifest file": {1, 0, 0, 0},
+		"permission:write the deployment manifest file | options:": {1, 0, 0, 0},
 	}}
 	d := semanticHarness(t, emb, "")
 	ctx := context.Background()
@@ -305,7 +307,7 @@ func TestResolveSignatureDisabledPassesThrough(t *testing.T) {
 func TestInitSemanticRebuildsFromStoreAndReembedsForeignModels(t *testing.T) {
 	ctx := context.Background()
 	emb := &fakeEmbedder{vectors: map[string][]float32{
-		"permission:push to remote": {0, 1, 0, 0},
+		"permission:push to remote | options:": {0, 1, 0, 0},
 	}}
 	dir := t.TempDir()
 	raw, err := store.Open(filepath.Join(dir, "test.db"))
@@ -315,10 +317,12 @@ func TestInitSemanticRebuildsFromStoreAndReembedsForeignModels(t *testing.T) {
 	t.Cleanup(func() { raw.Close() })
 
 	// A row persisted by an older/different model: wrong dims, other model id.
+	// (Current salient format — model drift, not the pre-#155 verb-only
+	// format, which migrate() would prune.)
 	if err := raw.UpsertSignatureEmbedding(ctx, domain.SignatureEmbedding{
 		Signature: "approval:legacy", SituationType: domain.SituationApproval,
 		AgentType: "claude", Model: "old-model", Dims: 2, Vector: []float32{1, 0},
-		Salient: "permission:push to remote", CreatedAt: time.Now(),
+		Salient: "permission:push to remote | options:", CreatedAt: time.Now(),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -356,6 +360,79 @@ func TestInitSemanticRebuildsFromStoreAndReembedsForeignModels(t *testing.T) {
 	}
 }
 
+// TestResolveSignatureApprovalRemapVetoedAcrossScreens pins the issue #155
+// residual: similarity score alone (cosine here) can bridge two DIFFERENT
+// approval screens that share a verb — a plan approval and a Bash command
+// approval both phrased "…to proceed?". The remap gate requires option-set
+// overlap, so even a perfect score must not merge them, while a paraphrase
+// of the same screen (same options, different verb wording) still remaps.
+func TestResolveSignatureApprovalRemapVetoedAcrossScreens(t *testing.T) {
+	planOpts := []string{"Yes, and use auto mode", "Yes, manually approve edits", "No, refine the plan"}
+	mkSit := func(verb string, opts []string) domain.Situation {
+		return domain.Situation{
+			Type: domain.SituationApproval, AgentType: "claude",
+			AgentID: "w1:p1", PaneID: "p1", PermissionVerb: verb, Options: opts,
+		}
+	}
+	planSit := mkSit("proceed", planOpts)
+	bashSit := mkSit("proceed", []string{
+		"Yes", "Yes, and don't ask again for go test commands",
+		"No, and tell Claude what to do differently"})
+	paraSit := mkSit("continue with this plan", planOpts)
+
+	// Vector geometry: bash and the paraphrase are both ≥ the 0.90 default
+	// similarity threshold vs plan, so only the option gate separates them.
+	emb := &fakeEmbedder{vectors: map[string][]float32{
+		domain.ComputeSignature(planSit).Salient: {1, 0, 0, 0},
+		domain.ComputeSignature(bashSit).Salient: {0.97, 0.2425, 0, 0},   // cos ≈ 0.97 vs plan
+		domain.ComputeSignature(paraSit).Salient: {0.9995, 0.0314, 0, 0}, // cos ≈ 0.9995 vs plan
+	}}
+	d := semanticHarness(t, emb, "")
+	ctx := context.Background()
+	cfg, _, _ := d.snapshot()
+
+	sigPlan := d.resolveSignature(ctx, cfg, domain.ComputeSignature(planSit), planSit)
+	if sigPlan.Signature != sigPlan.Raw {
+		t.Fatalf("first sight should mint its raw key, got %s", sigPlan.Signature)
+	}
+
+	// Different screen, same verb, cosine above threshold: gate must veto.
+	rawBash := domain.ComputeSignature(bashSit)
+	sigBash := d.resolveSignature(ctx, cfg, rawBash, bashSit)
+	if sigBash.Signature == sigPlan.Signature {
+		t.Fatal("bash approval merged with plan approval despite disjoint option sets")
+	}
+	if sigBash.Signature != rawBash.Raw || sigBash.Match.Method != domain.MatchNone {
+		t.Errorf("vetoed remap must mint a fresh key with no match method, got %s / %q",
+			sigBash.Signature, sigBash.Match.Method)
+	}
+	// The vetoed situation still persists its own identity for future events.
+	if n, _ := d.opt.Store.CountSignatureEmbeddings(ctx); n != 2 {
+		t.Errorf("embedding rows = %d, want 2 (plan + vetoed bash)", n)
+	}
+
+	// Same screen paraphrased (identical options): remap stays allowed.
+	sigPara := d.resolveSignature(ctx, cfg, domain.ComputeSignature(paraSit), paraSit)
+	if sigPara.Signature != sigPlan.Signature {
+		t.Errorf("paraphrase with identical options resolved to %s, want remap onto %s",
+			sigPara.Signature, sigPlan.Signature)
+	}
+
+	// BM25 fallback (embedder failing) must obey the same gate: a fresh
+	// bash-approval variant may text-match the learned plan salient, but must
+	// never resolve onto it.
+	emb.mu.Lock()
+	emb.fail = true
+	emb.mu.Unlock()
+	bash2 := mkSit("proceed", []string{
+		"Yes", "Yes, and don't ask again for npm install commands",
+		"No, and tell Claude what to do differently"})
+	sigBash2 := d.resolveSignature(ctx, cfg, domain.ComputeSignature(bash2), bash2)
+	if sigBash2.Signature == sigPlan.Signature {
+		t.Error("BM25 fallback merged a bash approval onto the plan approval")
+	}
+}
+
 // TestReembedNudgeSwapsEmbedderAndRetriesDegraded covers the KindReembed
 // path (reloadWith(true)): a failed re-embed pass — the shape a degraded
 // embedder latch leaves behind — is retried with a FRESH embedder even
@@ -373,7 +450,7 @@ func TestReembedNudgeSwapsEmbedderAndRetriesDegraded(t *testing.T) {
 	if err := raw.UpsertSignatureEmbedding(ctx, domain.SignatureEmbedding{
 		Signature: "approval:legacy", SituationType: domain.SituationApproval,
 		AgentType: "claude", Model: "old-model", Dims: 2, Vector: []float32{1, 0},
-		Salient: "permission:push to remote", CreatedAt: time.Now(),
+		Salient: "permission:push to remote | options:", CreatedAt: time.Now(),
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/domain/clauderemoteenv.go
+++ b/internal/domain/clauderemoteenv.go
@@ -27,6 +27,14 @@ var (
 	remoteEnvCheckSuffixRE = regexp.MustCompile(`\s*✔\s*$`)
 )
 
+// PermissionVerbSelectRemoteEnv is the fixed permission verb assigned to the
+// remote-environment picker. Its environment labels vary per launch and are
+// the learned ACTION, not the key, so signature generation keeps this
+// approval's salient verb-only (no option folding): equivalent pickers share
+// one signature and delivery re-maps the learned label onto the live option
+// set, failing closed when it is absent.
+const PermissionVerbSelectRemoteEnv = "select remote environment"
+
 // RemoteEnvForm is the parsed live state of Claude Code's "Select remote
 // environment" picker.
 type RemoteEnvForm struct {

--- a/internal/domain/clauderemoteenv_test.go
+++ b/internal/domain/clauderemoteenv_test.go
@@ -116,16 +116,24 @@ func TestClaudeRemoteEnvApprovalSignaturePassesOverMaskGuard(t *testing.T) {
 	// so the decision core never dismisses the picker as over_masked (the
 	// original failure: classified idle, raw trailing-window salient tripped
 	// the guard).
+	form, ok := ClaudeRemoteEnvForm(remoteEnvPicker)
+	if !ok {
+		t.Fatal("fixture no longer parses as a remote-env picker")
+	}
 	s := Situation{
 		AgentType:      "claude",
 		Type:           SituationApproval,
 		Content:        remoteEnvPicker,
-		PermissionVerb: "select remote environment",
+		PermissionVerb: PermissionVerbSelectRemoteEnv,
+		Options:        form.OptionLabels(),
 	}
 	sig := ComputeSignature(s)
 	if sig.Verdict != GuardOK {
 		t.Fatalf("verdict = %v, want %v (salient %q)", sig.Verdict, GuardOK, sig.Salient)
 	}
+	// The env labels are the learned action, not the key: even with Options
+	// populated the salient stays verb-only (the issue #155 option folding
+	// exempts this picker).
 	if sig.Salient != "permission:select remote environment" {
 		t.Errorf("salient = %q", sig.Salient)
 	}

--- a/internal/domain/signature.go
+++ b/internal/domain/signature.go
@@ -146,22 +146,104 @@ func ComputeSignatureN(s Situation, salientChars int) SignatureResult {
 	}
 }
 
+// NormalizedOptionSet folds an option-label list into an order-insensitive
+// canonical string: each label lowercased and trimmed, the set sorted and
+// joined with ";". Shared by the choice and approval salients so their
+// normalization cannot drift.
+func NormalizedOptionSet(options []string) string {
+	opts := make([]string, len(options))
+	for i, o := range options {
+		opts[i] = strings.ToLower(strings.TrimSpace(o))
+	}
+	sort.Strings(opts)
+	return strings.Join(opts, ";")
+}
+
+// approvalOptionsSegment returns the normalized option set encoded in an
+// approval salient and whether the salient carries one (pre-#155 salients
+// and the remote-env picker's are verb-only).
+func approvalOptionsSegment(salient string) (string, bool) {
+	_, opts, found := strings.Cut(salient, "| options:")
+	return strings.TrimSpace(opts), found
+}
+
+// ApprovalRemapCompatible reports whether a fresh approval salient may be
+// semantically remapped onto a stored candidate salient. Semantic matching
+// exists to bridge PARAPHRASES of one approval screen, and a paraphrase keeps
+// (nearly) the same reply options — so a remap requires both salients to
+// carry an option set and those sets to overlap by at least half (Jaccard).
+// Verb-only "permission:" salients never fuzzy-remap: equivalent ones
+// already share an exact hash. Verbless approvals (no permission verb
+// extracted) fall back to pane-tail salients with no option encoding — two
+// of those keep semantic similarity as their only comparison basis, exactly
+// as before issue #155. Fail-safe everywhere else: incompatible → the caller
+// keeps the fresh hash key, so the situation escalates instead of inheriting
+// another screen's rule (issue #155: without this, a plan approval and a
+// Bash approval sharing the verb "proceed" could still merge through the
+// cosine/BM25 fallback even though their exact hashes now differ).
+func ApprovalRemapCompatible(salient, candidate string) bool {
+	aPerm := strings.HasPrefix(salient, "permission:")
+	bPerm := strings.HasPrefix(candidate, "permission:")
+	if !aPerm && !bPerm {
+		return true // two pane-tail salients: similarity is the comparison
+	}
+	if aPerm != bPerm {
+		return false
+	}
+	a, aok := approvalOptionsSegment(salient)
+	b, bok := approvalOptionsSegment(candidate)
+	if !aok || !bok {
+		return false
+	}
+	as := splitOptionSet(a)
+	bs := splitOptionSet(b)
+	inter := 0
+	for o := range as {
+		if bs[o] {
+			inter++
+		}
+	}
+	union := len(as) + len(bs) - inter
+	// Jaccard ≥ 0.5; two empty sets (option-less approvals) are compatible.
+	return inter*2 >= union
+}
+
+// splitOptionSet splits a NormalizedOptionSet encoding back into a set,
+// dropping empty entries.
+func splitOptionSet(s string) map[string]bool {
+	out := make(map[string]bool)
+	for _, o := range strings.Split(s, ";") {
+		if o = strings.TrimSpace(o); o != "" {
+			out[o] = true
+		}
+	}
+	return out
+}
+
 // salientContent extracts the decision-relevant content per situation type:
-// the normalized option set for choices, the permission verb/action for
-// approvals, the error summary for errors, and the trailing salientChars
-// characters of the pane content otherwise.
+// the normalized option set for choices, the permission verb/action plus the
+// normalized option set for approvals (issue #155: the verb alone collapses
+// very different approval screens — a plan approval and a Bash command
+// approval both read "…to proceed?" — into one learned rule), the error
+// summary for errors, and the trailing salientChars characters of the pane
+// content otherwise.
 func salientContent(s Situation, salientChars int) string {
 	switch s.Type {
 	case SituationChoice:
-		opts := make([]string, len(s.Options))
-		for i, o := range s.Options {
-			opts[i] = strings.ToLower(strings.TrimSpace(o))
-		}
-		sort.Strings(opts)
-		return "options:" + strings.Join(opts, ";")
+		return "options:" + NormalizedOptionSet(s.Options)
 	case SituationApproval:
-		if s.PermissionVerb != "" {
+		if s.PermissionVerb == PermissionVerbSelectRemoteEnv {
+			// The picker's environment labels are the learned action, not
+			// the key (see PermissionVerbSelectRemoteEnv); folding them
+			// would fragment the signature per environment list.
 			return "permission:" + s.PermissionVerb
+		}
+		if s.PermissionVerb != "" {
+			// The "| options:" segment is always present (even when empty)
+			// so the format is self-describing: the store migration keys
+			// off it, and a new verb-only salient can never be byte-equal
+			// to a pre-#155 row.
+			return "permission:" + s.PermissionVerb + " | options:" + NormalizedOptionSet(s.Options)
 		}
 	case SituationError:
 		if s.ErrorSummary != "" {

--- a/internal/domain/signature.go
+++ b/internal/domain/signature.go
@@ -147,13 +147,20 @@ func ComputeSignatureN(s Situation, salientChars int) SignatureResult {
 }
 
 // NormalizedOptionSet folds an option-label list into an order-insensitive
-// canonical string: each label lowercased and trimmed, the set sorted and
-// joined with ";". Shared by the choice and approval salients so their
-// normalization cannot drift.
+// canonical string: each label lowercased and trimmed, delimiters escaped
+// ("\" → "\\", ";" → "\;"), the set sorted and joined with ";". The escaping
+// keeps the encoding injective — without it ["allow;once","deny"] and
+// ["allow","once;deny"] would both encode as "allow;once;deny", letting two
+// distinct screens collide into one signature. Labels without delimiters
+// (the overwhelmingly common case) encode exactly as they would unescaped.
+// Shared by the choice and approval salients so their normalization cannot
+// drift; splitOptionSet is the inverse.
 func NormalizedOptionSet(options []string) string {
 	opts := make([]string, len(options))
 	for i, o := range options {
-		opts[i] = strings.ToLower(strings.TrimSpace(o))
+		o = strings.ToLower(strings.TrimSpace(o))
+		o = strings.ReplaceAll(o, `\`, `\\`)
+		opts[i] = strings.ReplaceAll(o, ";", `\;`)
 	}
 	sort.Strings(opts)
 	return strings.Join(opts, ";")
@@ -208,15 +215,32 @@ func ApprovalRemapCompatible(salient, candidate string) bool {
 	return inter*2 >= union
 }
 
-// splitOptionSet splits a NormalizedOptionSet encoding back into a set,
-// dropping empty entries.
+// splitOptionSet is NormalizedOptionSet's inverse: it splits the encoding on
+// unescaped ";" back into a set of unescaped labels, dropping empty entries.
 func splitOptionSet(s string) map[string]bool {
 	out := make(map[string]bool)
-	for _, o := range strings.Split(s, ";") {
-		if o = strings.TrimSpace(o); o != "" {
+	var cur strings.Builder
+	flush := func() {
+		if o := strings.TrimSpace(cur.String()); o != "" {
 			out[o] = true
 		}
+		cur.Reset()
 	}
+	escaped := false
+	for _, r := range s {
+		switch {
+		case escaped:
+			cur.WriteRune(r)
+			escaped = false
+		case r == '\\':
+			escaped = true
+		case r == ';':
+			flush()
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	flush()
 	return out
 }
 

--- a/internal/domain/signature_test.go
+++ b/internal/domain/signature_test.go
@@ -132,12 +132,126 @@ func TestVarianceGuard(t *testing.T) {
 }
 
 func TestSalientContentUsesPermissionVerb(t *testing.T) {
+	opts := []string{"Yes", "No, and tell Claude what to do differently"}
 	a := ComputeSignature(Situation{Type: SituationApproval, AgentType: "claude",
-		PermissionVerb: "run shell command", Content: strings.Repeat("noise ", 100)})
+		PermissionVerb: "run shell command", Options: opts, Content: strings.Repeat("noise ", 100)})
 	b := ComputeSignature(Situation{Type: SituationApproval, AgentType: "claude",
-		PermissionVerb: "run shell command", Content: "completely different pane noise"})
+		PermissionVerb: "run shell command", Options: opts, Content: "completely different pane noise"})
 	if a.Signature != b.Signature {
-		t.Error("approval signatures should key on the permission verb, not pane noise")
+		t.Error("approval signatures should key on the permission verb and options, not pane noise")
+	}
+}
+
+func TestApprovalSalientFoldsOptions(t *testing.T) {
+	// Issue #155: the verb alone let a Claude plan-approval screen and a Bash
+	// command approval — both phrased "…to proceed?" — share one signature, so
+	// a rule learned on one auto-fired on the other. The option set is the
+	// screen's identity and must fold into the salient.
+	mk := func(verb string, opts ...string) Situation {
+		return Situation{Type: SituationApproval, AgentType: "claude",
+			PermissionVerb: verb, Options: opts,
+			Content: "Do you want to proceed with the requested action right now?"}
+	}
+	planOpts := []string{
+		"Yes, and use auto mode",
+		"Yes, manually approve edits",
+		"No, refine the plan",
+		"Tell Claude what to change",
+	}
+	bashOpts := []string{
+		"Yes",
+		"Yes, and don't ask again for: hap task commands",
+		"No, and tell Claude what to do differently",
+	}
+
+	plan := ComputeSignature(mk("proceed", planOpts...))
+	bash := ComputeSignature(mk("proceed", bashOpts...))
+	if plan.Verdict != GuardOK || bash.Verdict != GuardOK {
+		t.Fatalf("verdicts = %v / %v, want ok (salients %q / %q)",
+			plan.Verdict, bash.Verdict, plan.Salient, bash.Salient)
+	}
+	if plan.Signature == bash.Signature {
+		t.Errorf("plan approval and bash approval with the same verb must not share a signature (salient %q)", plan.Salient)
+	}
+
+	reordered := ComputeSignature(mk("proceed", "  no, refine the plan ",
+		"Tell Claude what to change", "YES, AND USE AUTO MODE", "yes, manually approve edits"))
+	if reordered.Signature != plan.Signature {
+		t.Errorf("option order/case/whitespace must not change the signature:\n%q\nvs\n%q",
+			reordered.Salient, plan.Salient)
+	}
+
+	bare := ComputeSignature(Situation{Type: SituationApproval, AgentType: "claude",
+		PermissionVerb: "proceed with the migration steps",
+		Content:        "Do you want to proceed with the migration steps?"})
+	if !strings.HasSuffix(bare.Salient, "| options:") {
+		t.Errorf("optionless approval salient must still carry the options segment, got %q", bare.Salient)
+	}
+	withOpts := ComputeSignature(Situation{Type: SituationApproval, AgentType: "claude",
+		PermissionVerb: "proceed with the migration steps", Options: []string{"Yes", "No"},
+		Content: "Do you want to proceed with the migration steps?"})
+	if bare.Signature == withOpts.Signature {
+		t.Error("empty and non-empty option sets must produce different signatures")
+	}
+
+	// The remote-env picker is exempt: its env labels are the learned action,
+	// not the key, so differing environment lists share one signature.
+	envA := ComputeSignature(Situation{Type: SituationApproval, AgentType: "claude",
+		PermissionVerb: PermissionVerbSelectRemoteEnv,
+		Options:        []string{"herdr-auto-pilot (env_A)", "Default (env_B)"},
+		Content:        "Select remote environment"})
+	envB := ComputeSignature(Situation{Type: SituationApproval, AgentType: "claude",
+		PermissionVerb: PermissionVerbSelectRemoteEnv,
+		Options:        []string{"other-project (env_C)"},
+		Content:        "Select remote environment"})
+	if envA.Signature != envB.Signature {
+		t.Errorf("remote-env pickers with different env lists must share a signature:\n%q\nvs\n%q",
+			envA.Salient, envB.Salient)
+	}
+}
+
+func TestApprovalRemapCompatible(t *testing.T) {
+	cases := []struct {
+		name, a, b string
+		want       bool
+	}{
+		{"identical option sets",
+			"permission:proceed | options:no;yes",
+			"permission:continue | options:no;yes", true},
+		{"half overlap passes",
+			"permission:proceed | options:no, and tell claude what to do differently;yes;yes, and don't ask again for go test commands",
+			"permission:proceed | options:no, and tell claude what to do differently;yes;yes, and don't ask again for npm install commands", true},
+		{"disjoint sets veto (plan vs bash)",
+			"permission:proceed | options:no, refine the plan;tell claude what to change;yes, and use auto mode;yes, manually approve edits",
+			"permission:proceed | options:no, and tell claude what to do differently;yes;yes, and don't ask again for go test commands", false},
+		{"below-half overlap vetoes",
+			"permission:proceed | options:a;b;c;d",
+			"permission:proceed | options:a;x;y;z", false},
+		{"both option-less approvals stay compatible",
+			"permission:edit the config file | options:",
+			"permission:modify the config file | options:", true},
+		{"empty vs populated vetoes",
+			"permission:proceed | options:",
+			"permission:proceed | options:no;yes", false},
+		{"verb-only candidate (pre-fix row) vetoes",
+			"permission:proceed | options:no;yes",
+			"permission:proceed", false},
+		{"verb-only query (remote-env picker) vetoes",
+			"permission:select remote environment",
+			"permission:select remote environment | options:x", false},
+		{"two pane-tail salients stay compatible (verbless approvals)",
+			"the agent wants approval to frobnicate the widget",
+			"the agent asks approval to frobnicate the widget now", true},
+		{"pane-tail vs permission salient vetoes",
+			"permission:proceed | options:no;yes",
+			"some trailing pane content asking for approval", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ApprovalRemapCompatible(c.a, c.b); got != c.want {
+				t.Errorf("ApprovalRemapCompatible(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+			}
+		})
 	}
 }
 

--- a/internal/domain/signature_test.go
+++ b/internal/domain/signature_test.go
@@ -87,6 +87,18 @@ func TestSignatureOptionSets(t *testing.T) {
 	if same.Signature == different.Signature {
 		t.Errorf("different option sets must produce different signatures")
 	}
+
+	// The encoding must stay injective for labels containing the delimiter:
+	// without escaping, both of these sets flatten to "allow;once;deny".
+	ambA := ComputeSignature(mk("allow;once", "deny"))
+	ambB := ComputeSignature(mk("allow", "once;deny"))
+	if ambA.Signature == ambB.Signature {
+		t.Errorf("delimiter-bearing labels collide: %q vs %q", ambA.Salient, ambB.Salient)
+	}
+	// Still deterministic: the same delimiter-bearing set matches itself.
+	if again := ComputeSignature(mk("deny", "allow;once")); again.Signature != ambA.Signature {
+		t.Errorf("escaped encoding lost order-insensitivity: %q vs %q", again.Salient, ambA.Salient)
+	}
 }
 
 func TestOverMaskingFloor(t *testing.T) {
@@ -245,6 +257,12 @@ func TestApprovalRemapCompatible(t *testing.T) {
 		{"pane-tail vs permission salient vetoes",
 			"permission:proceed | options:no;yes",
 			"some trailing pane content asking for approval", false},
+		{"escaped delimiters parse as one label, not two",
+			`permission:proceed | options:allow\;once;deny`,
+			"permission:proceed | options:allow;deny;once", false},
+		{"identical escaped sets stay compatible",
+			`permission:proceed | options:allow\;once;deny`,
+			`permission:continue | options:allow\;once;deny`, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -36,6 +36,9 @@ type Scope struct {
 type Hit struct {
 	Signature string
 	Score     float64 // cosine similarity for vectors, BM25 score for text
+	// Salient is the hit's stored salient text, so callers can vet the
+	// candidate before remapping onto it (the approval option-set gate).
+	Salient string
 }
 
 // Matcher wraps a swappable disk-backed bleve index. All methods are safe
@@ -186,11 +189,20 @@ func scopeFilter(s Scope) query.Query {
 	return bleve.NewConjunctionQuery(st, at)
 }
 
+// matchK bounds how many nearest candidates a lookup considers: the caller's
+// accept filter can veto the top hit (the approval option-set gate), so a
+// compatible candidate at rank 2-3 must stay reachable instead of being
+// permanently shadowed by an incompatible nearest neighbor.
+const matchK = 3
+
 // MatchVector returns the nearest stored signature by cosine similarity
-// within scope. ok is false when the index is empty for the scope; Score is
+// within scope that the accept filter admits (nil accepts everything).
+// Candidates are tried in descending similarity, so the returned hit is the
+// best acceptable one. ok is false when no candidate is acceptable; Score is
 // the raw cosine (bleve's cosine metric normalizes and inner-products, so
 // the hit score IS the cosine similarity) — thresholding is the caller's.
-func (m *Matcher) MatchVector(ctx context.Context, vec []float32, s Scope) (Hit, bool, error) {
+// accept must be a fast, pure content check (it runs inline per candidate).
+func (m *Matcher) MatchVector(ctx context.Context, vec []float32, s Scope, accept func(Hit) bool) (Hit, bool, error) {
 	m.mu.RLock()
 	idx, dims := m.idx, m.dims
 	m.mu.RUnlock()
@@ -202,25 +214,33 @@ func (m *Matcher) MatchVector(ctx context.Context, vec []float32, s Scope) (Hit,
 	}
 
 	req := bleve.NewSearchRequest(bleve.NewMatchNoneQuery())
-	req.Size = 1
-	req.AddKNNWithFilter("vector", vec, 1, 1.0, scopeFilter(s))
+	req.Size = matchK
+	req.Fields = []string{"salient"}
+	req.AddKNNWithFilter("vector", vec, matchK, 1.0, scopeFilter(s))
 	res, err := idx.SearchInContext(ctx, req)
 	if err != nil {
 		return Hit{}, false, err
 	}
-	if len(res.Hits) == 0 {
-		return Hit{}, false, nil
+	for _, h := range res.Hits { // descending similarity
+		stored, _ := h.Fields["salient"].(string)
+		hit := Hit{Signature: h.ID, Score: h.Score, Salient: stored}
+		if accept == nil || accept(hit) {
+			return hit, true, nil
+		}
 	}
-	h := res.Hits[0]
-	return Hit{Signature: h.ID, Score: h.Score}, true, nil
+	return Hit{}, false, nil
 }
 
-// MatchText returns the best BM25 match for the salient text within scope.
-// Score is NORMALIZED to (0,1]: the hit's BM25 score divided by the score
-// its own stored salient text achieves against the same index, so the
-// threshold stays meaningful as the corpus (and its IDF) grows. 1.0 means
-// the query matches as well as the stored text matches itself.
-func (m *Matcher) MatchText(ctx context.Context, salient string, s Scope) (Hit, bool, error) {
+// MatchText returns the best BM25 match for the salient text within scope
+// that the accept filter admits (nil accepts everything). Score is
+// NORMALIZED to (0,1]: the hit's BM25 score divided by the score its own
+// stored salient text achieves against the same index, so the threshold
+// stays meaningful as the corpus (and its IDF) grows. 1.0 means the query
+// matches as well as the stored text matches itself. Up to matchK candidates
+// are considered and the highest NORMALIZED acceptable one wins (raw BM25
+// order can differ from normalized order). accept must be a fast, pure
+// content check (it runs inline per candidate).
+func (m *Matcher) MatchText(ctx context.Context, salient string, s Scope, accept func(Hit) bool) (Hit, bool, error) {
 	m.mu.RLock()
 	idx := m.idx
 	m.mu.RUnlock()
@@ -228,45 +248,57 @@ func (m *Matcher) MatchText(ctx context.Context, salient string, s Scope) (Hit, 
 		return Hit{}, false, fmt.Errorf("text matching unavailable (no index)")
 	}
 
-	score, id, stored, ok, err := m.textTop1(ctx, idx, salient, s, true)
-	if err != nil || !ok {
-		return Hit{}, false, err
-	}
-	self, selfID, _, selfOK, err := m.textTop1(ctx, idx, stored, s, false)
+	mq := bleve.NewMatchQuery(salient)
+	mq.SetField("salient")
+	req := bleve.NewSearchRequest(bleve.NewConjunctionQuery(mq, scopeFilter(s)))
+	req.Size = matchK
+	req.Fields = []string{"salient"}
+	res, err := idx.SearchInContext(ctx, req)
 	if err != nil {
 		return Hit{}, false, err
 	}
-	if !selfOK || selfID != id || self <= 0 {
-		// The stored text should always be its own best match; anything
-		// else means the score is not normalizable — fail the match.
-		return Hit{}, false, nil
+
+	var best Hit
+	var found bool
+	for _, h := range res.Hits {
+		stored, _ := h.Fields["salient"].(string)
+		cand := Hit{Signature: h.ID, Score: h.Score, Salient: stored}
+		if accept != nil && !accept(cand) {
+			continue
+		}
+		self, selfID, selfOK, err := m.textSelfScore(ctx, idx, stored, s)
+		if err != nil {
+			return Hit{}, false, err
+		}
+		if !selfOK || selfID != h.ID || self <= 0 {
+			// The stored text should always be its own best match; anything
+			// else means this candidate's score is not normalizable — skip it.
+			continue
+		}
+		norm := h.Score / self
+		if norm > 1 {
+			norm = 1
+		}
+		if !found || norm > best.Score {
+			best = Hit{Signature: h.ID, Score: norm, Salient: stored}
+			found = true
+		}
 	}
-	norm := score / self
-	if norm > 1 {
-		norm = 1
-	}
-	return Hit{Signature: id, Score: norm}, true, nil
+	return best, found, nil
 }
 
-// textTop1 runs one scoped BM25 query, optionally loading the hit's stored
-// salient text.
-func (m *Matcher) textTop1(ctx context.Context, idx bleve.Index, text string, s Scope,
-	loadSalient bool) (score float64, id, salient string, ok bool, err error) {
-
+// textSelfScore runs one scoped BM25 query for a candidate's own stored text,
+// yielding the self-match score MatchText normalizes against.
+func (m *Matcher) textSelfScore(ctx context.Context, idx bleve.Index, text string, s Scope) (score float64, id string, ok bool, err error) {
 	mq := bleve.NewMatchQuery(text)
 	mq.SetField("salient")
 	req := bleve.NewSearchRequest(bleve.NewConjunctionQuery(mq, scopeFilter(s)))
 	req.Size = 1
-	if loadSalient {
-		req.Fields = []string{"salient"}
-	}
 	res, err := idx.SearchInContext(ctx, req)
 	if err != nil || len(res.Hits) == 0 {
-		return 0, "", "", false, err
+		return 0, "", false, err
 	}
-	h := res.Hits[0]
-	stored, _ := h.Fields["salient"].(string)
-	return h.Score, h.ID, stored, true, nil
+	return res.Hits[0].Score, res.Hits[0].ID, true, nil
 }
 
 // Close releases the underlying index and removes its cache directory.

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -42,19 +42,22 @@ func TestMatchVectorRanksByCosine(t *testing.T) {
 
 	// Query near the first vector: cos ≈ 0.995 with aaa, ≈ 0.1 with bbb.
 	q := unit(1, 0.1, 0, 0)
-	hit, ok, err := m.MatchVector(context.Background(), q, Scope{domain.SituationApproval, "claude"})
+	hit, ok, err := m.MatchVector(context.Background(), q, Scope{domain.SituationApproval, "claude"}, nil)
 	if err != nil || !ok {
 		t.Fatalf("MatchVector: ok=%v err=%v", ok, err)
 	}
 	if hit.Signature != "approval:aaa" {
 		t.Errorf("nearest = %s, want approval:aaa", hit.Signature)
 	}
+	if hit.Salient != "permission: edit files" {
+		t.Errorf("hit salient = %q, want the stored salient (remap gate depends on it)", hit.Salient)
+	}
 	if hit.Score < 0.98 || hit.Score > 1.0 {
 		t.Errorf("score = %v, want ≈0.995 (raw cosine)", hit.Score)
 	}
 
 	// Exact self-match scores ≈ 1.0.
-	self, ok, err := m.MatchVector(context.Background(), unit(0, 1, 0, 0), Scope{domain.SituationApproval, "claude"})
+	self, ok, err := m.MatchVector(context.Background(), unit(0, 1, 0, 0), Scope{domain.SituationApproval, "claude"}, nil)
 	if err != nil || !ok {
 		t.Fatalf("self match: ok=%v err=%v", ok, err)
 	}
@@ -75,7 +78,7 @@ func TestMatchVectorScopeFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hit, ok, err := m.MatchVector(context.Background(), unit(1, 0, 0), Scope{domain.SituationApproval, "codex"})
+	hit, ok, err := m.MatchVector(context.Background(), unit(1, 0, 0), Scope{domain.SituationApproval, "codex"}, nil)
 	if err != nil || !ok {
 		t.Fatalf("scoped match: ok=%v err=%v", ok, err)
 	}
@@ -84,7 +87,7 @@ func TestMatchVectorScopeFilter(t *testing.T) {
 	}
 
 	// A scope with no members returns no hit, not an error.
-	_, ok, err = m.MatchVector(context.Background(), unit(1, 0, 0), Scope{domain.SituationError, "claude"})
+	_, ok, err = m.MatchVector(context.Background(), unit(1, 0, 0), Scope{domain.SituationError, "claude"}, nil)
 	if err != nil {
 		t.Fatalf("empty scope errored: %v", err)
 	}
@@ -106,24 +109,86 @@ func TestMatchTextBM25(t *testing.T) {
 	}
 
 	hit, ok, err := m.MatchText(context.Background(),
-		"permission: edit the configuration files in project", Scope{domain.SituationApproval, "claude"})
+		"permission: edit the configuration files in project", Scope{domain.SituationApproval, "claude"}, nil)
 	if err != nil || !ok {
 		t.Fatalf("MatchText: ok=%v err=%v", ok, err)
 	}
 	if hit.Signature != "approval:edit" {
 		t.Errorf("best text match = %s, want approval:edit", hit.Signature)
 	}
+	if hit.Salient != "permission: edit the configuration files in project" {
+		t.Errorf("hit salient = %q, want the stored salient (remap gate depends on it)", hit.Salient)
+	}
 	if hit.Score <= 0 {
 		t.Errorf("BM25 score = %v, want > 0", hit.Score)
 	}
 
 	// Unrelated scope finds nothing.
-	_, ok, err = m.MatchText(context.Background(), "permission: edit files", Scope{domain.SituationApproval, "codex"})
+	_, ok, err = m.MatchText(context.Background(), "permission: edit files", Scope{domain.SituationApproval, "codex"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ok {
 		t.Error("out-of-scope text should not match")
+	}
+}
+
+func TestMatchVectorAcceptFilterFallsThroughToRank2(t *testing.T) {
+	// The nearest neighbor can be vetoed by the caller (approval option
+	// gate); an acceptable candidate at rank 2 must still be returned rather
+	// than being shadowed by the rejected top hit.
+	m := New(t.TempDir())
+	defer m.Close()
+	rows := []domain.SignatureEmbedding{
+		row("approval:near", domain.SituationApproval, "claude", "permission:proceed | options:plan", unit(1, 0, 0, 0)),
+		row("approval:far", domain.SituationApproval, "claude", "permission:proceed | options:bash", unit(0.9, 0.436, 0, 0)),
+	}
+	if err := m.Rebuild(rows, 4); err != nil {
+		t.Fatal(err)
+	}
+
+	q := unit(1, 0.05, 0, 0) // nearest: approval:near
+	reject := func(h Hit) bool { return h.Signature != "approval:near" }
+	hit, ok, err := m.MatchVector(context.Background(), q, Scope{domain.SituationApproval, "claude"}, reject)
+	if err != nil || !ok {
+		t.Fatalf("MatchVector: ok=%v err=%v", ok, err)
+	}
+	if hit.Signature != "approval:far" {
+		t.Errorf("filtered match = %s, want the rank-2 candidate approval:far", hit.Signature)
+	}
+
+	// A filter rejecting everything yields no hit, not an error.
+	none := func(Hit) bool { return false }
+	if _, ok, err := m.MatchVector(context.Background(), q, Scope{domain.SituationApproval, "claude"}, none); err != nil || ok {
+		t.Errorf("all-rejecting filter: ok=%v err=%v, want no hit and no error", ok, err)
+	}
+}
+
+func TestMatchTextAcceptFilterFallsThroughToRank2(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close()
+	rows := []domain.SignatureEmbedding{
+		row("approval:first", domain.SituationApproval, "claude", "permission: edit the configuration files in project", nil),
+		row("approval:second", domain.SituationApproval, "claude", "permission: edit the configuration files in repository", nil),
+	}
+	if err := m.Rebuild(rows, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	reject := func(h Hit) bool { return h.Signature != "approval:first" }
+	hit, ok, err := m.MatchText(context.Background(),
+		"permission: edit the configuration files in project", Scope{domain.SituationApproval, "claude"}, reject)
+	if err != nil || !ok {
+		t.Fatalf("MatchText: ok=%v err=%v", ok, err)
+	}
+	if hit.Signature != "approval:second" {
+		t.Errorf("filtered match = %s, want the runner-up approval:second", hit.Signature)
+	}
+
+	none := func(Hit) bool { return false }
+	if _, ok, err := m.MatchText(context.Background(), "permission: edit files",
+		Scope{domain.SituationApproval, "claude"}, none); err != nil || ok {
+		t.Errorf("all-rejecting filter: ok=%v err=%v, want no hit and no error", ok, err)
 	}
 }
 
@@ -135,7 +200,7 @@ func TestMatchVectorDimsMismatch(t *testing.T) {
 	}, 2); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := m.MatchVector(context.Background(), unit(1, 0, 0), Scope{domain.SituationIdle, "claude"}); err == nil {
+	if _, _, err := m.MatchVector(context.Background(), unit(1, 0, 0), Scope{domain.SituationIdle, "claude"}, nil); err == nil {
 		t.Error("dims mismatch should error")
 	}
 }
@@ -149,14 +214,14 @@ func TestAddAndDelete(t *testing.T) {
 	if err := m.Add(row("error:sig", domain.SituationError, "claude", "error: build failed", unit(0, 0, 1))); err != nil {
 		t.Fatal(err)
 	}
-	hit, ok, err := m.MatchVector(context.Background(), unit(0, 0, 1), Scope{domain.SituationError, "claude"})
+	hit, ok, err := m.MatchVector(context.Background(), unit(0, 0, 1), Scope{domain.SituationError, "claude"}, nil)
 	if err != nil || !ok || hit.Signature != "error:sig" {
 		t.Fatalf("added row not matchable: %+v ok=%v err=%v", hit, ok, err)
 	}
 	if err := m.Delete("error:sig"); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok, _ := m.MatchVector(context.Background(), unit(0, 0, 1), Scope{domain.SituationError, "claude"}); ok {
+	if _, ok, _ := m.MatchVector(context.Background(), unit(0, 0, 1), Scope{domain.SituationError, "claude"}, nil); ok {
 		t.Error("deleted row still matches")
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -241,6 +241,25 @@ func (s *Store) migrate() error {
 			return fmt.Errorf("migrate column: %w", err)
 		}
 	}
+	// Issue #155: pre-fix approval salients carried only the permission verb,
+	// so very different approval screens shared one embedding row. Post-fix
+	// salients always carry a "| options:" segment. The old verb-only rows
+	// must go: left in place, a new salient could cosine/BM25-match one and
+	// remap onto the old over-broad signature, re-bridging the collision the
+	// format change closed. Learned rules and audit rows are kept — their old
+	// keys simply become unreachable. The remote-env picker's salient is
+	// verb-only by design and stays. Idempotent: matches zero rows once the
+	// old-format rows are gone.
+	if _, err := s.db.Exec(
+		`DELETE FROM signature_embeddings
+		  WHERE situation_type = ?
+		    AND salient LIKE 'permission:%'
+		    AND salient NOT LIKE '%| options:%'
+		    AND salient <> 'permission:' || ?`,
+		string(domain.SituationApproval), domain.PermissionVerbSelectRemoteEnv,
+	); err != nil {
+		return fmt.Errorf("migrate prune verb-only approval embeddings: %w", err)
+	}
 	return nil
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1208,6 +1208,60 @@ func TestSignatureEmbeddingRoundTrip(t *testing.T) {
 	}
 }
 
+func TestMigratePrunesVerbOnlyApprovalEmbeddings(t *testing.T) {
+	// Issue #155: pre-fix approval salients carried only the permission verb.
+	// Left in place, a post-fix salient could semantically remap onto such an
+	// over-broad row, so migrate() deletes them — and only them.
+	s, path := openTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	for _, e := range []domain.SignatureEmbedding{
+		{Signature: "approval:old", SituationType: domain.SituationApproval,
+			AgentType: "claude", Salient: "permission:proceed", CreatedAt: now},
+		{Signature: "approval:new", SituationType: domain.SituationApproval,
+			AgentType: "claude", Salient: "permission:proceed | options:no;yes", CreatedAt: now},
+		{Signature: "approval:emptyopts", SituationType: domain.SituationApproval,
+			AgentType: "claude", Salient: "permission:continue | options:", CreatedAt: now},
+		{Signature: "approval:remoteenv", SituationType: domain.SituationApproval,
+			AgentType: "claude", Salient: "permission:" + domain.PermissionVerbSelectRemoteEnv, CreatedAt: now},
+		{Signature: "approval:fallback", SituationType: domain.SituationApproval,
+			AgentType: "claude", Salient: "trailing pane content window", CreatedAt: now},
+		{Signature: "choice:opts", SituationType: domain.SituationChoice,
+			AgentType: "claude", Salient: "options:no;yes", CreatedAt: now},
+	} {
+		if err := s.UpsertSignatureEmbedding(ctx, e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s.Close()
+
+	re, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer re.Close()
+	rows, err := re.ListSignatureEmbeddings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		got[r.Signature] = true
+	}
+	if got["approval:old"] {
+		t.Error("verb-only approval embedding survived migration")
+	}
+	for _, keep := range []string{
+		"approval:new", "approval:emptyopts", "approval:remoteenv",
+		"approval:fallback", "choice:opts",
+	} {
+		if !got[keep] {
+			t.Errorf("migration deleted %s, which must be kept", keep)
+		}
+	}
+}
+
 func TestCountStaleSignatureEmbeddings(t *testing.T) {
 	s, _ := openTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
Closes #155.

## Problem

Approval situation signatures hashed only `"v1" | type | agent_type | "permission:" + verb`. Both "Do you want to proceed?" and "Would you like to proceed?" extract just `proceed`, so a Claude **plan-approval** screen and a **Bash command approval** reduced to the same `permission:proceed` salient and resolved to the SAME signature. Once a "Yes" rule graduated, it auto-approved **any** approval phrased "…to proceed?" across the whole agent type.

## Fix

- **Fold the normalized option set into the approval salient** — `permission:<verb> | options:<sorted;lowered;trimmed>`, mirroring how `SituationChoice` already folds options (shared helper `domain.NormalizedOptionSet`). The `| options:` segment is always present (even when empty) so the format is self-describing. The option set is the screen's identity: the plan screen's 4 distinctive labels and a Bash approval's 2–3 labels can no longer share an exact hash, while `MaskVolatile` + semantic matching still generalize across paraphrases.
- **Remote-env picker exempt** (new `domain.PermissionVerbSelectRemoteEnv`): its environment labels are the learned *action*, not the key — the salient stays verb-only so pickers with differing env lists share one stable signature.
- **Migration**: `store.migrate()` idempotently deletes pre-fix verb-only approval `signature_embeddings` rows (sparing the remote-env row). Left in place, a new salient could cosine/BM25-match one and remap back onto the old over-broad key. Learned rules and audit rows are kept — their keys just become unreachable.
- **Remap gate** (closes the residual fuzzy bridge): cosine/BM25 remaps of approvals now require option-set compatibility (`domain.ApprovalRemapCompatible`, Jaccard ≥ 0.5; two pane-tail salients stay similarity-only as before). The matcher considers the top-3 candidates with an accept filter, so a vetoed nearest neighbor cannot shadow a compatible runner-up; when nothing is acceptable the situation mints a fresh key and escalates — fail-safe.

## Operator-facing note

Previously graduated **approval** rules (except the remote-env picker) stop auto-firing after this upgrade: their keys were minted under the colliding format and are intentionally orphaned. They re-learn/re-graduate under the new option-folded signatures. This is the safe direction — the old keys were exactly the over-broad ones.

## Tests

- `TestApprovalSalientFoldsOptions` — plan vs bash divergence (the regression), order/case/whitespace insensitivity, empty-options behavior, remote-env stability.
- `TestApprovalSignaturesDoNotCollideAcrossScreens` — end-to-end on the real classifier fixtures that collided live.
- `TestApprovalRemapCompatible` — Jaccard boundaries incl. verb-only and pane-tail cases.
- `TestResolveSignatureApprovalRemapVetoedAcrossScreens` — cosine 0.97 across screens vetoed; same-options paraphrase still remaps; BM25 leg gated.
- `TestMigratePrunesVerbOnlyApprovalEmbeddings` — keep/delete matrix.
- `TestMatch{Vector,Text}AcceptFilterFallsThroughToRank2` — rank-2 reachability.

## Verification

- `go test -tags "vectors cpu" ./... -count=1` — all 23 packages pass; golden classifier fixtures unchanged (`UPDATE_GOLDEN=1` produced no diff).
- `go test -tags "integration vectors cpu" ./test/integration/ -v` against a live herdr — all pass (Claude-CLI and embedding-model cases skip by design).
- `gofmt` / `go vet` / `golangci-lint run --build-tags "vectors,cpu"` — clean.

Patch release: merge as-is (manifest untouched; auto-release bumps and tags).