### PR TITLE
#156 fix: mark generated task [-] only at delivery, not at confirm

### DIFF
--- a/internal/domain/taskgen.go
+++ b/internal/domain/taskgen.go
@@ -231,3 +231,18 @@ func RenderGeneratedTaskList(agentName string, tasks []string) string {
 func GeneratedTaskItemText(i int, task string) string {
 	return strconv.Itoa(i+1) + ". " + task
 }
+
+// generatedItemIDRE matches the numbered-ID prefix GeneratedTaskItemText
+// writes ("1. ", "23. ", …), and nothing looser: the ID is always digits, a
+// dot, and a single space, at the very start of the item text.
+var generatedItemIDRE = regexp.MustCompile(`^\d+\. `)
+
+// GeneratedTaskIdentity strips the numbered-ID prefix GeneratedTaskItemText
+// adds, recovering the raw task as a position-independent identity. A
+// regeneration that inserts or reorders tasks renumbers every line, so
+// anything reconciling an old list with a new one (marker carry-over) must
+// recognize the same logical task under a different number. Hand-authored,
+// unnumbered text passes through unchanged.
+func GeneratedTaskIdentity(text string) string {
+	return generatedItemIDRE.ReplaceAllString(text, "")
+}

--- a/internal/domain/taskgen.go
+++ b/internal/domain/taskgen.go
@@ -192,10 +192,13 @@ func hasAlphanumeric(s string) bool {
 }
 
 // RenderGeneratedTaskList renders the normalized tasks as a checklist file:
-// the first task is in-progress ("[-]", the one sent to the agent now) and the
-// rest are pending ("[ ]", picked up by the normal declared-task flow on later
-// idles). Callers pass the result of NormalizeGeneratedTasks; an empty list
-// yields just the header.
+// every task is pending ("[ ]"), so the declared-task flow can hand each one
+// out on idle. The in-progress marker ("[-]") is written only at delivery
+// time by whoever actually sends a task (the confirm --send reservation, or
+// `hap task send`) — pre-marking here would strand the first item when no
+// send follows, since "[-]" is exactly what suppresses the idle resend
+// (issue #156). Callers pass the result of NormalizeGeneratedTasks; an empty
+// list yields just the header.
 //
 // Each item is prefixed with its 1-based position as a numbered ID ("1. ",
 // "2. ", …) rather than a plain bullet, so a standard markdown task-list
@@ -213,17 +216,18 @@ func RenderGeneratedTaskList(agentName string, tasks []string) string {
 	b.WriteString(agentName)
 	b.WriteString("\n\n")
 	for i, t := range tasks {
-		marker := "[ ]"
-		if i == 0 {
-			marker = "[" + MarkInProgress + "]"
-		}
-		b.WriteString("- ")
-		b.WriteString(marker)
-		b.WriteString(" ")
-		b.WriteString(strconv.Itoa(i + 1))
-		b.WriteString(". ")
-		b.WriteString(t)
+		b.WriteString("- [ ] ")
+		b.WriteString(GeneratedTaskItemText(i, t))
 		b.WriteString("\n")
 	}
 	return b.String()
+}
+
+// GeneratedTaskItemText is the checklist item text RenderGeneratedTaskList
+// writes for the i-th (0-based) generated task: the numbered ID plus the raw
+// task. It is the single source of truth for that format — the delivery-time
+// reservation must name exactly this text to claim the item, so the two sites
+// cannot be allowed to drift apart silently.
+func GeneratedTaskItemText(i int, task string) string {
+	return strconv.Itoa(i+1) + ". " + task
 }

--- a/internal/domain/taskgen_test.go
+++ b/internal/domain/taskgen_test.go
@@ -226,40 +226,42 @@ func TestNormalizeGeneratedTasksRealSample(t *testing.T) {
 }
 
 func TestRenderGeneratedTaskList(t *testing.T) {
-	// First task is in-progress "[-]"; the rest are pending "[ ]". Each item
+	// Every task renders pending "[ ]" — "[-]" is written only at delivery
+	// time (issue #156: pre-marking the first item stranded it whenever no
+	// send followed, because "[-]" suppresses the idle resend). Each item
 	// carries its 1-based position as a numbered ID ("1. ", "2. ", …) instead
 	// of a plain bullet, so a standard markdown task-list parser can read the
 	// file directly (the ID sits after the checkbox, not at the start of the
 	// line, so it is never read as a Markdown ordered list).
 	got := RenderGeneratedTaskList("brave-otter", []string{"first", "second", "third"})
-	want := "# Tasks for brave-otter\n\n- [-] 1. first\n- [ ] 2. second\n- [ ] 3. third\n"
+	want := "# Tasks for brave-otter\n\n- [ ] 1. first\n- [ ] 2. second\n- [ ] 3. third\n"
 	if got != want {
 		t.Errorf("RenderGeneratedTaskList =\n%q\nwant\n%q", got, want)
 	}
 
-	// The first (only) item of a single-task list is in-progress, and the
-	// declared-task parser treats it as not-actionable (no next "[ ]").
+	// A single-task list is pending and actionable: the declared-task parser
+	// must return it, so the daemon's idle flow can deliver it after a
+	// confirm-without-send.
 	single := RenderGeneratedTaskList("a", []string{"only task"})
-	if !strings.Contains(single, "- [-] 1. only task") {
-		t.Errorf("single task must be in-progress and numbered, got %q", single)
+	if !strings.Contains(single, "- [ ] 1. only task") {
+		t.Errorf("single task must be pending and numbered, got %q", single)
 	}
-	if NextDeclaredTask(single) != "" {
-		t.Errorf("an all-in-progress list must have no next declared task, got %q", NextDeclaredTask(single))
+	if next := NextDeclaredTask(single); next != "1. only task" {
+		t.Errorf("next declared task = %q, want the single pending item %q", next, "1. only task")
 	}
 
-	// A multi-task list's NEXT declared task is the first pending "[ ]" item,
-	// so the normal flow drives the queue after the in-progress one. The
-	// numbered ID marker is NOT stripped — it is indistinguishable from (and
-	// therefore treated exactly like) numbering an operator already may type
-	// into a hand-authored checklist, which is sent to the agent verbatim.
+	// A multi-task list's NEXT declared task is the FIRST item. The numbered
+	// ID marker is NOT stripped — it is indistinguishable from (and therefore
+	// treated exactly like) numbering an operator already may type into a
+	// hand-authored checklist, which is sent to the agent verbatim.
 	multi := RenderGeneratedTaskList("a", []string{"doing now", "up next", "later"})
 	if !strings.Contains(multi, "- [ ] 2. up next") {
 		t.Errorf("second item must carry numbered ID 2, got %q", multi)
 	}
-	if next := NextDeclaredTask(multi); next != "2. up next" {
-		t.Errorf("next declared task = %q, want the first pending item %q with its ID marker intact", next, "2. up next")
+	if next := NextDeclaredTask(multi); next != "1. doing now" {
+		t.Errorf("next declared task = %q, want the first pending item %q with its ID marker intact", next, "1. doing now")
 	}
-	if pending := PendingDeclaredTasks(multi); len(pending) != 2 || pending[0] != "2. up next" || pending[1] != "3. later" {
-		t.Errorf("pending declared tasks = %v, want [\"2. up next\" \"3. later\"] with ID markers intact", pending)
+	if pending := PendingDeclaredTasks(multi); len(pending) != 3 || pending[0] != "1. doing now" || pending[1] != "2. up next" {
+		t.Errorf("pending declared tasks = %v, want all three with ID markers intact", pending)
 	}
 }

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -195,9 +195,9 @@ type ChecklistItem struct {
 	// Mark is the raw checkbox rune (" ", "x", "X", "+", "-", "*"). Done is the
 	// binary pending/not-pending classification used for filtering; Mark is kept
 	// so a display can render a third state faithfully — notably the "-"
-	// in-progress marker this codebase's own generated-task flow writes for the
-	// task an agent is currently working on (RenderGeneratedTaskList), which
-	// would otherwise read as "[x] done".
+	// in-progress marker this codebase writes at delivery time for the task an
+	// agent is currently working on (the confirm --send reservation and
+	// `hap task send`), which would otherwise read as "[x] done".
 	Mark string
 	Done bool
 	Text string

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -848,15 +848,19 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 }
 
 // acceptGeneratedTask confirms an idle task suggestion: it writes a per-agent
-// tasks.md (a single in-progress "[-]" item), registers it as a task source in
+// tasks.md (every item pending "[ ]"), registers it as a task source in
 // config.toml, records the correction that resolves the escalation, and — when
-// send — hands the task to the agent. Side effects run source-first so a send
-// failure never leaves the agent without the task source that was just
+// send — reserves the first item "[-]" and hands it to the agent, rolling it
+// back to "[ ]" if the send fails. Without send the file stays all-pending so
+// the daemon's idle flow delivers the first item on the next idle; pre-marking
+// "[-]" at write time would strand it forever, since "[-]" is exactly what
+// suppresses the idle resend (issue #156). Side effects run source-first so a
+// send failure never leaves the agent without the task source that was just
 // established.
 func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord, send bool) error {
 	// The suggestion may carry one task or several (plain or as a Markdown
 	// list); normalize into clean bare task strings so the file is always a
-	// well-formed checklist, never raw multiline text written after "- [-] ".
+	// well-formed checklist, never raw multiline text written after "- [ ] ".
 	raw := strings.TrimPrefix(audit.Suggestion, domain.SuggestTaskPrefix)
 	tasks := domain.NormalizeGeneratedTasks(raw)
 	if len(tasks) == 0 {
@@ -897,9 +901,10 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	}
 
 	// Idempotent side effects FIRST (before the claim): writing the file and
-	// registering the source can be safely repeated — the file is rewritten
-	// with identical content and addTaskSourceIfAbsent de-dupes under
-	// UpdateConfig's advisory lock. Running them before the claim means a
+	// registering the source can be safely repeated — a re-confirm skips the
+	// rewrite when the file already carries these same items (markers ignored,
+	// so it never resets a reservation or completion) and addTaskSourceIfAbsent
+	// de-dupes under UpdateConfig's advisory lock. Running them before the claim means a
 	// failure here leaves the escalation still pending, so the operator can
 	// retry; only the non-idempotent send is gated by the claim below.
 	base := a.StateDir
@@ -911,11 +916,14 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 		return fmt.Errorf("create tasks dir: %w", err)
 	}
 	path := filepath.Join(dir, sanitizeTaskFileName(name)+".md")
-	// First task is in-progress ("[-]", sent to the agent now); any remaining
-	// tasks are pending ("[ ]") and the normal declared-task flow picks them up
-	// on later idles.
+	// Every task is written pending ("[ ]"); the first is marked in-progress
+	// ("[-]") only below, at delivery time, so a confirm that sends nothing
+	// leaves it for the daemon's normal declared-task flow (issue #156).
+	// ensureGeneratedTaskFile never resets progress markers: a stale
+	// re-confirm racing the winner must not flip a freshly reserved "[-]"
+	// (or a completed "[x]") back to "[ ]" and re-arm a second delivery.
 	content := domain.RenderGeneratedTaskList(name, tasks)
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+	if err := ensureGeneratedTaskFile(path, content); err != nil {
 		return fmt.Errorf("write tasks file: %w", err)
 	}
 	// Register the file as this agent's task source (writes config.toml and
@@ -949,17 +957,100 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	}
 
 	if send && a.Herdr != nil {
-		// Only the first task is sent — the operator's "start now" task. Render
-		// it through the same default next-task template used by a declared task
-		// source, so every idle-task handoff includes both the task and its list.
+		// Only the first task is sent — the operator's "start now" task. The
+		// order mirrors SendTaskToAgent and is load-bearing: RESERVE the item
+		// ([-] under the file lock) and only then deliver, so the daemon's idle
+		// flow can never hand it out mid-send, and a failed send rolls it back
+		// to [ ].
+		itemText := domain.GeneratedTaskItemText(0, tasks[0])
+		if _, err := mutateTaskFile(path, reserveTask(1, itemText)); err != nil {
+			return fmt.Errorf("task source created, but reserving task #1 (nothing was sent): %w", err)
+		}
+		// Render through the same default next-task template used by a declared
+		// task source, so every idle-task handoff includes both the task and
+		// its list. The prompt sends the raw normalized task, not the numbered
+		// file line.
 		prompt := domain.DeclaredTask{
 			Task: tasks[0], Path: path, AgentName: name,
 		}.Prompt()
 		if err := ports.SendToAgent(ctx, a.Herdr, audit.AgentID, audit.AgentType, prompt); err != nil {
+			if _, rbErr := mutateTaskFile(path, releaseTask(1, itemText)); rbErr != nil {
+				return fmt.Errorf("task source created, but sending the task failed (%w) and task #1 could not be returned to [ ] (%v) — "+
+					"it stays [-] and no agent will pick it up until you clear it", err, rbErr)
+			}
 			return fmt.Errorf("task source created, but sending the task to the agent failed: %w", err)
 		}
 	}
 	return a.nudge(ctx, control.KindReload)
+}
+
+// ensureGeneratedTaskFile writes the rendered generated-task checklist to
+// path as ONE locked read-compare-write, under the same per-path lock
+// mutateTaskFile takes — an unlocked check-then-write could land after a
+// concurrent confirm's reservation and silently reset its "[-]". A file
+// already carrying exactly these item texts is left untouched (a stale
+// re-confirm must not clobber markers or any operator edits); when the items
+// DO differ (a new generation), the rewrite carries over the existing marker
+// of every same-text item, so in-flight "[-]" and finished "[x]" work
+// survives regeneration. The write is atomic because the daemon reads this
+// file without the lock.
+func ensureGeneratedTaskFile(path, content string) error {
+	lockPath := taskLockPath(path)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return err
+	}
+	unlock, err := lockFile(lockPath)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	if existing, rerr := os.ReadFile(path); rerr == nil {
+		if sameChecklistTexts(string(existing), content) {
+			return nil
+		}
+		content = carryOverChecklistMarks(string(existing), content)
+	}
+	return writeFileAtomic(path, []byte(content), 0o600)
+}
+
+// sameChecklistTexts reports whether two checklist documents carry the same
+// items — same count, same texts, in the same order — ignoring the checkbox
+// markers. It answers "is this the same generated task list?" for the
+// re-confirm skip above without treating a [ ]→[-]/[x] progression as a
+// difference.
+func sameChecklistTexts(a, b string) bool {
+	ia, ib := domain.ParseChecklist(a), domain.ParseChecklist(b)
+	if len(ia) != len(ib) {
+		return false
+	}
+	for i := range ia {
+		if ia[i].Text != ib[i].Text {
+			return false
+		}
+	}
+	return true
+}
+
+// carryOverChecklistMarks returns rendered with each item's checkbox replaced
+// by the marker a same-text item carries in existing (first occurrence wins),
+// so regenerating a task list never resets progress on items it re-lists.
+// Items only in rendered keep their fresh "[ ]"; items only in existing are
+// dropped with the rewrite, as before.
+func carryOverChecklistMarks(existing, rendered string) string {
+	marks := map[string]string{}
+	for _, it := range domain.ParseChecklist(existing) {
+		if _, ok := marks[it.Text]; !ok {
+			marks[it.Text] = it.Mark
+		}
+	}
+	lines := strings.Split(rendered, "\n")
+	for _, it := range domain.ParseChecklist(rendered) {
+		if mark, ok := marks[it.Text]; ok && mark != it.Mark {
+			lines[it.LineNo] = it.Prefix + "[" + mark + "] " + it.Text
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // addTaskSourceIfAbsent registers a task list for an agent, skipping the append

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -1033,20 +1033,32 @@ func sameChecklistTexts(a, b string) bool {
 }
 
 // carryOverChecklistMarks returns rendered with each item's checkbox replaced
-// by the marker a same-text item carries in existing (first occurrence wins),
-// so regenerating a task list never resets progress on items it re-lists.
-// Items only in rendered keep their fresh "[ ]"; items only in existing are
-// dropped with the rewrite, as before.
+// by the marker a matching item carries in existing, so regenerating a task
+// list never resets progress on items it re-lists. Items match by their
+// position-independent identity (domain.GeneratedTaskIdentity — the raw task
+// with the numbered-ID prefix stripped): a regeneration that inserts or
+// reorders tasks renumbers every line, and matching on the rendered text
+// would lose the marker of any task whose number changed, resetting a
+// reserved "[-]" (or completed "[x]") back to "[ ]" and re-arming a second
+// delivery. Each existing marker is consumed at most once, in file order, so
+// duplicate texts map one-to-one. Items only in rendered keep their fresh
+// "[ ]"; items only in existing are dropped with the rewrite, as before.
 func carryOverChecklistMarks(existing, rendered string) string {
-	marks := map[string]string{}
+	marks := map[string][]string{}
 	for _, it := range domain.ParseChecklist(existing) {
-		if _, ok := marks[it.Text]; !ok {
-			marks[it.Text] = it.Mark
-		}
+		id := domain.GeneratedTaskIdentity(it.Text)
+		marks[id] = append(marks[id], it.Mark)
 	}
 	lines := strings.Split(rendered, "\n")
 	for _, it := range domain.ParseChecklist(rendered) {
-		if mark, ok := marks[it.Text]; ok && mark != it.Mark {
+		id := domain.GeneratedTaskIdentity(it.Text)
+		queue := marks[id]
+		if len(queue) == 0 {
+			continue
+		}
+		mark := queue[0]
+		marks[id] = queue[1:]
+		if mark != it.Mark {
 			lines[it.LineNo] = it.Prefix + "[" + mark + "] " + it.Text
 		}
 	}

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -543,7 +543,8 @@ func TestConfirmGeneratedTaskWritesSourceAndSends(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// tasks.md written with a single in-progress item.
+	// tasks.md written, and the delivered item reserved "[-]" (the marker is
+	// applied at delivery time, not at file-creation time — issue #156).
 	path := filepath.Join(stateDir, "tasks", name+".md")
 	body, err := os.ReadFile(path)
 	if err != nil {
@@ -591,13 +592,18 @@ func TestConfirmGeneratedTaskWritesSourceAndSends(t *testing.T) {
 }
 
 func TestConfirmGeneratedTaskWithoutSendStillWritesSource(t *testing.T) {
-	// send=false establishes the source and file but delivers nothing.
+	// send=false establishes the source and file but delivers nothing — and
+	// must leave the first item "[ ]" so the daemon's idle flow can hand it
+	// out later. Regression for issue #156: the item used to be pre-marked
+	// "[-]" at write time, which suppressed the idle resend forever.
 	app, st := testApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
-	app.StateDir = t.TempDir()
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
 	ctx := context.Background()
 
+	name, _ := st.EnsureAgentName(ctx, "w2:p2")
 	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: "w2:p2", SituationType: domain.SituationIdle, Trigger: "t",
 		Action: "escalated", Status: "escalated",
@@ -613,12 +619,22 @@ func TestConfirmGeneratedTaskWithoutSendStillWritesSource(t *testing.T) {
 	if len(cfg.TaskSources) != 1 {
 		t.Errorf("source must still be registered on a non-send confirm, got %d", len(cfg.TaskSources))
 	}
+	body, err := os.ReadFile(filepath.Join(stateDir, "tasks", name+".md"))
+	if err != nil {
+		t.Fatalf("tasks file not written: %v", err)
+	}
+	if !strings.Contains(string(body), "- [ ] 1. Write missing tests") {
+		t.Errorf("tasks file = %q, want the undelivered item pending \"[ ]\"", body)
+	}
+	if next := domain.NextDeclaredTask(string(body)); next != "1. Write missing tests" {
+		t.Errorf("next declared task = %q, want the undelivered first item — a stranded item would never be sent", next)
+	}
 }
 
 func TestConfirmGeneratedMultipleTasksWritesChecklist(t *testing.T) {
 	// A multiline suggestion (a Markdown checklist from the LLM) is normalized:
-	// the file lists the first task in-progress "[-]" and the rest pending
-	// "[ ]", and ONLY the first task is sent to the agent.
+	// ONLY the first task is sent to the agent, so after the send it reads
+	// in-progress "[-]" (reserved at delivery) and the rest stay pending "[ ]".
 	app, st := testApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
@@ -698,6 +714,151 @@ func TestConfirmGeneratedTaskIsIdempotent(t *testing.T) {
 	cfg, _ := config.Load(app.ConfigPath)
 	if len(cfg.TaskSources) != 1 {
 		t.Errorf("want exactly 1 task source after a double confirm, got %d", len(cfg.TaskSources))
+	}
+}
+
+func TestConfirmGeneratedTaskSendFailureRollsBackToPending(t *testing.T) {
+	// A failed --send delivery must roll the reserved item back to "[ ]" so
+	// the daemon's idle flow can retry it — mirroring SendTaskToAgent. Before
+	// issue #156 the item stayed "[-]" and was stranded forever.
+	app, st := testApp(t)
+	fake := &fakeHerdr{sendErr: errors.New("pane vanished")}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w5:p5")
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w5:p5", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Fix the flaky login test", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, id, true); err == nil {
+		t.Fatal("confirm must surface the failed delivery")
+	}
+	body, err := os.ReadFile(filepath.Join(stateDir, "tasks", name+".md"))
+	if err != nil {
+		t.Fatalf("tasks file not written: %v", err)
+	}
+	if !strings.Contains(string(body), "- [ ] 1. Fix the flaky login test") {
+		t.Errorf("tasks file = %q, want the failed-send item rolled back to \"[ ]\"", body)
+	}
+	if next := domain.NextDeclaredTask(string(body)); next != "1. Fix the flaky login test" {
+		t.Errorf("next declared task = %q, want the rolled-back item so the idle flow retries it", next)
+	}
+}
+
+func TestConfirmRepeatedGenerationPreservesMarkers(t *testing.T) {
+	// A later generation escalation carrying the SAME tasks (e.g. a stale
+	// duplicate raised before the first confirm registered the source) must
+	// not rewrite the file: resetting a delivered item's "[-]" back to "[ ]"
+	// would re-arm the daemon to send it a second time.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w6:p6")
+	suggestion := domain.SuggestTaskPrefix + "Profile the slow endpoint"
+	first, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w6:p6", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: suggestion, CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, first, true); err != nil {
+		t.Fatal(err)
+	}
+
+	second, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w6:p6", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: suggestion, CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, second, false); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(stateDir, "tasks", name+".md"))
+	if err != nil {
+		t.Fatalf("tasks file missing: %v", err)
+	}
+	if !strings.Contains(string(body), "- [-] 1. Profile the slow endpoint") {
+		t.Errorf("tasks file = %q, want the delivered item still reserved \"[-]\" after a same-tasks re-confirm", body)
+	}
+	if len(fake.inputs) != 1 {
+		t.Errorf("task must be delivered exactly once, got %d sends", len(fake.inputs))
+	}
+	cfg, _ := config.Load(app.ConfigPath)
+	if len(cfg.TaskSources) != 1 {
+		t.Errorf("want exactly 1 task source, got %d", len(cfg.TaskSources))
+	}
+
+	// The sharper duplicate: --send on yet another same-tasks escalation gets
+	// its own successful claim (a distinct audit row), reaches the reserve —
+	// and must refuse there, because the item is already "[-]". No second
+	// delivery, and the reservation stands.
+	third, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w6:p6", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: suggestion, CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, third, true); err == nil || !strings.Contains(err.Error(), "no longer pending") {
+		t.Fatalf("a --send duplicate must refuse to re-reserve the [-] item, got %v", err)
+	}
+	if len(fake.inputs) != 1 {
+		t.Errorf("the duplicate must not deliver again, got %d sends", len(fake.inputs))
+	}
+	body, _ = os.ReadFile(filepath.Join(stateDir, "tasks", name+".md"))
+	if !strings.Contains(string(body), "- [-] 1. Profile the slow endpoint") {
+		t.Errorf("tasks file = %q, want the reservation untouched by the refused duplicate", body)
+	}
+}
+
+func TestConfirmRegenerationCarriesOverMarkers(t *testing.T) {
+	// A later generation carrying a DIFFERENT task list rewrites the file, but
+	// items it re-lists keep their progress markers: resetting a delivered
+	// "[-]" to "[ ]" would re-arm the daemon for a duplicate send.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w7:p7")
+	first, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w7:p7", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Profile the slow endpoint", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, first, true); err != nil {
+		t.Fatal(err)
+	}
+
+	second, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w7:p7", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Profile the slow endpoint\nAdd a response cache", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, second, false); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(stateDir, "tasks", name+".md"))
+	if err != nil {
+		t.Fatalf("tasks file missing: %v", err)
+	}
+	if !strings.Contains(string(body), "- [-] 1. Profile the slow endpoint") {
+		t.Errorf("tasks file = %q, want the re-listed delivered item still \"[-]\"", body)
+	}
+	if !strings.Contains(string(body), "- [ ] 2. Add a response cache") {
+		t.Errorf("tasks file = %q, want the new item appended pending", body)
+	}
+	if next := domain.NextDeclaredTask(string(body)); next != "2. Add a response cache" {
+		t.Errorf("next declared task = %q, want only the new pending item", next)
 	}
 }
 

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -862,6 +862,108 @@ func TestConfirmRegenerationCarriesOverMarkers(t *testing.T) {
 	}
 }
 
+func TestConfirmRegenerationInsertionKeepsReservedMarker(t *testing.T) {
+	// A regeneration that INSERTS a task before a reserved one renumbers every
+	// line ("1. A" becomes "2. A"). Marker carry-over must match items by
+	// their raw task identity, not the rendered numbered text — otherwise the
+	// renumbered item resets to "[ ]" and the daemon re-sends work the agent
+	// already holds.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w8:p8")
+	first, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w8:p8", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Profile the slow endpoint\nAdd a response cache", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, first, true); err != nil {
+		t.Fatal(err)
+	}
+
+	second, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w8:p8", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Set up the load test rig\nProfile the slow endpoint\nAdd a response cache", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, second, false); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(stateDir, "tasks", name+".md"))
+	if err != nil {
+		t.Fatalf("tasks file missing: %v", err)
+	}
+	if !strings.Contains(string(body), "- [ ] 1. Set up the load test rig") {
+		t.Errorf("tasks file = %q, want the inserted item first and pending", body)
+	}
+	if !strings.Contains(string(body), "- [-] 2. Profile the slow endpoint") {
+		t.Errorf("tasks file = %q, want the delivered item still \"[-]\" under its new number", body)
+	}
+	if next := domain.NextDeclaredTask(string(body)); next != "1. Set up the load test rig" {
+		t.Errorf("next declared task = %q, want only the inserted item — the reserved one must not be re-armed", next)
+	}
+}
+
+func TestConfirmRegenerationInsertionKeepsCompletedMarker(t *testing.T) {
+	// Same renumbering hazard for FINISHED work: an item the agent completed
+	// ("[x]", e.g. via `hap task done`) must stay done when a regeneration
+	// re-lists it under a new number, not be re-queued.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w9:p9")
+	first, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Profile the slow endpoint", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, first, true); err != nil {
+		t.Fatal(err)
+	}
+	// The agent finishes the delivered task ("[-]" → "[x]").
+	path := filepath.Join(stateDir, "tasks", name+".md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("tasks file missing: %v", err)
+	}
+	done, err := domain.SetChecklistItemDone(string(body), 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(done), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	second, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Set up the load test rig\nProfile the slow endpoint", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, second, false); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("tasks file missing: %v", err)
+	}
+	if !strings.Contains(string(body), "- [x] 2. Profile the slow endpoint") {
+		t.Errorf("tasks file = %q, want the completed item still \"[x]\" under its new number", body)
+	}
+	if next := domain.NextDeclaredTask(string(body)); next != "1. Set up the load test rig" {
+		t.Errorf("next declared task = %q, want only the inserted item — completed work must not be re-queued", next)
+	}
+}
+
 func TestConfirmGeneratedTaskRefusesWhenAgentWorking(t *testing.T) {
 	// If the agent has started working by the time the operator confirms, the
 	// suggestion is stale: no source is created, nothing is sent, and the


### PR DESCRIPTION
Fixes #156.

## Problem

Confirming a task-generation escalation (`[task_source_exhausted]` / `[no_task_source]`) with plain `hap confirm <id>` (no `--send`) wrote the generated per-agent tasks file with item 1 pre-marked `[-]` in-progress while delivering nothing. Since `[-]` is exactly the marker that suppresses the idle-flow resend (`NextDeclaredTask` only matches `[ ]`), item 1 was permanently stranded — the daemon only ever sent items 2..N. A failed `--send` delivery stranded the item the same way (no rollback on that path).

## Fix

`[-]` is now written only at actual delivery time, mirroring `hap task send` (`App.SendTaskToAgent`):

- `RenderGeneratedTaskList` renders every item pending `[ ]`.
- The confirm `--send` path follows the load-bearing reserve → deliver → rollback order: item 1 is reserved `[-]` under the per-file lock via the existing `reserveTask` helper, and a failed send rolls it back to `[ ]` via `releaseTask` (a failed rollback parks it `[-]` with an explanatory error, same as `SendTaskToAgent`).
- Without `--send` the file stays all-pending, so the daemon's normal declared-task flow delivers item 1 on the next idle.
- The pre-claim idempotent file write is now one locked, atomic read-compare-write (`ensureGeneratedTaskFile`): a same-tasks re-confirm skips the rewrite entirely, and a regeneration carrying a different task list carries over the markers of items it re-lists — a stale duplicate escalation can never reset a reservation (`[-]`) or completed work (`[x]`) and re-arm a second delivery.
- `domain.GeneratedTaskItemText` is the single source of truth for the numbered item text shared by the renderer and the reservation.

## Tests

- Regression: confirm without `--send` leaves item 1 `[ ]` and `NextDeclaredTask` returns it.
- Failed `--send` delivery rolls item 1 back to `[ ]`.
- A same-tasks duplicate escalation preserves the `[-]` reservation (both `--send` and no-send re-confirm; the `--send` duplicate is refused at the reserve with no second delivery).
- A regeneration with a different task list keeps re-listed items' markers and queues only the new item.
- `TestRenderGeneratedTaskList` updated to the all-pending contract.

Full unit suite (`go test -tags "vectors cpu" ./... -count=1`) green — the single `internal/daemon` manual-capture failure seen in one run was verified as a pre-existing flake (passes 5/5 on both this branch and clean main).

https://claude.ai/code/session_01FKbYWbyEGhsT8iGnbyBJgr