### PR TITLE
#175 fix: LLM @noop no longer parks exhausted-source generation; LLM decisions get signature rows

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -549,6 +549,60 @@ func TestSignaturesReset(t *testing.T) {
 	}
 }
 
+func TestLLMLearnedSignatureIsCLIAddressable(t *testing.T) {
+	// #175: an LLM-recorded decision always has a signatures state row now
+	// (written by the daemon at decision time, or backfilled by the store
+	// migration), so the learned rule is listable, resettable, deletable,
+	// and named on escalations instead of hiding behind "rule=[none yet]".
+	app, st := testApp(t)
+	ctx := context.Background()
+	now := time.Now()
+	const sig = "idle:ffff0000aaaa1111"
+	if err := st.UpsertSignature(ctx, domain.SignatureState{
+		Signature: sig, SituationType: domain.SituationIdle,
+		AgentType: "claude", Mode: domain.ModeShadow, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.RecordDecision(ctx, domain.DecisionRecord{
+		Signature: sig, SituationType: domain.SituationIdle, AgentType: "claude",
+		ChosenAction: domain.ActionNoop, Source: domain.SourceLLM, CreatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	st.AppendAudit(ctx, domain.AuditRecord{Signature: sig,
+		Trigger: "agent idle", SituationType: domain.SituationIdle,
+		Action: "escalated", Rationale: "[shadow_mode]", Status: "escalated", CreatedAt: now})
+
+	out, err := run(t, app, "signatures")
+	if err != nil || !strings.Contains(out, "idle:ffff0000aaa") {
+		t.Errorf("LLM-learned signature must be listed (%v):\n%s", err, out)
+	}
+	out, err = run(t, app, "escalations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `top action "@noop" over 1 decision(s)`) ||
+		strings.Contains(out, "rule=[none yet]") {
+		t.Errorf("escalation must name the LLM-learned rule, got:\n%s", out)
+	}
+	out, err = run(t, app, "signatures", "reset", "idle:", "--yes")
+	if err != nil || !strings.Contains(out, "reset signature "+sig) {
+		t.Errorf("LLM-learned signature must be resettable (%v):\n%s", err, out)
+	}
+	out, err = run(t, app, "signatures", "delete", "idle:", "--yes")
+	if err != nil || !strings.Contains(out, "deleted signature "+sig) ||
+		!strings.Contains(out, "1 decision(s)") {
+		t.Errorf("LLM-learned signature must be deletable with its decisions (%v):\n%s", err, out)
+	}
+	if state, _ := st.GetSignature(ctx, sig); state != nil {
+		t.Error("signature row should be gone")
+	}
+	if recs, _ := st.DecisionsForSignature(ctx, sig, 10); len(recs) != 0 {
+		t.Error("decision history should be gone")
+	}
+}
+
 func TestDismissCLI(t *testing.T) {
 	app, st := testApp(t)
 	ctx := context.Background()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2990,6 +2990,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 				}); err != nil {
 					slog.Error("decision record write failed", "error", err)
 				}
+				d.ensureSignatureRow(ctx, res.sig.Signature, s.Type, s.AgentType, now)
 				// The runaway counter still advances (D3): a self-flapping agent
 				// must not consult-and-noop silently forever. lastAutoSend stays
 				// untouched (nothing was sent); lastAutoNoop is stamped so a
@@ -3139,6 +3140,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 				ChosenAction: d.llmLearnedAction(llmDec, taskReviewSend),
 				Source:       domain.SourceLLM, CreatedAt: now,
 			})
+			d.ensureSignatureRow(ctx, res.sig.Signature, s.Type, s.AgentType, now)
 			if rate2, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
 				updated := domain.RegisterAutoPrompt(*rate2, now)
 				updated.AgentID = s.AgentID
@@ -3155,6 +3157,27 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		})
 	if !executed {
 		d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "rejected")
+	}
+}
+
+// ensureSignatureRow makes an LLM-learned signature addressable: every
+// recorded decision gets a signatures state row, so `hap signatures
+// list/delete/reset` and the escalation rule line can reach it (#175).
+// EnsureSignature is a single atomic INSERT OR IGNORE, so an existing row is
+// never touched (a below-threshold consult on an already learned rule lands
+// here too — its mode/confirmations/floor must survive, including against a
+// concurrent correction writer). DecisionFloorID starts 0 so LLM decisions
+// keep counting toward the plurality until the operator first speaks;
+// applyCorrection floors them out at that point. Errors only log: the
+// decision and audit are already durable, and a failed visibility write must
+// not reject an accepted LLM decision (fail-safe daemon path).
+func (d *Daemon) ensureSignatureRow(ctx context.Context, signature string,
+	situationType domain.SituationType, agentType string, now time.Time) {
+	if err := d.opt.Store.EnsureSignature(ctx, domain.SignatureState{
+		Signature: signature, SituationType: situationType,
+		AgentType: agentType, Mode: domain.ModeShadow, UpdatedAt: now,
+	}); err != nil {
+		slog.Error("signature row write failed", "signature", signature, "error", err)
 	}
 }
 
@@ -3362,37 +3385,41 @@ func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domai
 			Signature: audit.Signature, SituationType: audit.SituationType,
 			AgentType: agentTypeOf(history, audit), Mode: domain.ModeShadow,
 		}
