### PR TITLE
#158 fix: task summary counts in-progress separately; reset AGE on recycled pane ids

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1270,9 +1270,14 @@ func formatTask(it domain.ChecklistItem) string {
 // printTaskList prints items matching the status filter, numbered by absolute
 // file position (the number never depends on the filter), then a count summary.
 func printTaskList(out io.Writer, items []domain.ChecklistItem, status string) {
-	shown, done := 0, 0
+	shown, inProgress, done := 0, 0, 0
 	for _, it := range items {
-		if it.Done {
+		// An in-progress "[-]" item has Done==true (it is no longer pending)
+		// but must not be summarized as done.
+		switch {
+		case it.Mark == domain.MarkInProgress:
+			inProgress++
+		case it.Done:
 			done++
 		}
 		if status == "pending" && it.Done {
@@ -1292,7 +1297,8 @@ func printTaskList(out io.Writer, items []domain.ChecklistItem, status string) {
 		}
 		return
 	}
-	fmt.Fprintf(out, "%d task(s): %d pending, %d done\n", len(items), len(items)-done, done)
+	fmt.Fprintf(out, "%d task(s): %d pending, %d in-progress, %d done\n",
+		len(items), len(items)-done-inProgress, inProgress, done)
 }
 
 func clearData(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -935,7 +935,7 @@ func TestTaskListStatusFilterPreservesNumbers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"#1", "#2", "#3", "one", "two", "three", "3 task(s): 2 pending, 1 done"} {
+	for _, want := range []string{"#1", "#2", "#3", "one", "two", "three", "3 task(s): 2 pending, 0 in-progress, 1 done"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("list missing %q, got:\n%s", want, out)
 		}
@@ -983,6 +983,22 @@ func TestTaskInProgressMarkerFaithful(t *testing.T) {
 	}
 	if !strings.Contains(out, "queued") {
 		t.Errorf("pending filter must show the truly-unchecked item, got:\n%s", out)
+	}
+}
+
+// TestTaskListSummaryCountsInProgress pins that the summary line reports "[-]"
+// items in their own in-progress bucket instead of lumping them into "done"
+// (issue #158: "[ ] [ ] [-]" printed "2 pending, 1 done").
+func TestTaskListSummaryCountsInProgress(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] one\n- [ ] two\n- [-] three\n")
+
+	out, err := run(t, app, "task", "--path", path, "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "3 task(s): 2 pending, 1 in-progress, 0 done") {
+		t.Errorf("summary must count [-] as in-progress, not done, got:\n%s", out)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -722,6 +722,9 @@ func (d *Daemon) reconcileAttention(ctx context.Context) {
 		slog.Error("reconcile: listing agents failed", "error", err)
 		return
 	}
+	// Before the parked-status filter: working agents must sync too, or a
+	// busy agent on a recycled pane id keeps the stale AGE until it parks.
+	d.syncTerminalIDs(ctx, agents)
 	for _, a := range agents {
 		switch a.Status {
 		case "blocked", "idle", "done":
@@ -745,6 +748,28 @@ func (d *Daemon) reconcileAttention(ctx context.Context) {
 		}
 		slog.Info("reconcile: re-driving parked agent", "agent", a.AgentID, "pane", a.PaneID, "status", a.Status)
 		d.scheduleCapture(ctx, a)
+	}
+}
+
+// syncTerminalIDs reconciles each live agent's herdr terminal id with its
+// agent_names row, so an agent landing on a recycled pane id gets its
+// created_at (the TUI AGE anchor) reset (issue #158). Piggybacks on the
+// ListAgents call reconcileAttention already makes — no extra shell-outs.
+// Best-effort: errors are logged and never abort the reconcile sweep.
+func (d *Daemon) syncTerminalIDs(ctx context.Context, agents []domain.AgentTransition) {
+	for _, a := range agents {
+		if a.TerminalID == "" {
+			continue // older herdr without terminal_id: keep today's behavior
+		}
+		reset, err := d.opt.Store.SyncAgentTerminalID(ctx, a.AgentID, a.TerminalID)
+		if err != nil {
+			slog.Warn("reconcile: terminal-id sync failed", "agent", a.AgentID, "error", err)
+			continue
+		}
+		if reset {
+			slog.Info("pane id recycled by a new terminal; agent age reset",
+				"agent", a.AgentID, "terminal", a.TerminalID)
+		}
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1469,6 +1469,60 @@ func TestReconcileEscalatesAlreadyParkedAgent(t *testing.T) {
 	}
 }
 
+// TestReconcileSyncsTerminalIDs covers issue #158: herdr reuses compact pane
+// ids, so an agent row whose stored terminal id differs from the live one is a
+// brand-new terminal — reconcile resets its created_at (the TUI AGE anchor).
+// The sync runs before the parked-status filter (a "working" agent must sync
+// too), and an empty live terminal id (older herdr) leaves everything alone.
+func TestReconcileSyncsTerminalIDs(t *testing.T) {
+	h := newHarness(t, "")
+	ctx := context.Background()
+
+	// Rows left by the panes' previous lives.
+	for id, term := range map[string]string{"pA": "term_old", "pB": "term_keep"} {
+		if _, err := h.raw.EnsureAgentName(ctx, id); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := h.raw.SyncAgentTerminalID(ctx, id, term); err != nil {
+			t.Fatal(err)
+		}
+	}
+	firstSeen := func(id string) time.Time {
+		t.Helper()
+		stats, err := h.raw.AgentStats(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return stats[id].FirstSeen
+	}
+	beforeA, beforeB := firstSeen("pA"), firstSeen("pB")
+	// created_at is unix-milli; make a reset distinguishable from the seed.
+	time.Sleep(15 * time.Millisecond)
+
+	h.herdr.setAgents([]domain.AgentTransition{
+		// Recycled pane id, new terminal — and "working", so only the
+		// terminal-id sync (not the parked-attention path) may touch it.
+		{AgentID: "pA", PaneID: "pA", AgentType: "claude", Status: "working", TerminalID: "term_new"},
+		// No terminal id reported (older herdr): today's behavior.
+		{AgentID: "pB", PaneID: "pB", AgentType: "claude", Status: "working"},
+	})
+	h.daemon.reconcileAttention(ctx)
+
+	if got := firstSeen("pA"); !got.After(beforeA) {
+		t.Errorf("recycled terminal must reset FirstSeen: %v -> %v", beforeA, got)
+	}
+	if got := firstSeen("pB"); !got.Equal(beforeB) {
+		t.Errorf("empty terminal id must not touch FirstSeen: %v -> %v", beforeB, got)
+	}
+
+	// The new id stuck: a repeat sweep with the same terminal is a no-op.
+	repeat := firstSeen("pA")
+	h.daemon.reconcileAttention(ctx)
+	if got := firstSeen("pA"); !got.Equal(repeat) {
+		t.Errorf("repeat sweep must not reset again: %v -> %v", repeat, got)
+	}
+}
+
 // TestReconcileAutoAnswersParkedAgentOnce proves the in-memory dedup guard for
 // the auto-answer path: a confident learned rule leaves NO escalation row, so
 // only episodeHandled (not the store check) stops a re-answer on the next

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -28,7 +28,12 @@ type AgentTransition struct {
 	TabID       string
 	WorkspaceID string
 	Status      string // idle | working | blocked | done | unknown | detected
-	At          time.Time
+	// TerminalID is herdr's unique per-terminal id (`terminal_id`). It changes
+	// whenever the terminal behind a (reusable) pane id is recreated. Only
+	// `agent list` transitions carry it; event-socket transitions and older
+	// herdr leave it empty.
+	TerminalID string
+	At         time.Time
 	// RetryAuditID marks a daemon-injected transition that re-evaluates a
 	// retired LLM-failure escalation. Transient: Herdr events leave it zero.
 	RetryAuditID int64
@@ -61,6 +66,7 @@ type PaneInfo struct {
 	Cwd            string // pane working directory; herdr renders a deleted dir with a " (deleted)" suffix
 	ForegroundCwd  string // cwd of the foreground process; absent in some herdr responses
 	AgentSessionID string // the agent's native session id (agent_session.value); empty when herdr has no stored session reference
+	TerminalID     string // herdr's unique per-terminal id; changes when the terminal behind a reused pane id is recreated
 }
 
 // Situation is a classified, attention-requiring state of one agent pane.

--- a/internal/herdr/cli.go
+++ b/internal/herdr/cli.go
@@ -336,6 +336,7 @@ type agentListResponse struct {
 			PaneID      string `json:"pane_id"`
 			TabID       string `json:"tab_id"`
 			WorkspaceID string `json:"workspace_id"`
+			TerminalID  string `json:"terminal_id"`
 		} `json:"agents"`
 	} `json:"result"`
 }
@@ -365,6 +366,7 @@ func (c *CLI) ListAgents(ctx context.Context) ([]domain.AgentTransition, error) 
 			AgentType:   a.Agent,
 			WorkspaceID: a.WorkspaceID,
 			Status:      a.AgentStatus,
+			TerminalID:  a.TerminalID,
 		})
 	}
 	return agents, nil
@@ -381,6 +383,7 @@ type paneGetResponse struct {
 			WorkspaceID   string `json:"workspace_id"`
 			Cwd           string `json:"cwd"`
 			ForegroundCwd string `json:"foreground_cwd"`
+			TerminalID    string `json:"terminal_id"`
 			// agent_session is a read-only object herdr attaches when it has a
 			// stored native session reference; its "value" is the agent's
 			// session id. Absent when no session is stored.
@@ -410,6 +413,7 @@ func (c *CLI) PaneInfo(ctx context.Context, paneID string) (domain.PaneInfo, err
 		Cwd:            p.Cwd,
 		ForegroundCwd:  p.ForegroundCwd,
 		AgentSessionID: p.AgentSession.Value,
+		TerminalID:     p.TerminalID,
 	}, nil
 }
 

--- a/internal/herdr/herdr_test.go
+++ b/internal/herdr/herdr_test.go
@@ -278,7 +278,7 @@ func TestCLIExecutor(t *testing.T) {
 
 	// agent list parsing (real herdr prints a JSON envelope)
 	fake.SetAgentList(`{"id":"cli:agent:list","result":{"agents":[` +
-		`{"agent":"claude","agent_status":"blocked","pane_id":"w1:p1","workspace_id":"w1"},` +
+		`{"agent":"claude","agent_status":"blocked","pane_id":"w1:p1","workspace_id":"w1","terminal_id":"term_656c9509757bf1"},` +
 		`{"agent":"codex","agent_status":"idle","pane_id":"w1:p2","workspace_id":"w1"}],"type":"agent_list"}}`)
 	agents, err := cli.ListAgents(ctx)
 	if err != nil {
@@ -286,6 +286,9 @@ func TestCLIExecutor(t *testing.T) {
 	}
 	if len(agents) != 2 || agents[0].AgentType != "claude" || agents[1].Status != "idle" {
 		t.Errorf("agent list parsing: %+v", agents)
+	}
+	if agents[0].TerminalID != "term_656c9509757bf1" || agents[1].TerminalID != "" {
+		t.Errorf("terminal_id parsing: %+v", agents)
 	}
 }
 
@@ -733,7 +736,8 @@ func TestPaneInfo(t *testing.T) {
 		`"source":"herdr:claude","value":"ba9a6f5a-ca6a-49dc-bcec-d4869ba97851"},` +
 		`"agent_status":"blocked","cwd":"/home/op/project",` +
 		`"foreground_cwd":"/home/op/project/sub","focused":false,"pane_id":"w1:p1",` +
-		`"revision":0,"tab_id":"w1:t1","workspace_id":"w1"},"type":"pane_info"}}`)
+		`"revision":0,"tab_id":"w1:t1","terminal_id":"term_656d948d811c53d",` +
+		`"workspace_id":"w1"},"type":"pane_info"}}`)
 	info, err := cli.PaneInfo(ctx, "w1:p1")
 	if err != nil {
 		t.Fatal(err)
@@ -746,6 +750,9 @@ func TestPaneInfo(t *testing.T) {
 	}
 	if info.AgentSessionID != "ba9a6f5a-ca6a-49dc-bcec-d4869ba97851" {
 		t.Errorf("agent_session.value parsing: %+v", info)
+	}
+	if info.TerminalID != "term_656d948d811c53d" {
+		t.Errorf("terminal_id parsing: %+v", info)
 	}
 
 	// Deleted cwd renders with a literal suffix and no foreground_cwd;
@@ -762,6 +769,9 @@ func TestPaneInfo(t *testing.T) {
 	}
 	if info.AgentSessionID != "" {
 		t.Errorf("absent agent_session must zero AgentSessionID: %+v", info)
+	}
+	if info.TerminalID != "" {
+		t.Errorf("absent terminal_id must zero TerminalID: %+v", info)
 	}
 
 	// CLI failure surfaces an error.

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -182,6 +182,12 @@ type DaemonStore interface {
 	// EnsureAgentName returns the agent's short name, generating one on
 	// first sight (insert-if-absent only; renames stay operator-owned).
 	EnsureAgentName(ctx context.Context, agentID string) (string, error)
+	// SyncAgentTerminalID reconciles the stored herdr terminal id for an
+	// agent row. Herdr reuses compact pane ids, so a differing live id means
+	// a new terminal recycled the id: created_at resets so AGE reflects the
+	// current session (name and history survive). Empty terminalID and
+	// unknown agentID are no-ops. Returns reset=true when created_at moved.
+	SyncAgentTerminalID(ctx context.Context, agentID, terminalID string) (bool, error)
 	StageLLMRequest(ctx context.Context, r domain.LLMRequest) (int64, error)
 	UpdateLLMRequestStatus(ctx context.Context, requestID, status string) error
 	// UpdateLLMRequestContext fills the context_json of an already-staged

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -184,6 +184,7 @@ CREATE TABLE IF NOT EXISTS agent_names (
 	agent_id TEXT PRIMARY KEY,
 	name TEXT NOT NULL UNIQUE,
 	disabled INTEGER NOT NULL DEFAULT 0,
+	terminal_id TEXT NOT NULL DEFAULT '',
 	created_at INTEGER NOT NULL
 );
 CREATE TABLE IF NOT EXISTS signature_embeddings (
@@ -235,6 +236,10 @@ func (s *Store) migrate() error {
 		// Operator-owned per-agent automation switch. Kept on agent_names so
 		// renames preserve it and disabled agents remain visible by name.
 		`ALTER TABLE agent_names ADD COLUMN disabled INTEGER NOT NULL DEFAULT 0`,
+		// Herdr's unique per-terminal id. Herdr reuses compact pane ids, so
+		// this is what tells "same agent" from "new terminal on a recycled
+		// pane id" (issue #158). '' = not yet observed.
+		`ALTER TABLE agent_names ADD COLUMN terminal_id TEXT NOT NULL DEFAULT ''`,
 	} {
 		if _, err := s.db.Exec(ddl); err != nil &&
 			!strings.Contains(err.Error(), "duplicate column name") {
@@ -1398,6 +1403,51 @@ func (s *Store) EnsureAgentName(ctx context.Context, agentID string) (string, er
 		}
 	}
 	return "", fmt.Errorf("could not assign a unique name to agent %s", agentID)
+}
+
+// SyncAgentTerminalID reconciles the stored herdr terminal id for an agent
+// row. Herdr reuses compact pane ids after panes close, so a differing
+// terminal id means the row now describes a brand-new terminal: created_at
+// is reset so AGE reflects the current session, while the name, disabled
+// flag, and audit history survive (issue #158). Returns reset=true when the
+// timestamp was reset. Empty terminalID (older herdr) and unknown agentID
+// (row not created yet — EnsureAgentName owns creation) are no-ops.
+func (s *Store) SyncAgentTerminalID(ctx context.Context, agentID, terminalID string) (bool, error) {
+	if terminalID == "" {
+		return false, nil
+	}
+	reset := false
+	err := s.tx(ctx, func(tx *sql.Tx) error {
+		var stored string
+		err := tx.QueryRowContext(ctx,
+			`SELECT terminal_id FROM agent_names WHERE agent_id = ?`, agentID).Scan(&stored)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		switch stored {
+		case terminalID:
+			return nil
+		case "":
+			// First observation for a pre-existing row: adopt the id without
+			// touching created_at (no evidence the terminal changed).
+			_, err = tx.ExecContext(ctx,
+				`UPDATE agent_names SET terminal_id = ? WHERE agent_id = ?`,
+				terminalID, agentID)
+			return err
+		default:
+			_, err = tx.ExecContext(ctx,
+				`UPDATE agent_names SET terminal_id = ?, created_at = ? WHERE agent_id = ?`,
+				terminalID, time.Now().UnixMilli(), agentID)
+			if err == nil {
+				reset = true
+			}
+			return err
+		}
+	})
+	return reset, err
 }
 
 func (s *Store) agentNameByID(ctx context.Context, agentID string) (string, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1416,7 +1416,9 @@ func (s *Store) SyncAgentTerminalID(ctx context.Context, agentID, terminalID str
 	if terminalID == "" {
 		return false, nil
 	}
-	reset := false
+	// Set inside the tx but only trusted after it commits, so a commit
+	// failure cannot report a reset that never became durable.
+	wantReset := false
 	err := s.tx(ctx, func(tx *sql.Tx) error {
 		var stored string
 		err := tx.QueryRowContext(ctx,
@@ -1442,12 +1444,15 @@ func (s *Store) SyncAgentTerminalID(ctx context.Context, agentID, terminalID str
 				`UPDATE agent_names SET terminal_id = ?, created_at = ? WHERE agent_id = ?`,
 				terminalID, time.Now().UnixMilli(), agentID)
 			if err == nil {
-				reset = true
+				wantReset = true
 			}
 			return err
 		}
 	})
-	return reset, err
+	if err != nil {
+		return false, err
+	}
+	return wantReset, nil
 }
 
 func (s *Store) agentNameByID(ctx context.Context, agentID string) (string, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -811,6 +811,8 @@ func TestAgentStats(t *testing.T) {
 	if _, err := s.SyncAgentTerminalID(ctx, "w1:p1", "term_old"); err != nil {
 		t.Fatal(err)
 	}
+	// created_at is unix-milli; make the reset distinguishable from base.
+	time.Sleep(15 * time.Millisecond)
 	reset, err := s.SyncAgentTerminalID(ctx, "w1:p1", "term_new")
 	if err != nil || !reset {
 		t.Fatalf("recycled terminal id must reset: reset=%v err=%v", reset, err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -804,6 +804,85 @@ func TestAgentStats(t *testing.T) {
 	if g := restart["w1:p3"]; g.AutoSends != 0 || g.Escalations != 0 || g.Confirmed != 0 || g.Corrections != 0 {
 		t.Errorf("new pane id must start empty, got %+v", g)
 	}
+
+	// Herdr can also RECYCLE a pane id for a brand-new terminal. The terminal
+	// id sync then resets FirstSeen (AGE anchor) while the audit-derived
+	// counts — keyed to the pane id — survive (issue #158).
+	if _, err := s.SyncAgentTerminalID(ctx, "w1:p1", "term_old"); err != nil {
+		t.Fatal(err)
+	}
+	reset, err := s.SyncAgentTerminalID(ctx, "w1:p1", "term_new")
+	if err != nil || !reset {
+		t.Fatalf("recycled terminal id must reset: reset=%v err=%v", reset, err)
+	}
+	recycled, err := s.AgentStats(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g := recycled["w1:p1"]; !g.FirstSeen.After(base) {
+		t.Errorf("recycled pane id must move FirstSeen past %v, got %v", base, g.FirstSeen)
+	} else if g.AutoSends != want.AutoSends || g.Escalations != want.Escalations {
+		t.Errorf("terminal-id reset must keep counts, got %+v", g)
+	}
+}
+
+func TestSyncAgentTerminalID(t *testing.T) {
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+
+	name, err := s.EnsureAgentName(ctx, "w1:p1")
+	if err != nil || name == "" {
+		t.Fatalf("ensure name: %q %v", name, err)
+	}
+	firstSeen := func() time.Time {
+		t.Helper()
+		stats, err := s.AgentStats(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return stats["w1:p1"].FirstSeen
+	}
+	created := firstSeen()
+
+	// Empty terminal id (older herdr) and unknown agent id are no-ops.
+	if reset, err := s.SyncAgentTerminalID(ctx, "w1:p1", ""); err != nil || reset {
+		t.Errorf("empty terminal id must no-op, got reset=%v err=%v", reset, err)
+	}
+	if reset, err := s.SyncAgentTerminalID(ctx, "w9:p9", "term_a"); err != nil || reset {
+		t.Errorf("unknown agent must no-op, got reset=%v err=%v", reset, err)
+	}
+
+	// First observation adopts the id without touching created_at.
+	if reset, err := s.SyncAgentTerminalID(ctx, "w1:p1", "term_a"); err != nil || reset {
+		t.Errorf("first observation must record without reset, got reset=%v err=%v", reset, err)
+	}
+	if got := firstSeen(); !got.Equal(created) {
+		t.Errorf("first observation moved FirstSeen %v -> %v", created, got)
+	}
+
+	// Matching id is a no-op.
+	if reset, err := s.SyncAgentTerminalID(ctx, "w1:p1", "term_a"); err != nil || reset {
+		t.Errorf("matching id must no-op, got reset=%v err=%v", reset, err)
+	}
+
+	// A differing id means the pane id was recycled: created_at resets,
+	// name survives.
+	before := time.Now().Truncate(time.Millisecond)
+	reset, err := s.SyncAgentTerminalID(ctx, "w1:p1", "term_b")
+	if err != nil || !reset {
+		t.Fatalf("differing id must reset, got reset=%v err=%v", reset, err)
+	}
+	if got := firstSeen(); got.Before(before) {
+		t.Errorf("reset must move FirstSeen to now, got %v (< %v)", got, before)
+	}
+	if after, err := s.agentNameByID(ctx, "w1:p1"); err != nil || after != name {
+		t.Errorf("reset must keep the name %q, got %q %v", name, after, err)
+	}
+
+	// The new id is now stored: re-sync is a no-op again.
+	if reset, err := s.SyncAgentTerminalID(ctx, "w1:p1", "term_b"); err != nil || reset {
+		t.Errorf("re-sync after reset must no-op, got reset=%v err=%v", reset, err)
+	}
 }
 
 func TestAgentNames(t *testing.T) {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -145,6 +145,11 @@ func TestRealPaneInfo(t *testing.T) {
 	if gotCwd != wantCwd {
 		t.Errorf("cwd = %q, want /tmp (resolved %q)", info.Cwd, wantCwd)
 	}
+	// The AGE reset on pane-id recycling (issue #158) hangs off this field —
+	// catch herdr dropping/renaming it.
+	if info.TerminalID == "" {
+		t.Errorf("expected a terminal_id, got %+v", info)
+	}
 }
 
 // TestRealConfirmDeliversMenuDigit is the end-to-end regression for the send

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -146,9 +146,10 @@ func TestRealPaneInfo(t *testing.T) {
 		t.Errorf("cwd = %q, want /tmp (resolved %q)", info.Cwd, wantCwd)
 	}
 	// The AGE reset on pane-id recycling (issue #158) hangs off this field —
-	// catch herdr dropping/renaming it.
+	// surface herdr dropping/renaming it. Skip (never fail) so a herdr
+	// predating terminal_id still runs the suite clean.
 	if info.TerminalID == "" {
-		t.Errorf("expected a terminal_id, got %+v", info)
+		t.Skipf("herdr reported no terminal_id (pre-terminal_id herdr, or the field was renamed): %+v", info)
 	}
 }
 


### PR DESCRIPTION
Fixes #158 — both display bugs from the 2026-07-17 live feature test.

## 1. `hap task <agent> list` summary counted `[-]` as "done"

`printTaskList` had only two buckets, and `domain.ParseChecklist` sets `Done=true` for any non-space mark. The summary now reports a third bucket keyed on `Mark == domain.MarkInProgress`:

```
3 task(s): 2 pending, 1 in-progress, 0 done
```

Filter semantics are unchanged (`--status pending` still excludes `[-]`, `--status done` still includes it, as pinned by `TestTaskInProgressMarkerFaithful`).

## 2. TUI Agents-tab AGE wildly wrong for fresh agents

Root cause: AGE renders `now - agent_names.created_at`, keyed by herdr's compact pane ids — which herdr **reuses** after panes close. A new agent on a recycled id inherited the previous terminal's timestamp (observed: `83:11:17` for a 16-minute-old agent).

Fix (verified live against herdr 0.7): both `agent list` and `pane get` emit a unique per-terminal `terminal_id` that changes when the terminal is recreated. Now:

- `internal/herdr` parses `terminal_id` into `AgentTransition` / `PaneInfo`
- `agent_names` gains a `terminal_id` column (idempotent ALTER migration)
- new `Store.SyncAgentTerminalID`: first observation adopts the id; a **differing** id means the pane id was recycled → `created_at` resets (name, disabled flag, and audit history survive)
- the daemon reconciles ids in `reconcileAttention`'s existing `ListAgents` sweep (startup + 1-minute ticker + frontend nudge) — zero new shell-outs, before the parked-status filter so working agents sync too
- fail-safe: empty `terminal_id` (older herdr) keeps today's behavior; sync errors log and never abort the sweep

## Tests

- CLI: exact issue repro pinned (`[ ] [ ] [-]` → `2 pending, 1 in-progress, 0 done`)
- Store: `TestSyncAgentTerminalID` (adopt / match / reset / no-op transitions), recycled-id case in `TestAgentStats` (FirstSeen resets, counts survive)
- Daemon: `TestReconcileSyncsTerminalIDs` (reset via sweep for a *working* agent; empty-id degrade; repeat-sweep idempotence)
- herdr adapter: `terminal_id` present/absent in both envelopes
- Integration (run against live herdr — all green): `TestRealPaneInfo` now asserts a non-empty `terminal_id` (skips on pre-`terminal_id` herdr)

Full unit suite (22 pkgs, `vectors cpu`), `go vet`, `golangci-lint`: clean.