### PR TITLE
#180 feat: accept a busy agent's generated-task suggestion by queuing to its task list

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -715,10 +715,26 @@ func confirm(ctx context.Context, app *frontend.App, out io.Writer, args []strin
 	if err != nil {
 		return fmt.Errorf("invalid audit id %q", idArg)
 	}
+	// Detect a generated-task suggestion up front so the success line can say
+	// the tasks were queued to the agent's declared list. Without --send they
+	// are only appended (the daemon delivers the first on the agent's next
+	// idle), so confirming without --send is the way to accept a suggestion for
+	// a busy agent without interrupting it (issue #180).
+	genTask := false
+	if audit, gerr := app.Store.GetAudit(ctx, id); gerr == nil && audit != nil {
+		genTask = strings.HasPrefix(audit.Suggestion, domain.SuggestTaskPrefix)
+	}
 	if err := app.Confirm(ctx, id, *send); err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "confirmed escalation #%d (recorded as a learning event)\n", id)
+	switch {
+	case genTask && *send:
+		fmt.Fprintf(out, "confirmed escalation #%d — added the suggested task(s) to the agent's task list and sent the first\n", id)
+	case genTask:
+		fmt.Fprintf(out, "confirmed escalation #%d — added the suggested task(s) to the agent's task list (not sent)\n", id)
+	default:
+		fmt.Fprintf(out, "confirmed escalation #%d (recorded as a learning event)\n", id)
+	}
 	return nil
 }
 