-		// A rule begins when the OPERATOR first speaks, so it starts on a clean
-		// slate: floor out every decision that predates this one. Before a state
-		// row exists every decision is SourceLLM (SourceRule needs a graduated
-		// rule, i.e. a row), so this can only ever discard the LLM's own guesses
-		// — never operator evidence, of which there is none yet by definition.
-		// (Modulo one narrow window: the decision below and the state row are
-		// written without a shared transaction, so a crash between them orphans
-		// an operator decision that the next correction floors out. Harmless —
-		// that rule restarts at 1.00, which is what this wants anyway.)
-		//
-		// Those guesses are not agreement about anything: an LLM that answered
-		// the same situation six different ways would otherwise hand its brand
-		// new rule a contradictory history it never earned, scoring it below the
-		// variance-guard floor and pinning it there — visibly inconsistent, since
-		// the operator has agreed with it exactly once and never disagreed. The
-		// rows are KEPT (the floor only hides them from confidence/graduation),
-		// so history and audit stay intact.
-		//
-		// history is read BEFORE the operator's decision is recorded below, so
-		// history[0] is the newest PRE-EXISTING decision: the new one lands above
-		// the floor and counts, giving the fresh rule 1.00 over its single
-		// operator decision. (Contrast ResetGraduation, which floors the newest
-		// decision INCLUDING itself — a reset has no evidence yet and reads "-".)
-		if len(history) > 0 {
-			state.DecisionFloorID = history[0].ID
-		}
 	} else if state.AgentType == "" || state.AgentType == "unknown" {
 		// Heal rules learned before the audit carried an agent type.
 		if at := agentTypeOf(history, audit); at != "unknown" {
 			state.AgentType = at
 		}
+	}
+
+	// A rule begins when the OPERATOR first speaks, so it starts on a clean
+	// slate: floor out every decision that predates this one. The trigger is
+	// "no operator/rule evidence in the pre-existing history yet" — NOT state
+	// row absence, because LLM decisions now create their own shadow row for
+	// CLI addressability (#175), so the row can exist while every decision is
+	// still SourceLLM. Flooring only a purely-LLM history means this can only
+	// ever discard the LLM's own guesses — never operator evidence.
+	// (Modulo one narrow window: the decision below and the state row are
+	// written without a shared transaction, so a crash between them orphans
+	// an operator decision that the next correction floors out. Harmless —
+	// that rule restarts at 1.00, which is what this wants anyway.)
+	//
+	// Those guesses are not agreement about anything: an LLM that answered
+	// the same situation six different ways would otherwise hand its brand
+	// new rule a contradictory history it never earned, scoring it below the
+	// variance-guard floor and pinning it there — visibly inconsistent, since
+	// the operator has agreed with it exactly once and never disagreed. The
+	// rows are KEPT (the floor only hides them from confidence/graduation),
+	// so history and audit stay intact.
+	//
+	// history is read BEFORE the operator's decision is recorded below, so
+	// history[0] is the newest PRE-EXISTING decision: the new one lands above
+	// the floor and counts, giving the fresh rule 1.00 over its single
+	// operator decision. (Contrast ResetGraduation, which floors the newest
+	// decision INCLUDING itself — a reset has no evidence yet and reads "-".)
+	if len(history) > 0 && !domain.HasOperatorEvidence(history) &&
+		history[0].ID > state.DecisionFloorID {
+		state.DecisionFloorID = history[0].ID
 	}
 
 	// Confidence/graduation see only post-reset decisions (id > the floor); the

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3394,11 +3394,26 @@ func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domai
 
 	// A rule begins when the OPERATOR first speaks, so it starts on a clean
 	// slate: floor out every decision that predates this one. The trigger is
-	// "no operator/rule evidence in the pre-existing history yet" — NOT state
+	// "no operator/rule evidence since the rule's last (re)birth" — NOT state
 	// row absence, because LLM decisions now create their own shadow row for
 	// CLI addressability (#175), so the row can exist while every decision is
-	// still SourceLLM. Flooring only a purely-LLM history means this can only
-	// ever discard the LLM's own guesses — never operator evidence.
+	// still SourceLLM. The evidence is checked over the POST-FLOOR slice of
+	// the same capped window that confidence and graduation consume, on
+	// purpose, so the floor decision and the score it protects always see
+	// the same rows:
+	//   - post-floor, not full-window: a reset rule's pre-reset operator rows
+	//     are "no evidence yet" by definition (the reset floored them), so
+	//     post-reset LLM guesses still get floored when the operator first
+	//     speaks again instead of polluting the re-earning score;
+	//   - capped, not unbounded: operator rows older than the read window
+	//     contribute nothing to confidence/graduation anywhere (every reader
+	//     caps at 50, and recency decay zeroes them long before that), so
+	//     when 50+ LLM guesses have buried old operator rows, advancing the
+	//     floor discards exactly the in-window guesses — an unbounded check
+	//     would instead keep that contradictory noise in the live window and
+	//     pin the rule under the variance guard.
+	// Flooring only a purely-LLM slice means this can only ever discard the
+	// LLM's own guesses — never operator evidence that still counts.
 	// (Modulo one narrow window: the decision below and the state row are
 	// written without a shared transaction, so a crash between them orphans
 	// an operator decision that the next correction floors out. Harmless —
