### PR TITLE
#161 fix: recognize codex hard usage-limit banner and unknown ■-banner errors

### DIFF
--- a/internal/classify/classify.go
+++ b/internal/classify/classify.go
@@ -60,9 +60,10 @@ func DefaultRules() []config.ClassifierRule {
 			Regex: nil,
 		},
 		{
-			// Codex's interrupt screen and footer-anchored rate-limit model
-			// switch modal are detected structurally via domain.CodexErrorForm
-			// at the error position in Classify, same as Claude above.
+			// Codex's interrupt screen, footer-anchored rate-limit model
+			// switch modal, hard usage-limit stop, and end-anchored "■" error
+			// banners are detected structurally via domain.CodexErrorForm at
+			// the error position in Classify, same as Claude above.
 			AgentType: "codex", Situation: "error",
 			Regex: nil,
 		},
@@ -181,8 +182,9 @@ func (c *Classifier) Classify(agentType, agentStatus, pane string) domain.Situat
 		if !matched && r.situation == domain.SituationError && strings.EqualFold(agentType, "claude") {
 			_, matched = domain.ClaudeErrorForm(pane)
 		}
-		// Codex's interrupt screen and rate-limit model switch modal are
-		// detected structurally the same way, scoped to codex.
+		// Codex's interrupt screen, rate-limit model switch modal, hard
+		// usage-limit stop, and live "■" error banners are detected
+		// structurally the same way, scoped to codex.
 		if !matched && r.situation == domain.SituationError && strings.EqualFold(agentType, "codex") {
 			_, matched = domain.CodexErrorForm(pane)
 		}
@@ -287,15 +289,19 @@ func enrich(s *domain.Situation) {
 		}
 		s.Options = append(s.Options, domain.OptionLabels(optionRegion)...)
 	case domain.SituationError:
