### PR TITLE
#175 fix: escalate idle noop rule when the declared source has pending tasks

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2256,6 +2256,45 @@ func TestIdleDeclaredTaskCompletedListEscalatesNoop(t *testing.T) {
 	}
 }
 
+func TestIdleAutonomousNoopRuleEscalatesPendingDeclaredTasks(t *testing.T) {
+	// #175 second live occurrence: a graduated, operator-backed noop rule
+	// (learned on no-work screens) matches an idle screen whose declared
+	// source has real pending items. Standing down silently would park the
+	// list forever with zero escalations — the conflict must escalate with
+	// the next declared task as the confirmable suggestion instead.
+	dir := t.TempDir()
+	taskFile := filepath.Join(dir, "tasks.md")
+	os.WriteFile(taskFile, []byte("- [x] step one\n- [ ] step two\n"), 0o600)
+
+	idlePane := "All tests pass. Task is complete.\n"
+	cfg := fmt.Sprintf("[[task_sources]]\nagent = \"agent-42\"\npath = %q\n", taskFile)
+	h := newHarness(t, cfg)
+	h.herdr.setPane(idlePane)
+	h.seedAutonomous(idlePane, domain.SituationIdle, domain.ActionNoop)
+
+	ctx := context.Background()
+	name, err := h.raw.EnsureAgentName(ctx, "agent-42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.push("agent-42", "idle")
+	var esc []domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	if !strings.Contains(esc[0].Rationale, string(domain.ReasonNoopVsPendingTasks)) {
+		t.Errorf("rationale should carry the noop-vs-pending tag, got %q", esc[0].Rationale)
+	}
+	want := "send next declared task: " + (&domain.DeclaredTask{Task: "step two", Path: taskFile, AgentName: name}).Prompt()
+	if esc[0].Suggestion != want {
+		t.Errorf("suggestion = %q, want %q", esc[0].Suggestion, want)
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Fatal("the conflict must not deliver anything autonomously")
+	}
+}
+
 func TestIdleTaskSourceMatchesWorkspaceNameWildcard(t *testing.T) {
 	// The workspace selector matches the workspace's herdr name (label)
 	// with "*" wildcards, not the raw workspace id.

--- a/internal/domain/decide.go
+++ b/internal/domain/decide.go
@@ -334,15 +334,30 @@ func Decide(in DecideInput) Decision {
 func resolveSituation(in DecideInput, conf ConfidenceResult) (candidate, suggestion string, escReason EscalateReason) {
 	switch in.Situation.Type {
 	case SituationIdle:
-		// A learned noop beats task resolution only when the OPERATOR (or a
-		// rule graduated from operator confirmations) said "leave this one
-		// alone" — that outranks re-sending tasks. A noop plurality built
-		// purely from LLM guesses does NOT outrank a declared task source:
-		// one consult-time "@noop" on an exhausted list would otherwise
-		// permanently park the task_source_exhausted → generation refill path
-		// (#175). Without a declared source there is nothing to park, so an
-		// LLM-learned noop still silences a chatty idle agent (the original
-		// nudge-loop case) instead of escalating no_task_source forever.
+		// A learned noop never silently parks REAL pending work. The
+		// declared-source state is not part of the idle signature, so a noop
+		// learned on "nothing to do" screens reuses on screens where the
+		// source has pending items — and an autonomous noop rule would then
+		// swallow the list with zero escalations, its self-recorded rule
+		// votes entrenching the plurality beyond what corrections can flip
+		// (#175, second live occurrence). Provenance cannot break that tie
+		// (the operator noops backing such a rule were given on the no-work
+		// screens), so the conflict escalates for the operator, suggesting
+		// the next declared task; confirming delivers it and teaches
+		// @next_task:declared.
+		if conf.TopAction == ActionNoop &&
+			in.DeclaredTask != nil && in.DeclaredTask.Task != NoTaskContent {
+			return "", "send next declared task: " + in.DeclaredTask.Prompt(), ReasonNoopVsPendingTasks
+		}
+		// With no pending work there is nothing to park, and a learned noop
+		// keeps its precedence — for an exhausted source only when the
+		// OPERATOR (or a rule graduated from operator confirmations) said
+		// "leave this one alone": a noop plurality built purely from LLM
+		// guesses must not park the task_source_exhausted → generation
+		// refill path (#175). Without a declared source, any provenance
+		// suffices: an LLM-learned noop still silences a chatty idle agent
+		// (the original nudge-loop case) instead of escalating
+		// no_task_source forever.
 		if conf.TopAction == ActionNoop && (conf.TopActionOperatorBacked || in.DeclaredTask == nil) {
 			return ActionNoop, ActionNoopSuggestion, ReasonNone
 		}
@@ -458,6 +473,8 @@ func rationaleFor(r EscalateReason) string {
 	switch r {
 	case ReasonUnfamiliarOptions:
 		return "learned option not offered"
+	case ReasonNoopVsPendingTasks:
+		return "learned noop rule, but the declared source has pending tasks"
 	default:
 		return "" // tag-only: [reason] says it all
 	}

--- a/internal/domain/noop_test.go
+++ b/internal/domain/noop_test.go
@@ -57,36 +57,47 @@ func TestDecideNoopChoiceBypassesOptionSet(t *testing.T) {
 	}
 }
 
-func TestDecideIdleNoopBeatsDeclaredTask(t *testing.T) {
-	// The OPERATOR repeatedly said "leave this one alone": that outranks
-	// re-sending the declared next task. Rule-sourced rows count the same —
-	// a graduated rule implies past operator confirmation.
-	for _, src := range []Source{SourceOperator, SourceRule} {
-		in := autonomous(baseInput(SituationIdle))
-		in.History = sourcedHistory(src, noopHistory()...)
-		in.DeclaredTask = &DeclaredTask{Task: "build the parser"}
-		d := Decide(in)
-		if d.Action != ActionKindNoop {
-			t.Fatalf("%s: idle noop must beat the declared task, got %+v", src, d)
+func TestDecideIdlePendingTasksEscalateOverNoopRule(t *testing.T) {
+	// A noop plurality — WHATEVER its provenance — never silently parks a
+	// declared source with real pending items (#175, second live
+	// occurrence): the operator noops backing an autonomous noop rule were
+	// given on no-work screens, and the source state is not part of the
+	// signature. The conflict escalates with the next declared task as the
+	// confirmable suggestion, in autonomous and shadow mode alike.
+	for _, src := range []Source{SourceOperator, SourceRule, SourceLLM} {
+		for _, mode := range []Mode{ModeAutonomous, ModeShadow} {
+			in := baseInput(SituationIdle)
+			in.State = &SignatureState{Mode: mode, ConsecutiveConfirmations: 8}
+			in.History = sourcedHistory(src, noopHistory()...)
+			in.DeclaredTask = &DeclaredTask{Task: "build the parser"}
+			d := Decide(in)
+			if d.Action != ActionEscalate || d.Reason != ReasonNoopVsPendingTasks {
+				t.Fatalf("%s/%s: pending declared work must escalate over a noop rule, got %+v", src, mode, d)
+			}
+			if !strings.Contains(d.Suggestion, "build the parser") {
+				t.Errorf("%s/%s: suggestion should carry the declared task, got %q", src, mode, d.Suggestion)
+			}
+			if d.Input != "" {
+				t.Errorf("%s/%s: nothing may be sent, got input %q", src, mode, d.Input)
+			}
 		}
 	}
 }
 
-func TestDecideIdleLLMNoopYieldsToDeclaredTask(t *testing.T) {
-	// A noop plurality built purely from LLM guesses must NOT outrank a
-	// declared task source (#175): operator-declared intent wins. The
-	// signature is shadow (LLM decisions never graduate a rule), so the
-	// declared task surfaces as a confirmable suggestion.
-	in := baseInput(SituationIdle)
-	in.State = &SignatureState{Mode: ModeShadow}
-	in.History = sourcedHistory(SourceLLM, noopHistory()...)
-	in.DeclaredTask = &DeclaredTask{Task: "build the parser"}
-	d := Decide(in)
-	if d.Action != ActionEscalate || d.Reason != ReasonShadowMode {
-		t.Fatalf("shadow LLM-noop signature must escalate the declared task, got %+v", d)
-	}
-	if !strings.Contains(d.Suggestion, "build the parser") {
-		t.Errorf("suggestion should carry the declared task, got %q", d.Suggestion)
+func TestDecideIdleOperatorNoopStillQuietOnExhaustedSource(t *testing.T) {
+	// The noop-vs-pending escalation is about REAL pending work only: with
+	// the declared list fully checked off, an operator-backed noop keeps
+	// the exhausted source quiet (the #176 self-heal — confirming the
+	// task_source_exhausted escalation's @noop suggestion earns exactly
+	// this silence).
+	for _, src := range []Source{SourceOperator, SourceRule} {
+		in := autonomous(baseInput(SituationIdle))
+		in.History = sourcedHistory(src, noopHistory()...)
+		in.DeclaredTask = &DeclaredTask{Task: NoTaskContent}
+		d := Decide(in)
+		if d.Action != ActionKindNoop {
+			t.Fatalf("%s: operator noop must keep an exhausted source quiet, got %+v", src, d)
+		}
 	}
 }
 

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -172,7 +172,17 @@ const (
 	// dismisses it (or, when both task_generate_command and
 	// task_generate_command_start are configured, the plugin generates more
 	// tasks instead of escalating this reason at all).
-	ReasonTaskSourceExhausted  EscalateReason = "task_source_exhausted"
+	ReasonTaskSourceExhausted EscalateReason = "task_source_exhausted"
+	// ReasonNoopVsPendingTasks: the learned plurality says "do nothing" but
+	// the agent's declared task source still has pending items. The source
+	// state is not part of the idle signature, so a noop learned on
+	// "nothing to do" screens reuses on screens where the source has real
+	// work — and an autonomous noop rule would otherwise park that work
+	// silently, its rule-sourced self-votes entrenching the plurality beyond
+	// what corrections can flip (#175). Escalated regardless of the noop's
+	// provenance; the suggestion carries the next declared task, so
+	// confirming both delivers it and teaches @next_task:declared.
+	ReasonNoopVsPendingTasks   EscalateReason = "noop_vs_pending_tasks"
 	ReasonUnfamiliarOptions    EscalateReason = "unfamiliar_options"
 	ReasonNoHistory            EscalateReason = "no_history"
 	ReasonNotConsecutiveEnough EscalateReason = "graduation_pending"


### PR DESCRIPTION
## Summary

Follow-up to #176, addressing the **second live occurrence** of #175 (see [issue comment](https://github.com/0xGosu/herdr-auto-pilot/issues/175#issuecomment-5010616179)).

A graduated, **operator-backed** `@noop` idle rule — legitimately learned on screens where the agent had nothing left to do — was reused by semantic signature matching on idle screens where the agent's **declared task source still had pending items**. Because the declared-source state is not part of the idle signature, the autonomous noop rule stood down silently forever (zero escalations, so the operator was never told), while each autonomous fire self-recorded a `source=rule` `@noop` decision that ratcheted the plurality beyond what operator corrections could mathematically flip.

#176's fix keyed the noop-precedence on operator provenance, but this rule **is** operator-backed — so that gate alone wouldn't catch it. The right discriminator is the **declared-source state**, not the noop's provenance.

## Change

In the idle resolver (`internal/domain/decide.go`), when the learned plurality is `@noop` **and** the declared source has a real pending item (`DeclaredTask != nil && Task != NoTaskContent`), escalate with a new reason `noop_vs_pending_tasks` — **regardless of the noop's provenance** — carrying the next declared task as the confirmable suggestion. Confirming it both delivers the task and teaches `@next_task:declared`, so the plurality self-heals.

The pre-existing operator-backed / no-source noop honor is preserved for the **no-pending-work** cases:
- **Exhausted source** (`Task == NoTaskContent`) + operator/rule-backed noop → still silently noops (the #176 self-heal).
- **Exhausted source** + LLM-only noop → still reaches `task_source_exhausted` / generation refill (#175 first fix).
- **No declared source** at all → LLM-learned noop still silences a chatty idle agent (original nudge-loop case).

Idle situations whose top action is not `@noop` are completely unchanged.

## Tests

- `internal/domain/noop_test.go` — `TestDecideIdlePendingTasksEscalateOverNoopRule` (escalates for every source × mode when work is pending); `TestDecideIdleOperatorNoopStillQuietOnExhaustedSource` (operator noop stays quiet on an exhausted list). These replace the old `TestDecideIdleNoopBeatsDeclaredTask`, whose asserted behavior (silently swallow pending work) is exactly the bug.
- `internal/daemon/daemon_test.go` — `TestIdleAutonomousNoopRuleEscalatesPendingDeclaredTasks`: end-to-end, seeds an autonomous idle `@noop` rule, pushes idle with a pending declared item, asserts one `noop_vs_pending_tasks` escalation + the declared-task suggestion + zero autonomous sends.

## Verification

- Full unit suite green: `go test -tags "vectors cpu" ./... -count=1` — 966 tests, 23 packages, 0 failures.
- `gofmt` clean; `go vet` and `golangci-lint run --build-tags "vectors,cpu"` clean.
- Confirm-path compatibility verified: `suggestionAction` / `frontend.SuggestedAction` map the `send next declared task: ` prefix to `@next_task:declared` independent of reason; nothing keys on specific escalate reasons; `IsRetryableLLMEscalation` correctly excludes the new reason.

Closes the follow-up raised on #175.

https://claude.ai/code/session_01FKbYWbyEGhsT8iGnbyBJgr