@@ -3417,7 +3432,8 @@ func (d *Daemon) applyCorrection(ctx context.Context, cfg config.Config, c domai
 	// the floor and counts, giving the fresh rule 1.00 over its single
 	// operator decision. (Contrast ResetGraduation, which floors the newest
 	// decision INCLUDING itself — a reset has no evidence yet and reads "-".)
-	if len(history) > 0 && !domain.HasOperatorEvidence(history) &&
+	if len(history) > 0 &&
+		!domain.HasOperatorEvidence(domain.DecisionsSince(history, state.DecisionFloorID)) &&
 		history[0].ID > state.DecisionFloorID {
 		state.DecisionFloorID = history[0].ID
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -757,6 +757,22 @@ func TestLLMPromotionDeliversMenuDigitForLabel(t *testing.T) {
 	if got := h.herdr.sentInputs()[0]; got != "1" {
 		t.Errorf("promoted LLM label \"Yes\" delivered as %q, want digit \"1\"", got)
 	}
+
+	// #175: the delivered LLM decision must also create a shadow signatures
+	// row (written after delivery, so wait for it rather than assert).
+	ctx := context.Background()
+	var st *domain.SignatureState
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := h.raw.AuditLog(ctx, 5)
+		if len(audits) == 0 {
+			return false
+		}
+		st, _ = h.raw.GetSignature(ctx, audits[0].Signature)
+		return st != nil
+	})
+	if st.Mode != domain.ModeShadow || st.DecisionFloorID != 0 {
+		t.Errorf("LLM-created row must be a fresh shadow state: %+v", st)
+	}
 }
 
 func TestLLMPromotionDeniedWhenDisableWinsFinalBarrier(t *testing.T) {
@@ -925,6 +941,61 @@ func TestFirstOperatorDecisionFloorsPriorLLMGuesses(t *testing.T) {
 	}
 	if st.ConsecutiveConfirmations != 1 {
 		t.Errorf("streak = %d, want 1", st.ConsecutiveConfirmations)
+	}
+}
+
+func TestFirstOperatorCorrectionFloorsLLMHistoryDespiteExistingRow(t *testing.T) {
+	// #175 companion: LLM decisions now create their own shadow signatures
+	// row at decision time, so the clean-slate floor must key on "no operator
+	// evidence in the history yet", not on state-row absence — otherwise the
+	// first operator correction would inherit every prior LLM guess into the
+	// fresh rule's confidence, the exact pathology the floor exists to stop.
+	h := newHarness(t, "[learning]\ngraduation_n = 3\n")
+	h.herdr.setPane(approvalPane)
+	ctx := context.Background()
+	sig := seedLLMHistory(t, h, approvalPane, domain.SituationApproval,
+		"No", "@noop", "No, and tell the agent what to do differently", "Yes")
+	// The row ensureSignatureRow would have written at LLM decision time.
+	if err := h.raw.UpsertSignature(ctx, domain.SignatureState{
+		Signature: sig, SituationType: domain.SituationApproval,
+		AgentType: "claude", Mode: domain.ModeShadow, UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := h.raw.DecisionsForSignature(ctx, sig, 50)
+	if err != nil || len(before) != 4 {
+		t.Fatalf("seed history: %d rows, %v", len(before), err)
+	}
+
+	app := frontend.App{Store: h.raw, Herdr: h.herdr, ControlPath: h.ctlPath, Author: "test"}
+	h.push("agent-floor-row", "blocked")
+	var esc domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		pend, _ := h.raw.PendingEscalations(ctx)
+		if len(pend) != 1 {
+			return false
+		}
+		esc = pend[0]
+		return true
+	})
+	if err := app.Resolve(ctx, esc.ID, "Yes", false); err != nil {
+		t.Fatal(err)
+	}
+
+	var st *domain.SignatureState
+	waitFor(t, 3*time.Second, func() bool {
+		st, _ = h.raw.GetSignature(ctx, sig)
+		return st != nil && st.DecisionFloorID != 0
+	})
+	if st.DecisionFloorID != before[0].ID {
+		t.Errorf("floor = %d, want the newest pre-existing decision %d", st.DecisionFloorID, before[0].ID)
+	}
+	if st.CachedConfidence != 1 {
+		t.Errorf("a fresh rule scores 1.00 over its one operator decision, got %.4f", st.CachedConfidence)
+	}
+	after, _ := h.raw.DecisionsForSignature(ctx, sig, 50)
+	if n := len(domain.DecisionsSince(after, st.DecisionFloorID)); n != 1 {
+		t.Errorf("post-floor decisions = %d, want only the operator's 1", n)
 	}
 }
 
@@ -3757,6 +3828,22 @@ func TestLLMPromotionDeliversRemoteEnvSelection(t *testing.T) {
 	}
 	if len(h.herdr.sentInputs()) != 0 {
 		t.Errorf("the picker must be answered with keystrokes, not a text send: %v", h.herdr.sentInputs())
+	}
+
+	// #175: the delivered picker decision must also create a shadow
+	// signatures row (written after delivery, so wait rather than assert).
+	ctx := context.Background()
+	var st *domain.SignatureState
+	waitFor(t, 3*time.Second, func() bool {
+		audits, _ := h.raw.AuditLog(ctx, 5)
+		if len(audits) == 0 {
+			return false
+		}
+		st, _ = h.raw.GetSignature(ctx, audits[0].Signature)
+		return st != nil
+	})
+	if st.Mode != domain.ModeShadow || st.DecisionFloorID != 0 {
+		t.Errorf("LLM-created row must be a fresh shadow state: %+v", st)
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -999,6 +999,83 @@ func TestFirstOperatorCorrectionFloorsLLMHistoryDespiteExistingRow(t *testing.T)
 	}
 }
 