-		if m := errorLineRE.FindStringSubmatch(s.Content); m != nil {
-			s.ErrorSummary = domain.MaskVolatile(strings.TrimSpace(m[1]))
-		} else if kind, ok := domain.ClaudeErrorForm(s.Content); ok {
+		// Structural form kinds take precedence over the generic error-line
+		// scrape: a pane can carry both (build output printing "error: …"
+		// above a live usage-limit banner), and only the stable kind keeps
+		// paraphrased instances deduped to one signature.
+		if kind, ok := domain.ClaudeErrorForm(s.Content); ok && strings.EqualFold(s.AgentType, "claude") {
 			// Claude's built-in error forms carry no "error:"-prefixed line;
 			// use the stable kind so paraphrases share one signature.
 			s.ErrorSummary = kind
-		} else if kind, ok := domain.CodexErrorForm(s.Content); ok {
+		} else if kind, ok := domain.CodexErrorForm(s.Content); ok && strings.EqualFold(s.AgentType, "codex") {
 			// Same reasoning as Claude above, for Codex's built-in error forms.
 			s.ErrorSummary = kind
+		} else if m := errorLineRE.FindStringSubmatch(s.Content); m != nil {
+			s.ErrorSummary = domain.MaskVolatile(strings.TrimSpace(m[1]))
 		}
 		if strings.EqualFold(s.AgentType, "codex") && domain.CodexRateLimitForm(s.Content) {
 			s.Options = append(s.Options, domain.OptionLabels(domain.ExtractCodexRateLimitForm(s.Content))...)

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -23,6 +23,8 @@ func TestGoldenTranscripts(t *testing.T) {
 		"codex_idle.txt":                 "idle",
 		"approval_codex_plan.txt":        "idle",
 		"error_codex_rate_limit.txt":     "idle",
+		"error_codex_usage_limit.txt":    "idle",
+		"error_codex_banner.txt":         "idle",
 		"approval_claude_remote_env.txt": "idle",
 	}
 	agentTypeFor := map[string]string{
@@ -31,6 +33,8 @@ func TestGoldenTranscripts(t *testing.T) {
 		"choice_codex_mcq.txt":        "codex",
 		"error_codex_interrupted.txt": "codex",
 		"error_codex_rate_limit.txt":  "codex",
+		"error_codex_usage_limit.txt": "codex",
+		"error_codex_banner.txt":      "codex",
 	}
 
 	entries, err := os.ReadDir("testdata/transcripts")
@@ -376,18 +380,60 @@ func TestClaudeErrorSituations(t *testing.T) {
 
 func TestCodexErrorSituations(t *testing.T) {
 	c := New(nil)
-	for _, name := range []string{"error_codex_interrupted.txt", "error_codex_rate_limit.txt"} {
-		data, err := os.ReadFile(filepath.Join("testdata", "transcripts", name))
+	cases := []struct {
+		name string
+		// The usage-limit fixture's "You've hit your usage limit" phrasing is
+		// shared with Claude's own limit stop (claudeLimitRE), so it genuinely
+		// classifies error on both agent types; every other codex form is
+		// codex-scoped and must NOT classify error on claude.
+		claudeAlsoErrors bool
+	}{
+		{"error_codex_interrupted.txt", false},
+		{"error_codex_rate_limit.txt", false},
+		{"error_codex_usage_limit.txt", true},
+		{"error_codex_banner.txt", false},
+	}
+	for _, tc := range cases {
+		data, err := os.ReadFile(filepath.Join("testdata", "transcripts", tc.name))
 		if err != nil {
 			t.Fatal(err)
 		}
 		if s := c.Classify("codex", "blocked", string(data)); s.Type != domain.SituationError {
-			t.Errorf("%s: type = %v, want error", name, s.Type)
+			t.Errorf("%s: type = %v, want error", tc.name, s.Type)
 		}
-		// Error detection is codex-scoped: the same content on another agent
-		// type must NOT classify as error (no rule for it yet).
-		if s := c.Classify("claude", "blocked", string(data)); s.Type == domain.SituationError {
-			t.Errorf("%s on non-codex agent must not classify error, got %v", name, s.Type)
+		if s := c.Classify("claude", "blocked", string(data)); (s.Type == domain.SituationError) != tc.claudeAlsoErrors {
+			t.Errorf("%s on claude: type = %v, want error=%v", tc.name, s.Type, tc.claudeAlsoErrors)
+		}
+	}
+}
+
+// The live failure mode from issue #161: herdr reports the hard-blocked agent
+// as IDLE, so error detection must not depend on a blocked status — otherwise
+// a learned idle rule answers "do nothing" and the operator never hears about
+// an agent that cannot progress for days.
+func TestCodexErrorBannersDetectedAtIdle(t *testing.T) {
+	c := New(nil)
+	cases := []struct {
+		name        string
+		wantSummary string
+	}{
+		{"error_codex_usage_limit.txt", domain.CodexErrorUsageLimit},
+		{"error_codex_banner.txt", "banner: stream error: connection reset by peer; retrying may help"},
+	}
+	for _, tc := range cases {
+		data, err := os.ReadFile(filepath.Join("testdata", "transcripts", tc.name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := c.Classify("codex", "idle", string(data))
+		if s.Type != domain.SituationError {
+			t.Fatalf("%s at idle: type = %v, want error", tc.name, s.Type)
+		}
+		// The exact stable kind is load-bearing: it is the error signature's
+		// salient, so instances with different volatile details must keep
+		// deduping to one learned signature.
+		if s.ErrorSummary != tc.wantSummary {
+			t.Errorf("%s: ErrorSummary = %q, want %q", tc.name, s.ErrorSummary, tc.wantSummary)
 		}
 	}
 }

--- a/internal/classify/testdata/classifications.golden
+++ b/internal/classify/testdata/classifications.golden
@@ -13,7 +13,9 @@ error_build.txt status=blocked type=unclassifiable verb= options=0
 error_claude_api_retry.txt status=blocked type=error verb= options=0
 error_claude_interrupted.txt status=blocked type=error verb= options=0
 error_claude_limit.txt status=blocked type=error verb= options=0
+error_codex_banner.txt status=idle type=error verb= options=0
 error_codex_interrupted.txt status=blocked type=error verb= options=0
 error_codex_rate_limit.txt status=idle type=error verb= options=3
+error_codex_usage_limit.txt status=idle type=error verb= options=0
 idle_finished.txt status=idle type=idle verb= options=0
 unclassifiable_blocked.txt status=blocked type=unclassifiable verb= options=0

--- a/internal/classify/testdata/transcripts/error_codex_banner.txt
+++ b/internal/classify/testdata/transcripts/error_codex_banner.txt
@@ -4,4 +4,4 @@
 
 ›
 
-  gpt-5.6-sol high · /tmp
+  gpt-5.6-sol high · /workspaces/my project

--- a/internal/classify/testdata/transcripts/error_codex_banner.txt
+++ b/internal/classify/testdata/transcripts/error_codex_banner.txt
@@ -1,0 +1,7 @@
+• Applied patch to internal/store/db.go
+
+■ stream error: connection reset by peer; retrying may help
+
+›
+
+  gpt-5.6-sol high · /tmp

--- a/internal/classify/testdata/transcripts/error_codex_usage_limit.txt
+++ b/internal/classify/testdata/transcripts/error_codex_usage_limit.txt
@@ -1,0 +1,7 @@
+• Exploring the repository structure
+
+■ You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Jul 23rd, 2026 4:19 AM.
+
+›
+
+  gpt-5.6-sol high · /workspaces/herdr-auto-pilot

--- a/internal/domain/codexerror.go
+++ b/internal/domain/codexerror.go
@@ -37,13 +37,18 @@ var (
 	// Codex's live composer/input-box line ("›", possibly with typed text).
 	codexComposerLineRE = regexp.MustCompile(`^[ \t]*›`)
 	// The composer status footer: model name and cwd joined by " · /"
-	// (e.g. "gpt-5.6-sol high · /tmp", a deleted cwd renders as
-	// "/path (deleted)"). Full-line shape, same " · /" separator
-	// codexComposerBeforeFooterRE keys on; like that regex this is a text
-	// heuristic — a final narration line of exactly this shape right after a
-	// scrollback banner would be misread as the footer (accepted risk, see
-	// the codexComposerBeforeFooterRE comment).
-	codexStatusFooterLineRE = regexp.MustCompile(`^[ \t]*\S[^\n·]*\s·\s+/\S*( \(deleted\))?[ \t]*$`)
+	// (e.g. "gpt-5.6-sol high · /tmp"), the same shape (greedy: the LAST
+	// " · /" on the line) codexComposerBeforeFooterRE keys on. Both sides of
+	// the separator accept any text: the model part may grow extra
+	// "·"-separated segments, and cwds may contain spaces or render as
+	// "/path (deleted)" — rejecting a real footer here reads as "no live
+	// banner" and silently idles a hard-blocked agent (#161), so the matcher
+	// must err loose. Like the composer regex this is a text heuristic — a
+	// final narration line of exactly this shape right after a scrollback
+	// banner would be misread as the footer, failing safe toward a spurious
+	// escalation (accepted risk, see the codexComposerBeforeFooterRE
+	// comment).
+	codexStatusFooterLineRE = regexp.MustCompile(`^[ \t]*\S[^\n]*\s·\s+/[^\n]*$`)
 )
 
 // Stable ErrorSummary label for Codex's built-in error forms — used as the

--- a/internal/domain/codexerror.go
+++ b/internal/domain/codexerror.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 // Codex surfaces a blocking interrupt screen when a run is manually
@@ -15,6 +16,14 @@ import (
 var (
 	codexInterruptedRE = regexp.MustCompile(`(?i)conversation interrupted\b.{0,20}tell the model what to do differently`)
 
+	// Codex's hard usage-limit stop ("■ You've hit your usage limit. Upgrade
+	// to Pro …, purchase more credits or try again at <date>."). Mirrors
+	// claudeLimitRE's apostrophe tolerance; the volatile reset date never
+	// enters the signature because the kind label below is the ErrorSummary.
+	// Matched only against a live extracted banner (never the whole pane), so
+	// a stale copy in scrollback cannot re-error a recovered agent.
+	codexUsageLimitRE = regexp.MustCompile(`(?i)you['’]?ve hit your usage limit\b`)
+
 	// Codex parks this model-switch reminder at the bottom of the pane when
 	// account credits approach their limit. The header/question/footer form a
 	// narrow live-modal envelope; the footer's \z anchor prevents an older copy
@@ -22,6 +31,19 @@ var (
 	codexRateLimitHeaderRE   = regexp.MustCompile(`(?im)^[ \t]*Approaching rate limits[ \t]*$`)
 	codexRateLimitQuestionRE = regexp.MustCompile(`(?im)^[ \t]*Switch to[ \t]+.+[ \t]+for lower credit usage\?[ \t]*$`)
 	codexRateLimitFooterRE   = regexp.MustCompile(`(?im)^[ \t]*Press enter to confirm or esc to go back[ \t]*\s*\z`)
+
+	// Codex prefixes blocking error/notice banners with "■" at line start.
+	codexBannerLineRE = regexp.MustCompile(`(?m)^[ \t]*■[ \t]+\S`)
+	// Codex's live composer/input-box line ("›", possibly with typed text).
+	codexComposerLineRE = regexp.MustCompile(`^[ \t]*›`)
+	// The composer status footer: model name and cwd joined by " · /"
+	// (e.g. "gpt-5.6-sol high · /tmp", a deleted cwd renders as
+	// "/path (deleted)"). Full-line shape, same " · /" separator
+	// codexComposerBeforeFooterRE keys on; like that regex this is a text
+	// heuristic — a final narration line of exactly this shape right after a
+	// scrollback banner would be misread as the footer (accepted risk, see
+	// the codexComposerBeforeFooterRE comment).
+	codexStatusFooterLineRE = regexp.MustCompile(`^[ \t]*\S[^\n·]*\s·\s+/\S*( \(deleted\))?[ \t]*$`)
 )
 
 // Stable ErrorSummary label for Codex's built-in error forms — used as the
@@ -30,11 +52,22 @@ var (
 const (
 	CodexErrorInterrupted = "interrupted"
 	CodexErrorRateLimit   = "rate-limit"
+	CodexErrorUsageLimit  = "usage-limit"
 )
 
+// codexBannerSummaryMax bounds the generic-banner ErrorSummary so a very long
+// banner cannot bloat the signature salient.
+const codexBannerSummaryMax = 120
+
 // CodexErrorForm reports whether pane content shows one of Codex's blocking
-// error/interrupt conditions, and which kind. kind is "" exactly when ok is
-// false.
+// error/interrupt conditions, and which kind. The rate-limit modal and the
+// interrupt screen keep their existing pane-wide detection (both verified
+// live); every other "■" banner is recognized only when it stands live at the
+// end of the pane (ExtractCodexErrorBanner) — a known banner (the hard usage
+// limit) yields its stable kind label, and any unknown banner (network drops,
+// auth failures, quota variants) falls back to a masked-text label so it
+// still classifies as an error while distinct banners keep distinct
+// signatures. kind is "" exactly when ok is false.
 func CodexErrorForm(pane string) (kind string, ok bool) {
 	switch {
 	case CodexRateLimitForm(pane):
@@ -42,7 +75,68 @@ func CodexErrorForm(pane string) (kind string, ok bool) {
 	case codexInterruptedRE.MatchString(pane):
 		return CodexErrorInterrupted, true
 	}
-	return "", false
+	banner := ExtractCodexErrorBanner(pane)
+	if banner == "" {
+		return "", false
+	}
+	if codexUsageLimitRE.MatchString(banner) {
+		return CodexErrorUsageLimit, true
+	}
+	summary := MaskVolatile(banner)
+	if len(summary) > codexBannerSummaryMax {
+		cut := codexBannerSummaryMax
+		for cut > 0 && !utf8.RuneStart(summary[cut]) {
+			cut--
+		}
+		summary = summary[:cut]
+	}
+	return "banner: " + summary, true
+}
+
+// ExtractCodexErrorBanner returns the text of a live "■"-prefixed banner
+// standing at the end of the pane: the last line-leading "■" block (the "■"
+// line plus contiguous wrapped continuation lines), after which only blank
+// lines and the composer UI chrome — at most one "›" composer line (present
+// when the pane was not run through StripCodexComposer) followed by at most
+// one status-footer line (model · cwd) — may remain. Anything else after the
+// block means the banner is scrollback, not a live blocking condition, and
+// "" is returned. Callers must additionally gate this on agent_type ==
+// "codex".
+func ExtractCodexErrorBanner(pane string) string {
+	locs := codexBannerLineRE.FindAllStringIndex(pane, -1)
+	if len(locs) == 0 {
+		return ""
+	}
+	tail := pane[locs[len(locs)-1][0]:]
+	lines := strings.Split(tail, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, "\r")
+	}
+	// The banner block: leading run of contiguous non-blank lines.
+	end := len(lines)
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			end = i
+			break
+		}
+	}
+	var rest []string
+	for _, line := range lines[end:] {
+		if strings.TrimSpace(line) != "" {
+			rest = append(rest, line)
+		}
+	}
+	if len(rest) > 0 && codexComposerLineRE.MatchString(rest[0]) {
+		rest = rest[1:]
+	}
+	if len(rest) > 0 && codexStatusFooterLineRE.MatchString(rest[0]) {
+		rest = rest[1:]
+	}
+	if len(rest) != 0 {
+		return ""
+	}
+	banner := strings.TrimSpace(strings.Join(lines[:end], " "))
+	return strings.TrimSpace(strings.TrimPrefix(banner, "■"))
 }
 
 // CodexRateLimitForm reports whether pane ends in Codex's live

--- a/internal/domain/codexerror_test.go
+++ b/internal/domain/codexerror_test.go
@@ -1,0 +1,204 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+// Captured verbatim from live codex sessions (issue #161, codex_error.log).
+const (
+	codexInterruptedBanner = "■ Conversation interrupted - tell the model what to do differently. Something went wrong? Hit `/feedback` to\nreport the issue.\n"
+	codexUsageLimitBanner  = "■ You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Jul 23rd, 2026 4:19 AM.\n"
+)
+
+func TestCodexErrorFormKinds(t *testing.T) {
+	cases := []struct {
+		name     string
+		pane     string
+		wantKind string
+		wantOK   bool
+	}{
+		{"interrupted verbatim", codexInterruptedBanner, CodexErrorInterrupted, true},
+		{"usage limit verbatim", codexUsageLimitBanner, CodexErrorUsageLimit, true},
+		{"usage limit curly apostrophe", "■ You’ve hit your usage limit. Try again later.\n", CodexErrorUsageLimit, true},
+		{
+			"unknown banner falls back to masked-text kind",
+			"older narration.\n\n■ stream error: connection reset by peer; retrying may help\n",
+			"banner: stream error: connection reset by peer; retrying may help",
+			true,
+		},
+		{"ordinary output", "I refactored the parser and all tests pass.\n", "", false},
+		{
+			"claude-style limit without usage does not match codex form",
+			"You've hit your limit · resets 6pm (UTC)\n",
+			"", false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, ok := CodexErrorForm(tc.pane)
+			if ok != tc.wantOK || kind != tc.wantKind {
+				t.Fatalf("CodexErrorForm = (%q, %v), want (%q, %v)", kind, ok, tc.wantKind, tc.wantOK)
+			}
+		})
+	}
+}
+
+// codexErrorSignature mirrors the classifier's enrich path: the form's kind
+// becomes ErrorSummary, which is the error signature's salient content.
+func codexErrorSignature(t *testing.T, pane string) SignatureResult {
+	t.Helper()
+	kind, ok := CodexErrorForm(pane)
+	if !ok {
+		t.Fatalf("pane did not classify as a codex error: %q", pane)
+	}
+	sig := ComputeSignature(Situation{
+		Type:         SituationError,
+		AgentType:    "codex",
+		Content:      pane,
+		ErrorSummary: kind,
+	})
+	if sig.Verdict != GuardOK {
+		t.Fatalf("signature verdict = %v, want ok (salient %q)", sig.Verdict, sig.Salient)
+	}
+	return sig
+}
+
+// Different reset timestamps must dedup to one error:usage-limit signature —
+// the stable kind label keeps the volatile date out of the salient entirely.
+func TestCodexUsageLimitSignatureStableAcrossResetTimes(t *testing.T) {
+	a := codexErrorSignature(t, codexUsageLimitBanner)
+	b := codexErrorSignature(t, "■ You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Aug 2nd, 2026 11:03 PM.\n")
+	if a.Signature != b.Signature {
+		t.Fatalf("usage-limit signatures differ across reset times: %q vs %q", a.Signature, b.Signature)
+	}
+}
+
+// Distinct unknown banners must keep distinct signatures: a rule learned on a
+// network drop must never auto-fire on an auth failure.
+func TestCodexDistinctBannersDistinctSignatures(t *testing.T) {
+	a := codexErrorSignature(t, "■ stream error: connection reset by peer; retrying may help\n")
+	b := codexErrorSignature(t, "■ authentication failed. Please run codex login and retry.\n")
+	if a.Signature == b.Signature {
+		t.Fatalf("distinct banners collapsed to one signature %q", a.Signature)
+	}
+}
+
+func TestExtractCodexErrorBanner(t *testing.T) {
+	cases := []struct {
+		name string
+		pane string
+		want string
+	}{
+		{
+			"banner at end of pane",
+			"narration.\n\n■ stream error: connection reset\n",
+			"stream error: connection reset",
+		},
+		{
+			"wrapped banner lines join",
+			codexInterruptedBanner,
+			"Conversation interrupted - tell the model what to do differently. Something went wrong? Hit `/feedback` to report the issue.",
+		},
+		{
+			"composer status footer below is tolerated",
+			"■ stream error: connection reset\n\n  gpt-5.6-sol high · /tmp\n",
+			"stream error: connection reset",
+		},
+		{
+			"newer agent output after banner means scrollback",
+			"■ stream error: connection reset\n\nThe agent recovered and kept working.\n",
+			"",
+		},
+		{
+			"two paragraphs after banner mean scrollback even with footer",
+			"■ stream error: connection reset\n\nmore output\n\n  gpt-5.6-sol high · /tmp\n",
+			"",
+		},
+		{
+			"unstripped composer line and footer are tolerated",
+			"■ stream error: connection reset\n\n›\n\n  gpt-5.6-sol high · /tmp\n",
+			"stream error: connection reset",
+		},
+		{
+			"CRLF pane",
+			"■ stream error: connection\r\nreset by peer\r\n\r\n  gpt-5.6-sol high · /tmp\r\n",
+			"stream error: connection reset by peer",
+		},
+		{
+			"mid-line square is not a banner",
+			"the legend uses ■ for filled cells\n",
+			"",
+		},
+		{
+			"no banner",
+			"ordinary output\n",
+			"",
+		},
+		{
+			"empty pane",
+			"",
+			"",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ExtractCodexErrorBanner(tc.pane); got != tc.want {
+				t.Fatalf("ExtractCodexErrorBanner = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A mostly-volatile banner still classifies as an error, but its masked kind
+// trips the over-masking guard: no signature is minted, so the situation
+// always escalates instead of being learnable — the fail-safe outcome.
+func TestCodexBannerOverMaskedStillClassifiesButMintsNoSignature(t *testing.T) {
+	pane := "■ /foo/bar 12345\n"
+	kind, ok := CodexErrorForm(pane)
+	if !ok {
+		t.Fatal("volatile banner not recognized as error")
+	}
+	sig := ComputeSignature(Situation{
+		Type:         SituationError,
+		AgentType:    "codex",
+		Content:      pane,
+		ErrorSummary: kind,
+	})
+	if sig.Verdict != GuardOverMasked {
+		t.Fatalf("verdict = %v (salient %q), want over_masked", sig.Verdict, sig.Salient)
+	}
+	if sig.Signature != "" {
+		t.Fatalf("over-masked banner minted signature %q", sig.Signature)
+	}
+}
+
+// A stale usage-limit banner in scrollback — the agent recovered and produced
+// newer output — must NOT re-classify the pane as an error.
+func TestCodexUsageLimitInScrollbackIsNotLive(t *testing.T) {
+	pane := codexUsageLimitBanner + "\nCredits were added; resuming the refactor now.\n"
+	if kind, ok := CodexErrorForm(pane); ok {
+		t.Fatalf("scrollback usage-limit classified as live error (kind %q)", kind)
+	}
+}
+
+// A long banner's fallback kind is truncated on a rune boundary so the
+// signature salient stays bounded and valid UTF-8.
+func TestCodexBannerKindTruncation(t *testing.T) {
+	pane := "■ fatal exchange failure · " + strings.Repeat("é", 200) + "\n"
+	kind, ok := CodexErrorForm(pane)
+	if !ok {
+		t.Fatal("long banner not recognized")
+	}
+	if len(kind) > len("banner: ")+codexBannerSummaryMax {
+		t.Fatalf("kind length %d exceeds bound", len(kind))
+	}
+	if !strings.HasPrefix(kind, "banner: fatal exchange failure") {
+		t.Fatalf("kind = %q", kind)
+	}
+	for _, r := range kind {
+		if r == '�' {
+			t.Fatalf("kind contains invalid UTF-8: %q", kind)
+		}
+	}
+}

--- a/internal/domain/codexerror_test.go
+++ b/internal/domain/codexerror_test.go
@@ -121,6 +121,21 @@ func TestExtractCodexErrorBanner(t *testing.T) {
 			"stream error: connection reset",
 		},
 		{
+			"footer cwd containing spaces is tolerated",
+			"■ stream error: connection reset\n\n  gpt-5.6-sol high · /workspaces/my project\n",
+			"stream error: connection reset",
+		},
+		{
+			"footer with deleted cwd is tolerated",
+			"■ stream error: connection reset\n\n  gpt-5.6-sol high · /tmp/gone (deleted)\n",
+			"stream error: connection reset",
+		},
+		{
+			"footer with extra ·-separated segment is tolerated",
+			"■ stream error: connection reset\n\n  gpt-5.6-sol · 56% context left · /tmp\n",
+			"stream error: connection reset",
+		},
+		{
 			"CRLF pane",
 			"■ stream error: connection\r\nreset by peer\r\n\r\n  gpt-5.6-sol high · /tmp\r\n",
 			"stream error: connection reset by peer",


### PR DESCRIPTION
Fixes #161.

## Problem

Codex's hard usage-limit banner (`■ You've hit your usage limit. … try again at Jul 23rd, 2026 4:19 AM.`) was neither the interrupt phrase nor the model-switch modal, so `CodexErrorForm` returned false and the pane classified as ordinary **idle** — a learned idle `@noop` rule answered "do nothing" and the operator was never told the agent was hard-blocked for days.

## Changes

- **`usage-limit` kind** (`domain.CodexErrorUsageLimit`): recognized via the stable phrase, matched only against a **live extracted banner** so a stale copy in scrollback cannot re-error a recovered agent. The stable kind label is the `ErrorSummary`, so the volatile reset timestamp never enters the signature — all instances dedup to one `error:usage-limit` rule.
- **Generic `■`-banner fallback** (`domain.ExtractCodexErrorBanner`): the last line-leading `■` block standing at the end of the pane (tolerating only blank lines, an unstripped `›` composer line, and one `model · /cwd` status-footer line after it) classifies as an error even when the phrasing is unknown — network drops, auth failures, quota variants. The kind is `banner: <masked text>` (truncated on a rune boundary), so **distinct** banners keep **distinct** signatures while volatile tokens are masked out. End-anchoring keeps scrollback copies from erroring a working agent.
- **Structural kinds now take precedence over the generic `error:`-line scrape in `enrich`** (agent-type-gated): build output printing `error: …` above a live usage-limit banner no longer fragments the signature per build error.
- A mostly-volatile banner still classifies as an error but trips the over-masking guard: no signature is minted, so it always escalates (fail-safe) — pinned by test.

## Tests

- New `internal/domain/codexerror_test.go`: both live-captured samples verbatim, masked-timestamp signature dedup, distinct-banner signature separation, end-anchoring/scrollback rejection, CRLF/empty-pane/unstripped-composer edge cases, over-mask fail-safe, rune-safe truncation.
- Golden classifier fixtures `error_codex_usage_limit.txt` + `error_codex_banner.txt` (both classified at **idle** — the live failure mode) with exact-kind assertions in `TestCodexErrorBannersDetectedAtIdle`.

## Verification

- Full unit suite (`-tags "vectors cpu"`, 23 packages): pass.
- Integration suite (`-tags "integration vectors cpu"`): 5 pass, 3 skip (optional deps absent).
- `gofmt`, `go vet`, `golangci-lint`: clean.