--- a/internal/cli/confirm_test.go
+++ b/internal/cli/confirm_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// confirmTestApp wires a store-backed App to a recording herdr fake whose only
+// agent reports the given status, and seeds one LLM-generated-task escalation
+// for it. Returns the app, the fake, the agent's short name, and the audit id.
+func confirmTestApp(t *testing.T, status, task string) (*frontend.App, *sendRecorderHerdr, string, int64) {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	h := &sendRecorderHerdr{agents: []domain.AgentTransition{
+		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: status},
+	}}
+	app := &frontend.App{Store: st, Herdr: h, StateDir: dir,
+		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+	name, _ := st.EnsureAgentName(context.Background(), "w1:p1")
+	id, err := st.AppendAudit(context.Background(), domain.AuditRecord{
+		AgentID: "w1:p1", Signature: "sig", Trigger: "t",
+		SituationType: domain.SituationIdle, Action: "escalated",
+		Status: "escalated", Suggestion: domain.SuggestTaskPrefix + task, CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return app, h, name, id
+}
+
+func runConfirm(t *testing.T, app *frontend.App, args ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	err := Run(context.Background(), app, &out, "confirm", args)
+	return out.String(), err
+}
+
+// TestConfirmGeneratedTaskWithoutSendAddsToList: `confirm <id>` (no --send) on a
+// generated-task escalation queues the tasks to the agent's list even while the
+// agent is busy — nothing is delivered, and the message says so (issue #180).
+func TestConfirmGeneratedTaskWithoutSendAddsToList(t *testing.T) {
+	app, h, name, id := confirmTestApp(t, "working", "Write missing tests")
+
+	out, err := runConfirm(t, app, "1")
+	if err != nil {
+		t.Fatalf("confirm without --send must succeed for a busy agent: %v", err)
+	}
+	if !strings.Contains(out, "added the suggested task(s) to the agent's task list (not sent)") {
+		t.Errorf("message should explain tasks were queued, got %q", out)
+	}
+	if len(h.sent) != 0 {
+		t.Errorf("nothing may be delivered to a busy agent, got %v", h.sent)
+	}
+	// The task landed pending "[ ]" in the agent's declared file.
+	body, err := os.ReadFile(filepath.Join(app.StateDir, "tasks", name+".md"))
+	if err != nil {
+		t.Fatalf("tasks file not written: %v", err)
+	}
+	if !strings.Contains(string(body), "- [ ] 1. Write missing tests") {
+		t.Errorf("tasks file = %q, want the queued item pending \"[ ]\"", body)
+	}
+	// The escalation is resolved (accepted).
+	audit, _ := app.Store.GetAudit(context.Background(), id)
+	if audit.Status != "resolved" {
+		t.Errorf("escalation must be resolved after add, got %q", audit.Status)
+	}
+}
+
+// TestConfirmGeneratedTaskSendBusyRefuses: `confirm <id> --send` still refuses a
+// busy agent (delivering would interrupt it) and guides the operator to drop
+// --send.
+func TestConfirmGeneratedTaskSendBusyRefuses(t *testing.T) {
+	app, h, _, _ := confirmTestApp(t, "working", "Write missing tests")
+
+	_, err := runConfirm(t, app, "1", "--send")
+	if err == nil {
+		t.Fatal("confirm --send must refuse a busy agent")
+	}
+	if !strings.Contains(err.Error(), "without --send") {
+		t.Errorf("refusal should guide dropping --send, got %v", err)
+	}
+	if len(h.sent) != 0 {
+		t.Errorf("refused send must not deliver, got %v", h.sent)
+	}
+}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -848,6 +848,13 @@ func (a *App) Resolve(ctx context.Context, auditID int64, action string, send bo
 	return a.nudge(ctx, control.KindReload)
 }
 
+// ErrSuggestionStaleAgentBusy is returned by a confirm+send (send=true) of a
+// generated-task suggestion whose agent has since started working: delivering
+// the task would interrupt it. The tasks can instead be QUEUED by re-confirming
+// with send=false, which succeeds while the agent is busy (the daemon delivers
+// on the next idle). Callers detect this with errors.Is to offer that fallback.
+var ErrSuggestionStaleAgentBusy = errors.New("agent is no longer idle; the suggested task is stale")
+
 // acceptGeneratedTask confirms an idle task suggestion. When the agent
 // already has a declared task source, the generated tasks refill THAT list:
 // they are appended to the source's own file (appendGeneratedTasks) — never
@@ -882,19 +889,22 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	}
 
 	// Staleness: the operator may confirm minutes after the suggestion was
-	// raised. If the agent has since started working, sending an outdated task
-	// would interrupt it — refuse rather than create a source and send. Fail
-	// open when the status is unknown (list error / agent absent): the operator
-	// explicitly asked to confirm. The matched transition is kept for the
-	// declared-source resolution below (workspace-scoped selectors need the
-	// agent's live workspace).
+	// raised. If the agent has since started working, SENDING an outdated task
+	// would interrupt it — refuse rather than create a source and send. This
+	// only matters when send is set: an add-only confirm (send=false) queues
+	// the task in the declared list without touching the pane, so a busy agent
+	// is fine — the daemon delivers it on the agent's next idle. Fail open when
+	// the status is unknown (list error / agent absent): the operator explicitly
+	// asked to confirm. The matched transition is kept for the declared-source
+	// resolution below (workspace-scoped selectors need the agent's live
+	// workspace) in both cases.
 	var live *domain.AgentTransition
 	if a.Herdr != nil {
 		if agents, lerr := a.Herdr.ListAgents(ctx); lerr == nil {
 			for i, ag := range agents {
 				if ag.AgentID == audit.AgentID {
-					if domain.AgentBusy(ag.Status) {
-						return fmt.Errorf("agent is no longer idle (%s); the suggested task is stale — dismiss it or wait until the agent is idle", ag.Status)
+					if send && domain.AgentBusy(ag.Status) {
+						return fmt.Errorf("%w (agent status: %s) — dismiss it, or confirm without --send to queue the tasks to the agent's list", ErrSuggestionStaleAgentBusy, ag.Status)
 					}
 					live = &agents[i]
 					break

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -979,8 +979,14 @@ func TestConfirmGeneratedTaskRefusesWhenAgentWorking(t *testing.T) {
 		Action: "escalated", Status: "escalated",
 		Suggestion: domain.SuggestTaskPrefix + "Do the thing", CreatedAt: time.Now(),
 	})
-	if err := app.Confirm(ctx, id, true); err == nil {
+	err := app.Confirm(ctx, id, true)
+	if err == nil {
 		t.Fatal("confirming a stale suggestion for a working agent must fail")
+	}
+	// The sentinel is the contract the TUI keys off to offer "add to list
+	// instead" — a plain error would strand that fallback.
+	if !errors.Is(err, frontend.ErrSuggestionStaleAgentBusy) {
+		t.Errorf("send refusal must wrap ErrSuggestionStaleAgentBusy, got %v", err)
 	}
 	if len(fake.inputs) != 0 {
 		t.Errorf("nothing may be sent to a working agent, got %v", fake.inputs)
@@ -993,6 +999,62 @@ func TestConfirmGeneratedTaskRefusesWhenAgentWorking(t *testing.T) {
 	audit, _ := st.GetAudit(ctx, id)
 	if audit.Status != "escalated" {
 		t.Errorf("escalation must remain pending after a refused confirm, got %q", audit.Status)
+	}
+}
+
+func TestConfirmGeneratedTaskAddOnlyWhileAgentWorking(t *testing.T) {
+	// send=false QUEUES the tasks even while the agent is working: nothing
+	// reaches the pane (so the busy agent is never interrupted), the source and
+	// pending-"[ ]" file are created, the correction is recorded, and the
+	// escalation is resolved (accepted). The daemon delivers the item on the
+	// agent's next idle. This is the "a: add to list" path — the staleness
+	// refusal only applies to a send (issue #180).
+	app, st := testApp(t)
+	fake := &fakeHerdr{agents: []domain.AgentTransition{{AgentID: "w5:p5", Status: "working"}}}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w5:p5")
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w5:p5", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Write missing tests", CreatedAt: time.Now(),
+	})
+
+	if err := app.Confirm(ctx, id, false); err != nil {
+		t.Fatalf("add-only confirm must succeed for a working agent: %v", err)
+	}
+	// Nothing delivered to the busy agent's pane.
+	if len(fake.inputs) != 0 {
+		t.Errorf("add-only must deliver nothing to a working agent, got %v", fake.inputs)
+	}
+	// Source registered and the item left pending "[ ]" so the daemon's idle
+	// flow hands it out later.
+	cfg, _ := config.Load(app.ConfigPath)
+	if len(cfg.TaskSources) != 1 {
+		t.Fatalf("add-only must register the task source, got %d", len(cfg.TaskSources))
+	}
+	body, err := os.ReadFile(filepath.Join(stateDir, "tasks", name+".md"))
+	if err != nil {
+		t.Fatalf("tasks file not written: %v", err)
+	}
+	if !strings.Contains(string(body), "- [ ] 1. Write missing tests") {
+		t.Errorf("tasks file = %q, want the queued item pending \"[ ]\"", body)
+	}
+	if next := domain.NextDeclaredTask(string(body)); next != "1. Write missing tests" {
+		t.Errorf("next declared task = %q, want the queued item — a stranded item would never be sent", next)
+	}
+	// Accepted: the correction learns the declared-task action and the
+	// escalation is resolved.
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 1 || corr[0].CorrectedAction != domain.ActionNextDeclaredTask || corr[0].AuditID != id {
+		t.Errorf("add-only should record a declared-task correction: %+v", corr)
+	}
+	audit, _ := st.GetAudit(ctx, id)
+	if audit.Status != "resolved" {
+		t.Errorf("escalation must be resolved (accepted) after add-only, got %q", audit.Status)
 	}
 }
 

--- a/internal/tui/add_prompt_test.go
+++ b/internal/tui/add_prompt_test.go
@@ -1,0 +1,178 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// seedGenTaskEscalation seeds an LLM-generated-task escalation for agent w1:p1
+// and returns its audit id.
+func seedGenTaskEscalation(t *testing.T, st *store.Store, task string) int64 {
+	t.Helper()
+	id, err := st.AppendAudit(context.Background(), domain.AuditRecord{
+		AgentID: "w1:p1", Signature: "sig", Trigger: "t",
+		SituationType: domain.SituationIdle, Action: "escalated",
+		Status: "escalated", Suggestion: domain.SuggestTaskPrefix + task, CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// TestConfirmBusyAgentOpensAddPrompt: confirming+sending a generated-task
+// escalation whose agent has started working must NOT surface an error — it
+// chains to the "add to the task list instead?" prompt (issue #180).
+func TestConfirmBusyAgentOpensAddPrompt(t *testing.T) {
+	m, st, fh := correctTestModel(t)
+	fh.agents = []domain.AgentTransition{{AgentID: "w1:p1", Status: "working"}}
+	id := seedGenTaskEscalation(t, st, "Write missing tests")
+
+	// confirm+send returns a command; running it yields the chained prompt msg.
+	upd, cmd := m.confirmAuditID(id)
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("confirm should return a command")
+	}
+	msg := cmd()
+	ap, ok := msg.(openAddPromptMsg)
+	if !ok {
+		t.Fatalf("a busy send refusal should chain openAddPromptMsg, got %T (%v)", msg, msg)
+	}
+	upd, _ = m.Update(ap)
+	m = upd.(Model)
+	if m.prompt == nil || !strings.HasPrefix(strings.ToLower(m.prompt.input), "y") {
+		t.Fatalf("add prompt should open defaulting to 'y', got %+v", m.prompt)
+	}
+	// Nothing was delivered to the busy agent.
+	if len(fh.inputs) != 0 {
+		t.Errorf("no send may reach a busy agent, got %v", fh.inputs)
+	}
+}
+
+// TestAddPromptYesQueuesTasks: answering "y" queues the tasks (send=false),
+// resolves the escalation, records the acceptance, and delivers nothing.
+func TestAddPromptYesQueuesTasks(t *testing.T) {
+	m, st, fh := correctTestModel(t)
+	fh.agents = []domain.AgentTransition{{AgentID: "w1:p1", Status: "working"}}
+	ctx := context.Background()
+	name, _ := st.EnsureAgentName(ctx, "w1:p1")
+	id := seedGenTaskEscalation(t, st, "Write missing tests")
+
+	upd, cmd := m.confirmAuditID(id)
+	m = upd.(Model)
+	upd, _ = m.Update(cmd().(openAddPromptMsg))
+	m = upd.(Model)
+
+	m, _ = runPromptSubmit(t, m, "y")
+
+	// Nothing delivered to the pane.
+	if len(fh.inputs) != 0 {
+		t.Errorf("queueing must deliver nothing, got %v", fh.inputs)
+	}
+	// The escalation is resolved (accepted).
+	audit, _ := st.GetAudit(ctx, id)
+	if audit.Status != "resolved" {
+		t.Errorf("escalation must be resolved after queueing, got %q", audit.Status)
+	}
+	// The acceptance is recorded as a declared-task correction.
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 1 || corr[0].CorrectedAction != domain.ActionNextDeclaredTask {
+		t.Errorf("queueing should record a declared-task correction: %+v", corr)
+	}
+	// The task landed in the agent's declared list, left pending "[ ]".
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(m.app.ConfigPath), "tasks", name+".md"))
+	if err != nil {
+		t.Fatalf("tasks file not written: %v", err)
+	}
+	if !strings.Contains(string(body), "- [ ] 1. Write missing tests") {
+		t.Errorf("tasks file = %q, want the queued item pending \"[ ]\"", body)
+	}
+}
+
+// TestAddPromptNoLeavesPending: answering "n" declines — nothing is queued,
+// nothing sent, and the escalation stays pending so it can be dismissed later.
+func TestAddPromptNoLeavesPending(t *testing.T) {
+	m, st, fh := correctTestModel(t)
+	fh.agents = []domain.AgentTransition{{AgentID: "w1:p1", Status: "working"}}
+	ctx := context.Background()
+	id := seedGenTaskEscalation(t, st, "Write missing tests")
+
+	upd, cmd := m.confirmAuditID(id)
+	m = upd.(Model)
+	upd, _ = m.Update(cmd().(openAddPromptMsg))
+	m = upd.(Model)
+
+	runPromptSubmit(t, m, "n")
+
+	if len(fh.inputs) != 0 {
+		t.Errorf("declining must deliver nothing, got %v", fh.inputs)
+	}
+	audit, _ := st.GetAudit(ctx, id)
+	if audit.Status != "escalated" {
+		t.Errorf("declining must leave the escalation pending, got %q", audit.Status)
+	}
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 0 {
+		t.Errorf("declining must record no correction, got %+v", corr)
+	}
+}
+
+// TestAddPromptBareEnterQueues: a bare Enter (no edit to the pre-filled "y")
+// commits the default — the tasks are queued and the escalation resolved. Locks
+// in the "confirm already meant accept, so Enter queues" contract.
+func TestAddPromptBareEnterQueues(t *testing.T) {
+	m, st, fh := correctTestModel(t)
+	fh.agents = []domain.AgentTransition{{AgentID: "w1:p1", Status: "working"}}
+	ctx := context.Background()
+	id := seedGenTaskEscalation(t, st, "Write missing tests")
+
+	upd, cmd := m.confirmAuditID(id)
+	m = upd.(Model)
+	upd, _ = m.Update(cmd().(openAddPromptMsg))
+	m = upd.(Model)
+
+	// Submit WITHOUT overwriting m.prompt.input, so the pre-filled "y" default
+	// is what commits.
+	_, c := m.submitPrompt()
+	if c != nil {
+		c()
+	}
+
+	audit, _ := st.GetAudit(ctx, id)
+	if audit.Status != "resolved" {
+		t.Errorf("bare Enter should queue (default y) and resolve, got %q", audit.Status)
+	}
+	if len(fh.inputs) != 0 {
+		t.Errorf("queueing must deliver nothing, got %v", fh.inputs)
+	}
+}
+
+// TestConfirmIdleAgentSendsDirectly: when the agent is idle, confirm+send
+// delivers the task and never opens the add prompt (the busy fallback is
+// busy-only).
+func TestConfirmIdleAgentSendsDirectly(t *testing.T) {
+	m, st, fh := correctTestModel(t)
+	fh.agents = []domain.AgentTransition{{AgentID: "w1:p1", Status: "idle"}}
+	id := seedGenTaskEscalation(t, st, "Write missing tests")
+
+	_, cmd := m.confirmAuditID(id)
+	msg := cmd()
+	if _, ok := msg.(openAddPromptMsg); ok {
+		t.Fatal("an idle agent must send directly, not open the add prompt")
+	}
+	res, ok := msg.(actionResultMsg)
+	if !ok || res.err != nil {
+		t.Fatalf("idle confirm should succeed, got %T %+v", msg, msg)
+	}
+	if len(fh.inputs) != 1 {
+		t.Errorf("idle confirm should deliver exactly one task, got %v", fh.inputs)
+	}
+}

--- a/internal/tui/correct_test.go
+++ b/internal/tui/correct_test.go
@@ -18,6 +18,7 @@ import (
 type fakeHerdrTUI struct {
 	inputs []string
 	pane   string
+	agents []domain.AgentTransition // returned by ListAgents (live statuses)
 }
 
 func (f *fakeHerdrTUI) Send(_ context.Context, _, input string) error {
@@ -26,7 +27,7 @@ func (f *fakeHerdrTUI) Send(_ context.Context, _, input string) error {
 }
 func (f *fakeHerdrTUI) ReadPane(context.Context, string, int) (string, error) { return f.pane, nil }
 func (f *fakeHerdrTUI) ListAgents(context.Context) ([]domain.AgentTransition, error) {
-	return nil, nil
+	return f.agents, nil
 }
 
 func correctTestModel(t *testing.T) (Model, *store.Store, *fakeHerdrTUI) {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -9,6 +9,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -92,6 +93,15 @@ type actionResultMsg struct {
 type openSendPromptMsg struct {
 	id     int64
 	action string
+}
+
+// openAddPromptMsg re-opens a prompt after a confirm+send was refused because
+// the suggested task's agent is busy, asking whether to queue the tasks to its
+// declared list instead (no send). Chaining goes through a message for the same
+// reason as openSendPromptMsg: the confirm command runs async and cannot open a
+// prompt directly.
+type openAddPromptMsg struct {
+	id int64
 }
 
 // statusNote is a durable action outcome shown in the status area until the
@@ -773,6 +783,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.refresh()
 	case openSendPromptMsg:
 		return m.openSendPrompt(msg.id, msg.action)
+	case openAddPromptMsg:
+		return m.openAddPrompt(msg.id)
 	case tickMsg:
 		return m, tea.Batch(m.refresh(), tick())
 	case clockTickMsg:
@@ -1346,13 +1358,61 @@ func (m Model) confirmSelected() (tea.Model, tea.Cmd) {
 	return m.confirmAuditID(rec.ID)
 }
 
-// confirmAuditID confirms+sends a specific escalation by id (used by the
-// list and by the detail overlay, which confirms the record it snapshotted).
+// confirmAuditID confirms+sends a specific escalation by id (used by the list
+// and by the detail overlay, which confirms the record it snapshotted). When the
+// send is refused because the suggested task's agent has started working, the
+// task is still valid but delivering it now would interrupt the agent — so it
+// chains to an "add to the task list instead?" prompt (openAddPromptMsg) rather
+// than surfacing the error. Any other failure surfaces as-is.
 func (m Model) confirmAuditID(id int64) (tea.Model, tea.Cmd) {
+	app, ctx, wg := m.app, m.ctx, m.inflight
 	m.beginAction()
-	return m, m.do(fmt.Sprintf("confirmed #%d and sent", id), func(ctx context.Context) error {
-		return m.app.Confirm(ctx, id, true)
-	})
+	if wg != nil {
+		wg.Add(1)
+	}
+	return m, func() tea.Msg {
+		if wg != nil {
+			defer wg.Done()
+		}
+		err := app.Confirm(ctx, id, true)
+		if err == nil {
+			return actionResultMsg{message: fmt.Sprintf("confirmed #%d and sent", id)}
+		}
+		if errors.Is(err, frontend.ErrSuggestionStaleAgentBusy) {
+			return openAddPromptMsg{id: id}
+		}
+		return actionResultMsg{err: err}
+	}
+}
+
+// openAddPrompt asks whether to queue a stale generated-task suggestion onto the
+// agent's declared task list without sending — the agent is busy, so a send
+// would interrupt it, but the task itself is still valid. Adding accepts the
+// escalation: it appends the tasks, resolves the escalation, and records the
+// acceptance to Audits (the daemon delivers the first task on the next idle).
+// Defaults to "y" — the operator already chose to accept by confirming, and
+// queueing sends nothing.
+func (m Model) openAddPrompt(id int64) (tea.Model, tea.Cmd) {
+	app, ctx := m.app, m.ctx
+	m.message = ""
+	m.prompt = &prompt{
+		label: fmt.Sprintf("agent is busy — add the tasks to its task list instead? [Y/n] (#%d)", id),
+		input: "y",
+		onSubmit: func(input string) tea.Cmd {
+			if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(input)), "y") {
+				return func() tea.Msg {
+					return actionResultMsg{message: fmt.Sprintf("#%d left pending — not added", id)}
+				}
+			}
+			return func() tea.Msg {
+				if err := app.Confirm(ctx, id, false); err != nil {
+					return actionResultMsg{err: err}
+				}
+				return actionResultMsg{message: fmt.Sprintf("added #%d to task list (not sent)", id)}
+			}
+		},
+	}
+	return m, nil
 }
 
 func (m Model) correctSelected() (tea.Model, tea.Cmd) {


### PR DESCRIPTION
Closes #180.

## Problem

Confirming an escalation that carries an LLM-**generated task** appended the tasks to the agent's declared source **and** sent the first to the pane. If the agent had since started other work, the whole confirm was refused:

> ✗ agent is no longer idle (working); the suggested task is stale — dismiss it or wait until the agent is idle

The suggested tasks are often still valid — the operator just wants to **queue** them for the agent to pick up on its next idle, not interrupt current work. The only alternative was to dismiss (discard) them.

## Change

Gate the busy/staleness refusal in `acceptGeneratedTask` by `send`: queuing to the declared list (`send=false`) never touches the pane, so a busy agent is fine — the daemon delivers the item on the agent's next idle. Only an actual send is refused, now wrapping a new exported sentinel `ErrSuggestionStaleAgentBusy` so callers can detect it via `errors.Is`.

- **TUI** — `enter`/`y` still confirms+sends. On a busy refusal it chains a prompt (`openAddPromptMsg` → `openAddPrompt`): `agent is busy — add the tasks to its task list instead? [Y/n]`, defaulting to yes (the operator already chose to accept, and queuing sends nothing). Yes queues via `Confirm(send=false)`; no leaves it pending. Idle agents still send directly.
- **CLI** — `hap confirm <id>` **without** `--send` queues the tasks (works while busy) with a clearer message; `--send` on a busy agent still refuses and points at dropping `--send`.

Queuing resolves the escalation and records the acceptance in Audits, same as a normal confirm. No schema/store changes — it reuses the existing `ResolveEscalation` + `ActionNextDeclaredTask` correction → daemon audit-lineage row.

## Tests

Added 8 unit tests across frontend / TUI / CLI:
- frontend: add-only succeeds while busy; send-refusal wraps the sentinel.
- TUI: busy send opens the add prompt; yes queues; no leaves pending; bare-Enter queues; idle sends directly.
- CLI: `confirm` without `--send` queues while busy; `--send` refuses while busy.

Full suite (`go test -tags "vectors cpu" ./...`), `go vet`, `gofmt`, and `golangci-lint` all pass.

https://claude.ai/code/session_01FKbYWbyEGhsT8iGnbyBJgr