### PR TITLE
#1 fix: build match package without the vectors tag via KNN build-tag split

### DIFF
--- a/internal/daemon/semantic.go
+++ b/internal/daemon/semantic.go
@@ -116,7 +116,12 @@ func (d *Daemon) resolveSignature(ctx context.Context, cfg config.Config,
 			accept := func(h match.Hit) bool { return remapAllowed(s, sig, h) }
 			hit, ok, err := d.matcher.MatchVector(ctx, vec, scope, accept)
 			if err != nil {
+				// Fall back to BM25 below: clear vec so the vec==nil text path
+				// runs (e.g. a degraded latch, or a text-only build where KNN is
+				// unavailable). Without this the "trying text match" promise is
+				// empty and resolution drops to hash-only.
 				slog.Warn("vector match failed; trying text match", "error", err)
+				vec = nil
 			} else if ok && hit.Score >= cfg.Embedding.SimilarityThreshold {
 				slog.Info("semantic match: reusing learned signature",
 					"signature", hit.Signature, "cosine", hit.Score, "raw", sig.Raw)

--- a/internal/match/knn_novectors.go
+++ b/internal/match/knn_novectors.go
@@ -1,0 +1,23 @@
+//go:build !vectors
+
+package match
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/search/query"
+)
+
+// vectorSearchSupported is false in text-only builds (no `vectors` tag): bleve
+// is linked without its KNN engine, so MatchVector degrades to unavailable and
+// callers fall back to BM25 (MatchText). See knn_vectors.go for the real path.
+const vectorSearchSupported = false
+
+// knnSearch reports that vector search is unavailable in this build. bleve's
+// SearchRequest.AddKNNWithFilter exists only under the `vectors` tag, so a
+// text-only build cannot run KNN; the daemon falls back to BM25 matching.
+func knnSearch(_ context.Context, _ bleve.Index, _ []float32, _ int, _ []string, _ query.Query) (*bleve.SearchResult, error) {
+	return nil, fmt.Errorf("vector matching unavailable (built without the \"vectors\" tag)")
+}

--- a/internal/match/knn_vectors.go
+++ b/internal/match/knn_vectors.go
@@ -1,0 +1,29 @@
+//go:build vectors
+
+package match
+
+import (
+	"context"
+
+	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/search/query"
+)
+
+// vectorSearchSupported reports whether this build links bleve's KNN engine
+// (the `vectors` build tag). MatchVector only works when true; without it the
+// daemon falls back to BM25 (MatchText).
+const vectorSearchSupported = true
+
+// knnSearch runs a k-nearest-neighbor query for vec over the "vector" field,
+// pre-filtered to filter (the scope conjunction) so the k nearest are chosen
+// only from in-scope docs, and returns the top-k hits by cosine similarity.
+// It lives behind the `vectors` tag because bleve defines
+// SearchRequest.AddKNNWithFilter only there; the !vectors stub (knn_novectors.go)
+// reports the capability unavailable.
+func knnSearch(ctx context.Context, idx bleve.Index, vec []float32, k int, fields []string, filter query.Query) (*bleve.SearchResult, error) {
+	req := bleve.NewSearchRequest(bleve.NewMatchNoneQuery())
+	req.Size = k
+	req.Fields = fields
+	req.AddKNNWithFilter("vector", vec, int64(k), 1.0, filter)
+	return idx.SearchInContext(ctx, req)
+}

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -101,6 +101,15 @@ func buildIndex(path string, dims int) (bleve.Index, error) {
 // dimensionality of the active embedding model (0 indexes text only; any
 // row's vector with a different length is indexed as text only).
 func (m *Matcher) Rebuild(rows []domain.SignatureEmbedding, dims int) error {
+	if !vectorSearchSupported {
+		// No KNN engine is linked (built without the `vectors` tag), so the
+		// index must be text-only. Force dims to 0: a positive dims would make
+		// buildIndex call bleve's mapping.NewVectorFieldMapping(), which is nil
+		// in a !vectors build (mapping_no_vectors.go) and would panic on the
+		// field assignment. An embedder can still be present (dims>0) via the
+		// `cpu` tag, so this path is reachable — it degrades to BM25.
+		dims = 0
+	}
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -203,6 +203,9 @@ const matchK = 3
 // the hit score IS the cosine similarity) — thresholding is the caller's.
 // accept must be a fast, pure content check (it runs inline per candidate).
 func (m *Matcher) MatchVector(ctx context.Context, vec []float32, s Scope, accept func(Hit) bool) (Hit, bool, error) {
+	if !vectorSearchSupported {
+		return Hit{}, false, fmt.Errorf("vector matching unavailable (built without the \"vectors\" tag)")
+	}
 	m.mu.RLock()
 	idx, dims := m.idx, m.dims
 	m.mu.RUnlock()
@@ -213,11 +216,7 @@ func (m *Matcher) MatchVector(ctx context.Context, vec []float32, s Scope, accep
 		return Hit{}, false, fmt.Errorf("query vector dims %d != index dims %d", len(vec), dims)
 	}
 
-	req := bleve.NewSearchRequest(bleve.NewMatchNoneQuery())
-	req.Size = matchK
-	req.Fields = []string{"salient"}
-	req.AddKNNWithFilter("vector", vec, matchK, 1.0, scopeFilter(s))
-	res, err := idx.SearchInContext(ctx, req)
+	res, err := knnSearch(ctx, idx, vec, matchK, []string{"salient"}, scopeFilter(s))
 	if err != nil {
 		return Hit{}, false, err
 	}

--- a/internal/match/match_novectors_test.go
+++ b/internal/match/match_novectors_test.go
@@ -1,0 +1,61 @@
+//go:build !vectors
+
+package match
+
+import (
+	"context"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// TestRebuildTextOnlyWithoutVectors is the regression test for the !vectors
+// build: an embedder can still be present (via the `cpu` tag) and hand Rebuild
+// a positive dims with real vectors — exactly what a warmed embedder does. Before
+// the fix, buildIndex called bleve's mapping.NewVectorFieldMapping(), which is
+// nil in a !vectors build (mapping_no_vectors.go), and panicked on the field
+// assignment; the daemon guard turned that into a failed initSemantic, so
+// semanticReady never flipped and the promised BM25 fallback was never reached.
+// Rebuild must instead index text-only: it must not panic, MatchText (BM25) must
+// resolve, and MatchVector must report unavailable rather than panic. This is the
+// tag-free runtime path CI's `vectors cpu`-only jobs do not exercise.
+func TestRebuildTextOnlyWithoutVectors(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close()
+
+	// dims = 3 with real vectors, exactly what a warmed embedder passes.
+	rows := []domain.SignatureEmbedding{
+		row("approval:edit", domain.SituationApproval, "claude", "permission: edit the configuration files in project", []float32{1, 0, 0}),
+		row("approval:net", domain.SituationApproval, "claude", "permission: fetch a url from the network", []float32{0, 1, 0}),
+	}
+	if err := m.Rebuild(rows, 3); err != nil { // must not panic; must succeed text-only
+		t.Fatalf("Rebuild with dims>0 in a !vectors build errored: %v", err)
+	}
+
+	// BM25 fallback resolves — the promise the panic broke.
+	hit, ok, err := m.MatchText(context.Background(),
+		"permission: edit the configuration files in project", Scope{domain.SituationApproval, "claude"}, nil)
+	if err != nil || !ok {
+		t.Fatalf("MatchText fallback: ok=%v err=%v", ok, err)
+	}
+	if hit.Signature != "approval:edit" {
+		t.Errorf("BM25 match = %s, want approval:edit", hit.Signature)
+	}
+
+	// Vector matching is reported unavailable (not panicked) in this build.
+	if _, ok, err := m.MatchVector(context.Background(), []float32{1, 0, 0},
+		Scope{domain.SituationApproval, "claude"}, nil); ok || err == nil {
+		t.Errorf("MatchVector without vectors: ok=%v err=%v, want no hit and an unavailable error", ok, err)
+	}
+
+	// Add with a vector row must also stay panic-free: after the text-only
+	// Rebuild, toDoc must not emit a vector field the mapping can't handle.
+	if err := m.Add(row("approval:more", domain.SituationApproval, "claude",
+		"permission: delete a temporary file", []float32{0, 0, 1})); err != nil {
+		t.Fatalf("Add with a vector row in a !vectors build errored: %v", err)
+	}
+	if _, ok, err := m.MatchText(context.Background(), "permission: delete a temporary file",
+		Scope{domain.SituationApproval, "claude"}, nil); err != nil || !ok {
+		t.Errorf("added row not text-matchable: ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -2,7 +2,6 @@ package match
 
 import (
 	"context"
-	"math"
 	"testing"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -12,87 +11,6 @@ func row(sig string, st domain.SituationType, agent, salient string, vec []float
 	return domain.SignatureEmbedding{
 		Signature: sig, SituationType: st, AgentType: agent,
 		Salient: salient, Vector: vec, Dims: len(vec), Model: "test",
-	}
-}
-
-// unit returns an L2-normalized copy of v.
-func unit(v ...float32) []float32 {
-	var norm float64
-	for _, x := range v {
-		norm += float64(x) * float64(x)
-	}
-	n := float32(math.Sqrt(norm))
-	out := make([]float32, len(v))
-	for i, x := range v {
-		out[i] = x / n
-	}
-	return out
-}
-
-func TestMatchVectorRanksByCosine(t *testing.T) {
-	m := New(t.TempDir())
-	defer m.Close()
-	rows := []domain.SignatureEmbedding{
-		row("approval:aaa", domain.SituationApproval, "claude", "permission: edit files", unit(1, 0, 0, 0)),
-		row("approval:bbb", domain.SituationApproval, "claude", "permission: run tests", unit(0, 1, 0, 0)),
-	}
-	if err := m.Rebuild(rows, 4); err != nil {
-		t.Fatal(err)
-	}
-
-	// Query near the first vector: cos ≈ 0.995 with aaa, ≈ 0.1 with bbb.
-	q := unit(1, 0.1, 0, 0)
-	hit, ok, err := m.MatchVector(context.Background(), q, Scope{domain.SituationApproval, "claude"}, nil)
-	if err != nil || !ok {
-		t.Fatalf("MatchVector: ok=%v err=%v", ok, err)
-	}
-	if hit.Signature != "approval:aaa" {
-		t.Errorf("nearest = %s, want approval:aaa", hit.Signature)
-	}
-	if hit.Salient != "permission: edit files" {
-		t.Errorf("hit salient = %q, want the stored salient (remap gate depends on it)", hit.Salient)
-	}
-	if hit.Score < 0.98 || hit.Score > 1.0 {
-		t.Errorf("score = %v, want ≈0.995 (raw cosine)", hit.Score)
-	}
-
-	// Exact self-match scores ≈ 1.0.
-	self, ok, err := m.MatchVector(context.Background(), unit(0, 1, 0, 0), Scope{domain.SituationApproval, "claude"}, nil)
-	if err != nil || !ok {
-		t.Fatalf("self match: ok=%v err=%v", ok, err)
-	}
-	if self.Signature != "approval:bbb" || self.Score < 0.999 {
-		t.Errorf("self match = %s score %v, want approval:bbb ≈1.0", self.Signature, self.Score)
-	}
-}
-
-func TestMatchVectorScopeFilter(t *testing.T) {
-	m := New(t.TempDir())
-	defer m.Close()
-	rows := []domain.SignatureEmbedding{
-		row("approval:claude1", domain.SituationApproval, "claude", "permission: edit", unit(1, 0, 0)),
-		row("approval:codex1", domain.SituationApproval, "codex", "permission: edit", unit(1, 0, 0)),
-		row("choice:claude1", domain.SituationChoice, "claude", "options:no;yes", unit(1, 0, 0)),
-	}
-	if err := m.Rebuild(rows, 3); err != nil {
-		t.Fatal(err)
-	}
-
-	hit, ok, err := m.MatchVector(context.Background(), unit(1, 0, 0), Scope{domain.SituationApproval, "codex"}, nil)
-	if err != nil || !ok {
-		t.Fatalf("scoped match: ok=%v err=%v", ok, err)
-	}
-	if hit.Signature != "approval:codex1" {
-		t.Errorf("scope leak: matched %s, want approval:codex1", hit.Signature)
-	}
-
-	// A scope with no members returns no hit, not an error.
-	_, ok, err = m.MatchVector(context.Background(), unit(1, 0, 0), Scope{domain.SituationError, "claude"}, nil)
-	if err != nil {
-		t.Fatalf("empty scope errored: %v", err)
-	}
-	if ok {
-		t.Error("empty scope should have no hit")
 	}
 }
 
@@ -133,37 +51,6 @@ func TestMatchTextBM25(t *testing.T) {
 	}
 }
 
-func TestMatchVectorAcceptFilterFallsThroughToRank2(t *testing.T) {
-	// The nearest neighbor can be vetoed by the caller (approval option
-	// gate); an acceptable candidate at rank 2 must still be returned rather
-	// than being shadowed by the rejected top hit.
-	m := New(t.TempDir())
-	defer m.Close()
-	rows := []domain.SignatureEmbedding{
-		row("approval:near", domain.SituationApproval, "claude", "permission:proceed | options:plan", unit(1, 0, 0, 0)),
-		row("approval:far", domain.SituationApproval, "claude", "permission:proceed | options:bash", unit(0.9, 0.436, 0, 0)),
-	}
-	if err := m.Rebuild(rows, 4); err != nil {
-		t.Fatal(err)
-	}
-
-	q := unit(1, 0.05, 0, 0) // nearest: approval:near
-	reject := func(h Hit) bool { return h.Signature != "approval:near" }
-	hit, ok, err := m.MatchVector(context.Background(), q, Scope{domain.SituationApproval, "claude"}, reject)
-	if err != nil || !ok {
-		t.Fatalf("MatchVector: ok=%v err=%v", ok, err)
-	}
-	if hit.Signature != "approval:far" {
-		t.Errorf("filtered match = %s, want the rank-2 candidate approval:far", hit.Signature)
-	}
-
-	// A filter rejecting everything yields no hit, not an error.
-	none := func(Hit) bool { return false }
-	if _, ok, err := m.MatchVector(context.Background(), q, Scope{domain.SituationApproval, "claude"}, none); err != nil || ok {
-		t.Errorf("all-rejecting filter: ok=%v err=%v, want no hit and no error", ok, err)
-	}
-}
-
 func TestMatchTextAcceptFilterFallsThroughToRank2(t *testing.T) {
 	m := New(t.TempDir())
 	defer m.Close()
@@ -189,39 +76,5 @@ func TestMatchTextAcceptFilterFallsThroughToRank2(t *testing.T) {
 	if _, ok, err := m.MatchText(context.Background(), "permission: edit files",
 		Scope{domain.SituationApproval, "claude"}, none); err != nil || ok {
 		t.Errorf("all-rejecting filter: ok=%v err=%v, want no hit and no error", ok, err)
-	}
-}
-
-func TestMatchVectorDimsMismatch(t *testing.T) {
-	m := New(t.TempDir())
-	defer m.Close()
-	if err := m.Rebuild([]domain.SignatureEmbedding{
-		row("idle:x", domain.SituationIdle, "claude", "todo list", unit(1, 0)),
-	}, 2); err != nil {
-		t.Fatal(err)
-	}
-	if _, _, err := m.MatchVector(context.Background(), unit(1, 0, 0), Scope{domain.SituationIdle, "claude"}, nil); err == nil {
-		t.Error("dims mismatch should error")
-	}
-}
-
-func TestAddAndDelete(t *testing.T) {
-	m := New(t.TempDir())
-	defer m.Close()
-	if err := m.Rebuild(nil, 3); err != nil {
-		t.Fatal(err)
-	}
-	if err := m.Add(row("error:sig", domain.SituationError, "claude", "error: build failed", unit(0, 0, 1))); err != nil {
-		t.Fatal(err)
-	}
-	hit, ok, err := m.MatchVector(context.Background(), unit(0, 0, 1), Scope{domain.SituationError, "claude"}, nil)
-	if err != nil || !ok || hit.Signature != "error:sig" {
-		t.Fatalf("added row not matchable: %+v ok=%v err=%v", hit, ok, err)
-	}
-	if err := m.Delete("error:sig"); err != nil {
-		t.Fatal(err)
-	}
-	if _, ok, _ := m.MatchVector(context.Background(), unit(0, 0, 1), Scope{domain.SituationError, "claude"}, nil); ok {
-		t.Error("deleted row still matches")
 	}
 }

--- a/internal/match/match_vectors_test.go
+++ b/internal/match/match_vectors_test.go
@@ -1,0 +1,198 @@
+//go:build vectors
+
+package match
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// unit returns an L2-normalized copy of v.
+func unit(v ...float32) []float32 {
+	var norm float64
+	for _, x := range v {
+		norm += float64(x) * float64(x)
+	}
+	n := float32(math.Sqrt(norm))
+	out := make([]float32, len(v))
+	for i, x := range v {
+		out[i] = x / n
+	}
+	return out
+}
+
+func TestMatchVectorRanksByCosine(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close()
+	rows := []domain.SignatureEmbedding{
+		row("approval:aaa", domain.SituationApproval, "claude", "permission: edit files", unit(1, 0, 0, 0)),
+		row("approval:bbb", domain.SituationApproval, "claude", "permission: run tests", unit(0, 1, 0, 0)),
+	}
+	if err := m.Rebuild(rows, 4); err != nil {
+		t.Fatal(err)
+	}
+
+	// Query near the first vector: cos ≈ 0.995 with aaa, ≈ 0.1 with bbb.
+	q := unit(1, 0.1, 0, 0)
+	hit, ok, err := m.MatchVector(context.Background(), q, Scope{domain.SituationApproval, "claude"}, nil)
+	if err != nil || !ok {
+		t.Fatalf("MatchVector: ok=%v err=%v", ok, err)
+	}
+	if hit.Signature != "approval:aaa" {
+		t.Errorf("nearest = %s, want approval:aaa", hit.Signature)
+	}
+	if hit.Salient != "permission: edit files" {
+		t.Errorf("hit salient = %q, want the stored salient (remap gate depends on it)", hit.Salient)
+	}
+	if hit.Score < 0.98 || hit.Score > 1.0 {
+		t.Errorf("score = %v, want ≈0.995 (raw cosine)", hit.Score)
+	}
+
+	// Exact self-match scores ≈ 1.0.
+	self, ok, err := m.MatchVector(context.Background(), unit(0, 1, 0, 0), Scope{domain.SituationApproval, "claude"}, nil)
+	if err != nil || !ok {
+		t.Fatalf("self match: ok=%v err=%v", ok, err)
+	}
+	if self.Signature != "approval:bbb" || self.Score < 0.999 {
+		t.Errorf("self match = %s score %v, want approval:bbb ≈1.0", self.Signature, self.Score)
+	}
+}
+
+func TestMatchVectorScopeFilter(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close()
+	rows := []domain.SignatureEmbedding{
+		row("approval:claude1", domain.SituationApproval, "claude", "permission: edit", unit(1, 0, 0)),
+		row("approval:codex1", domain.SituationApproval, "codex", "permission: edit", unit(1, 0, 0)),
+		row("choice:claude1", domain.SituationChoice, "claude", "options:no;yes", unit(1, 0, 0)),
+	}
+	if err := m.Rebuild(rows, 3); err != nil {
+		t.Fatal(err)
+	}
+
+	hit, ok, err := m.MatchVector(context.Background(), unit(1, 0, 0), Scope{domain.SituationApproval, "codex"}, nil)
+	if err != nil || !ok {
+		t.Fatalf("scoped match: ok=%v err=%v", ok, err)
+	}
+	if hit.Signature != "approval:codex1" {
+		t.Errorf("scope leak: matched %s, want approval:codex1", hit.Signature)
+	}
+
+	// A scope with no members returns no hit, not an error.
+	_, ok, err = m.MatchVector(context.Background(), unit(1, 0, 0), Scope{domain.SituationError, "claude"}, nil)
+	if err != nil {
+		t.Fatalf("empty scope errored: %v", err)
+	}
+	if ok {
+		t.Error("empty scope should have no hit")
+	}
+}
+
+// TestMatchVectorFilteredKNNExcludesNearerOutOfScope is the regression test for
+// KNN pre-filtering: the scope filter must constrain the candidate set BEFORE
+// the k nearest are selected, not merely re-rank afterwards. Here four
+// out-of-scope neighbors (more than matchK=3) sit closer to the query than the
+// single in-scope row, so an unfiltered top-k would be entirely out-of-scope
+// and MatchVector(claude) would find nothing — the far in-scope row would be
+// shadowed out of the top-k.
+// With AddKNNWithFilter the candidate set is pre-restricted to the claude scope,
+// keeping the in-scope row reachable. This fails loudly if the scope filter is
+// dropped or downgraded to a plain (unfiltered) AddKNN.
+func TestMatchVectorFilteredKNNExcludesNearerOutOfScope(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close()
+
+	// Four codex rows crowd the query; one claude row sits far away. With
+	// matchK == 3, an unfiltered nearest-k would be entirely codex.
+	rows := []domain.SignatureEmbedding{
+		row("approval:codex1", domain.SituationApproval, "codex", "permission: a", unit(1, 0.01, 0, 0)),
+		row("approval:codex2", domain.SituationApproval, "codex", "permission: b", unit(1, 0.02, 0, 0)),
+		row("approval:codex3", domain.SituationApproval, "codex", "permission: c", unit(1, 0.03, 0, 0)),
+		row("approval:codex4", domain.SituationApproval, "codex", "permission: d", unit(1, 0.04, 0, 0)),
+		row("approval:claude1", domain.SituationApproval, "claude", "permission: z", unit(0.6, 0.8, 0, 0)),
+	}
+	if err := m.Rebuild(rows, 4); err != nil {
+		t.Fatal(err)
+	}
+
+	// Query's nearest neighbors are all codex; the only claude row is far.
+	q := unit(1, 0, 0, 0)
+	hit, ok, err := m.MatchVector(context.Background(), q, Scope{domain.SituationApproval, "claude"}, nil)
+	if err != nil {
+		t.Fatalf("filtered KNN errored: %v", err)
+	}
+	if !ok {
+		t.Fatal("filtered KNN found no in-scope hit: the far claude row was shadowed — scope filter not applied at KNN time")
+	}
+	if hit.Signature != "approval:claude1" {
+		t.Errorf("filtered KNN matched %s, want approval:claude1 (an out-of-scope neighbor leaked past the filter)", hit.Signature)
+	}
+}
+
+func TestMatchVectorAcceptFilterFallsThroughToRank2(t *testing.T) {
+	// The nearest neighbor can be vetoed by the caller (approval option
+	// gate); an acceptable candidate at rank 2 must still be returned rather
+	// than being shadowed by the rejected top hit.
+	m := New(t.TempDir())
+	defer m.Close()
+	rows := []domain.SignatureEmbedding{
+		row("approval:near", domain.SituationApproval, "claude", "permission:proceed | options:plan", unit(1, 0, 0, 0)),
+		row("approval:far", domain.SituationApproval, "claude", "permission:proceed | options:bash", unit(0.9, 0.436, 0, 0)),
+	}
+	if err := m.Rebuild(rows, 4); err != nil {
+		t.Fatal(err)
+	}
+
+	q := unit(1, 0.05, 0, 0) // nearest: approval:near
+	reject := func(h Hit) bool { return h.Signature != "approval:near" }
+	hit, ok, err := m.MatchVector(context.Background(), q, Scope{domain.SituationApproval, "claude"}, reject)
+	if err != nil || !ok {
+		t.Fatalf("MatchVector: ok=%v err=%v", ok, err)
+	}
+	if hit.Signature != "approval:far" {
+		t.Errorf("filtered match = %s, want the rank-2 candidate approval:far", hit.Signature)
+	}
+
+	// A filter rejecting everything yields no hit, not an error.
+	none := func(Hit) bool { return false }
+	if _, ok, err := m.MatchVector(context.Background(), q, Scope{domain.SituationApproval, "claude"}, none); err != nil || ok {
+		t.Errorf("all-rejecting filter: ok=%v err=%v, want no hit and no error", ok, err)
+	}
+}
+
+func TestMatchVectorDimsMismatch(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close()
+	if err := m.Rebuild([]domain.SignatureEmbedding{
+		row("idle:x", domain.SituationIdle, "claude", "todo list", unit(1, 0)),
+	}, 2); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := m.MatchVector(context.Background(), unit(1, 0, 0), Scope{domain.SituationIdle, "claude"}, nil); err == nil {
+		t.Error("dims mismatch should error")
+	}
+}
+
+func TestAddAndDelete(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close()
+	if err := m.Rebuild(nil, 3); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Add(row("error:sig", domain.SituationError, "claude", "error: build failed", unit(0, 0, 1))); err != nil {
+		t.Fatal(err)
+	}
+	hit, ok, err := m.MatchVector(context.Background(), unit(0, 0, 1), Scope{domain.SituationError, "claude"}, nil)
+	if err != nil || !ok || hit.Signature != "error:sig" {
+		t.Fatalf("added row not matchable: %+v ok=%v err=%v", hit, ok, err)
+	}
+	if err := m.Delete("error:sig"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := m.MatchVector(context.Background(), unit(0, 0, 1), Scope{domain.SituationError, "claude"}, nil); ok {
+		t.Error("deleted row still matches")
+	}
+}


### PR DESCRIPTION
## Problem

`internal/match/match.go` called bleve v2.6.0's `SearchRequest.AddKNNWithFilter` unconditionally, but bleve defines that method **only** under its `//go:build vectors` constraint (`search_knn.go`; the `!vectors` build gets `search_no_knn.go`). So the `match` package — and therefore any tag-free `go build ./...` / `go vet` — failed to compile without the `vectors` tag:

```
internal/match/match.go:219:6: req.AddKNNWithFilter undefined
    (type *bleve.SearchRequest has no field or method AddKNNWithFilter)
```

This is the only symbol that broke the tag-free build; the rest of the tree already compiles without `vectors`.

## Fix

Split the KNN search call into build-tagged helpers, mirroring bleve's own `search_knn.go` / `search_no_knn.go` pattern:

- **`knn_vectors.go`** (`//go:build vectors`) — runs the real `AddKNNWithFilter` KNN query.
- **`knn_novectors.go`** (`//go:build !vectors`) — stub returning "vector matching unavailable", so callers fall back to BM25 text matching.

`MatchVector` short-circuits with a clear *"built without the vectors tag"* error when `vectorSearchSupported` is false.

The daemon's `resolveSignature` now clears `vec` on **any** `MatchVector` error so the `vec == nil` BM25 fallback actually runs — previously the *"trying text match"* log was empty and resolution silently dropped to hash-only.

## Tests

- Vector cases moved behind `//go:build vectors`; text/BM25 cases stay untagged so they run in **both** configs (validating the BM25 fallback path independently).
- Adds **`TestMatchVectorFilteredKNNExcludesNearerOutOfScope`** — a regression test that crowds the query with four out-of-scope neighbors (more than `matchK=3`) and one far in-scope row, so a dropped or unfiltered KNN filter fails loudly.

Verified:
- `go build ./...` and `go vet ./internal/match/` now pass **without** the `vectors` tag.
- `go build -tags "vectors cpu" ./...` passes.
- `go test -tags "vectors cpu" ./internal/match/ ./internal/daemon/` — 124 tests pass (8 match + 116 daemon).
- `go test ./internal/match/` (no tags) — BM25 tests pass; vector tests correctly gated out.

https://claude.ai/code/session_01FKbYWbyEGhsT8iGnbyBJgr