### PR TITLE
#160 fix: strip codex composer when footer cwd renders as ~-relative path

### DIFF
--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -567,22 +567,30 @@ func TestApprovalFixturesStillApproval(t *testing.T) {
 // codex's Content has the "› ..." line gone and keeps the footer.
 func TestCodexComposerStrippedOnlyForCodex(t *testing.T) {
 	c := New(nil)
-	pane := "─ Worked for 10m 49s ─────\n\n› Summarize recent commits\n\n  gpt-5.6-sol high · /workspaces/herdr-auto-pilot\n"
-
-	codex := c.Classify("codex", "idle", pane)
-	if strings.Contains(codex.Content, "›") {
-		t.Errorf("codex situation content must have composer line stripped, got %q", codex.Content)
+	panes := map[string]string{
+		"absolute cwd": "─ Worked for 10m 49s ─────\n\n› Summarize recent commits\n\n  gpt-5.6-sol high · /workspaces/herdr-auto-pilot\n",
+		// Issue #160: cwds under $HOME render ~-relative in the footer; the
+		// strip must fire for those sessions too.
+		"tilde cwd": "─ Worked for 10m 49s ─────\n\n› Use /skills to list available skills\n\n  gpt-5.6-sol high · ~/hap-codex-test\n",
 	}
-	if !strings.Contains(codex.Content, "gpt-5.6-sol high") {
-		t.Errorf("codex situation content must keep the footer, got %q", codex.Content)
-	}
+	for name, pane := range panes {
+		t.Run(name, func(t *testing.T) {
+			codex := c.Classify("codex", "idle", pane)
+			if strings.Contains(codex.Content, "›") {
+				t.Errorf("codex situation content must have composer line stripped, got %q", codex.Content)
+			}
+			if !strings.Contains(codex.Content, "gpt-5.6-sol high") {
+				t.Errorf("codex situation content must keep the footer, got %q", codex.Content)
+			}
 
-	claude := c.Classify("claude", "idle", pane)
-	if claude.Content != pane {
-		t.Errorf("claude situation content must be untouched, got %q, want %q", claude.Content, pane)
-	}
+			claude := c.Classify("claude", "idle", pane)
+			if claude.Content != pane {
+				t.Errorf("claude situation content must be untouched, got %q, want %q", claude.Content, pane)
+			}
 
-	if codex.Content == claude.Content {
-		t.Error("expected codex and claude content to differ after gating")
+			if codex.Content == claude.Content {
+				t.Error("expected codex and claude content to differ after gating")
+			}
+		})
 	}
 }

--- a/internal/daemon/paneexcerpt_test.go
+++ b/internal/daemon/paneexcerpt_test.go
@@ -27,7 +27,6 @@ func TestPaneExcerptStripsCodexComposer(t *testing.T) {
 	t.Cleanup(func() { raw.Close() })
 
 	fh := &fakeHerdr{}
-	fh.setPane("─ Worked for 10m 49s ─────\n\n› Summarize recent commits\n\n  gpt-5.6-sol high · /workspaces/herdr-auto-pilot\n")
 	d, err := New(Options{ConfigPath: cfgPath, Store: raw, Herdr: fh, LLM: &fakeLLM{}})
 	if err != nil {
 		t.Fatal(err)
@@ -36,18 +35,30 @@ func TestPaneExcerptStripsCodexComposer(t *testing.T) {
 	ctx := context.Background()
 	cfg, _, _ := d.snapshot()
 
-	codexSituation := domain.Situation{AgentType: "codex", PaneID: "pane-1", Content: "stale snapshot"}
-	excerpt := d.paneExcerpt(ctx, cfg, codexSituation)
-	if strings.Contains(excerpt, "›") {
-		t.Errorf("codex pane excerpt must have composer line stripped, got %q", excerpt)
+	panes := map[string]string{
+		"absolute cwd": "─ Worked for 10m 49s ─────\n\n› Summarize recent commits\n\n  gpt-5.6-sol high · /workspaces/herdr-auto-pilot\n",
+		// Issue #160: cwds under $HOME render ~-relative in the footer; the
+		// strip must fire for those sessions too.
+		"tilde cwd": "─ Worked for 10m 49s ─────\n\n› Use /skills to list available skills\n\n  gpt-5.6-sol high · ~/hap-codex-test\n",
 	}
-	if !strings.Contains(excerpt, "gpt-5.6-sol high") {
-		t.Errorf("footer must survive in codex excerpt, got %q", excerpt)
-	}
+	for name, pane := range panes {
+		t.Run(name, func(t *testing.T) {
+			fh.setPane(pane)
 
-	claudeSituation := domain.Situation{AgentType: "claude", PaneID: "pane-1", Content: "stale snapshot"}
-	claudeExcerpt := d.paneExcerpt(ctx, cfg, claudeSituation)
-	if !strings.Contains(claudeExcerpt, "› Summarize recent commits") {
-		t.Errorf("claude pane excerpt must be untouched, got %q", claudeExcerpt)
+			codexSituation := domain.Situation{AgentType: "codex", PaneID: "pane-1", Content: "stale snapshot"}
+			excerpt := d.paneExcerpt(ctx, cfg, codexSituation)
+			if strings.Contains(excerpt, "›") {
+				t.Errorf("codex pane excerpt must have composer line stripped, got %q", excerpt)
+			}
+			if !strings.Contains(excerpt, "gpt-5.6-sol high") {
+				t.Errorf("footer must survive in codex excerpt, got %q", excerpt)
+			}
+
+			claudeSituation := domain.Situation{AgentType: "claude", PaneID: "pane-1", Content: "stale snapshot"}
+			claudeExcerpt := d.paneExcerpt(ctx, cfg, claudeSituation)
+			if !strings.Contains(claudeExcerpt, "›") {
+				t.Errorf("claude pane excerpt must be untouched, got %q", claudeExcerpt)
+			}
+		})
 	}
 }

--- a/internal/domain/codex.go
+++ b/internal/domain/codex.go
@@ -141,12 +141,14 @@ func ExtractCodexMCQForm(pane string) string {
 // codexComposerBeforeFooterRE matches Codex's live composer/input-box line —
 // prefixed with "›" (U+203A) at line start — ONLY when it directly precedes
 // (modulo blank lines) the composer's status footer, a line naming the model
-// and the working directory (e.g. "gpt-5.6-sol high · /tmp"), AND that
+// and the working directory (e.g. "gpt-5.6-sol high · /tmp"; cwds under $HOME
+// render ~-relative, "gpt-5.6-sol high · ~/project", so the path may start
+// with "~" as well as "/" — issue #160), AND that
 // footer is the very last thing in the captured text (anchored on \z, not
 // end-of-line): every live capture shows the composer+footer pair sitting at
 // the true bottom of the screen, so requiring end-of-text is what actually
 // distinguishes the live footer from an agent response that merely contains
-// the same " · /" shape (e.g. "the config lives at foo · /etc/app.conf")
+// the same " · /" or " · ~" shape (e.g. "the config lives at foo · /etc/app.conf")
 // mid-transcript — a per-line "$" anchor alone would wrongly accept that as
 // a footer and delete the real submitted message above it. Confirmed via
 // live capture: Codex reuses the SAME "›" glyph to render a past SUBMITTED
@@ -166,13 +168,17 @@ func ExtractCodexMCQForm(pane string) string {
 // Residual, accepted risk: this is a text-only heuristic, not a real parse —
 // if a genuinely-submitted message's real response is itself the literal
 // last thing in the captured text AND that response happens to contain the
-// same " · /" shape, the message above it is misidentified as a composer
-// line and stripped. Narrower than the mid-transcript case \z closes (the
+// same " · /" or " · ~" shape, the message above it is misidentified as a
+// composer line and stripped. Accepting "~" (issue #160) widens this class
+// beyond path-shaped trailers to approximation tildes ("took · ~2s"), which
+// are more common in agent output — but the structural gates (a "›" line
+// directly above, the pair at the true tail of the buffer) still bound it.
+// Narrower than the mid-transcript case \z closes (the
 // confusable text must be the true tail of the buffer, which in practice is
 // almost always the real footer), and not fully closeable without semantic
 // understanding of the pane, so it is left as a known limitation rather than
 // chased further.
-var codexComposerBeforeFooterRE = regexp.MustCompile(`(?m)^[ \t]*›[^\n]*\n((?:[ \t]*\r?\n)*[ \t]*[^\n]*\s·\s+/[^\n]*\r?\n?)\z`)
+var codexComposerBeforeFooterRE = regexp.MustCompile(`(?m)^[ \t]*›[^\n]*\n((?:[ \t]*\r?\n)*[ \t]*[^\n]*\s·\s+[~/][^\n]*\r?\n?)\z`)
 
 // StripCodexComposer removes Codex's live composer/input-box line from pane
 // text, keeping its footer (model name + cwd) and any real submitted

--- a/internal/domain/codex.go
+++ b/internal/domain/codex.go
@@ -142,13 +142,15 @@ func ExtractCodexMCQForm(pane string) string {
 // prefixed with "›" (U+203A) at line start — ONLY when it directly precedes
 // (modulo blank lines) the composer's status footer, a line naming the model
 // and the working directory (e.g. "gpt-5.6-sol high · /tmp"; cwds under $HOME
-// render ~-relative, "gpt-5.6-sol high · ~/project", so the path may start
-// with "~" as well as "/" — issue #160), AND that
+// render ~-relative, "gpt-5.6-sol high · ~/project", so the path may also be
+// "~/..." or a bare "~" — issue #160. The tilde branch is deliberately that
+// narrow: a "~" followed by anything but "/" or end-of-line, e.g. an
+// approximation trailer like "took · ~2s", is NOT a footer), AND that
 // footer is the very last thing in the captured text (anchored on \z, not
 // end-of-line): every live capture shows the composer+footer pair sitting at
 // the true bottom of the screen, so requiring end-of-text is what actually
 // distinguishes the live footer from an agent response that merely contains
-// the same " · /" or " · ~" shape (e.g. "the config lives at foo · /etc/app.conf")
+// the same " · /" or " · ~/" shape (e.g. "the config lives at foo · /etc/app.conf")
 // mid-transcript — a per-line "$" anchor alone would wrongly accept that as
 // a footer and delete the real submitted message above it. Confirmed via
 // live capture: Codex reuses the SAME "›" glyph to render a past SUBMITTED
@@ -168,17 +170,16 @@ func ExtractCodexMCQForm(pane string) string {
 // Residual, accepted risk: this is a text-only heuristic, not a real parse —
 // if a genuinely-submitted message's real response is itself the literal
 // last thing in the captured text AND that response happens to contain the
-// same " · /" or " · ~" shape, the message above it is misidentified as a
-// composer line and stripped. Accepting "~" (issue #160) widens this class
-// beyond path-shaped trailers to approximation tildes ("took · ~2s"), which
-// are more common in agent output — but the structural gates (a "›" line
-// directly above, the pair at the true tail of the buffer) still bound it.
+// same " · /" (or " · ~/", " · ~") shape, the message above it is
+// misidentified as a composer line and stripped. The tilde branch accepts
+// only "~/..." and bare "~" — approximation tildes ("took · ~2s"), common in
+// agent output, deliberately do not match (issue #160 review).
 // Narrower than the mid-transcript case \z closes (the
 // confusable text must be the true tail of the buffer, which in practice is
 // almost always the real footer), and not fully closeable without semantic
 // understanding of the pane, so it is left as a known limitation rather than
 // chased further.
-var codexComposerBeforeFooterRE = regexp.MustCompile(`(?m)^[ \t]*›[^\n]*\n((?:[ \t]*\r?\n)*[ \t]*[^\n]*\s·\s+[~/][^\n]*\r?\n?)\z`)
+var codexComposerBeforeFooterRE = regexp.MustCompile(`(?m)^[ \t]*›[^\n]*\n((?:[ \t]*\r?\n)*[ \t]*[^\n]*\s·\s+(?:/[^\n]*|~(?:/[^\n]*)?[ \t]*)\r?\n?)\z`)
 
 // StripCodexComposer removes Codex's live composer/input-box line from pane
 // text, keeping its footer (model name + cwd) and any real submitted

--- a/internal/domain/codex_test.go
+++ b/internal/domain/codex_test.go
@@ -160,6 +160,37 @@ func TestStripCodexComposer(t *testing.T) {
 			"some output\n\n  gpt-5.6-sol high · /tmp\n",
 		},
 		{
+			// Live-observed (issue #160): codex renders a cwd under $HOME as a
+			// ~-relative path in the footer. The strip must fire for those
+			// sessions too, not only absolute "/" paths.
+			"tilde-cwd footer: placeholder stripped, footer kept",
+			"some output\n\n› Use /skills to list available skills\n\n  gpt-5.6-sol high · ~/hap-codex-test\n",
+			"some output\n\n\n  gpt-5.6-sol high · ~/hap-codex-test\n",
+		},
+		{
+			"tilde-cwd footer with no composer line is a no-op",
+			"some output\n\n  gpt-5.6-sol high · ~/hap-codex-test\n",
+			"some output\n\n  gpt-5.6-sol high · ~/hap-codex-test\n",
+		},
+		{
+			// A "·"-separated trailer whose path starts with neither "/" nor
+			// "~" is not the footer shape — the line above it is real content.
+			"non-path trailer after · does not strip the line above",
+			"› is this a composer?\n\n  gpt-5.6-sol high · unknown\n",
+			"› is this a composer?\n\n  gpt-5.6-sol high · unknown\n",
+		},
+		{
+			// Pins the documented residual, accepted risk widened by accepting
+			// "~" (issue #160; see codexComposerBeforeFooterRE's comment): a
+			// response ending the capture with an approximation-tilde trailer
+			// (" · ~2s") is confusable with the footer, so the real submitted
+			// "›" message above it strips. Structurally bounded (needs a "›"
+			// line directly above, at the true tail) and accepted, not chased.
+			"known limitation: trailing approximation-tilde response strips the message above",
+			"› how long did the build take?\n\nbuild finished · ~2s\n",
+			"\nbuild finished · ~2s\n",
+		},
+		{
 			"leading whitespace before glyph stripped",
 			"some output\n\n  › draft text\n\n  gpt-5.6-sol high · /tmp\n",
 			"some output\n\n\n  gpt-5.6-sol high · /tmp\n",

--- a/internal/domain/codex_test.go
+++ b/internal/domain/codex_test.go
@@ -180,15 +180,19 @@ func TestStripCodexComposer(t *testing.T) {
 			"› is this a composer?\n\n  gpt-5.6-sol high · unknown\n",
 		},
 		{
-			// Pins the documented residual, accepted risk widened by accepting
-			// "~" (issue #160; see codexComposerBeforeFooterRE's comment): a
-			// response ending the capture with an approximation-tilde trailer
-			// (" · ~2s") is confusable with the footer, so the real submitted
-			// "›" message above it strips. Structurally bounded (needs a "›"
-			// line directly above, at the true tail) and accepted, not chased.
-			"known limitation: trailing approximation-tilde response strips the message above",
+			// The tilde branch accepts only "~/..." and bare "~" (issue #160
+			// review): an approximation-tilde trailer (" · ~2s") is common in
+			// agent output and must NOT read as the footer — the submitted
+			// "›" message above it survives.
+			"approximation-tilde trailer does not strip the message above",
 			"› how long did the build take?\n\nbuild finished · ~2s\n",
-			"\nbuild finished · ~2s\n",
+			"› how long did the build take?\n\nbuild finished · ~2s\n",
+		},
+		{
+			// cwd exactly $HOME renders as a bare "~" footer.
+			"bare-tilde footer: placeholder stripped, footer kept",
+			"some output\n\n› Explain this codebase\n\n  gpt-5.6-sol high · ~\n",
+			"some output\n\n\n  gpt-5.6-sol high · ~\n",
 		},
 		{
 			"leading whitespace before glyph stripped",


### PR DESCRIPTION
Fixes #160.

## Problem

`codexComposerBeforeFooterRE` (`internal/domain/codex.go`) required the composer footer's path to start with `/`. Codex renders cwds under `$HOME` as `~`-relative (`gpt-5.6-sol high · ~/hap-codex-test`), so for those sessions `StripCodexComposer` no-oped and the rotating `› …` placeholder leaked into every consumer of captured pane text: classification content, LLM consult excerpts, and — post-#159 — action-review excerpts (where it live-poisoned a rewrite into `/skills`, audit #942).

## Fix

- Accept `[~/]` as the footer path prefix (the one-character change the issue suggested). A `~`-prefixed path is still unambiguous next to the model-name footer shape; all structural gates (`›` line directly above, blank-line tolerance, `\z` end-of-text anchor) are unchanged.
- Documented the widened residual risk: an approximation-tilde trailer (`took · ~2s`) at the true tail of the buffer is now confusable with the footer — same accepted-risk class the comment already carried for `· /`, and pinned by a new known-limitation test case.

## Tests

- `TestStripCodexComposer`: `~`-cwd strip (live-captured shape from the issue), `~`-footer no-composer no-op, negative `· unknown` (neither `/` nor `~`) case, and the approximation-tilde known-limitation pin.
- `TestCodexComposerStrippedOnlyForCodex` and `TestPaneExcerptStripsCodexComposer`: converted to subtests over absolute-cwd and `~`-cwd fixtures.
- Full suite (`go test -tags "vectors cpu" ./... -count=1`) green; gofmt/vet clean. Verified no other regex anchors on the `· /` footer shape.

## Not in scope (issue's hardening follow-ups)

The issue lists three follow-ups beyond the regex fix — auditing other agent types' idle chrome, review-prompt hardening against trailing chrome, and free-text delivery verification. Those are separate work items.