### PR TITLE
#183 fix: append generated tasks to the agent's list instead of replacing it

### DIFF
--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -17,6 +17,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1116,6 +1117,21 @@ func mergeGeneratedTasks(existing string, generated []string) []string {
 	return merged
 }
 
+// checklistMarkRank ranks a checkbox mark by how far along the task is, so a
+// collapsed duplicate identity keeps its furthest-along state: done ("[x]" and
+// its parse variants X/+/*) outranks in-progress ("[-]"), which outranks
+// pending ("[ ]"). See ChecklistItem.Mark for the mark alphabet.
+func checklistMarkRank(mark string) int {
+	switch strings.TrimSpace(mark) {
+	case "":
+		return 0 // pending "[ ]"
+	case domain.MarkInProgress:
+		return 1 // in-progress "[-]"
+	default:
+		return 2 // done "[x]"/"[X]"/"[+]"/"[*]"
+	}
+}
+
 // generatedTaskPosition returns the 1-based position of task within merged
 // (matched by domain.GeneratedTaskIdentity, so a numbered or raw form both
 // find it), or 1 if absent — the reservation's own text check then fails loudly
@@ -1163,16 +1179,18 @@ func carryOverChecklistMarks(existing, rendered string) string {
 	marks := map[string][]string{}
 	for _, it := range domain.ParseChecklist(existing) {
 		id := domain.GeneratedTaskIdentity(it.Text)
-		// Advanced marks ("[-]"/"[x]") go to the FRONT of the queue so that when
-		// the merge collapses a duplicate identity to one rendered item, that
-		// item keeps its in-progress/done state — a pending "[ ]" duplicate must
-		// never win and re-arm the daemon for a task already underway. Distinct
-		// items (post-merge identities are unique) still map one-to-one.
-		if strings.TrimSpace(it.Mark) == "" {
-			marks[id] = append(marks[id], it.Mark)
-		} else {
-			marks[id] = append([]string{it.Mark}, marks[id]...)
-		}
+		marks[id] = append(marks[id], it.Mark)
+	}
+	// Order each identity's marks most-advanced first (done "[x]" > in-progress
+	// "[-]" > pending "[ ]"). When the merge collapses a duplicate identity to
+	// one rendered item it is assigned marks[id][0], so ranking guarantees the
+	// survivor keeps the FURTHEST-along state regardless of the order the
+	// duplicates appeared in the file — a completed or in-progress task is never
+	// regressed (which would re-arm the daemon for work already underway).
+	for id := range marks {
+		sort.SliceStable(marks[id], func(a, b int) bool {
+			return checklistMarkRank(marks[id][a]) > checklistMarkRank(marks[id][b])
+		})
 	}
 	lines := strings.Split(rendered, "\n")
 	for _, it := range domain.ParseChecklist(rendered) {

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -971,11 +971,13 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	// Every task is written pending ("[ ]"); the first is marked in-progress
 	// ("[-]") only below, at delivery time, so a confirm that sends nothing
 	// leaves it for the daemon's normal declared-task flow (issue #156).
-	// ensureGeneratedTaskFile never resets progress markers: a stale
-	// re-confirm racing the winner must not flip a freshly reserved "[-]"
-	// (or a completed "[x]") back to "[ ]" and re-arm a second delivery.
-	content := domain.RenderGeneratedTaskList(name, tasks)
-	if err := ensureGeneratedTaskFile(path, content); err != nil {
+	// ensureGeneratedTaskFile APPENDS: a later generation preserves every
+	// existing task (its order and its "[-]"/"[x]" marker) and only appends
+	// tasks not already present — it never drops or reorders the agent's list
+	// (issue #183). `merged` is that combined list, so the send reservation
+	// below can locate the first suggested task by its real position.
+	merged, err := ensureGeneratedTaskFile(path, name, tasks)
+	if err != nil {
 		return fmt.Errorf("write tasks file: %w", err)
 	}
 	// Register the file as this agent's task source (writes config.toml and
@@ -1009,26 +1011,34 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	}
 
 	if send && a.Herdr != nil {
-		// Only the first task is sent — the operator's "start now" task. The
-		// order mirrors SendTaskToAgent and is load-bearing: RESERVE the item
-		// ([-] under the file lock) and only then deliver, so the daemon's idle
-		// flow can never hand it out mid-send, and a failed send rolls it back
-		// to [ ].
-		itemText := domain.GeneratedTaskItemText(0, tasks[0])
-		if _, err := mutateTaskFile(path, reserveTask(1, itemText)); err != nil {
-			return fmt.Errorf("task source created, but reserving task #1 (nothing was sent): %w", err)
+		// Only the first task is sent — the operator's "start now" task. With
+		// existing tasks preserved above it, that task is no longer necessarily
+		// item #1, so locate it by identity in the merged list and reserve THAT
+		// position. The order mirrors SendTaskToAgent and is load-bearing:
+		// RESERVE the item ([-] under the file lock) and only then deliver, so
+		// the daemon's idle flow can never hand it out mid-send, and a failed
+		// send rolls it back to [ ].
+		pos := generatedTaskPosition(merged, tasks[0])
+		// Reserve and send the SAME text the file was rendered from — merged
+		// carries the stripped task identity, so a task whose normalized text
+		// itself begins with a "N. " prefix renders (and must be reserved) under
+		// its identity, not the raw suggestion, or reserveTask's text check would
+		// fail spuriously after the escalation is already claimed.
+		taskText := merged[pos-1]
+		itemText := domain.GeneratedTaskItemText(pos-1, taskText)
+		if _, err := mutateTaskFile(path, reserveTask(pos, itemText)); err != nil {
+			return fmt.Errorf("task source created, but reserving task #%d (nothing was sent): %w", pos, err)
 		}
 		// Render through the same default next-task template used by a declared
 		// task source, so every idle-task handoff includes both the task and
-		// its list. The prompt sends the raw normalized task, not the numbered
-		// file line.
+		// its list. The prompt sends the task text, not the numbered file line.
 		prompt := domain.DeclaredTask{
-			Task: tasks[0], Path: path, AgentName: name,
+			Task: taskText, Path: path, AgentName: name,
 		}.Prompt()
 		if err := ports.SendToAgent(ctx, a.Herdr, audit.AgentID, audit.AgentType, prompt); err != nil {
-			if _, rbErr := mutateTaskFile(path, releaseTask(1, itemText)); rbErr != nil {
-				return fmt.Errorf("task source created, but sending the task failed (%w) and task #1 could not be returned to [ ] (%v) — "+
-					"it stays [-] and no agent will pick it up until you clear it", err, rbErr)
+			if _, rbErr := mutateTaskFile(path, releaseTask(pos, itemText)); rbErr != nil {
+				return fmt.Errorf("task source created, but sending the task failed (%w) and task #%d could not be returned to [ ] (%v) — "+
+					"it stays [-] and no agent will pick it up until you clear it", err, pos, rbErr)
 			}
 			return fmt.Errorf("task source created, but sending the task to the agent failed: %w", err)
 		}
@@ -1036,34 +1046,88 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	return a.nudge(ctx, control.KindReload)
 }
 
-// ensureGeneratedTaskFile writes the rendered generated-task checklist to
-// path as ONE locked read-compare-write, under the same per-path lock
-// mutateTaskFile takes — an unlocked check-then-write could land after a
-// concurrent confirm's reservation and silently reset its "[-]". A file
-// already carrying exactly these item texts is left untouched (a stale
-// re-confirm must not clobber markers or any operator edits); when the items
-// DO differ (a new generation), the rewrite carries over the existing marker
-// of every same-text item, so in-flight "[-]" and finished "[x]" work
-// survives regeneration. The write is atomic because the daemon reads this
-// file without the lock.
-func ensureGeneratedTaskFile(path, content string) error {
+// ensureGeneratedTaskFile writes the agent's generated-task checklist to path
+// as ONE locked read-merge-write, under the same per-path lock mutateTaskFile
+// takes — an unlocked check-then-write could land after a concurrent confirm's
+// reservation and silently reset its "[-]". It APPENDS: every task already in
+// the file is preserved (its order and its "[-]"/"[x]" marker), and only tasks
+// from `tasks` not already present are added at the end — a later generation
+// never drops or reorders the agent's list (issue #183). A file already
+// carrying exactly the merged items is left untouched (a stale re-confirm must
+// not clobber markers or operator edits). The write is atomic because the
+// daemon reads this file without the lock. Returns the merged task list (raw,
+// unnumbered) so the caller can locate a task's rendered position.
+func ensureGeneratedTaskFile(path, name string, tasks []string) ([]string, error) {
 	lockPath := taskLockPath(path)
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
-		return err
+		return nil, err
 	}
 	unlock, err := lockFile(lockPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer unlock()
 
-	if existing, rerr := os.ReadFile(path); rerr == nil {
-		if sameChecklistTexts(string(existing), content) {
-			return nil
-		}
-		content = carryOverChecklistMarks(string(existing), content)
+	existing := ""
+	if b, rerr := os.ReadFile(path); rerr == nil {
+		existing = string(b)
 	}
-	return writeFileAtomic(path, []byte(content), 0o600)
+	merged := mergeGeneratedTasks(existing, tasks)
+	content := domain.RenderGeneratedTaskList(name, merged)
+	if existing != "" {
+		if sameChecklistTexts(existing, content) {
+			return merged, nil
+		}
+		// merged lists every existing task, so carry-over drops nothing — it
+		// only restores each preserved item's "[-]"/"[x]" marker onto its
+		// freshly rendered "[ ]" line.
+		content = carryOverChecklistMarks(existing, content)
+	}
+	if err := writeFileAtomic(path, []byte(content), 0o600); err != nil {
+		return nil, err
+	}
+	return merged, nil
+}
+
+// mergeGeneratedTasks builds the task list for a (re)generated file: every task
+// already in existing, in file order, followed by each task from generated
+// whose identity is not already present. Existing tasks are never dropped or
+// reordered, so a later generation that lists only new work APPENDS to — rather
+// than replaces — the agent's list (issue #183). Dedup is by
+// domain.GeneratedTaskIdentity, so re-listing an existing task does not
+// duplicate it. Returns raw (unnumbered) task strings for RenderGeneratedTaskList.
+func mergeGeneratedTasks(existing string, generated []string) []string {
+	var merged []string
+	seen := map[string]bool{}
+	add := func(raw string) {
+		id := domain.GeneratedTaskIdentity(raw)
+		if id == "" || seen[id] {
+			return
+		}
+		seen[id] = true
+		merged = append(merged, id)
+	}
+	for _, it := range domain.ParseChecklist(existing) {
+		add(it.Text)
+	}
+	for _, task := range generated {
+		add(task)
+	}
+	return merged
+}
+
+// generatedTaskPosition returns the 1-based position of task within merged
+// (matched by domain.GeneratedTaskIdentity, so a numbered or raw form both
+// find it), or 1 if absent — the reservation's own text check then fails loudly
+// rather than silently reserving the wrong item.
+func generatedTaskPosition(merged []string, task string) int {
+	id := domain.GeneratedTaskIdentity(task)
+	for i, t := range merged {
+		if domain.GeneratedTaskIdentity(t) == id {
+			return i + 1
+		}
+	}
+	return 1
 }
 
 // sameChecklistTexts reports whether two checklist documents carry the same
@@ -1099,7 +1163,16 @@ func carryOverChecklistMarks(existing, rendered string) string {
 	marks := map[string][]string{}
 	for _, it := range domain.ParseChecklist(existing) {
 		id := domain.GeneratedTaskIdentity(it.Text)
-		marks[id] = append(marks[id], it.Mark)
+		// Advanced marks ("[-]"/"[x]") go to the FRONT of the queue so that when
+		// the merge collapses a duplicate identity to one rendered item, that
+		// item keeps its in-progress/done state — a pending "[ ]" duplicate must
+		// never win and re-arm the daemon for a task already underway. Distinct
+		// items (post-merge identities are unique) still map one-to-one.
+		if strings.TrimSpace(it.Mark) == "" {
+			marks[id] = append(marks[id], it.Mark)
+		} else {
+			marks[id] = append([]string{it.Mark}, marks[id]...)
+		}
 	}
 	lines := strings.Split(rendered, "\n")
 	for _, it := range domain.ParseChecklist(rendered) {

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -862,12 +862,12 @@ func TestConfirmRegenerationCarriesOverMarkers(t *testing.T) {
 	}
 }
 
-func TestConfirmRegenerationInsertionKeepsReservedMarker(t *testing.T) {
-	// A regeneration that INSERTS a task before a reserved one renumbers every
-	// line ("1. A" becomes "2. A"). Marker carry-over must match items by
-	// their raw task identity, not the rendered numbered text — otherwise the
-	// renumbered item resets to "[ ]" and the daemon re-sends work the agent
-	// already holds.
+func TestConfirmRegenerationAppendsKeepingReservedMarker(t *testing.T) {
+	// A later generation APPENDS new work and preserves the existing list in
+	// place (issue #183): the already-reserved "[-]" item keeps its marker AND
+	// its position, and the new task lands at the end pending — never reordered
+	// ahead of it, and never reset to "[ ]" (which would re-arm the daemon for a
+	// duplicate send).
 	app, st := testApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
@@ -885,6 +885,9 @@ func TestConfirmRegenerationInsertionKeepsReservedMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// The second suggestion lists a brand-new task first, then re-lists the two
+	// existing ones — append-only keeps the existing order and appends only the
+	// genuinely-new task at the end.
 	second, _ := st.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: "w8:p8", SituationType: domain.SituationIdle, Trigger: "t",
 		Action: "escalated", Status: "escalated",
@@ -898,21 +901,24 @@ func TestConfirmRegenerationInsertionKeepsReservedMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tasks file missing: %v", err)
 	}
-	if !strings.Contains(string(body), "- [ ] 1. Set up the load test rig") {
-		t.Errorf("tasks file = %q, want the inserted item first and pending", body)
+	if !strings.Contains(string(body), "- [-] 1. Profile the slow endpoint") {
+		t.Errorf("tasks file = %q, want the delivered item still \"[-]\" in its original position", body)
 	}
-	if !strings.Contains(string(body), "- [-] 2. Profile the slow endpoint") {
-		t.Errorf("tasks file = %q, want the delivered item still \"[-]\" under its new number", body)
+	if !strings.Contains(string(body), "- [ ] 2. Add a response cache") {
+		t.Errorf("tasks file = %q, want the existing pending item preserved", body)
 	}
-	if next := domain.NextDeclaredTask(string(body)); next != "1. Set up the load test rig" {
-		t.Errorf("next declared task = %q, want only the inserted item — the reserved one must not be re-armed", next)
+	if !strings.Contains(string(body), "- [ ] 3. Set up the load test rig") {
+		t.Errorf("tasks file = %q, want the new item appended pending at the end", body)
+	}
+	if next := domain.NextDeclaredTask(string(body)); next != "2. Add a response cache" {
+		t.Errorf("next declared task = %q, want the first still-pending item — the reserved one must not be re-armed", next)
 	}
 }
 
-func TestConfirmRegenerationInsertionKeepsCompletedMarker(t *testing.T) {
-	// Same renumbering hazard for FINISHED work: an item the agent completed
-	// ("[x]", e.g. via `hap task done`) must stay done when a regeneration
-	// re-lists it under a new number, not be re-queued.
+func TestConfirmRegenerationAppendsKeepingCompletedMarker(t *testing.T) {
+	// Same for FINISHED work: an item the agent completed ("[x]", e.g. via
+	// `hap task done`) stays done and in place when a later generation appends
+	// new work — it is never re-queued (issue #183).
 	app, st := testApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
@@ -956,11 +962,11 @@ func TestConfirmRegenerationInsertionKeepsCompletedMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tasks file missing: %v", err)
 	}
-	if !strings.Contains(string(body), "- [x] 2. Profile the slow endpoint") {
-		t.Errorf("tasks file = %q, want the completed item still \"[x]\" under its new number", body)
+	if !strings.Contains(string(body), "- [x] 1. Profile the slow endpoint") {
+		t.Errorf("tasks file = %q, want the completed item still \"[x]\" in its original position", body)
 	}
-	if next := domain.NextDeclaredTask(string(body)); next != "1. Set up the load test rig" {
-		t.Errorf("next declared task = %q, want only the inserted item — completed work must not be re-queued", next)
+	if next := domain.NextDeclaredTask(string(body)); next != "2. Set up the load test rig" {
+		t.Errorf("next declared task = %q, want the appended new item — completed work must not be re-queued", next)
 	}
 }
 

--- a/internal/frontend/generated_task_append_test.go
+++ b/internal/frontend/generated_task_append_test.go
@@ -183,50 +183,63 @@ func TestConfirmGeneratedTaskSendReservesNumberedFirstTask(t *testing.T) {
 	}
 }
 
-// TestConfirmGeneratedTaskCollapsesDuplicateKeepingAdvancedMark: if the existing
-// file carries the same task identity twice — a pending "[ ]" ordered before an
-// in-progress "[-]" — the merge collapses them to one item that keeps the
-// ADVANCED mark, so a task already underway is not re-armed for a duplicate send
-// (issue #183 carry-over hardening).
+// TestConfirmGeneratedTaskCollapsesDuplicateKeepingAdvancedMark: when the
+// existing file carries the same task identity twice, the merge collapses them
+// to one item that keeps the MOST-ADVANCED mark (done > in-progress > pending),
+// regardless of the order the duplicates appear — a completed or in-progress
+// task is never regressed (which would re-arm the daemon for work already done
+// or underway). Issue #183 carry-over hardening.
 func TestConfirmGeneratedTaskCollapsesDuplicateKeepingAdvancedMark(t *testing.T) {
-	app, st := testApp(t)
-	fake := &fakeHerdr{}
-	app.Herdr = fake
-	stateDir := t.TempDir()
-	app.StateDir = stateDir
-	ctx := context.Background()
+	cases := []struct {
+		name     string
+		dupLines string // the two duplicate "Alpha" lines, in file order
+		wantMark string // the mark the collapsed Alpha must keep
+	}{
+		{"pending_before_inprogress", "- [ ] 1. Alpha\n- [-] 2. Alpha\n", "-"},
+		{"inprogress_before_pending", "- [-] 1. Alpha\n- [ ] 2. Alpha\n", "-"},
+		{"done_before_inprogress", "- [x] 1. Alpha\n- [-] 2. Alpha\n", "x"},
+		{"inprogress_before_done", "- [-] 1. Alpha\n- [x] 2. Alpha\n", "x"},
+		{"pending_before_done", "- [ ] 1. Alpha\n- [x] 2. Alpha\n", "x"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app, st := testApp(t)
+			fake := &fakeHerdr{}
+			app.Herdr = fake
+			stateDir := t.TempDir()
+			app.StateDir = stateDir
+			ctx := context.Background()
 
-	name, _ := st.EnsureAgentName(ctx, "w9:p9")
-	first, _ := st.AppendAudit(ctx, domain.AuditRecord{
-		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
-		Action: "escalated", Status: "escalated",
-		Suggestion: domain.SuggestTaskPrefix + "Alpha", CreatedAt: time.Now(),
-	})
-	if err := app.Confirm(ctx, first, false); err != nil {
-		t.Fatal(err)
-	}
-	// Hand-edit the file to carry a duplicate identity: pending BEFORE in-progress.
-	path := filepath.Join(stateDir, "tasks", name+".md")
-	if err := os.WriteFile(path, []byte("# Tasks for "+name+"\n\n- [ ] 1. Alpha\n- [-] 2. Alpha\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	second, _ := st.AppendAudit(ctx, domain.AuditRecord{
-		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
-		Action: "escalated", Status: "escalated",
-		Suggestion: domain.SuggestTaskPrefix + "Beta", CreatedAt: time.Now(),
-	})
-	if err := app.Confirm(ctx, second, false); err != nil {
-		t.Fatal(err)
-	}
-	body, _ := os.ReadFile(path)
-	if !strings.Contains(string(body), "- [-] 1. Alpha") {
-		t.Errorf("collapsed duplicate must keep the in-progress mark, file = %q", body)
-	}
-	if !strings.Contains(string(body), "- [ ] 2. Beta") {
-		t.Errorf("new task must be appended pending, file = %q", body)
-	}
-	// Only the [ ] Beta is a next declared task — Alpha stays [-].
-	if next := domain.NextDeclaredTask(string(body)); next != "2. Beta" {
-		t.Errorf("next declared task = %q, want the appended Beta only", next)
+			name, _ := st.EnsureAgentName(ctx, "w9:p9")
+			first, _ := st.AppendAudit(ctx, domain.AuditRecord{
+				AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+				Action: "escalated", Status: "escalated",
+				Suggestion: domain.SuggestTaskPrefix + "Alpha", CreatedAt: time.Now(),
+			})
+			if err := app.Confirm(ctx, first, false); err != nil {
+				t.Fatal(err)
+			}
+			// Hand-edit the file to carry the duplicate identity in this order.
+			path := filepath.Join(stateDir, "tasks", name+".md")
+			if err := os.WriteFile(path, []byte("# Tasks for "+name+"\n\n"+tc.dupLines), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			second, _ := st.AppendAudit(ctx, domain.AuditRecord{
+				AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+				Action: "escalated", Status: "escalated",
+				Suggestion: domain.SuggestTaskPrefix + "Beta", CreatedAt: time.Now(),
+			})
+			if err := app.Confirm(ctx, second, false); err != nil {
+				t.Fatal(err)
+			}
+			body, _ := os.ReadFile(path)
+			wantAlpha := "- [" + tc.wantMark + "] 1. Alpha"
+			if !strings.Contains(string(body), wantAlpha) {
+				t.Errorf("collapsed duplicate must keep the most-advanced mark %q, file = %q", wantAlpha, body)
+			}
+			if !strings.Contains(string(body), "- [ ] 2. Beta") {
+				t.Errorf("new task must be appended pending, file = %q", body)
+			}
+		})
 	}
 }

--- a/internal/frontend/generated_task_append_test.go
+++ b/internal/frontend/generated_task_append_test.go
@@ -1,0 +1,232 @@
+package frontend_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// TestConfirmGeneratedTaskAppendsToBootstrapList: a second generation that
+// lists only NEW tasks (not re-listing the existing ones) must APPEND to the
+// agent's bootstrapped list, never replace it (issue #183).
+func TestConfirmGeneratedTaskAppendsToBootstrapList(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w9:p9")
+	first, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Task A - fix login", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, first, false); err != nil {
+		t.Fatal(err)
+	}
+	// A later generation suggests only NEW work — it does NOT re-list Task A.
+	second, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Task B - add tests\nTask C - update docs", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, second, false); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(stateDir, "tasks", name+".md"))
+	if err != nil {
+		t.Fatalf("tasks file missing: %v", err)
+	}
+	// All three tasks present, existing first, new appended in order.
+	want := "- [ ] 1. Task A - fix login\n- [ ] 2. Task B - add tests\n- [ ] 3. Task C - update docs\n"
+	if !strings.Contains(string(body), want) {
+		t.Errorf("tasks file = %q, want existing Task A preserved with B and C appended:\n%q", body, want)
+	}
+}
+
+// TestConfirmGeneratedTaskAppendsWhileAgentBusy: the queue-while-busy path
+// (send=false, busy agent) also appends — existing tasks survive and the new
+// ones are added, with nothing delivered to the busy pane (issue #180 + #183).
+func TestConfirmGeneratedTaskAppendsWhileAgentBusy(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w9:p9")
+	first, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Existing task", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, first, false); err != nil {
+		t.Fatal(err)
+	}
+	// Agent is now busy; queue a new generated task (send=false).
+	fake.agents = []domain.AgentTransition{{AgentID: "w9:p9", Status: "working"}}
+	second, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Newly queued task", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, second, false); err != nil {
+		t.Fatalf("queueing to a busy agent must succeed: %v", err)
+	}
+
+	if len(fake.inputs) != 0 {
+		t.Errorf("nothing may be delivered to a busy agent, got %v", fake.inputs)
+	}
+	body, _ := os.ReadFile(filepath.Join(stateDir, "tasks", name+".md"))
+	if !strings.Contains(string(body), "- [ ] 1. Existing task") {
+		t.Errorf("existing task must survive, file = %q", body)
+	}
+	if !strings.Contains(string(body), "- [ ] 2. Newly queued task") {
+		t.Errorf("new task must be appended, file = %q", body)
+	}
+}
+
+// TestConfirmGeneratedTaskSendAppendsAndReservesNewItem: with an existing DONE
+// task, a confirm+send appends the new task and reserves IT (at its real
+// position, not #1) — the completed item stays "[x]" and the new one is
+// delivered and marked "[-]" (issue #183 reservation-position fix).
+func TestConfirmGeneratedTaskSendAppendsAndReservesNewItem(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w9:p9")
+	first, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Old done task", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, first, false); err != nil {
+		t.Fatal(err)
+	}
+	// Mark the existing item completed.
+	path := filepath.Join(stateDir, "tasks", name+".md")
+	body, _ := os.ReadFile(path)
+	done, err := domain.SetChecklistItemDone(string(body), 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(done), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Confirm+send a new task while idle.
+	fake.agents = []domain.AgentTransition{{AgentID: "w9:p9", Status: "idle"}}
+	second, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Fresh task", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, second, true); err != nil {
+		t.Fatalf("confirm+send must succeed: %v", err)
+	}
+
+	body, _ = os.ReadFile(path)
+	if !strings.Contains(string(body), "- [x] 1. Old done task") {
+		t.Errorf("completed task must stay done, file = %q", body)
+	}
+	if !strings.Contains(string(body), "- [-] 2. Fresh task") {
+		t.Errorf("new task must be reserved [-] at its real position #2, file = %q", body)
+	}
+	if len(fake.inputs) != 1 || !strings.Contains(fake.inputs[0], "Fresh task") {
+		t.Errorf("the new task must be delivered exactly once, got %v", fake.inputs)
+	}
+}
+
+// TestConfirmGeneratedTaskSendReservesNumberedFirstTask: a normalized task whose
+// text itself begins with a "N. " prefix (an LLM doubly-numbered list like
+// "- 1. Foo") renders under its stripped identity — the send reservation must
+// name that same rendered text, not the raw "1. Foo", or it fails spuriously
+// after the escalation is claimed (issue #183 reservation-text fix).
+func TestConfirmGeneratedTaskSendReservesNumberedFirstTask(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeHerdr{agents: []domain.AgentTransition{{AgentID: "w9:p9", Status: "idle"}}}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w9:p9")
+	// "- 1. Foo bar": NormalizeGeneratedTasks strips the outer "- " bullet,
+	// leaving the task text "1. Foo bar" (identity "Foo bar").
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "- 1. Foo bar", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatalf("confirm+send of a numbered-body task must succeed: %v", err)
+	}
+	body, _ := os.ReadFile(filepath.Join(stateDir, "tasks", name+".md"))
+	if !strings.Contains(string(body), "- [-] 1. Foo bar") {
+		t.Errorf("task must be reserved [-] under its rendered identity, file = %q", body)
+	}
+	if len(fake.inputs) != 1 {
+		t.Errorf("the task must be delivered exactly once, got %v", fake.inputs)
+	}
+}
+
+// TestConfirmGeneratedTaskCollapsesDuplicateKeepingAdvancedMark: if the existing
+// file carries the same task identity twice — a pending "[ ]" ordered before an
+// in-progress "[-]" — the merge collapses them to one item that keeps the
+// ADVANCED mark, so a task already underway is not re-armed for a duplicate send
+// (issue #183 carry-over hardening).
+func TestConfirmGeneratedTaskCollapsesDuplicateKeepingAdvancedMark(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w9:p9")
+	first, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Alpha", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, first, false); err != nil {
+		t.Fatal(err)
+	}
+	// Hand-edit the file to carry a duplicate identity: pending BEFORE in-progress.
+	path := filepath.Join(stateDir, "tasks", name+".md")
+	if err := os.WriteFile(path, []byte("# Tasks for "+name+"\n\n- [ ] 1. Alpha\n- [-] 2. Alpha\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	second, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "Beta", CreatedAt: time.Now(),
+	})
+	if err := app.Confirm(ctx, second, false); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := os.ReadFile(path)
+	if !strings.Contains(string(body), "- [-] 1. Alpha") {
+		t.Errorf("collapsed duplicate must keep the in-progress mark, file = %q", body)
+	}
+	if !strings.Contains(string(body), "- [ ] 2. Beta") {
+		t.Errorf("new task must be appended pending, file = %q", body)
+	}
+	// Only the [ ] Beta is a next declared task — Alpha stays [-].
+	if next := domain.NextDeclaredTask(string(body)); next != "2. Beta" {
+		t.Errorf("next declared task = %q, want the appended Beta only", next)
+	}
+}

--- a/internal/tui/add_prompt_test.go
+++ b/internal/tui/add_prompt_test.go
@@ -48,8 +48,16 @@ func TestConfirmBusyAgentOpensAddPrompt(t *testing.T) {
 	}
 	upd, _ = m.Update(ap)
 	m = upd.(Model)
-	if m.prompt == nil || !strings.HasPrefix(strings.ToLower(m.prompt.input), "y") {
-		t.Fatalf("add prompt should open defaulting to 'y', got %+v", m.prompt)
+	// The prompt opens with NO pre-filled default: a pre-filled "y" would make a
+	// typed "n" append to "yn" (still HasPrefix "y") and the decline unreachable.
+	if m.prompt == nil {
+		t.Fatal("a busy send refusal should open the add prompt")
+	}
+	if m.prompt.input != "" {
+		t.Errorf("add prompt must open empty (no default), got %q", m.prompt.input)
+	}
+	if !strings.Contains(m.prompt.label, "add the tasks") {
+		t.Errorf("prompt label should offer to add the tasks, got %q", m.prompt.label)
 	}
 	// Nothing was delivered to the busy agent.
 	if len(fh.inputs) != 0 {
@@ -125,10 +133,11 @@ func TestAddPromptNoLeavesPending(t *testing.T) {
 	}
 }
 
-// TestAddPromptBareEnterQueues: a bare Enter (no edit to the pre-filled "y")
-// commits the default — the tasks are queued and the escalation resolved. Locks
-// in the "confirm already meant accept, so Enter queues" contract.
-func TestAddPromptBareEnterQueues(t *testing.T) {
+// TestAddPromptBareEnterDeclines: a bare Enter (empty input, no default) is the
+// SAFE outcome — it cancels the prompt and leaves the escalation pending rather
+// than silently queueing. Queueing requires an explicit "y" (see the empty-input
+// rationale on openAddPrompt).
+func TestAddPromptBareEnterDeclines(t *testing.T) {
 	m, st, fh := correctTestModel(t)
 	fh.agents = []domain.AgentTransition{{AgentID: "w1:p1", Status: "working"}}
 	ctx := context.Background()
@@ -139,19 +148,51 @@ func TestAddPromptBareEnterQueues(t *testing.T) {
 	upd, _ = m.Update(cmd().(openAddPromptMsg))
 	m = upd.(Model)
 
-	// Submit WITHOUT overwriting m.prompt.input, so the pre-filled "y" default
-	// is what commits.
+	// Submit WITHOUT typing anything: the empty input cancels.
 	_, c := m.submitPrompt()
 	if c != nil {
 		c()
 	}
 
 	audit, _ := st.GetAudit(ctx, id)
-	if audit.Status != "resolved" {
-		t.Errorf("bare Enter should queue (default y) and resolve, got %q", audit.Status)
+	if audit.Status != "escalated" {
+		t.Errorf("bare Enter must leave the escalation pending, got %q", audit.Status)
 	}
 	if len(fh.inputs) != 0 {
-		t.Errorf("queueing must deliver nothing, got %v", fh.inputs)
+		t.Errorf("nothing may be delivered, got %v", fh.inputs)
+	}
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 0 {
+		t.Errorf("bare Enter must record no correction, got %+v", corr)
+	}
+}
+
+// TestAddPromptDeclineTypingN: typing "n" (which, with no pre-fill, is exactly
+// "n" — not "yn") declines cleanly and leaves the escalation pending. This is
+// the decline path the pre-filled-"y" version broke (issue #180 review).
+func TestAddPromptDeclineTypingN(t *testing.T) {
+	m, st, fh := correctTestModel(t)
+	fh.agents = []domain.AgentTransition{{AgentID: "w1:p1", Status: "working"}}
+	ctx := context.Background()
+	id := seedGenTaskEscalation(t, st, "Write missing tests")
+
+	upd, cmd := m.confirmAuditID(id)
+	m = upd.(Model)
+	upd, _ = m.Update(cmd().(openAddPromptMsg))
+	m = upd.(Model)
+
+	runPromptSubmit(t, m, "n")
+
+	audit, _ := st.GetAudit(ctx, id)
+	if audit.Status != "escalated" {
+		t.Errorf("typing n must leave the escalation pending, got %q", audit.Status)
+	}
+	if len(fh.inputs) != 0 {
+		t.Errorf("declining must deliver nothing, got %v", fh.inputs)
+	}
+	corr, _ := st.UnprocessedCorrections(ctx)
+	if len(corr) != 0 {
+		t.Errorf("declining must record no correction, got %+v", corr)
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1387,17 +1387,20 @@ func (m Model) confirmAuditID(id int64) (tea.Model, tea.Cmd) {
 
 // openAddPrompt asks whether to queue a stale generated-task suggestion onto the
 // agent's declared task list without sending — the agent is busy, so a send
-// would interrupt it, but the task itself is still valid. Adding accepts the
-// escalation: it appends the tasks, resolves the escalation, and records the
+// would interrupt it, but the task itself is still valid. Answering "y" accepts
+// the escalation: it appends the tasks, resolves the escalation, and records the
 // acceptance to Audits (the daemon delivers the first task on the next idle).
-// Defaults to "y" — the operator already chose to accept by confirming, and
-// queueing sends nothing.
+//
+// The prompt is deliberately left EMPTY (not pre-filled "y"): the input box
+// APPENDS keystrokes, so a pre-filled "y" would turn a typed "n" into "yn" —
+// still HasPrefix "y" — making the decline unreachable. With no default, a bare
+// Enter submits nothing → submitPrompt cancels (leaves the escalation pending,
+// the safe outcome), and only an explicit "y" queues. Hence the "[y/N]" hint.
 func (m Model) openAddPrompt(id int64) (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	m.message = ""
 	m.prompt = &prompt{
-		label: fmt.Sprintf("agent is busy — add the tasks to its task list instead? [Y/n] (#%d)", id),
-		input: "y",
+		label: fmt.Sprintf("agent is busy — add the tasks to its task list instead? [y/N] (#%d)", id),
 		onSubmit: func(input string) tea.Cmd {
 			if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(input)), "y") {
 				return func() tea.Msg {


### PR DESCRIPTION
Closes #183.

## Problem

Confirming an LLM-generated-task escalation for an agent whose task list is the plugin's own bootstrapped generated file **replaced** the list with only the newly-suggested tasks — any existing task the new generation did not re-list was **dropped** (data loss). It surfaces via the queue-while-busy path (#180, PR #181) and the exhausted-source regeneration (#157) whenever the generation lists only new work.

Root cause: the bootstrap path in `acceptGeneratedTask` re-rendered the file from only the current suggestion, and `carryOverChecklistMarks` dropped items present only in the existing file.

## Fix — append-only

- `ensureGeneratedTaskFile` now merges existing + new under the file lock: existing tasks first (preserving order and their `[-]`/`[x]` markers), then only tasks not already present (deduped by identity) appended at the end. It returns the merged list. Nothing is dropped or reordered.
- The confirm+send reservation locates the first task's **real** position in the merged list (no longer necessarily #1) and reserves the same text the file was rendered from (the stripped identity) — so a task whose normalized text itself begins with `N. ` (an LLM doubly-numbered list) no longer fails the reservation spuriously after the escalation is claimed.
- `carryOverChecklistMarks` prefers the most-advanced mark when collapsing a duplicate identity, so a task already underway is never re-armed for a duplicate send.

## Tests

- Updated the two regeneration tests to the append semantics (existing kept in place, new appended at the end).
- New regression tests: bootstrap-append (the exact reported bug), busy-append, send-appends-and-reserves-new-item, numbered-first-task reservation, and duplicate-identity mark collapse.
- Full suite (`go test -tags "vectors cpu" ./...`), `go vet`, `gofmt`, `golangci-lint` all pass. Two code-review findings (reservation-text divergence; duplicate-mark collapse) were caught and fixed before this PR.

## Live verification

Rebuilt and hot-swapped the `dev` daemon inside herdr; drove a real haiku agent to a generated-task escalation and confirmed it without send — the bootstrapped list was created correctly with the new CLI message ("added the suggested task(s) to the agent's task list (not sent)"). Test workspace cleaned up afterward.

> Note: builds on the #180 feature already merged via PR #181.

https://claude.ai/code/session_01FKbYWbyEGhsT8iGnbyBJgr