### PR TITLE
#157 fix: append generated tasks to the exhausted declared source

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -245,6 +245,20 @@ type TaskSource struct {
 	MaxTasks int `toml:"max_tasks,omitempty"`
 }
 
+// MatchesAgent reports whether this source's agent selector matches the given
+// agent. The selector matches the agent/pane id, the agent type, or the
+// agent's short name; an empty selector matches any agent. This is the single
+// definition of the selector semantics — the daemon's task-source matcher and
+// the frontend's confirm-time source resolution must agree, or a generated
+// task confirm can bootstrap a duplicate source next to a declared one.
+func (s TaskSource) MatchesAgent(agentID, agentType, agentName string) bool {
+	if s.Agent == "" {
+		return true
+	}
+	return s.Agent == agentID || s.Agent == agentType ||
+		(agentName != "" && s.Agent == agentName)
+}
+
 // DefaultMaxTasks is the fallback for TaskSource.MaxTasks when unset (0).
 const DefaultMaxTasks = 20
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1224,3 +1224,32 @@ func TestCaptureDelayLoadedFromTOML(t *testing.T) {
 		t.Errorf("unmatched start delay = %v, want 10s", got)
 	}
 }
+
+func TestTaskSourceMatchesAgent(t *testing.T) {
+	// MatchesAgent is the single definition of the agent-selector semantics,
+	// shared by the daemon's task-source matcher and the frontend's
+	// generated-task confirm: id, type, or short name; "" matches any.
+	cases := []struct {
+		name     string
+		selector string
+		id, typ  string
+		short    string
+		want     bool
+	}{
+		{"empty selector matches any", "", "w1:p1", "claude", "alpha", true},
+		{"matches agent id", "w1:p1", "w1:p1", "claude", "alpha", true},
+		{"matches agent type", "claude", "w1:p1", "claude", "alpha", true},
+		{"matches short name", "alpha", "w1:p1", "claude", "alpha", true},
+		{"no match", "beta", "w1:p1", "claude", "alpha", false},
+		{"empty short name never matches a named selector", "alpha", "w1:p1", "claude", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := TaskSource{Agent: tc.selector}
+			if got := src.MatchesAgent(tc.id, tc.typ, tc.short); got != tc.want {
+				t.Errorf("TaskSource{Agent:%q}.MatchesAgent(%q,%q,%q) = %v, want %v",
+					tc.selector, tc.id, tc.typ, tc.short, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1900,8 +1900,12 @@ func (d *Daemon) generateTask(ctx context.Context, cfg config.Config, s domain.S
 	// a pending-consult row that the in-flight guard then trips on forever.
 	if sourceExhausted {
 		agentName, _ := d.opt.Store.EnsureAgentName(ctx, s.AgentID)
+		// At-cap counts as full (n >= limit, matching AddTask and the
+		// confirm-time append): appending even one generated task to a list
+		// already holding max_tasks items would exceed the cap, so generating
+		// would only raise escalations every confirm must refuse.
 		if m, ok := d.matchTaskSource(ctx, cfg, tr.AgentID, tr.AgentType, tr.WorkspaceID, agentName); ok {
-			if n, limit := len(domain.ParseChecklist(string(m.data))), m.src.MaxTasksLimit(); n > limit {
+			if n, limit := len(domain.ParseChecklist(string(m.data))), m.src.MaxTasksLimit(); n >= limit {
 				name := agentName
 				if name == "" {
 					name = s.AgentID
@@ -3524,8 +3528,7 @@ func (d *Daemon) matchTaskSource(ctx context.Context, cfg config.Config, agentID
 	var completed *taskSourceMatch
 	wsName, wsResolved := "", false
 	for _, src := range cfg.TaskSources {
-		if src.Agent != "" && src.Agent != agentID && src.Agent != agentType &&
-			(agentName == "" || src.Agent != agentName) {
+		if !src.MatchesAgent(agentID, agentType, agentName) {
 			continue
 		}
 		if src.Workspace != "" && src.Workspace != "*" {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2553,9 +2553,11 @@ func TestIdleTaskGenSkipsWhenOverMaxTasks(t *testing.T) {
 	// call returns.
 	dir := t.TempDir()
 	taskFile := filepath.Join(dir, "tasks.md")
-	// Four items (all done → pending exhausted, so generation would fire) with
-	// max_tasks = 3, i.e. 4 > 3 → over the cap.
-	os.WriteFile(taskFile, []byte("- [x] a\n- [x] b\n- [x] c\n- [x] d\n"), 0o600)
+	// Three items (all done → pending exhausted, so generation would fire)
+	// with max_tasks = 3: at-cap counts as full (3 >= 3) — appending even one
+	// generated task would exceed the cap, and the confirm-time append would
+	// refuse it, so generating would only raise unconfirmable escalations.
+	os.WriteFile(taskFile, []byte("- [x] a\n- [x] b\n- [x] c\n"), 0o600)
 
 	cfg := fmt.Sprintf(
 		"[[task_sources]]\nagent = \"agent-77\"\npath = %q\nmax_tasks = 3\n\n[llm]\ntask_generate_command = [\"fake\"]\ntask_generate_command_start = [\"fake-start\"]\n",

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -733,9 +733,10 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 	// means the sentinel, and the literal spelling must never be learned
 	// as pane text (free text like "do nothing" stays literal).
 	action = domain.NormalizeNoopAction(action)
-	// Confirming an idle task suggestion is not a pane send: it writes a
-	// per-agent tasks.md, registers it as a task source, and (when send) hands
-	// the task to the agent. Handle it before the send-oriented flow below.
+	// Confirming an idle task suggestion is not a pane send: it appends the
+	// tasks to the agent's declared task source (or bootstraps a per-agent
+	// tasks.md when none exists) and, when send, hands the first task to the
+	// agent. Handle it before the send-oriented flow below.
 	if action == domain.SuggestGenerateTask {
 		return a.acceptGeneratedTask(ctx, audit, send)
 	}
@@ -847,16 +848,21 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 	return a.nudge(ctx, control.KindReload)
 }
 
-// acceptGeneratedTask confirms an idle task suggestion: it writes a per-agent
-// tasks.md (every item pending "[ ]"), registers it as a task source in
-// config.toml, records the correction that resolves the escalation, and — when
-// send — reserves the first item "[-]" and hands it to the agent, rolling it
+// acceptGeneratedTask confirms an idle task suggestion. When the agent
+// already has a declared task source, the generated tasks refill THAT list:
+// they are appended to the source's own file (appendGeneratedTasks) — never
+// written to a second per-agent file, which would register a duplicate
+// [[task_sources]] entry and make `hap task <agent>` ambiguous (issue #157).
+// Only when no declared source matches does it bootstrap: write a per-agent
+// tasks.md (every item pending "[ ]"), register it as a task source in
+// config.toml, record the correction that resolves the escalation, and — when
+// send — reserve the first item "[-]" and hand it to the agent, rolling it
 // back to "[ ]" if the send fails. Without send the file stays all-pending so
 // the daemon's idle flow delivers the first item on the next idle; pre-marking
 // "[-]" at write time would strand it forever, since "[-]" is exactly what
-// suppresses the idle resend (issue #156). Side effects run source-first so a
-// send failure never leaves the agent without the task source that was just
-// established.
+// suppresses the idle resend (issue #156). Bootstrap side effects run
+// source-first so a send failure never leaves the agent without the task
+// source that was just established.
 func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord, send bool) error {
 	// The suggestion may carry one task or several (plain or as a Markdown
 	// list); normalize into clean bare task strings so the file is always a
@@ -879,14 +885,18 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	// raised. If the agent has since started working, sending an outdated task
 	// would interrupt it — refuse rather than create a source and send. Fail
 	// open when the status is unknown (list error / agent absent): the operator
-	// explicitly asked to confirm.
+	// explicitly asked to confirm. The matched transition is kept for the
+	// declared-source resolution below (workspace-scoped selectors need the
+	// agent's live workspace).
+	var live *domain.AgentTransition
 	if a.Herdr != nil {
 		if agents, lerr := a.Herdr.ListAgents(ctx); lerr == nil {
-			for _, ag := range agents {
+			for i, ag := range agents {
 				if ag.AgentID == audit.AgentID {
 					if domain.AgentBusy(ag.Status) {
 						return fmt.Errorf("agent is no longer idle (%s); the suggested task is stale — dismiss it or wait until the agent is idle", ag.Status)
 					}
+					live = &agents[i]
 					break
 				}
 			}
@@ -898,6 +908,21 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	name, err := a.Store.EnsureAgentName(ctx, audit.AgentID)
 	if err != nil || name == "" {
 		name = audit.AgentID
+	}
+
+	// Exhausted-declared-source case (issue #157): when a declared source
+	// already matches this agent, generation was refilling that list — append
+	// to its file. Bootstrapping here instead would register a second source
+	// for the same agent and break `hap task <agent>` with a "matches 2 task
+	// sources" ambiguity. A config read error fails the confirm (the bootstrap
+	// path could not register its source either), leaving the escalation
+	// pending for a retry.
+	cfg, cerr := a.Config()
+	if cerr != nil {
+		return fmt.Errorf("read config: %w", cerr)
+	}
+	if src, ok := pickAppendTarget(a.matchingDeclaredSources(ctx, cfg, audit, name, live)); ok {
+		return a.appendGeneratedTasks(ctx, audit, src, name, tasks, send)
 	}
 
 	// Idempotent side effects FIRST (before the claim): writing the file and
@@ -930,7 +955,7 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	// nudges the daemon to reload). Idempotent: a re-confirm for the same
 	// agent+path never stacks duplicate entries. Scope by the agent selector;
 	// workspace "" = any so the source follows the agent across workspaces.
-	if err := a.addTaskSourceIfAbsent(ctx, name, path); err != nil {
+	if err := a.addTaskSourceIfAbsent(ctx, audit.AgentID, audit.AgentType, name, path); err != nil {
 		return fmt.Errorf("register task source: %w", err)
 	}
 
@@ -1065,20 +1090,247 @@ func carryOverChecklistMarks(existing, rendered string) string {
 	return strings.Join(lines, "\n")
 }
 
+// matchingDeclaredSources returns the [[task_sources]] entries that match the
+// confirming agent, using the same selector semantics as the daemon's
+// matchTaskSource (agent id / type / short name; workspace name with "*"
+// wildcards, falling back to the raw workspace id). Workspace-scoped sources
+// are matched best-effort against the agent's live workspace; when that is
+// unresolvable (no live transition, no locator) only unscoped ("" / "*")
+// selectors match, failing soft toward the bootstrap path — where the
+// addTaskSourceIfAbsent guard still refuses to create a duplicate.
+func (a *App) matchingDeclaredSources(ctx context.Context, cfg config.Config, audit *domain.AuditRecord, agentName string, live *domain.AgentTransition) []config.TaskSource {
+	var out []config.TaskSource
+	wsTarget, wsResolved := "", false
+	for _, src := range cfg.TaskSources {
+		if !src.MatchesAgent(audit.AgentID, audit.AgentType, agentName) {
+			continue
+		}
+		if src.Workspace != "" && src.Workspace != "*" {
+			if !wsResolved {
+				wsTarget, wsResolved = a.agentWorkspaceTarget(ctx, live), true
+			}
+			if wsTarget == "" || !domain.MatchWorkspace(src.Workspace, wsTarget) {
+				continue
+			}
+		}
+		out = append(out, src)
+	}
+	return out
+}
+
+// agentWorkspaceTarget resolves the string a workspace selector matches
+// against for the given live agent: the workspace's display name (label) when
+// a LocatorPort can resolve it, else the raw workspace id — the same
+// name-falling-back-to-id rule as the daemon's workspaceName. "" means the
+// workspace is unknown.
+func (a *App) agentWorkspaceTarget(ctx context.Context, live *domain.AgentTransition) string {
+	if live == nil || live.WorkspaceID == "" || a.Herdr == nil {
+		return ""
+	}
+	if loc, ok := a.Herdr.(ports.LocatorPort); ok {
+		if wss, err := loc.ListWorkspaces(ctx); err == nil {
+			for _, w := range wss {
+				if w.ID == live.WorkspaceID && w.Label != "" {
+					return w.Label
+				}
+			}
+		}
+	}
+	return live.WorkspaceID
+}
+
+// pickAppendTarget chooses which matched declared source receives the
+// generated tasks, mirroring matchTaskSource's precedence so the confirm
+// appends to the source the daemon reasoned about: first with a pending
+// "[ ]" item, else first whose file has checklist items, else the first
+// match in config order (which also covers an empty or not-yet-created file —
+// appending there bootstraps the DECLARED path instead of a duplicate).
+func pickAppendTarget(sources []config.TaskSource) (config.TaskSource, bool) {
+	if len(sources) == 0 {
+		return config.TaskSource{}, false
+	}
+	var withItems *config.TaskSource
+	for i := range sources {
+		p := sources[i].Path
+		if abs, err := filepath.Abs(p); err == nil {
+			p = abs
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		if domain.NextDeclaredTask(string(data)) != "" {
+			return sources[i], true
+		}
+		if withItems == nil && domain.HasChecklistItems(string(data)) {
+			withItems = &sources[i]
+		}
+	}
+	if withItems != nil {
+		return *withItems, true
+	}
+	return sources[0], true
+}
+
+// appendGeneratedTasks confirms generated tasks for an agent that already has
+// a declared task source: the tasks are appended to that source's own file.
+// Ordering differs from the bootstrap path — an append is NOT idempotent, so
+// the escalation is claimed FIRST and the append runs after it, exactly like
+// the non-idempotent send (a double-submit fails at the claim). All items are
+// appended pending ("[ ]"); when send succeeds, the first is flipped to
+// in-progress ("[-]") afterwards, so a failed send never strands an
+// in-progress item the daemon would refuse to re-deliver.
+func (a *App) appendGeneratedTasks(ctx context.Context, audit *domain.AuditRecord, src config.TaskSource, name string, tasks []string, send bool) error {
+	path := src.Path
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	limit := src.MaxTasksLimit()
+
+	// Pre-claim cap check: the daemon gated generation when it ran, but the
+	// list may have grown since (manual adds). Refusing BEFORE the claim
+	// leaves the escalation pending, so the operator can prune the list and
+	// confirm again. A missing file is fine (created below); any other read
+	// error must also refuse pre-claim — claiming first and then failing the
+	// in-lock read would consume the escalation with nothing appended.
+	if data, err := os.ReadFile(path); err == nil {
+		if current := len(domain.ParseChecklist(string(data))); current >= limit {
+			return fmt.Errorf("maximum number of tasks reached for %s (%d items, cap %d) — clean up the task list to make room, then confirm again", path, current, limit)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read task list %s: %w", path, err)
+	}
+	// The declared file may not exist yet (a freshly added source): create it
+	// so mutateTaskFile's stat succeeds. Idempotent, so it runs pre-claim.
+	if _, err := os.Stat(path); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return fmt.Errorf("create task list dir: %w", err)
+		}
+		if err := os.WriteFile(path, []byte("# Tasks for "+name+"\n\n"), 0o600); err != nil {
+			return fmt.Errorf("create task list file: %w", err)
+		}
+	}
+
+	// Atomically CLAIM the escalation. Only the writer that flips
+	// escalated→resolved proceeds to the append and send, so a double-submit
+	// can never append or send the tasks twice.
+	claimed, err := a.Store.ResolveEscalation(ctx, audit.ID)
+	if err != nil {
+		return err
+	}
+	if !claimed {
+		return fmt.Errorf("audit record %d is no longer a pending escalation", audit.ID)
+	}
+
+	firstIndex := 0
+	if _, err := mutateTaskFile(path, func(content string) (string, error) {
+		// Recomputed inside the lock: a racing add may have consumed the room
+		// the pre-claim check saw. Appending fewer tasks than suggested beats
+		// refusing the operator's explicit "start now" — but zero room means
+		// nothing can land, so surface that.
+		room := limit - len(domain.ParseChecklist(content))
+		if room <= 0 {
+			return "", fmt.Errorf("maximum number of tasks reached (cap %d)", limit)
+		}
+		if room < len(tasks) {
+			slog.Warn("truncating generated tasks to the source's max_tasks cap",
+				"path", path, "cap", limit, "dropped", len(tasks)-room)
+			tasks = tasks[:room]
+		}
+		out := content
+		for i, task := range tasks {
+			var idx int
+			var e error
+			out, idx, e = domain.AppendChecklistItem(out, domain.EncodeTaskNewlines(task))
+			if e != nil {
+				return "", e
+			}
+			if i == 0 {
+				firstIndex = idx
+			}
+		}
+		return out, nil
+	}); err != nil {
+		return fmt.Errorf("escalation resolved, but appending the generated tasks to %s failed: %w", path, err)
+	}
+
+	// Record the correction so the idle signature learns to drive from its
+	// declared task list. Best-effort, as in the bootstrap path.
+	if _, err := a.Store.InsertCorrection(ctx, domain.CorrectionRecord{
+		AuditID: audit.ID, CorrectedAction: domain.ActionNextDeclaredTask,
+		Author: a.Author, CreatedAt: time.Now(),
+	}); err != nil {
+		slog.Warn("recording generated-task confirmation correction failed", "audit", audit.ID, "error", err)
+	}
+
+	if send && a.Herdr != nil {
+		// Only the first task is sent — the operator's "start now" task —
+		// rendered through the SOURCE's template (not the built-in default),
+		// pointing at the declared file. {cwd} is resolved only when the
+		// template references it, matching the daemon's declaredTask.
+		cwd := ""
+		if strings.Contains(domain.TemplateOrDefault(src.NextTaskTemplate), "{cwd}") {
+			if insp, ok := a.Herdr.(ports.InspectorPort); ok {
+				if pi, e := insp.PaneInfo(ctx, audit.AgentID); e == nil {
+					cwd = pi.ForegroundCwd
+					if cwd == "" {
+						cwd = pi.Cwd
+					}
+				}
+			}
+		}
+		prompt := domain.DeclaredTask{
+			Task: tasks[0], Path: path, Template: src.NextTaskTemplate,
+			AgentName: name, Cwd: cwd,
+		}.Prompt()
+		if err := ports.SendToAgent(ctx, a.Herdr, audit.AgentID, audit.AgentType, prompt); err != nil {
+			return fmt.Errorf("tasks appended to %s, but sending the task to the agent failed: %w", path, err)
+		}
+		// Delivery succeeded: flip the delivered task to in-progress so the
+		// daemon's declared flow does not re-send it on the next idle.
+		// Best-effort — a failed flip only risks a duplicate send later,
+		// which is safer than an undelivered "[-]" the daemon skips. Indices
+		// are positional and renumber on delete, so the flip is text-guarded
+		// (expectTaskText) against a concurrent edit in the send window.
+		if _, err := mutateTaskFile(path, func(content string) (string, error) {
+			if err := expectTaskText(content, firstIndex, domain.EncodeTaskNewlines(tasks[0])); err != nil {
+				return "", err
+			}
+			return domain.MarkChecklistItemInProgress(content, firstIndex)
+		}); err != nil {
+			slog.Warn("marking the delivered generated task in-progress failed", "path", path, "index", firstIndex, "error", err)
+		}
+	}
+	return a.nudge(ctx, control.KindReload)
+}
+
 // addTaskSourceIfAbsent registers a task list for an agent, skipping the append
 // when an identical agent+path entry already exists — so confirming the same
-// generated-task escalation twice never accumulates duplicate sources.
-func (a *App) addTaskSourceIfAbsent(ctx context.Context, agent, path string) error {
+// generated-task escalation twice never accumulates duplicate sources. An
+// existing source whose non-empty selector matches this agent (by id, type,
+// or short name — the same MatchesAgent semantics the daemon uses) under a
+// DIFFERENT path is refused outright: two sources matching one agent is
+// exactly the "matches 2 task sources" ambiguity issue #157 fixed, so this
+// guard keeps any residual bootstrap path (e.g. a workspace-scoped source the
+// confirm could not resolve) from re-creating it. An empty ("" = any-agent)
+// selector is deliberately not refused — a catch-all scoped to another
+// workspace must not block an unrelated agent's bootstrap.
+func (a *App) addTaskSourceIfAbsent(ctx context.Context, agentID, agentType, name, path string) error {
 	if abs, err := filepath.Abs(path); err == nil {
 		path = abs
 	}
 	return a.UpdateConfig(ctx, func(cfg *config.Config) error {
 		for _, ts := range cfg.TaskSources {
-			if ts.Agent == agent && ts.Path == path {
+			if ts.Agent == name && ts.Path == path {
 				return nil
 			}
 		}
-		cfg.TaskSources = append(cfg.TaskSources, config.TaskSource{Agent: agent, Path: path})
+		for _, ts := range cfg.TaskSources {
+			if ts.Agent != "" && ts.MatchesAgent(agentID, agentType, name) {
+				return fmt.Errorf("agent %q already has a task source (%s); refusing to register a second — append the generated tasks to it instead", name, ts.Path)
+			}
+		}
+		cfg.TaskSources = append(cfg.TaskSources, config.TaskSource{Agent: name, Path: path})
 		return nil
 	})
 }

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -921,7 +921,29 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	if cerr != nil {
 		return fmt.Errorf("read config: %w", cerr)
 	}
-	if src, ok := pickAppendTarget(a.matchingDeclaredSources(ctx, cfg, audit, name, live)); ok {
+	// The agent's own bootstrapped generated file is NOT an append target: a
+	// re-confirm or regeneration of a generated list must go through the
+	// bootstrap flow below, whose locked compare-rewrite carries progress
+	// markers across regenerations and keeps the numbered-ID rendering
+	// (issue #156). Only sources declared elsewhere take the append path —
+	// which also makes a legacy dual-source config (one declared source plus
+	// a bug-era bootstrap file) prefer the declared one.
+	base := a.StateDir
+	if base == "" {
+		base = filepath.Dir(a.ConfigPath)
+	}
+	bootstrapPath := filepath.Join(base, "tasks", sanitizeTaskFileName(name)+".md")
+	var external []config.TaskSource
+	for _, src := range a.matchingDeclaredSources(ctx, cfg, audit, name, live) {
+		p := src.Path
+		if abs, err := filepath.Abs(p); err == nil {
+			p = abs
+		}
+		if p != bootstrapPath {
+			external = append(external, src)
+		}
+	}
+	if src, ok := pickAppendTarget(external); ok {
 		return a.appendGeneratedTasks(ctx, audit, src, name, tasks, send)
 	}
 
@@ -932,15 +954,10 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	// de-dupes under UpdateConfig's advisory lock. Running them before the claim means a
 	// failure here leaves the escalation still pending, so the operator can
 	// retry; only the non-idempotent send is gated by the claim below.
-	base := a.StateDir
-	if base == "" {
-		base = filepath.Dir(a.ConfigPath)
-	}
-	dir := filepath.Join(base, "tasks")
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(bootstrapPath), 0o700); err != nil {
 		return fmt.Errorf("create tasks dir: %w", err)
 	}
-	path := filepath.Join(dir, sanitizeTaskFileName(name)+".md")
+	path := bootstrapPath
 	// Every task is written pending ("[ ]"); the first is marked in-progress
 	// ("[-]") only below, at delivery time, so a confirm that sends nothing
 	// leaves it for the daemon's normal declared-task flow (issue #156).
@@ -1174,12 +1191,15 @@ func pickAppendTarget(sources []config.TaskSource) (config.TaskSource, bool) {
 
 // appendGeneratedTasks confirms generated tasks for an agent that already has
 // a declared task source: the tasks are appended to that source's own file.
-// Ordering differs from the bootstrap path — an append is NOT idempotent, so
-// the escalation is claimed FIRST and the append runs after it, exactly like
-// the non-idempotent send (a double-submit fails at the claim). All items are
-// appended pending ("[ ]"); when send succeeds, the first is flipped to
-// in-progress ("[-]") afterwards, so a failed send never strands an
-// in-progress item the daemon would refuse to re-deliver.
+// The append runs BEFORE the escalation claim and is idempotent — tasks whose
+// text the checklist already carries are skipped, mirroring
+// ensureGeneratedTaskFile's re-confirm skip — so ANY append-side failure (cap
+// full, unreadable file, failed write) leaves the escalation pending and
+// retryable; claiming first would consume it with nothing appended. Items are
+// appended pending ("[ ]"), and delivery mirrors SendTaskToAgent's
+// load-bearing order: the first task is RESERVED ("[-]" under the file lock)
+// before the send, so the daemon's idle flow can never hand it out mid-send,
+// and a failed send rolls it back to "[ ]".
 func (a *App) appendGeneratedTasks(ctx context.Context, audit *domain.AuditRecord, src config.TaskSource, name string, tasks []string, send bool) error {
 	path := src.Path
 	if abs, err := filepath.Abs(path); err == nil {
@@ -1187,22 +1207,13 @@ func (a *App) appendGeneratedTasks(ctx context.Context, audit *domain.AuditRecor
 	}
 	limit := src.MaxTasksLimit()
 
-	// Pre-claim cap check: the daemon gated generation when it ran, but the
-	// list may have grown since (manual adds). Refusing BEFORE the claim
-	// leaves the escalation pending, so the operator can prune the list and
-	// confirm again. A missing file is fine (created below); any other read
-	// error must also refuse pre-claim — claiming first and then failing the
-	// in-lock read would consume the escalation with nothing appended.
-	if data, err := os.ReadFile(path); err == nil {
-		if current := len(domain.ParseChecklist(string(data))); current >= limit {
-			return fmt.Errorf("maximum number of tasks reached for %s (%d items, cap %d) — clean up the task list to make room, then confirm again", path, current, limit)
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("read task list %s: %w", path, err)
-	}
 	// The declared file may not exist yet (a freshly added source): create it
-	// so mutateTaskFile's stat succeeds. Idempotent, so it runs pre-claim.
+	// so mutateTaskFile's stat succeeds. Idempotent, so it runs pre-claim; any
+	// other stat error refuses now, while the escalation is still pending.
 	if _, err := os.Stat(path); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("stat task list %s: %w", path, err)
+		}
 		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 			return fmt.Errorf("create task list dir: %w", err)
 		}
@@ -1211,47 +1222,86 @@ func (a *App) appendGeneratedTasks(ctx context.Context, audit *domain.AuditRecor
 		}
 	}
 
+	// ONE locked compare-append: skip already-present tasks (a retry after a
+	// failed claim, or the loser of a concurrent double-confirm, must not
+	// duplicate them), enforce the max_tasks cap on what is actually missing,
+	// and record where the first task lives for the reservation below. The cap
+	// is the same limit the daemon's generation gate and manual `task add`
+	// enforce; refusing here — pre-claim — lets the operator prune the list
+	// and confirm again.
+	firstText := domain.EncodeTaskNewlines(tasks[0])
+	firstIndex := 0
+	if _, err := mutateTaskFile(path, func(content string) (string, error) {
+		items := domain.ParseChecklist(content)
+		present := map[string]int{}
+		for _, it := range items {
+			if _, ok := present[it.Text]; !ok {
+				present[it.Text] = it.Index
+			}
+		}
+		// A send needs the first task pending: discovering an already-[x]/[-]
+		// copy at reserve time would be AFTER the claim consumed the
+		// escalation, so refuse here, pre-claim, while the operator can still
+		// act on it.
+		if send {
+			for _, it := range items {
+				if it.Text == firstText {
+					if it.Done {
+						return "", fmt.Errorf("task %q is already [%s] in %s — confirm without --send, or dismiss the suggestion", tasks[0], it.Mark, path)
+					}
+					break
+				}
+			}
+		}
+		// -1 marks a text claimed by an earlier element of tasks: a suggestion
+		// repeating a task appends it once, and firstIndex stays on the first
+		// copy (the append below overwrites -1 with the real index).
+		var missing []string
+		for _, task := range tasks {
+			if text := domain.EncodeTaskNewlines(task); present[text] == 0 {
+				missing = append(missing, text)
+				present[text] = -1
+			}
+		}
+		if len(missing) > 0 {
+			room := limit - len(items)
+			if room <= 0 {
+				return "", fmt.Errorf("maximum number of tasks reached for %s (%d items, cap %d) — clean up the task list to make room, then confirm again", path, len(items), limit)
+			}
+			if room < len(missing) {
+				slog.Warn("truncating generated tasks to the source's max_tasks cap",
+					"path", path, "cap", limit, "dropped", len(missing)-room)
+				missing = missing[:room]
+			}
+		}
+		out := content
+		for _, text := range missing {
+			var idx int
+			var e error
+			out, idx, e = domain.AppendChecklistItem(out, text)
+			if e != nil {
+				return "", e
+			}
+			present[text] = idx
+		}
+		// tasks[0] is either pre-existing or missing[0] (order-preserving, and
+		// truncation keeps at least one missing item), so it is always present
+		// by now.
+		firstIndex = present[firstText]
+		return out, nil
+	}); err != nil {
+		return fmt.Errorf("appending the generated tasks to %s failed (nothing was resolved — retry after fixing this): %w", path, err)
+	}
+
 	// Atomically CLAIM the escalation. Only the writer that flips
-	// escalated→resolved proceeds to the append and send, so a double-submit
-	// can never append or send the tasks twice.
+	// escalated→resolved proceeds to the non-idempotent send, so a
+	// double-submit can never send the task twice.
 	claimed, err := a.Store.ResolveEscalation(ctx, audit.ID)
 	if err != nil {
 		return err
 	}
 	if !claimed {
 		return fmt.Errorf("audit record %d is no longer a pending escalation", audit.ID)
-	}
-
-	firstIndex := 0
-	if _, err := mutateTaskFile(path, func(content string) (string, error) {
-		// Recomputed inside the lock: a racing add may have consumed the room
-		// the pre-claim check saw. Appending fewer tasks than suggested beats
-		// refusing the operator's explicit "start now" — but zero room means
-		// nothing can land, so surface that.
-		room := limit - len(domain.ParseChecklist(content))
-		if room <= 0 {
-			return "", fmt.Errorf("maximum number of tasks reached (cap %d)", limit)
-		}
-		if room < len(tasks) {
-			slog.Warn("truncating generated tasks to the source's max_tasks cap",
-				"path", path, "cap", limit, "dropped", len(tasks)-room)
-			tasks = tasks[:room]
-		}
-		out := content
-		for i, task := range tasks {
-			var idx int
-			var e error
-			out, idx, e = domain.AppendChecklistItem(out, domain.EncodeTaskNewlines(task))
-			if e != nil {
-				return "", e
-			}
-			if i == 0 {
-				firstIndex = idx
-			}
-		}
-		return out, nil
-	}); err != nil {
-		return fmt.Errorf("escalation resolved, but appending the generated tasks to %s failed: %w", path, err)
 	}
 
 	// Record the correction so the idle signature learns to drive from its
@@ -1267,38 +1317,25 @@ func (a *App) appendGeneratedTasks(ctx context.Context, audit *domain.AuditRecor
 		// Only the first task is sent — the operator's "start now" task —
 		// rendered through the SOURCE's template (not the built-in default),
 		// pointing at the declared file. {cwd} is resolved only when the
-		// template references it, matching the daemon's declaredTask.
+		// template references it (before reserving, like SendTaskToAgent: a
+		// herdr shell-out failure should not have to unwind a reservation).
 		cwd := ""
 		if strings.Contains(domain.TemplateOrDefault(src.NextTaskTemplate), "{cwd}") {
-			if insp, ok := a.Herdr.(ports.InspectorPort); ok {
-				if pi, e := insp.PaneInfo(ctx, audit.AgentID); e == nil {
-					cwd = pi.ForegroundCwd
-					if cwd == "" {
-						cwd = pi.Cwd
-					}
-				}
-			}
+			cwd = a.paneCwd(ctx, audit.AgentID)
+		}
+		if _, err := mutateTaskFile(path, reserveTask(firstIndex, firstText)); err != nil {
+			return fmt.Errorf("tasks appended to %s, but reserving task #%d (nothing was sent): %w", path, firstIndex, err)
 		}
 		prompt := domain.DeclaredTask{
 			Task: tasks[0], Path: path, Template: src.NextTaskTemplate,
 			AgentName: name, Cwd: cwd,
 		}.Prompt()
 		if err := ports.SendToAgent(ctx, a.Herdr, audit.AgentID, audit.AgentType, prompt); err != nil {
-			return fmt.Errorf("tasks appended to %s, but sending the task to the agent failed: %w", path, err)
-		}
-		// Delivery succeeded: flip the delivered task to in-progress so the
-		// daemon's declared flow does not re-send it on the next idle.
-		// Best-effort — a failed flip only risks a duplicate send later,
-		// which is safer than an undelivered "[-]" the daemon skips. Indices
-		// are positional and renumber on delete, so the flip is text-guarded
-		// (expectTaskText) against a concurrent edit in the send window.
-		if _, err := mutateTaskFile(path, func(content string) (string, error) {
-			if err := expectTaskText(content, firstIndex, domain.EncodeTaskNewlines(tasks[0])); err != nil {
-				return "", err
+			if _, rbErr := mutateTaskFile(path, releaseTask(firstIndex, firstText)); rbErr != nil {
+				return fmt.Errorf("sending the task failed (%w) and task #%d could not be returned to [ ] (%v) — "+
+					"it stays [-] and no agent will pick it up until you clear it", err, firstIndex, rbErr)
 			}
-			return domain.MarkChecklistItemInProgress(content, firstIndex)
-		}); err != nil {
-			slog.Warn("marking the delivered generated task in-progress failed", "path", path, "index", firstIndex, "error", err)
+			return fmt.Errorf("tasks appended to %s, but sending the task to the agent failed: %w", path, err)
 		}
 	}
 	return a.nudge(ctx, control.KindReload)

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -996,6 +996,477 @@ func TestConfirmGeneratedTaskRefusesWhenAgentWorking(t *testing.T) {
 	}
 }
 
+// declaredSourceApp builds a testApp with one declared task source for the
+// named agent, seeding its checklist file with content. It returns the app,
+// store, fake herdr, the agent's short name, and the absolute source path.
+func declaredSourceApp(t *testing.T, agentID, content string) (*frontend.App, *store.Store, *fakeHerdr, string, string) {
+	t.Helper()
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	app.StateDir = t.TempDir()
+	ctx := context.Background()
+	name, _ := st.EnsureAgentName(ctx, agentID)
+	path := filepath.Join(t.TempDir(), "declared.md")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(ctx, name, "", path, ""); err != nil {
+		t.Fatal(err)
+	}
+	return app, st, fake, name, path
+}
+
+// generatedEscalation seeds a pending generated-task escalation for agentID.
+func generatedEscalation(t *testing.T, st *store.Store, agentID, suggestion string) int64 {
+	t.Helper()
+	id, err := st.AppendAudit(context.Background(), domain.AuditRecord{
+		AgentID: agentID, SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + suggestion, CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func TestConfirmGeneratedTaskAppendsToExhaustedSource(t *testing.T) {
+	// Issue #157: when the agent already has a declared task source (whose
+	// checklist ran dry and triggered generation), confirming appends the
+	// generated task to THAT file — it must not write a second per-agent
+	// tasks.md and register a duplicate [[task_sources]] entry, which makes
+	// `hap task <agent>` ambiguous.
+	app, st, fake, name, path := declaredSourceApp(t, "w1:p1", "- [x] 1. old task\n")
+	ctx := context.Background()
+	taskText := "Investigate the flaky auth test and add a retry guard"
+	id := generatedEscalation(t, st, "w1:p1", taskText)
+
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Appended to the declared file, delivered task flipped in-progress, the
+	// existing completed item untouched.
+	want := "- [x] 1. old task\n- [-] " + taskText + "\n"
+	if string(body) != want {
+		t.Errorf("declared file = %q, want %q", body, want)
+	}
+
+	// No per-agent bootstrap file, and still exactly ONE task source with the
+	// original path.
+	if _, err := os.Stat(filepath.Join(app.StateDir, "tasks")); !os.IsNotExist(err) {
+		t.Errorf("no <state>/tasks bootstrap dir may be created, stat err = %v", err)
+	}
+	cfg, _ := config.Load(app.ConfigPath)
+	if len(cfg.TaskSources) != 1 || cfg.TaskSources[0].Path != path {
+		t.Fatalf("want exactly 1 task source at %q, got %+v", path, cfg.TaskSources)
+	}
+
+	// The prompt points at the DECLARED file, and the correction learns the
+	// declared-task action.
+	wantPrompt := domain.DeclaredTask{Task: taskText, Path: path, AgentName: name}.Prompt()
+	if len(fake.inputs) != 1 || fake.inputs[0] != wantPrompt {
+		t.Errorf("delivered %v, want the declared-source prompt %q", fake.inputs, wantPrompt)
+	}
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 1 || corr[0].CorrectedAction != domain.ActionNextDeclaredTask {
+		t.Errorf("confirm should record a declared-task correction: %+v", corr)
+	}
+	audit, _ := st.GetAudit(ctx, id)
+	if audit.Status != "resolved" {
+		t.Errorf("escalation status = %q, want resolved", audit.Status)
+	}
+}
+
+func TestConfirmGeneratedMultipleTasksAppendToExhaustedSource(t *testing.T) {
+	// A multi-task suggestion appends every task to the declared file: the
+	// delivered first task in-progress, the rest pending for the normal
+	// declared-task flow. Only the first is sent.
+	app, st, fake, name, path := declaredSourceApp(t, "w1:p1", "- [x] 1. old task\n")
+	ctx := context.Background()
+	suggestion := "- [ ] Investigate the flaky auth test\n- [ ] Add a retry guard\n- [ ] Backfill unit tests"
+	id := generatedEscalation(t, st, "w1:p1", suggestion)
+
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := os.ReadFile(path)
+	want := "- [x] 1. old task\n- [-] Investigate the flaky auth test\n- [ ] Add a retry guard\n- [ ] Backfill unit tests\n"
+	if string(body) != want {
+		t.Errorf("declared file = %q, want %q", body, want)
+	}
+	wantPrompt := domain.DeclaredTask{Task: "Investigate the flaky auth test", Path: path, AgentName: name}.Prompt()
+	if len(fake.inputs) != 1 || fake.inputs[0] != wantPrompt {
+		t.Errorf("delivered %v, want only the first task as %q", fake.inputs, wantPrompt)
+	}
+	// The queue drives on later idles from the declared file.
+	if next := domain.NextDeclaredTask(string(body)); next != "Add a retry guard" {
+		t.Errorf("next declared task = %q, want the first appended pending item", next)
+	}
+}
+
+func TestConfirmGeneratedTaskAppendWithoutSend(t *testing.T) {
+	// send=false appends every task pending ("[ ]") and delivers nothing: the
+	// daemon's declared flow hands them out on later idles. No in-progress
+	// marker may be left behind (an undelivered "[-]" is never re-sent).
+	app, st, fake, _, path := declaredSourceApp(t, "w2:p2", "- [x] 1. old task\n")
+	ctx := context.Background()
+	id := generatedEscalation(t, st, "w2:p2", "Write missing tests")
+
+	if err := app.Confirm(ctx, id, false); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.inputs) != 0 {
+		t.Errorf("send=false must deliver nothing, got %v", fake.inputs)
+	}
+	body, _ := os.ReadFile(path)
+	want := "- [x] 1. old task\n- [ ] Write missing tests\n"
+	if string(body) != want {
+		t.Errorf("declared file = %q, want %q", body, want)
+	}
+	cfg, _ := config.Load(app.ConfigPath)
+	if len(cfg.TaskSources) != 1 {
+		t.Errorf("want exactly 1 task source, got %d", len(cfg.TaskSources))
+	}
+	audit, _ := st.GetAudit(ctx, id)
+	if audit.Status != "resolved" {
+		t.Errorf("escalation status = %q, want resolved", audit.Status)
+	}
+}
+
+func TestConfirmGeneratedTaskAppendIsIdempotent(t *testing.T) {
+	// The atomic claim gates the (non-idempotent) append: a double-submit must
+	// not append the task twice or send twice.
+	app, st, fake, _, path := declaredSourceApp(t, "w3:p3", "- [x] 1. old task\n")
+	ctx := context.Background()
+	id := generatedEscalation(t, st, "w3:p3", "Do the thing")
+
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.Confirm(ctx, id, true); err == nil {
+		t.Error("second confirm on a resolved escalation must fail")
+	}
+	body, _ := os.ReadFile(path)
+	if got := strings.Count(string(body), "Do the thing"); got != 1 {
+		t.Errorf("task appended %d times, want exactly once: %q", got, body)
+	}
+	if len(fake.inputs) != 1 {
+		t.Errorf("task must be sent exactly once, got %d sends", len(fake.inputs))
+	}
+}
+
+func TestConfirmGeneratedTaskAppendRespectsMaxTasks(t *testing.T) {
+	// The confirm-time append honors the source's max_tasks cap — the same
+	// limit the daemon's generation gate and manual `task add` enforce.
+	t.Run("full list refuses and stays pending", func(t *testing.T) {
+		app, st, fake, _, path := declaredSourceApp(t, "w1:p1", "- [x] 1. a\n- [x] 2. b\n")
+		ctx := context.Background()
+		if err := app.UpdateConfig(ctx, func(cfg *config.Config) error {
+			cfg.TaskSources[0].MaxTasks = 2
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		id := generatedEscalation(t, st, "w1:p1", "One more thing")
+
+		if err := app.Confirm(ctx, id, true); err == nil ||
+			!strings.Contains(err.Error(), "maximum number of tasks") {
+			t.Fatalf("confirm on a full list must refuse with the cap error, got %v", err)
+		}
+		body, _ := os.ReadFile(path)
+		if string(body) != "- [x] 1. a\n- [x] 2. b\n" {
+			t.Errorf("full list must stay unchanged, got %q", body)
+		}
+		if len(fake.inputs) != 0 {
+			t.Errorf("nothing may be sent on a refused confirm, got %v", fake.inputs)
+		}
+		audit, _ := st.GetAudit(ctx, id)
+		if audit.Status != "escalated" {
+			t.Errorf("escalation must stay pending so the operator can prune and retry, got %q", audit.Status)
+		}
+	})
+	t.Run("partial room truncates the appended set", func(t *testing.T) {
+		app, st, fake, _, path := declaredSourceApp(t, "w1:p1", "- [x] 1. a\n")
+		ctx := context.Background()
+		if err := app.UpdateConfig(ctx, func(cfg *config.Config) error {
+			cfg.TaskSources[0].MaxTasks = 3
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		id := generatedEscalation(t, st, "w1:p1", "- [ ] first\n- [ ] second\n- [ ] third")
+
+		if err := app.Confirm(ctx, id, true); err != nil {
+			t.Fatal(err)
+		}
+		body, _ := os.ReadFile(path)
+		want := "- [x] 1. a\n- [-] first\n- [ ] second\n"
+		if string(body) != want {
+			t.Errorf("declared file = %q, want the set truncated to the cap %q", body, want)
+		}
+		if len(fake.inputs) != 1 {
+			t.Errorf("the first task must still be sent, got %v", fake.inputs)
+		}
+	})
+}
+
+func TestConfirmGeneratedTaskUsesSourceTemplate(t *testing.T) {
+	// The append path renders the outbound prompt through the SOURCE's own
+	// next_task_template, like any declared-task send — not the built-in
+	// default the bootstrap path uses.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	app.StateDir = t.TempDir()
+	ctx := context.Background()
+	name, _ := st.EnsureAgentName(ctx, "w1:p1")
+	path := filepath.Join(t.TempDir(), "declared.md")
+	if err := os.WriteFile(path, []byte("- [x] 1. old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tpl := "DO {next_task_content} FROM {task_list_path} AS {agent_name}"
+	if err := app.AddTaskSource(ctx, name, "", path, tpl); err != nil {
+		t.Fatal(err)
+	}
+	id := generatedEscalation(t, st, "w1:p1", "Ship it")
+
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+	want := "DO Ship it FROM " + path + " AS " + name
+	if len(fake.inputs) != 1 || fake.inputs[0] != want {
+		t.Errorf("delivered %v, want the source-template prompt %q", fake.inputs, want)
+	}
+}
+
+func TestConfirmGeneratedTaskAppendCreatesMissingDeclaredFile(t *testing.T) {
+	// A declared source whose file does not exist yet still receives the
+	// tasks at ITS path — never a second bootstrap source.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	app.StateDir = t.TempDir()
+	ctx := context.Background()
+	name, _ := st.EnsureAgentName(ctx, "w1:p1")
+	path := filepath.Join(t.TempDir(), "sub", "declared.md")
+	if err := app.AddTaskSource(ctx, name, "", path, ""); err != nil {
+		t.Fatal(err)
+	}
+	id := generatedEscalation(t, st, "w1:p1", "Bootstrap the declared file")
+
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("declared file not created: %v", err)
+	}
+	if !strings.Contains(string(body), "- [-] Bootstrap the declared file") {
+		t.Errorf("declared file = %q, want the in-progress appended task", body)
+	}
+	cfg, _ := config.Load(app.ConfigPath)
+	if len(cfg.TaskSources) != 1 || cfg.TaskSources[0].Path != path {
+		t.Fatalf("want exactly 1 task source at %q, got %+v", path, cfg.TaskSources)
+	}
+}
+
+// locatorHerdr wraps fakeHerdr with a LocatorPort so workspace-scoped
+// selectors can resolve display names at confirm time.
+type locatorHerdr struct {
+	*fakeHerdr
+	workspaces []domain.WorkspaceInfo
+}
+
+func (l *locatorHerdr) ListWorkspaces(context.Context) ([]domain.WorkspaceInfo, error) {
+	return l.workspaces, nil
+}
+
+func (l *locatorHerdr) ListTabs(context.Context) ([]domain.TabInfo, error) { return nil, nil }
+
+func TestConfirmGeneratedTaskAppendMatchesDaemonSelectors(t *testing.T) {
+	// The confirm-time source resolution must use the daemon's selector
+	// semantics — agent id, agent type, and workspace name/id scoping — not
+	// just the short name, or an id-/type-selected declared source would be
+	// bypassed and bootstrapped into a duplicate.
+	t.Run("agent id selector", func(t *testing.T) {
+		app, st := testApp(t)
+		fake := &fakeHerdr{}
+		app.Herdr = fake
+		app.StateDir = t.TempDir()
+		ctx := context.Background()
+		path := filepath.Join(t.TempDir(), "declared.md")
+		os.WriteFile(path, []byte("- [x] 1. old\n"), 0o600)
+		if err := app.AddTaskSource(ctx, "w1:p1", "", path, ""); err != nil {
+			t.Fatal(err)
+		}
+		id := generatedEscalation(t, st, "w1:p1", "By id")
+		if err := app.Confirm(ctx, id, false); err != nil {
+			t.Fatal(err)
+		}
+		body, _ := os.ReadFile(path)
+		if !strings.Contains(string(body), "- [ ] By id") {
+			t.Errorf("declared file = %q, want the appended task", body)
+		}
+	})
+	t.Run("agent type selector", func(t *testing.T) {
+		app, st := testApp(t)
+		fake := &fakeHerdr{}
+		app.Herdr = fake
+		app.StateDir = t.TempDir()
+		ctx := context.Background()
+		path := filepath.Join(t.TempDir(), "declared.md")
+		os.WriteFile(path, []byte("- [x] 1. old\n"), 0o600)
+		if err := app.AddTaskSource(ctx, "claude", "", path, ""); err != nil {
+			t.Fatal(err)
+		}
+		id, err := st.AppendAudit(ctx, domain.AuditRecord{
+			AgentID: "w1:p1", AgentType: "claude", SituationType: domain.SituationIdle,
+			Trigger: "t", Action: "escalated", Status: "escalated",
+			Suggestion: domain.SuggestTaskPrefix + "By type", CreatedAt: time.Now(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := app.Confirm(ctx, id, false); err != nil {
+			t.Fatal(err)
+		}
+		body, _ := os.ReadFile(path)
+		if !strings.Contains(string(body), "- [ ] By type") {
+			t.Errorf("declared file = %q, want the appended task", body)
+		}
+	})
+	t.Run("workspace name selector via locator", func(t *testing.T) {
+		app, st := testApp(t)
+		fake := &locatorHerdr{
+			fakeHerdr:  &fakeHerdr{agents: []domain.AgentTransition{{AgentID: "w1:p1", Status: "idle", WorkspaceID: "ws-1"}}},
+			workspaces: []domain.WorkspaceInfo{{ID: "ws-1", Label: "codex-main"}},
+		}
+		app.Herdr = fake
+		app.StateDir = t.TempDir()
+		ctx := context.Background()
+		name, _ := st.EnsureAgentName(ctx, "w1:p1")
+		path := filepath.Join(t.TempDir(), "declared.md")
+		os.WriteFile(path, []byte("- [x] 1. old\n"), 0o600)
+		if err := app.AddTaskSource(ctx, name, "codex-*", path, ""); err != nil {
+			t.Fatal(err)
+		}
+		id := generatedEscalation(t, st, "w1:p1", "By workspace name")
+		if err := app.Confirm(ctx, id, false); err != nil {
+			t.Fatal(err)
+		}
+		body, _ := os.ReadFile(path)
+		if !strings.Contains(string(body), "- [ ] By workspace name") {
+			t.Errorf("declared file = %q, want the appended task", body)
+		}
+		cfg, _ := config.Load(app.ConfigPath)
+		if len(cfg.TaskSources) != 1 {
+			t.Errorf("want exactly 1 task source, got %+v", cfg.TaskSources)
+		}
+	})
+	t.Run("workspace raw id fallback without locator", func(t *testing.T) {
+		app, st := testApp(t)
+		fake := &fakeHerdr{agents: []domain.AgentTransition{{AgentID: "w1:p1", Status: "idle", WorkspaceID: "ws-1"}}}
+		app.Herdr = fake
+		app.StateDir = t.TempDir()
+		ctx := context.Background()
+		name, _ := st.EnsureAgentName(ctx, "w1:p1")
+		path := filepath.Join(t.TempDir(), "declared.md")
+		os.WriteFile(path, []byte("- [x] 1. old\n"), 0o600)
+		if err := app.AddTaskSource(ctx, name, "ws-1", path, ""); err != nil {
+			t.Fatal(err)
+		}
+		id := generatedEscalation(t, st, "w1:p1", "By raw workspace id")
+		if err := app.Confirm(ctx, id, false); err != nil {
+			t.Fatal(err)
+		}
+		body, _ := os.ReadFile(path)
+		if !strings.Contains(string(body), "- [ ] By raw workspace id") {
+			t.Errorf("declared file = %q, want the appended task", body)
+		}
+	})
+}
+
+func TestConfirmGeneratedTaskPrefersSourceWithPendingWork(t *testing.T) {
+	// With several matching sources, the append lands on the one the daemon
+	// would reason about: a source with a pending "[ ]" item beats a fully
+	// completed one, regardless of config order.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	app.StateDir = t.TempDir()
+	ctx := context.Background()
+	name, _ := st.EnsureAgentName(ctx, "w1:p1")
+	dir := t.TempDir()
+	donePath := filepath.Join(dir, "done.md")
+	pendingPath := filepath.Join(dir, "pending.md")
+	os.WriteFile(donePath, []byte("- [x] 1. finished\n"), 0o600)
+	os.WriteFile(pendingPath, []byte("- [ ] 1. queued\n"), 0o600)
+	// The completed source is registered FIRST, so config order alone would
+	// pick the wrong file.
+	if err := app.AddTaskSource(ctx, name, "", donePath, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(ctx, name, "", pendingPath, ""); err != nil {
+		t.Fatal(err)
+	}
+	id := generatedEscalation(t, st, "w1:p1", "Go to the live list")
+
+	if err := app.Confirm(ctx, id, false); err != nil {
+		t.Fatal(err)
+	}
+	pendingBody, _ := os.ReadFile(pendingPath)
+	if !strings.Contains(string(pendingBody), "- [ ] Go to the live list") {
+		t.Errorf("pending-work source = %q, want the appended task there", pendingBody)
+	}
+	doneBody, _ := os.ReadFile(donePath)
+	if strings.Contains(string(doneBody), "Go to the live list") {
+		t.Errorf("completed source must stay untouched, got %q", doneBody)
+	}
+}
+
+func TestConfirmGeneratedTaskRefusesDuplicateAgentSource(t *testing.T) {
+	// Defense-in-depth: a source registered under this agent's name but scoped
+	// to a workspace the confirm cannot match falls through to the bootstrap
+	// path — which must REFUSE to register a second source for the same agent
+	// selector (that duplicate is exactly the `hap task` ambiguity of #157).
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	app.StateDir = t.TempDir()
+	ctx := context.Background()
+	name, _ := st.EnsureAgentName(ctx, "w1:p1")
+	path := filepath.Join(t.TempDir(), "declared.md")
+	if err := os.WriteFile(path, []byte("- [x] 1. old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(ctx, name, "other-workspace", path, ""); err != nil {
+		t.Fatal(err)
+	}
+	id := generatedEscalation(t, st, "w1:p1", "Do the thing")
+
+	if err := app.Confirm(ctx, id, true); err == nil ||
+		!strings.Contains(err.Error(), "already has a task source") {
+		t.Fatalf("confirm must refuse to register a duplicate agent source, got %v", err)
+	}
+	cfg, _ := config.Load(app.ConfigPath)
+	if len(cfg.TaskSources) != 1 {
+		t.Errorf("config must be unchanged, got %+v", cfg.TaskSources)
+	}
+	if len(fake.inputs) != 0 {
+		t.Errorf("nothing may be sent, got %v", fake.inputs)
+	}
+	audit, _ := st.GetAudit(ctx, id)
+	if audit.Status != "escalated" {
+		t.Errorf("escalation must stay pending, got %q", audit.Status)
+	}
+}
+
 func TestConfirmDeliversMenuDigitNotLabel(t *testing.T) {
 	// Regression: an LLM/learned approval carries the option LABEL ("Yes"),
 	// but Claude's numbered menu only accepts the digit. Confirm must

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -1190,6 +1190,27 @@ func TestConfirmGeneratedTaskAppendRespectsMaxTasks(t *testing.T) {
 		if audit.Status != "escalated" {
 			t.Errorf("escalation must stay pending so the operator can prune and retry, got %q", audit.Status)
 		}
+		// The refusal is retryable: raise the cap and the SAME escalation
+		// confirms cleanly, appending exactly one copy.
+		if err := app.UpdateConfig(ctx, func(cfg *config.Config) error {
+			cfg.TaskSources[0].MaxTasks = 10
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := app.Confirm(ctx, id, true); err != nil {
+			t.Fatalf("re-confirm after raising the cap must succeed, got %v", err)
+		}
+		body, _ = os.ReadFile(path)
+		if got := strings.Count(string(body), "One more thing"); got != 1 {
+			t.Errorf("retried confirm appended %d copies, want exactly 1: %q", got, body)
+		}
+		if !strings.Contains(string(body), "- [-] One more thing") {
+			t.Errorf("retried confirm must leave the delivered task reserved, got %q", body)
+		}
+		if len(fake.inputs) != 1 {
+			t.Errorf("the retried confirm must send exactly once, got %d sends", len(fake.inputs))
+		}
 	})
 	t.Run("partial room truncates the appended set", func(t *testing.T) {
 		app, st, fake, _, path := declaredSourceApp(t, "w1:p1", "- [x] 1. a\n")
@@ -1214,6 +1235,105 @@ func TestConfirmGeneratedTaskAppendRespectsMaxTasks(t *testing.T) {
 			t.Errorf("the first task must still be sent, got %v", fake.inputs)
 		}
 	})
+}
+
+// sendHookHerdr wraps fakeHerdr to observe on-disk state at the exact moment
+// Send runs — the only way to assert reserve-BEFORE-send ordering, since the
+// final file state after a rollback is identical to never having reserved.
+type sendHookHerdr struct {
+	*fakeHerdr
+	onSend func()
+}
+
+func (h *sendHookHerdr) Send(ctx context.Context, paneID, input string) error {
+	if h.onSend != nil {
+		h.onSend()
+	}
+	return h.fakeHerdr.Send(ctx, paneID, input)
+}
+
+func TestConfirmGeneratedTaskAppendReservesAndRollsBackOnSendFailure(t *testing.T) {
+	// The delivery mirrors SendTaskToAgent: the first task is reserved [-]
+	// before the send (so the daemon's idle flow can never hand it out
+	// mid-send), and a failed send releases it back to [ ] so the declared
+	// flow delivers it on a later idle — never a stranded [-] nobody will
+	// send.
+	app, st, fake, _, path := declaredSourceApp(t, "w5:p5", "- [x] 1. old task\n")
+	fake.sendErr = errors.New("induced send failure")
+	reservedMidSend := false
+	app.Herdr = &sendHookHerdr{fakeHerdr: fake, onSend: func() {
+		body, _ := os.ReadFile(path)
+		reservedMidSend = strings.Contains(string(body), "- [-] Deliver me later")
+	}}
+	ctx := context.Background()
+	id := generatedEscalation(t, st, "w5:p5", "Deliver me later")
+
+	err := app.Confirm(ctx, id, true)
+	if err == nil || !strings.Contains(err.Error(), "sending the task to the agent failed") {
+		t.Fatalf("confirm with a failing send must surface the send error, got %v", err)
+	}
+	if !reservedMidSend {
+		t.Error("the task must already be reserved [-] while Send is in flight")
+	}
+	body, _ := os.ReadFile(path)
+	want := "- [x] 1. old task\n- [ ] Deliver me later\n"
+	if string(body) != want {
+		t.Errorf("declared file = %q, want the task released to pending %q", body, want)
+	}
+	// The claim gates the send, so the escalation is consumed even though the
+	// send failed — the appended task is recovered via the declared flow (or
+	// `hap task send`), not by re-confirming.
+	audit, _ := st.GetAudit(ctx, id)
+	if audit.Status != "resolved" {
+		t.Errorf("escalation status = %q, want resolved (claim precedes the send)", audit.Status)
+	}
+}
+
+func TestConfirmGeneratedTaskSendRefusedWhenFirstTaskNotPending(t *testing.T) {
+	// A suggestion whose first task already sits [x]/[-] in the declared file
+	// cannot be delivered: the refusal must land PRE-claim (escalation stays
+	// pending, actionable) instead of surfacing from reserveTask after the
+	// claim consumed it.
+	app, st, fake, _, path := declaredSourceApp(t, "w6:p6", "- [x] Deliver me later\n")
+	ctx := context.Background()
+	id := generatedEscalation(t, st, "w6:p6", "Deliver me later")
+
+	err := app.Confirm(ctx, id, true)
+	if err == nil || !strings.Contains(err.Error(), "already [x]") {
+		t.Fatalf("confirm with an already-done first task must refuse with the mark, got %v", err)
+	}
+	if len(fake.inputs) != 0 {
+		t.Errorf("nothing may be sent, got %v", fake.inputs)
+	}
+	audit, _ := st.GetAudit(ctx, id)
+	if audit.Status != "escalated" {
+		t.Errorf("escalation must stay pending after the pre-claim refusal, got %q", audit.Status)
+	}
+	body, _ := os.ReadFile(path)
+	if string(body) != "- [x] Deliver me later\n" {
+		t.Errorf("declared file must stay unchanged, got %q", body)
+	}
+}
+
+func TestConfirmGeneratedTaskAppendDeduplicatesRepeatedSuggestion(t *testing.T) {
+	// A suggestion repeating the same task text appends it once — a
+	// repetitive LLM output must not stack duplicate checklist items or burn
+	// cap room on copies.
+	app, st, fake, _, path := declaredSourceApp(t, "w7:p7", "- [x] 1. old task\n")
+	ctx := context.Background()
+	id := generatedEscalation(t, st, "w7:p7", "- [ ] Same thing\n- [ ] Other thing\n- [ ] Same thing")
+
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := os.ReadFile(path)
+	want := "- [x] 1. old task\n- [-] Same thing\n- [ ] Other thing\n"
+	if string(body) != want {
+		t.Errorf("declared file = %q, want the repeated task appended once: %q", body, want)
+	}
+	if len(fake.inputs) != 1 {
+		t.Errorf("only the first task may be sent, got %v", fake.inputs)
+	}
 }
 
 func TestConfirmGeneratedTaskUsesSourceTemplate(t *testing.T) {


### PR DESCRIPTION
Fixes #157.

## Problem

When an agent's **declared** task source ran dry and LLM task generation produced new tasks, confirming the escalation wrote them to a NEW per-agent file (`<state>/tasks/<agent>.md`) and registered it as a **second** `[[task_sources]]` entry for the same agent:

1. `hap task <agent> …` immediately failed with `matches 2 task sources … use --path`.
2. The default prompt template's marking commands (`hap task <agent> list/start/done`) all hit that error, so agents completed generated tasks but the checklist stayed unmarked.
3. `max_tasks` accounting and source retirement split across two files.

## Fix

The confirm path (`acceptGeneratedTask`) now **re-resolves the agent's declared sources at confirm time** and appends the generated tasks to the matched source's own file — generation refills the declared list, exactly as the docs frame it. The per-agent bootstrap file + registration remains only for the genuine no-source case.

- **`config.TaskSource.MatchesAgent`** — the agent-selector semantics (id / type / short name; `""` = any) extracted into one shared definition; the daemon's `matchTaskSource` now uses it too, so daemon and frontend can't drift.
- **`appendGeneratedTasks`** — claims the escalation first (appends are not idempotent), appends all tasks pending `[ ]` inside one locked mutation, sends the first task rendered through the **source's own template** pointing at the declared path, and flips it to `[-]` only **after** a successful send (text-guarded), so a failed send never strands an undeliverable in-progress item.
- **max_tasks respected at confirm time** — a full list refuses pre-claim (escalation stays pending so the operator can prune and retry); a race that shrinks the room truncates the appended set. The daemon's generation gate now treats an **at-cap** list as full (`n >= limit`, matching `task add`), so it can no longer raise escalations every confirm must refuse.
- **Multiple matching sources** — deterministic pick mirroring the daemon's precedence (pending work → has items → config order), never an error.
- **Defense-in-depth** — `addTaskSourceIfAbsent` refuses to register a source when an existing non-empty selector already matches the agent (by id, type, or name), converting any residual duplicate-creation path into a clear error.

## Tests

- 8 new frontend confirm tests: append/multi-append/without-send/idempotency/cap-refusal+truncation/source-template/missing-declared-file/duplicate-guard, plus daemon-parity selector cases (id, type, workspace label via locator, raw workspace-id fallback) and multi-source precedence.
- `MatchesAgent` table test; daemon cap-gate test tightened to the new at-cap boundary.
- Full suite: `go test -tags "vectors cpu" ./... -count=1` — 23 packages, 0 failures. `golangci-lint`: 0 issues.
- Local integration suite (real herdr): 5 pass, 3 expected skips.