+func TestCorrectionFloorsPostResetLLMGuesses(t *testing.T) {
+	// The clean-slate floor keys on POST-floor evidence, scoped to the same
+	// capped window confidence reads: a reset rule's pre-reset operator rows
+	// are floored ("no evidence yet" by definition), so when the post-reset
+	// history is pure LLM guesswork, the operator's next correction advances
+	// the floor over those guesses instead of letting them pollute the
+	// re-earning score. (A full-window check would see the pre-reset operator
+	// rows and refuse to stamp.)
+	h := newHarness(t, "[learning]\ngraduation_n = 3\n")
+	h.herdr.setPane(approvalPane)
+	ctx := context.Background()
+
+	s := classifierForTest().Classify("claude", "blocked", approvalPane)
+	sig := domain.ComputeSignature(s)
+	// Pre-reset operator history, still inside the 50-row read window.
+	for i, a := range []string{"Yes", "Yes"} { // oldest → newest
+		if _, err := h.raw.RecordDecision(ctx, domain.DecisionRecord{
+			Signature: sig.Signature, SituationType: domain.SituationApproval,
+			AgentType: "claude", ChosenAction: a, Source: domain.SourceOperator,
+			CreatedAt: time.Now().Add(-time.Duration(20-i) * time.Minute),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	newestOp, _ := h.raw.DecisionsForSignature(ctx, sig.Signature, 1)
+	// The reset: floor everything recorded so far, newest INCLUSIVE.
+	if err := h.raw.UpsertSignature(ctx, domain.SignatureState{
+		Signature: sig.Signature, SituationType: domain.SituationApproval,
+		AgentType: "claude", Mode: domain.ModeShadow,
+		DecisionFloorID: newestOp[0].ID, CachedConfidence: 1, UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Post-reset: contradictory LLM guesses.
+	for i, a := range []string{"No", "@noop", "Yes"} { // oldest → newest
+		if _, err := h.raw.RecordDecision(ctx, domain.DecisionRecord{
+			Signature: sig.Signature, SituationType: domain.SituationApproval,
+			AgentType: "claude", ChosenAction: a, Source: domain.SourceLLM,
+			CreatedAt: time.Now().Add(-time.Duration(10-i) * time.Minute),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	before, _ := h.raw.DecisionsForSignature(ctx, sig.Signature, 50)
+
+	app := frontend.App{Store: h.raw, Herdr: h.herdr, ControlPath: h.ctlPath, Author: "test"}
+	h.push("agent-reset-floor", "blocked")
+	var esc domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		pend, _ := h.raw.PendingEscalations(ctx)
+		if len(pend) != 1 {
+			return false
+		}
+		esc = pend[0]
+		return true
+	})
+	if err := app.Resolve(ctx, esc.ID, "Yes", false); err != nil {
+		t.Fatal(err)
+	}
+
+	var st *domain.SignatureState
+	waitFor(t, 3*time.Second, func() bool {
+		st, _ = h.raw.GetSignature(ctx, sig.Signature)
+		return st != nil && st.DecisionFloorID > newestOp[0].ID
+	})
+	if st.DecisionFloorID != before[0].ID {
+		t.Errorf("floor = %d, want the newest pre-existing decision %d", st.DecisionFloorID, before[0].ID)
+	}
+	if st.CachedConfidence != 1 {
+		t.Errorf("the re-born rule scores 1.00 over its one operator decision, got %.4f", st.CachedConfidence)
+	}
+	after, _ := h.raw.DecisionsForSignature(ctx, sig.Signature, 50)
+	if n := len(domain.DecisionsSince(after, st.DecisionFloorID)); n != 1 {
+		t.Errorf("post-floor decisions = %d, want only the operator's 1", n)
+	}
+}
+
 func TestCorrectingLLMAutoRowWithNoRuleStartsStreak(t *testing.T) {
 	// An LLM auto-act writes audit.Status "auto" for a signature that has NO
 	// rule. That must not be mistaken for "a graduated rule acted": treating it

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1023,7 +1023,10 @@ func TestCorrectionFloorsPostResetLLMGuesses(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	newestOp, _ := h.raw.DecisionsForSignature(ctx, sig.Signature, 1)
+	newestOp, err := h.raw.DecisionsForSignature(ctx, sig.Signature, 1)
+	if err != nil || len(newestOp) != 1 {
+		t.Fatalf("seed operator history: %d rows, %v", len(newestOp), err)
+	}
 	// The reset: floor everything recorded so far, newest INCLUSIVE.
 	if err := h.raw.UpsertSignature(ctx, domain.SignatureState{
 		Signature: sig.Signature, SituationType: domain.SituationApproval,
@@ -1042,7 +1045,10 @@ func TestCorrectionFloorsPostResetLLMGuesses(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	before, _ := h.raw.DecisionsForSignature(ctx, sig.Signature, 50)
+	before, err := h.raw.DecisionsForSignature(ctx, sig.Signature, 50)
+	if err != nil || len(before) != 5 {
+		t.Fatalf("seed history: %d rows, %v", len(before), err)
+	}
 
 	app := frontend.App{Store: h.raw, Herdr: h.herdr, ControlPath: h.ctlPath, Author: "test"}
 	h.push("agent-reset-floor", "blocked")

--- a/internal/daemon/noop_test.go
+++ b/internal/daemon/noop_test.go
@@ -90,6 +90,17 @@ func TestLLMNoopPromotionRecordsWithoutSend(t *testing.T) {
 		t.Errorf("LLM noop decision not learned: %+v", decs)
 	}
 
+	// #175: the recorded LLM decision must also create a shadow signatures
+	// row, so the learned rule is visible to `signatures list` and
+	// addressable by delete/reset.
+	st, err := h.raw.GetSignature(ctx, audits[0].Signature)
+	if err != nil || st == nil {
+		t.Fatalf("LLM decision must create a signatures row: %v %v", st, err)
+	}
+	if st.Mode != domain.ModeShadow || st.DecisionFloorID != 0 || st.ConsecutiveConfirmations != 0 {
+		t.Errorf("LLM-created row must be a fresh shadow state: %+v", st)
+	}
+
 	pending, _ := h.raw.PendingLLMDecisions(ctx)
 	if len(pending) != 0 {
 		t.Errorf("staged decision should be accepted, still pending: %+v", pending)

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -475,6 +475,7 @@ func (d *Daemon) deliverSeriesLLM(ctx context.Context, ks ports.KeystrokeSender,
 					}); err != nil {
 						slog.Error("decision record write failed", "error", err)
 					}
+					d.ensureSignatureRow(ctx, sig.Signature, s.Type, s.AgentType, now)
 					if rate, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
 						updated := domain.RegisterAutoPrompt(*rate, now)
 						updated.AgentID = s.AgentID
@@ -613,6 +614,7 @@ func (d *Daemon) deliverRemoteEnvLLM(ctx context.Context, ks ports.KeystrokeSend
 					}); err != nil {
 						slog.Error("decision record write failed", "error", err)
 					}
+					d.ensureSignatureRow(ctx, sig.Signature, s.Type, s.AgentType, now)
 					if rate, err := d.opt.Store.GetAgentRate(ctx, s.AgentID); err == nil {
 						updated := domain.RegisterAutoPrompt(*rate, now)
 						updated.AgentID = s.AgentID

--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -521,6 +521,17 @@ func TestLLMMultiTabConsultAndSeriesPromotion(t *testing.T) {
 	if !strings.HasSuffix(keys, "1 2 1") {
 		t.Errorf("promoted series keystrokes missing: %v", keys)
 	}
+
+	// #175: the delivered series decision must also create a shadow
+	// signatures row (written after delivery, so wait rather than assert).
+	var st *domain.SignatureState
+	waitFor(t, 3*time.Second, func() bool {
+		st, _ = h.raw.GetSignature(ctx, audits[0].Signature)
+		return st != nil
+	})
+	if st.Mode != domain.ModeShadow || st.DecisionFloorID != 0 {
+		t.Errorf("LLM-created row must be a fresh shadow state: %+v", st)
+	}
 }
 
 func TestLLMMultiTabSeriesDeniedWhenDisableWinsFinalBarrier(t *testing.T) {

--- a/internal/domain/confidence.go
+++ b/internal/domain/confidence.go
@@ -27,6 +27,14 @@ type ConfidenceResult struct {
 	TopAction string
 	// Decisions is the number of history records considered.
 	Decisions int
+	// TopActionOperatorBacked is true when at least one considered decision
+	// for TopAction was operator- or rule-sourced. A SourceRule row
+	// existentially implies past operator confirmation (graduation requires
+	// it), so it counts even after the operator rows age out of the history
+	// window. A plurality built purely from SourceLLM guesses is NOT
+	// operator-backed — resolvers use this to keep a single LLM answer from
+	// outranking operator-declared intent (#175).
+	TopActionOperatorBacked bool
 }
 
 // DecisionsSince returns the decisions newer than a signature's reset floor
@@ -48,6 +56,21 @@ func DecisionsSince(history []DecisionRecord, floorID int64) []DecisionRecord {
 	return out
 }
 
+// HasOperatorEvidence reports whether any decision in history is operator-
+// or rule-sourced. A history without such evidence is purely LLM guesses —
+// the clean-slate floor in correction processing keys on this (a rule begins
+// when the operator first speaks), and it must key on the HISTORY rather
+// than on state-row absence now that LLM decisions create their own
+// signatures row for CLI addressability (#175).
+func HasOperatorEvidence(history []DecisionRecord) bool {
+	for _, d := range history {
+		if d.Source == SourceOperator || d.Source == SourceRule {
+			return true
+		}
+	}
+	return false
+}
+
 // LiveConfidence is the confidence the decision core gates on RIGHT NOW for a
 // signature: the recency-weighted agreement over post-floor decisions only.
 // The TopAction, however, still comes from the FULL learned history when the
@@ -64,9 +87,12 @@ func LiveConfidence(history []DecisionRecord, floorID int64, confirmWeight float
 	post := DecisionsSince(history, floorID)
 	conf := Confidence(post, confirmWeight)
 	if len(post) == 0 {
-		// Only TopAction falls back; Score and Decisions stay zero so a reset
-		// rule reads as "no post-reset evidence yet", not as agreement.
-		conf.TopAction = Confidence(history, confirmWeight).TopAction
+		// Only TopAction (and its provenance) falls back; Score and Decisions
+		// stay zero so a reset rule reads as "no post-reset evidence yet",
+		// not as agreement.
+		full := Confidence(history, confirmWeight)
+		conf.TopAction = full.TopAction
+		conf.TopActionOperatorBacked = full.TopActionOperatorBacked
 	}
 	return conf
 }
@@ -88,12 +114,16 @@ func Confidence(history []DecisionRecord, confirmWeight float64) ConfidenceResul
 		confirmWeight = 1
 	}
 	weights := map[string]float64{}
+	operatorBacked := map[string]bool{}
 	var total float64
 	w := 1.0
 	for _, d := range history {
 		weight := w
 		if d.Source == SourceOperator && !d.IsCorrection {
 			weight *= confirmWeight
+		}
+		if d.Source == SourceOperator || d.Source == SourceRule {
+			operatorBacked[d.ChosenAction] = true
 		}
 		weights[d.ChosenAction] += weight
 		total += weight
@@ -106,5 +136,6 @@ func Confidence(history []DecisionRecord, confirmWeight float64) ConfidenceResul
 			top, topW = action, aw
 		}
 	}
-	return ConfidenceResult{Score: topW / total, TopAction: top, Decisions: len(history)}
+	return ConfidenceResult{Score: topW / total, TopAction: top, Decisions: len(history),
+		TopActionOperatorBacked: operatorBacked[top]}
 }

--- a/internal/domain/confidence_test.go
+++ b/internal/domain/confidence_test.go
@@ -80,6 +80,77 @@ func opHistory(actions ...string) []DecisionRecord {
 	return recs
 }
 
+// sourcedHistory builds newest-first records that all carry the given source.
+// opHistory cannot express an operator "@noop" (its "@" prefix is the
+// SourceRule marker), so noop provenance tests build records through this.
+func sourcedHistory(src Source, actions ...string) []DecisionRecord {
+	recs := history(actions...)
+	for i := range recs {
+		recs[i].Source = src
+	}
+	return recs
+}
+
+func TestConfidenceTopActionOperatorBacked(t *testing.T) {
+	cases := map[string]struct {
+		history    []DecisionRecord
+		wantTop    string
+		wantBacked bool
+	}{
+		"llm only": {sourcedHistory(SourceLLM, ActionNoop, ActionNoop, ActionNoop),
+			ActionNoop, false},
+		"test-helper zero source": {history(ActionNoop, ActionNoop), ActionNoop, false},
+		"operator mixed with llm": {append(sourcedHistory(SourceLLM, ActionNoop, ActionNoop),
+			sourcedHistory(SourceOperator, ActionNoop)...), ActionNoop, true},
+		"rule sourced": {sourcedHistory(SourceRule, ActionNoop), ActionNoop, true},
+		"operator backs a different action only": {append(sourcedHistory(SourceLLM,
+			ActionNoop, ActionNoop, ActionNoop, ActionNoop),
+			sourcedHistory(SourceOperator, "yes")...), ActionNoop, false},
+	}
+	for name, tc := range cases {
+		c := Confidence(tc.history, 1.0) // no confirmation boost: keep TopAction on vote count
+		if c.TopAction != tc.wantTop {
+			t.Fatalf("%s: top action = %q, want %q", name, c.TopAction, tc.wantTop)
+		}
+		if c.TopActionOperatorBacked != tc.wantBacked {
+			t.Errorf("%s: TopActionOperatorBacked = %v, want %v", name, c.TopActionOperatorBacked, tc.wantBacked)
+		}
+	}
+}
+
+func TestLiveConfidenceFloorFallbackCarriesProvenance(t *testing.T) {
+	// A reset rule's TopAction falls back to the full history; the operator
+	// provenance must travel with it, or a reset operator-taught noop would
+	// stop outranking a declared task until re-confirmed.
+	recs := sourcedHistory(SourceOperator, ActionNoop, ActionNoop)
+	for i := range recs {
+		recs[i].ID = int64(i + 1)
+	}
+	c := LiveConfidence(recs, 10, DefaultConfirmationWeight) // floor excludes all
+	if c.Score != 0 || c.Decisions != 0 {
+		t.Fatalf("floored history must score zero, got %+v", c)
+	}
+	if c.TopAction != ActionNoop || !c.TopActionOperatorBacked {
+		t.Errorf("fallback must carry TopAction with provenance, got %+v", c)
+	}
+}
+
+func TestHasOperatorEvidence(t *testing.T) {
+	if HasOperatorEvidence(sourcedHistory(SourceLLM, ActionNoop, "1", ActionNoop)) {
+		t.Error("purely-LLM history must have no operator evidence")
+	}
+	if HasOperatorEvidence(nil) {
+		t.Error("empty history must have no operator evidence")
+	}
+	if !HasOperatorEvidence(append(sourcedHistory(SourceLLM, ActionNoop),
+		sourcedHistory(SourceOperator, "1")...)) {
+		t.Error("an operator decision is evidence regardless of action")
+	}
+	if !HasOperatorEvidence(sourcedHistory(SourceRule, "1")) {
+		t.Error("a rule decision implies past operator confirmation")
+	}
+}
+
 func TestConfirmationBoostRaisesContestedScore(t *testing.T) {
 	// FR-005 (revised): an operator confirmation weighs more than a passive
 	// auto-send. Newest is a confirmation of "yes" against two older auto "no"

--- a/internal/domain/decide.go
+++ b/internal/domain/decide.go
@@ -334,9 +334,16 @@ func Decide(in DecideInput) Decision {
 func resolveSituation(in DecideInput, conf ConfidenceResult) (candidate, suggestion string, escReason EscalateReason) {
 	switch in.Situation.Type {
 	case SituationIdle:
-		// A learned noop beats task resolution: the operator repeatedly said
-		// "leave this one alone", which outranks re-sending tasks.
-		if conf.TopAction == ActionNoop {
+		// A learned noop beats task resolution only when the OPERATOR (or a
+		// rule graduated from operator confirmations) said "leave this one
+		// alone" — that outranks re-sending tasks. A noop plurality built
+		// purely from LLM guesses does NOT outrank a declared task source:
+		// one consult-time "@noop" on an exhausted list would otherwise
+		// permanently park the task_source_exhausted → generation refill path
+		// (#175). Without a declared source there is nothing to park, so an
+		// LLM-learned noop still silences a chatty idle agent (the original
+		// nudge-loop case) instead of escalating no_task_source forever.
+		if conf.TopAction == ActionNoop && (conf.TopActionOperatorBacked || in.DeclaredTask == nil) {
 			return ActionNoop, ActionNoopSuggestion, ReasonNone
 		}
 		// Two-tier next-task resolution (FR-011). A matched source with a real

--- a/internal/domain/noop_test.go
+++ b/internal/domain/noop_test.go
@@ -58,13 +58,95 @@ func TestDecideNoopChoiceBypassesOptionSet(t *testing.T) {
 }
 
 func TestDecideIdleNoopBeatsDeclaredTask(t *testing.T) {
-	// The operator repeatedly said "leave this one alone": that outranks
-	// re-sending the declared next task.
-	in := autonomous(baseInput(SituationIdle), noopHistory()...)
+	// The OPERATOR repeatedly said "leave this one alone": that outranks
+	// re-sending the declared next task. Rule-sourced rows count the same —
+	// a graduated rule implies past operator confirmation.
+	for _, src := range []Source{SourceOperator, SourceRule} {
+		in := autonomous(baseInput(SituationIdle))
+		in.History = sourcedHistory(src, noopHistory()...)
+		in.DeclaredTask = &DeclaredTask{Task: "build the parser"}
+		d := Decide(in)
+		if d.Action != ActionKindNoop {
+			t.Fatalf("%s: idle noop must beat the declared task, got %+v", src, d)
+		}
+	}
+}
+
+func TestDecideIdleLLMNoopYieldsToDeclaredTask(t *testing.T) {
+	// A noop plurality built purely from LLM guesses must NOT outrank a
+	// declared task source (#175): operator-declared intent wins. The
+	// signature is shadow (LLM decisions never graduate a rule), so the
+	// declared task surfaces as a confirmable suggestion.
+	in := baseInput(SituationIdle)
+	in.State = &SignatureState{Mode: ModeShadow}
+	in.History = sourcedHistory(SourceLLM, noopHistory()...)
 	in.DeclaredTask = &DeclaredTask{Task: "build the parser"}
 	d := Decide(in)
+	if d.Action != ActionEscalate || d.Reason != ReasonShadowMode {
+		t.Fatalf("shadow LLM-noop signature must escalate the declared task, got %+v", d)
+	}
+	if !strings.Contains(d.Suggestion, "build the parser") {
+		t.Errorf("suggestion should carry the declared task, got %q", d.Suggestion)
+	}
+}
+
+func TestDecideIdleLLMNoopDoesNotBlockExhaustedGeneration(t *testing.T) {
+	// The #175 repro: the LLM answered @noop once on an exhausted list, and
+	// that learned plurality must not park the task_source_exhausted →
+	// generation refill path forever.
+	in := baseInput(SituationIdle)
+	in.State = &SignatureState{Mode: ModeShadow}
+	in.History = sourcedHistory(SourceLLM, noopHistory()...)
+	in.DeclaredTask = &DeclaredTask{Task: NoTaskContent}
+	in.GenerateTaskConfigured = true
+	in.GenerateTaskStartConfigured = true
+	d := Decide(in)
+	if d.Action != ActionGenerateTask {
+		t.Fatalf("LLM noop must not block exhausted-source generation, got %+v", d)
+	}
+}
+
+func TestDecideIdleLLMNoopExhaustedWithoutGenerateEscalates(t *testing.T) {
+	// Same suppression, no generation opt-in: the exhausted source surfaces
+	// as its own confirmable escalation instead of a silent shadow noop.
+	// Confirming @noop there records an operator decision, which makes the
+	// plurality operator-backed and restores quiet noop precedence.
+	in := baseInput(SituationIdle)
+	in.State = &SignatureState{Mode: ModeShadow}
+	in.History = sourcedHistory(SourceLLM, noopHistory()...)
+	in.DeclaredTask = &DeclaredTask{Task: NoTaskContent}
+	d := Decide(in)
+	if d.Action != ActionEscalate || d.Reason != ReasonTaskSourceExhausted {
+		t.Fatalf("exhausted source must escalate as such, got %+v", d)
+	}
+	if d.Suggestion != ActionNoopSuggestion {
+		t.Errorf("suggestion = %q, want %q", d.Suggestion, ActionNoopSuggestion)
+	}
+}
+
+func TestDecideIdleLLMNoopStillHonoredWithoutDeclaredSource(t *testing.T) {
+	// Without a declared source there is no refill path to park: an
+	// LLM-learned noop keeps silencing a chatty idle agent (the original
+	// nudge-loop case) instead of escalating no_task_source forever.
+	in := autonomous(baseInput(SituationIdle))
+	in.History = sourcedHistory(SourceLLM, noopHistory()...)
+	d := Decide(in)
 	if d.Action != ActionKindNoop {
-		t.Fatalf("idle noop must beat the declared task, got %+v", d)
+		t.Fatalf("idle LLM noop without a declared source must still fire, got %+v", d)
+	}
+}
+
+func TestDecideLLMNoopHonoredForNonIdleSituations(t *testing.T) {
+	// The operator-provenance gate is idle-only: approval/choice/error noop
+	// rules have no competing declared-source path and keep firing on an
+	// LLM-learned plurality.
+	for _, st := range []SituationType{SituationApproval, SituationChoice, SituationError} {
+		in := autonomous(baseInput(st))
+		in.History = sourcedHistory(SourceLLM, noopHistory()...)
+		d := Decide(in)
+		if d.Action != ActionKindNoop {
+			t.Fatalf("%s: LLM-learned noop must still fire, got %+v", st, d)
+		}
 	}
 }
 

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -166,6 +166,10 @@ type DaemonStore interface {
 	WithAgentAutomation(ctx context.Context, agentID string, fn func()) (disabled bool, err error)
 
 	UpsertSignature(ctx context.Context, s domain.SignatureState) error
+	// EnsureSignature atomically creates a fresh signature state row if none
+	// exists yet (INSERT OR IGNORE) — never touching an existing row. The
+	// daemon uses it to make LLM-learned signatures CLI-addressable (#175).
+	EnsureSignature(ctx context.Context, s domain.SignatureState) error
 	RecordDecision(ctx context.Context, d domain.DecisionRecord) (int64, error)
 	AppendAudit(ctx context.Context, a domain.AuditRecord) (int64, error)
 	UpdateAuditStatus(ctx context.Context, auditID int64, status string) error

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -265,6 +265,26 @@ func (s *Store) migrate() error {
 	); err != nil {
 		return fmt.Errorf("migrate prune verb-only approval embeddings: %w", err)
 	}
+	// Issue #175: LLM decisions used to be recorded without a signatures state
+	// row, leaving the learned rule invisible to `signatures list` and
+	// unaddressable by delete/reset. The daemon now creates the row at
+	// decision time; this backfills the rows such databases already lack.
+	// SQLite's bare-column-with-MAX rule makes the inner select carry each
+	// signature's newest decision BY ID — the autoincrement PK is strictly
+	// insertion-ordered, unlike created_at, whose millisecond values can tie
+	// within a burst and break the tie arbitrarily. Idempotent: INSERT OR
+	// IGNORE never touches an existing row.
+	if _, err := s.db.Exec(
+		`INSERT OR IGNORE INTO signatures (signature, situation_type, agent_type,
+		    mode, consecutive_confirmations, cached_confidence, decision_floor_id,
+		    guard_state, updated_at)
+		 SELECT signature, situation_type, agent_type, ?, 0, 0, 0, '', created_at
+		   FROM (SELECT signature, situation_type, agent_type, created_at, MAX(id)
+		           FROM decisions GROUP BY signature)`,
+		string(domain.ModeShadow),
+	); err != nil {
+		return fmt.Errorf("migrate backfill signature rows: %w", err)
+	}
 	return nil
 }
 
@@ -316,6 +336,24 @@ func (s *Store) UpsertSignature(ctx context.Context, sig domain.SignatureState) 
 			sig.ConsecutiveConfirmations, sig.CachedConfidence, sig.DecisionFloorID, sig.GuardState, unix(sig.UpdatedAt))
 		return err
 	})
+}
+
+// EnsureSignature creates a fresh signatures state row when none exists, as a
+// single atomic INSERT OR IGNORE — an existing row's mode, streak, floor, and
+// confidence are never touched. The daemon calls it after recording an LLM
+// decision so the learned rule is CLI-addressable (#175); a read-then-upsert
+// here would race the correction/reset writers and could clobber their state
+// with a fresh shadow row. Learning-state fields are forced to their fresh
+// zero values: only identity fields (signature, types, mode, timestamp) come
+// from the caller.
+func (s *Store) EnsureSignature(ctx context.Context, sig domain.SignatureState) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO signatures (signature, situation_type, agent_type,
+			mode, consecutive_confirmations, cached_confidence, decision_floor_id,
+			guard_state, updated_at)
+		VALUES (?, ?, ?, ?, 0, 0, 0, '', ?)`,
+		sig.Signature, string(sig.SituationType), sig.AgentType, string(sig.Mode), unix(sig.UpdatedAt))
+	return err
 }
 
 // RecordDecision appends a decision record (daemon-owned).

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1113,6 +1113,116 @@ func TestListSignaturesFiltersAndOrder(t *testing.T) {
 	}
 }
 
+func TestEnsureSignature(t *testing.T) {
+	// #175: EnsureSignature is the atomic insert-if-absent the daemon uses
+	// after recording an LLM decision. It must create a fresh shadow row when
+	// none exists and never touch an existing row (a read-then-upsert would
+	// race the correction/reset writers and clobber their state).
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	if err := s.EnsureSignature(ctx, domain.SignatureState{
+		Signature: "idle:fresh", SituationType: domain.SituationIdle,
+		AgentType: "claude", Mode: domain.ModeShadow, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	st, err := s.GetSignature(ctx, "idle:fresh")
+	if err != nil || st == nil {
+		t.Fatalf("ensure must create a missing row: %v %v", st, err)
+	}
+	if st.Mode != domain.ModeShadow || st.ConsecutiveConfirmations != 0 ||
+		st.CachedConfidence != 0 || st.DecisionFloorID != 0 {
+		t.Errorf("created row must be a fresh shadow state: %+v", st)
+	}
+
+	// An existing row survives untouched — even learning-state fields the
+	// caller happens to pass are ignored on the existing-row path.
+	seedSignature(t, s, "approval:learned", domain.SituationApproval, "claude", domain.ModeAutonomous, 0.9, now)
+	if err := s.EnsureSignature(ctx, domain.SignatureState{
+		Signature: "approval:learned", SituationType: domain.SituationApproval,
+		AgentType: "codex", Mode: domain.ModeShadow, UpdatedAt: now.Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	st, _ = s.GetSignature(ctx, "approval:learned")
+	if st == nil || st.Mode != domain.ModeAutonomous || st.AgentType != "claude" ||
+		st.ConsecutiveConfirmations != 2 || st.CachedConfidence != 0.9 {
+		t.Errorf("ensure must never touch an existing row: %+v", st)
+	}
+}
+
+func TestMigrateBackfillsSignatureRows(t *testing.T) {
+	// #175: databases from before LLM decisions created signatures rows hold
+	// decisions-only signatures that `signatures list/delete/reset` cannot
+	// address. Reopening the store backfills a shadow row per such signature
+	// (type fields from its newest decision) and never touches existing rows.
+	s, path := openTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	seedSignature(t, s, "approval:kept", domain.SituationApproval, "claude", domain.ModeAutonomous, 0.9, now)
+	if _, err := s.RecordDecision(ctx, domain.DecisionRecord{
+		Signature: "approval:kept", SituationType: domain.SituationApproval,
+		AgentType: "claude", ChosenAction: "1", Source: domain.SourceRule, CreatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Same CreatedAt on purpose: the backfill must pick type fields from the
+	// newest decision BY ID (insertion order), not by a created_at that can
+	// tie within a burst.
+	for _, agentType := range []string{"codex", "claude"} { // oldest → newest
+		if _, err := s.RecordDecision(ctx, domain.DecisionRecord{
+			Signature: "idle:orphan", SituationType: domain.SituationIdle,
+			AgentType: agentType, ChosenAction: domain.ActionNoop, Source: domain.SourceLLM,
+			CreatedAt: now,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if st, _ := s.GetSignature(ctx, "idle:orphan"); st != nil {
+		t.Fatalf("fixture must start decisions-only, got %+v", st)
+	}
+	s.Close()
+
+	re, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer re.Close()
+
+	st, err := re.GetSignature(ctx, "idle:orphan")
+	if err != nil || st == nil {
+		t.Fatalf("backfill must create the missing row: %v %v", st, err)
+	}
+	if st.Mode != domain.ModeShadow || st.DecisionFloorID != 0 || st.ConsecutiveConfirmations != 0 {
+		t.Errorf("backfilled row must be a fresh shadow state: %+v", st)
+	}
+	if st.SituationType != domain.SituationIdle || st.AgentType != "claude" {
+		t.Errorf("backfilled type fields must come from the newest decision: %+v", st)
+	}
+	// The signature is now CLI-addressable end to end.
+	if got, err := re.ResolveSignature(ctx, "idle:"); err != nil || got != "idle:orphan" {
+		t.Errorf("backfilled signature must resolve: got %q, %v", got, err)
+	}
+	if n, err := re.DeleteSignature(ctx, "idle:orphan"); err != nil || n != 2 {
+		t.Errorf("backfilled signature must delete with its decisions: n=%d, %v", n, err)
+	}
+	// Existing rows are untouched (INSERT OR IGNORE), and re-running the
+	// migration after the delete must not resurrect the deleted signature's
+	// row (its decisions are gone too).
+	kept, _ := re.GetSignature(ctx, "approval:kept")
+	if kept == nil || kept.Mode != domain.ModeAutonomous || kept.CachedConfidence != 0.9 {
+		t.Errorf("existing row must be untouched by the backfill: %+v", kept)
+	}
+	if err := re.migrate(); err != nil {
+		t.Fatal(err)
+	}
+	if st, _ := re.GetSignature(ctx, "idle:orphan"); st != nil {
+		t.Error("deleted signature must stay gone on re-migration")
+	}
+}
+
 func TestResolveSignaturePrefix(t *testing.T) {
 	s, _ := openTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #175.

## Problem

A single LLM-answered `@noop` on an idle signature (reasonable in the moment — the declared task source had just run dry):

1. **Parked the refill feature forever** — idle resolution honored the learned-noop plurality BEFORE declared-source resolution, and the plurality was source-blind, so `task_source_exhausted` → generation (`llm.task_generate_command`) was never reached again. The agent produced `[shadow_mode]` "do nothing" escalations indefinitely.
2. **Was CLI-unreachable** — no `signatures` state row was created, so `hap signatures list` omitted the rule and `signatures delete/reset` failed with `no signature matches`.
3. **Hid its provenance** — escalations showed `rule=[none yet]` while the decision-table plurality actually drove the suggestion.

## Fix

- **`internal/domain`**: `ConfidenceResult.TopActionOperatorBacked` — true when an operator- or rule-sourced decision backs the top action (a `SourceRule` row implies past operator confirmation). The idle noop precedence now requires `TopActionOperatorBacked || DeclaredTask == nil`:
  - operator-taught noops still outrank declared tasks (unchanged behavior, now provenance-scoped);
  - a pure-LLM noop yields to a pending declared task, and to `task_source_exhausted` → `ActionGenerateTask` (the #175 repro);
  - with no declared source an LLM noop still silences a chatty idle agent (the original nudge-loop case);
  - approval/choice/error noop handling is untouched.
- **`internal/daemon`**: new atomic `Store.EnsureSignature` (single `INSERT OR IGNORE`, never touches an existing row) called after all four LLM `RecordDecision` sites (noop promotion, action send, multi-tab series, remote-env picker), so every LLM-learned rule is listable/deletable/resettable. Companion: `applyCorrection`'s clean-slate `DecisionFloorID` stamp is re-keyed from "no state row" to "no operator/rule evidence in the pre-existing history" (`domain.HasOperatorEvidence`), preserving the guarantee that the first operator correction floors out prior LLM guesses now that a row exists by then.
- **`internal/store`**: idempotent `migrate()` backfill creates shadow rows for decisions-only signatures in existing databases (type fields from each signature's newest decision by id).
- **Display**: no code change needed — with the row present, escalations render the real rule summary (`rule=[shadow — 0/N confirmations, … top action "@noop" …]`); `rule=[none yet]` remains only for truly-unseen signatures.

## Testing

- New/updated unit tests across `internal/domain` (provenance matrix, the #175 repro, exhausted-without-generation escalation, nudge-loop preservation, non-idle noop unchanged), `internal/daemon` (row creation on the noop/send/series/picker paths; first-operator-correction flooring with a pre-existing LLM-created row), `internal/store` (`EnsureSignature` contract, migration backfill end-to-end incl. delete + re-migrate), `internal/cli` (LLM-learned signature list/reset/delete + escalation rule rendering).
- Full suite `go test -tags "vectors cpu" ./... -count=1` green; `go vet` and `golangci-lint run --build-tags "vectors,cpu"` clean.

https://claude.ai/code/session_01FKbYWbyEGhsT8iGnbyBJgr