### PR TITLE
#1 fix: build the embedder without the cpu tag so go test needs no Vulkan libs

### DIFF
--- a/internal/embedder/client_cpu_test.go
+++ b/internal/embedder/client_cpu_test.go
@@ -1,0 +1,84 @@
+//go:build cpu
+
+package embedder
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+)
+
+// TestClientRealModel exercises the full subprocess path with the real gguf:
+// the framing, spawn, model load, and embed all work end to end, and the warm
+// worker is reused across calls. Skips when the model is absent. Needs the CGO
+// engine, so it lives in the `cpu` build (testModelPath is shared from
+// engine_cpu_test.go).
+func TestClientRealModel(t *testing.T) {
+	c := NewReexecClient(config.Embedding{ModelPath: testModelPath(t)})
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	v1, err := c.EmbedText(ctx, "permission: edit the configuration file")
+	if err != nil {
+		t.Fatalf("embed via worker: %v", err)
+	}
+	if len(v1) != 384 {
+		t.Errorf("dims = %d, want 384 (MiniLM-L6)", len(v1))
+	}
+	if c.Dims() != len(v1) {
+		t.Errorf("Dims() = %d, want %d", c.Dims(), len(v1))
+	}
+	var norm float64
+	for _, x := range v1 {
+		norm += float64(x) * float64(x)
+	}
+	if math.Abs(norm-1.0) > 1e-3 {
+		t.Errorf("norm² = %v, want 1.0 (worker must return a normalized vector)", norm)
+	}
+
+	// Second call reuses the warm worker (no reload) and is deterministic.
+	v2, err := c.EmbedText(ctx, "permission: edit the configuration file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dot float64
+	for i := range v1 {
+		dot += float64(v1[i]) * float64(v2[i])
+	}
+	if dot < 0.999 {
+		t.Errorf("self-similarity across warm-worker calls = %v, want ≈1.0", dot)
+	}
+}
+
+// TestClientRecoversAfterWorkerCrash proves per-call recovery: with the worker
+// set to crash on its SECOND request, the first embed succeeds, the second
+// surfaces an error (not a process death), and the third succeeds again on a
+// freshly respawned worker — a single bad embed no longer latches the whole
+// process to BM25. Needs the real model (the first embed must load it).
+func TestClientRecoversAfterWorkerCrash(t *testing.T) {
+	c := NewReexecClient(config.Embedding{ModelPath: testModelPath(t)}, EnvWorkerCrash+"=2")
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	if _, err := c.EmbedText(ctx, "first"); err != nil {
+		t.Fatalf("first embed should succeed: %v", err)
+	}
+	if _, err := c.EmbedText(ctx, "second"); err == nil {
+		t.Fatal("second embed should error (worker crashes on its 2nd request)")
+	}
+	if c.Degraded() {
+		t.Fatal("one crash must not latch degraded")
+	}
+	// A fresh worker was spawned; it crashes only on ITS second request, so the
+	// next call succeeds.
+	if _, err := c.EmbedText(ctx, "third"); err != nil {
+		t.Fatalf("third embed should succeed on a respawned worker: %v", err)
+	}
+}

--- a/internal/embedder/client_test.go
+++ b/internal/embedder/client_test.go
@@ -4,17 +4,17 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"math"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 )
 
 // TestMain lets a Client under test spawn the embed worker by re-execing this
-// test binary (see NewReexecClient / RunWorkerHelperIfChild).
+// test binary (see NewReexecClient / RunWorkerHelperIfChild). It runs in both
+// the CGO (`cpu`) and stub (`!cpu`) builds; the worker uses whichever engine
+// this build linked.
 func TestMain(m *testing.M) {
 	RunWorkerHelperIfChild() // returns immediately in a normal test run
 	os.Exit(m.Run())
@@ -70,7 +70,9 @@ func TestProtocolRoundTrip(t *testing.T) {
 // child before it responds) surfaces as a Go ERROR on the parent — never a
 // panic or a parent death — and after maxConsecutiveFailures the Client latches
 // ErrDegraded, i.e. semantic matching degrades to BM25 while the daemon stays
-// up. Needs no model: the worker exits before loading one.
+// up. Needs no model AND no CGO engine: the worker exits before loading one, so
+// this runs in the tag-free (stub) build too, covering the Client supervision
+// path there.
 func TestClientWorkerCrashDegrades(t *testing.T) {
 	c := NewReexecClient(
 		config.Embedding{ModelPath: filepath.Join(t.TempDir(), "unused.gguf")},
@@ -118,75 +120,5 @@ func TestClientContextCancelNotCounted(t *testing.T) {
 	}
 	if c.Degraded() {
 		t.Error("a cancelled call must not count as an embedder fault")
-	}
-}
-
-// TestClientRealModel exercises the full subprocess path with the real gguf:
-// the framing, spawn, model load, and embed all work end to end, and the warm
-// worker is reused across calls. Skips when the model is absent.
-func TestClientRealModel(t *testing.T) {
-	c := NewReexecClient(config.Embedding{ModelPath: testModelPath(t)})
-	defer c.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	v1, err := c.EmbedText(ctx, "permission: edit the configuration file")
-	if err != nil {
-		t.Fatalf("embed via worker: %v", err)
-	}
-	if len(v1) != 384 {
-		t.Errorf("dims = %d, want 384 (MiniLM-L6)", len(v1))
-	}
-	if c.Dims() != len(v1) {
-		t.Errorf("Dims() = %d, want %d", c.Dims(), len(v1))
-	}
-	var norm float64
-	for _, x := range v1 {
-		norm += float64(x) * float64(x)
-	}
-	if math.Abs(norm-1.0) > 1e-3 {
-		t.Errorf("norm² = %v, want 1.0 (worker must return a normalized vector)", norm)
-	}
-
-	// Second call reuses the warm worker (no reload) and is deterministic.
-	v2, err := c.EmbedText(ctx, "permission: edit the configuration file")
-	if err != nil {
-		t.Fatal(err)
-	}
-	var dot float64
-	for i := range v1 {
-		dot += float64(v1[i]) * float64(v2[i])
-	}
-	if dot < 0.999 {
-		t.Errorf("self-similarity across warm-worker calls = %v, want ≈1.0", dot)
-	}
-}
-
-// TestClientRecoversAfterWorkerCrash proves per-call recovery: with the worker
-// set to crash on its SECOND request, the first embed succeeds, the second
-// surfaces an error (not a process death), and the third succeeds again on a
-// freshly respawned worker — a single bad embed no longer latches the whole
-// process to BM25. Needs the real model (the first embed must load it).
-func TestClientRecoversAfterWorkerCrash(t *testing.T) {
-	c := NewReexecClient(config.Embedding{ModelPath: testModelPath(t)}, EnvWorkerCrash+"=2")
-	defer c.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	if _, err := c.EmbedText(ctx, "first"); err != nil {
-		t.Fatalf("first embed should succeed: %v", err)
-	}
-	if _, err := c.EmbedText(ctx, "second"); err == nil {
-		t.Fatal("second embed should error (worker crashes on its 2nd request)")
-	}
-	if c.Degraded() {
-		t.Fatal("one crash must not latch degraded")
-	}
-	// A fresh worker was spawned; it crashes only on ITS second request, so the
-	// next call succeeds.
-	if _, err := c.EmbedText(ctx, "third"); err != nil {
-		t.Fatalf("third embed should succeed on a respawned worker: %v", err)
 	}
 }

--- a/internal/embedder/embedder.go
+++ b/internal/embedder/embedder.go
@@ -3,20 +3,23 @@
 // Every failure mode returns an error — model missing, load failure, a hung
 // native call — so the daemon can degrade to BM25/exact matching instead of
 // crashing or stalling its select loop (fail-safe rule).
+//
+// The CGO engine that actually links llama.cpp lives in a build-tagged file so
+// the rest of the tree stays buildable on hosts without the native libraries:
+//   - engine_cpu.go   (//go:build cpu)  — the real llama-go engine.
+//   - engine_stub.go  (//go:build !cpu) — a no-CGO stub reporting unavailable.
+//
+// Real builds always pass `cpu` (the same tag that selects llama.cpp's CPU
+// GGML backend, so no GPU/Vulkan libraries are ever linked); a tag-free build
+// (e.g. a plain `go test ./...` on a CPU-only box) compiles the stub and needs
+// no native libraries at all. This file holds the pieces both engines share.
 package embedder
 
 import (
-	"context"
 	"fmt"
-	"log/slog"
-	"math"
 	"os"
 	"path/filepath"
-	"sync"
-	"sync/atomic"
 	"time"
-
-	llama "github.com/tcpipuk/llama-go"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 )
@@ -45,12 +48,6 @@ const maxConsecutiveFailures = 3
 // Overridable per model via config Embedding.ModelContextWindow.
 const DefaultContextWindow = 512
 
-// specialTokenHeadroom is reserved out of the context window for the special
-// tokens the model adds ([CLS]/[SEP], plus a small margin) so the assembled
-// sequence stays strictly under the limit even if Tokenize and the internal
-// GetEmbeddings tokenizer disagree by a token or two.
-const specialTokenHeadroom = 8
-
 // minContextWindow floors any positive ModelContextWindow override. A window
 // small enough that the budget can't even hold the special tokens (e.g. 1 or
 // 2) makes every input — including the empty string, which still tokenizes to
@@ -59,50 +56,16 @@ const specialTokenHeadroom = 8
 // misconfiguration; clamp up to it rather than trust it.
 const minContextWindow = 256
 
-// truncateIters bounds the proportional-cut retry loop so a pathological
-// text→token ratio can never spin; each pass overshoots the cut, so it
-// converges in one or two iterations in practice.
-const truncateIters = 8
+// specialTokenHeadroom is reserved out of the context window for the special
+// tokens the model adds ([CLS]/[SEP], plus a small margin) so the assembled
+// sequence stays strictly under the limit even if Tokenize and the internal
+// GetEmbeddings tokenizer disagree by a token or two. Consumed by the CGO
+// engine's truncateToBudget (engine_cpu.go); kept here so the tag-free build
+// and its tests can still reference the boundary.
+const specialTokenHeadroom = 8
 
 // ErrDegraded is returned once the failure latch has tripped.
 var ErrDegraded = fmt.Errorf("embedder degraded after %d consecutive failures", maxConsecutiveFailures)
-
-// Llama is the production EmbedderPort implementation.
-type Llama struct {
-	modelPath string
-	gpuLayers int
-	ctxWindow int // model position-embedding limit (n_ctx); see DefaultContextWindow
-
-	initOnce sync.Once
-	initErr  error
-	model    *llama.Model
-	lctx     *llama.Context
-
-	mu       sync.Mutex // serializes native embed calls; guards model/lctx
-	dims     atomic.Int32
-	warmed   atomic.Bool // first successful embed done (model loaded)
-	failures atomic.Int32
-	degraded atomic.Bool
-	closed   atomic.Bool
-}
-
-// NewEngine builds the in-process, CGO-backed embedder from config. An empty
-// ModelPath resolves to the bundled model under the plugin root
-// (<root>/models/...).
-//
-// This is the engine that actually links llama.cpp. In production it runs
-// inside the `hap embed-worker` child process (see RunWorker), never in the
-// daemon itself: a native abort in llama.cpp (GGML_ASSERT → SIGABRT) is
-// uncatchable from Go and would take the whole process down, so the daemon
-// drives it out-of-process through Client instead (see New). Direct callers
-// are the worker and the engine's own tests.
-func NewEngine(cfg config.Embedding) *Llama {
-	return &Llama{
-		modelPath: ResolveModelPath(cfg),
-		gpuLayers: cfg.GPULayers,
-		ctxWindow: ResolveContextWindow(cfg),
-	}
-}
 
 // ResolveContextWindow returns the effective embedding context window: the
 // bundled model's default when unset/non-positive, otherwise the override
@@ -142,195 +105,4 @@ func PluginRoot() string {
 		exe = resolved
 	}
 	return filepath.Dir(filepath.Dir(exe))
-}
-
-// init loads the model and an embeddings context once.
-func (l *Llama) init() {
-	if _, err := os.Stat(l.modelPath); err != nil {
-		l.initErr = fmt.Errorf("embedding model unavailable: %w", err)
-		return
-	}
-	model, err := llama.LoadModel(l.modelPath, llama.WithGPULayers(l.gpuLayers))
-	if err != nil {
-		l.initErr = fmt.Errorf("load embedding model %s: %w", l.modelPath, err)
-		return
-	}
-	// WithContext caps the KV/positional window at the model's limit — defense
-	// in depth alongside truncateToBudget; the truncation is what actually
-	// prevents the >n_ctx position-embedding overflow (#82).
-	lctx, err := model.NewContext(llama.WithEmbeddings(), llama.WithContext(l.ctxWindow))
-	if err != nil {
-		model.Close()
-		l.initErr = fmt.Errorf("create embedding context: %w", err)
-		return
-	}
-	l.model, l.lctx = model, lctx
-}
-
-// EmbedText returns the L2-normalized embedding of text. The first call
-// loads the model (generous timeout); later calls are guarded by a short
-// stall timeout. Consecutive failures latch degraded mode.
-func (l *Llama) EmbedText(ctx context.Context, text string) ([]float32, error) {
-	if l.closed.Load() {
-		return nil, fmt.Errorf("embedder closed")
-	}
-	if l.degraded.Load() {
-		return nil, ErrDegraded
-	}
-
-	timeout := embedTimeout
-	if !l.warmed.Load() { // model load still pending: allow the warm budget
-		timeout = warmTimeout
-	}
-
-	type result struct {
-		vec []float32
-		err error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		l.mu.Lock()
-		defer l.mu.Unlock()
-		if l.closed.Load() { // Close won the mutex while we queued
-			ch <- result{nil, fmt.Errorf("embedder closed")}
-			return
-		}
-		l.initOnce.Do(l.init)
-		if l.initErr != nil {
-			ch <- result{nil, l.initErr}
-			return
-		}
-		vec, err := l.lctx.GetEmbeddings(l.truncateToBudget(text))
-		ch <- result{vec, err}
-	}()
-
-	select {
-	case <-ctx.Done():
-		// The caller gave up (shutdown, deadline); the embedder itself is
-		// not at fault, so this must not push toward the degraded latch.
-		return nil, ctx.Err()
-	case <-time.After(timeout):
-		l.recordFailure()
-		return nil, fmt.Errorf("embed call exceeded %s stall guard", timeout)
-	case r := <-ch:
-		if r.err != nil {
-			l.recordFailure()
-			return nil, r.err
-		}
-		l.failures.Store(0)
-		normalize(r.vec)
-		l.dims.Store(int32(len(r.vec)))
-		l.warmed.Store(true)
-		return r.vec, nil
-	}
-}
-
-// truncateToBudget shortens text so its tokenization stays within tokenBudget,
-// guaranteeing the sequence GetEmbeddings assembles never exceeds the model's
-// position-embedding limit (which would SIGABRT the native library, #82). It
-// must be called with l.mu held and after init (l.lctx valid).
-//
-// GetEmbeddings tokenizes internally and takes text, not tokens, so the cut is
-// made on the text: tokenize to measure, and if over budget, keep a prefix
-// sized by the current token→rune ratio (overshooting downward), then re-check.
-// The salient content is front-loaded, so a prefix is the right thing to keep.
-// A Tokenize error is non-fatal — fall through to GetEmbeddings, which will
-// surface its own error (degrading, never aborting the daemon).
-func (l *Llama) truncateToBudget(text string) string {
-	budget := l.ctxWindow - specialTokenHeadroom
-	if budget < 1 {
-		budget = 1
-	}
-	toks, err := l.lctx.Tokenize(text)
-	if err != nil || len(toks) <= budget {
-		return text
-	}
-	runes := []rune(text)
-	for i := 0; i < truncateIters && len(toks) > budget; i++ {
-		if len(runes) <= 1 {
-			break // nothing left to trim
-		}
-		// Overshoot by 5% under the proportional target so a sub-linear
-		// token→rune relationship still converges downward each pass.
-		keep := int(float64(len(runes)) * float64(budget) / float64(len(toks)) * 0.95)
-		if keep < 1 {
-			keep = 1
-		}
-		if keep >= len(runes) { // ratio made no progress: force a real cut
-			keep = len(runes) / 2
-		}
-		runes = runes[:keep]
-		toks, err = l.lctx.Tokenize(string(runes))
-		if err != nil {
-			break
-		}
-	}
-	// Guarantee the invariant the whole function exists for: the returned text
-	// must tokenize within budget, or GetEmbeddings SIGABRTs the worker (#82).
-	// The proportional loop can exit still-over-budget — bounded iterations, a
-	// Tokenize error, or an override window set above the model's real limit —
-	// so hard-halve the prefix until it fits. Halving reaches 1 rune, so this
-	// always terminates; a Tokenize error leaves toks stale and stops the loop
-	// (the embed then surfaces its own error and degrades, never aborts).
-	for err == nil && len(toks) > budget && len(runes) > 1 {
-		runes = runes[:len(runes)/2]
-		toks, err = l.lctx.Tokenize(string(runes))
-	}
-	return string(runes)
-}
-
-func (l *Llama) recordFailure() {
-	if l.failures.Add(1) >= maxConsecutiveFailures && !l.degraded.Swap(true) {
-		slog.Warn("embedder degraded; semantic matching falls back to text search",
-			"model", l.modelPath, "consecutive_failures", maxConsecutiveFailures)
-	}
-}
-
-// ModelID identifies the loaded model for persistence scoping.
-func (l *Llama) ModelID() string { return filepath.Base(l.modelPath) }
-
-// Dims is the embedding dimensionality (0 before the first success).
-func (l *Llama) Dims() int { return int(l.dims.Load()) }
-
-// Degraded reports whether the failure latch has tripped (embed calls now
-// short-circuit to text matching). Exposed for the daemon's health heartbeat;
-// callers type-assert this optional accessor rather than widening EmbedderPort.
-func (l *Llama) Degraded() bool { return l.degraded.Load() }
-
-// Close releases the model. It must never block the caller (the daemon
-// select loop calls it on reload/shutdown), so when a native embed call is
-// in flight — possibly hung, which is why the stall guard exists — the
-// model is leaked instead of freed underneath the running call.
-func (l *Llama) Close() error {
-	if l.closed.Swap(true) {
-		return nil
-	}
-	if !l.mu.TryLock() {
-		return nil // in-flight native call owns the model; leak, don't block
-	}
-	defer l.mu.Unlock()
-	if l.lctx != nil {
-		l.lctx.Close()
-		l.lctx = nil
-	}
-	if l.model != nil {
-		l.model.Close()
-		l.model = nil
-	}
-	return nil
-}
-
-// normalize L2-normalizes v in place (no-op for a zero vector).
-func normalize(v []float32) {
-	var norm float64
-	for _, x := range v {
-		norm += float64(x) * float64(x)
-	}
-	if norm == 0 {
-		return
-	}
-	inv := float32(1 / math.Sqrt(norm))
-	for i := range v {
-		v[i] *= inv
-	}
 }

--- a/internal/embedder/embedder_test.go
+++ b/internal/embedder/embedder_test.go
@@ -1,155 +1,16 @@
 package embedder
 
 import (
-	"context"
-	"math"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 )
 
-// testModelPath resolves the real gguf for integration-style tests:
-// HAP_TEST_EMBED_MODEL, then <repo>/models/<default>. Tests skip when absent
-// so `go test ./...` stays green on machines without the model.
-func testModelPath(t *testing.T) string {
-	t.Helper()
-	if p := os.Getenv("HAP_TEST_EMBED_MODEL"); p != "" {
-		return p
-	}
-	p := filepath.Join("..", "..", "models", DefaultModelFile)
-	if _, err := os.Stat(p); err != nil {
-		t.Skipf("embedding model not present (%s); set HAP_TEST_EMBED_MODEL to run", p)
-	}
-	return p
-}
-
-func cosine(a, b []float32) float64 {
-	var dot float64
-	for i := range a {
-		dot += float64(a[i]) * float64(b[i])
-	}
-	return dot // inputs are L2-normalized
-}
-
-func TestEmbedTextRealModel(t *testing.T) {
-	l := NewEngine(config.Embedding{ModelPath: testModelPath(t)})
-	defer l.Close()
-	ctx := context.Background()
-
-	v1, err := l.EmbedText(ctx, "permission: edit the configuration file")
-	if err != nil {
-		t.Fatalf("embed: %v", err)
-	}
-	if len(v1) != 384 {
-		t.Errorf("dims = %d, want 384 (MiniLM-L6)", len(v1))
-	}
-	if l.Dims() != len(v1) {
-		t.Errorf("Dims() = %d, want %d", l.Dims(), len(v1))
-	}
-
-	// Output is L2-normalized.
-	var norm float64
-	for _, x := range v1 {
-		norm += float64(x) * float64(x)
-	}
-	if math.Abs(norm-1.0) > 1e-3 {
-		t.Errorf("norm² = %v, want 1.0", norm)
-	}
-
-	// Determinism / self-similarity.
-	again, err := l.EmbedText(ctx, "permission: edit the configuration file")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if self := cosine(v1, again); self < 0.999 {
-		t.Errorf("self-similarity = %v, want ≈1.0", self)
-	}
-
-	// A paraphrase lands closer than an unrelated prompt.
-	para, err := l.EmbedText(ctx, "permission: modify the config file")
-	if err != nil {
-		t.Fatal(err)
-	}
-	other, err := l.EmbedText(ctx, "error: connection to database refused")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cosine(v1, para) <= cosine(v1, other) {
-		t.Errorf("paraphrase similarity %v should exceed unrelated %v",
-			cosine(v1, para), cosine(v1, other))
-	}
-	t.Logf("paraphrase cos=%.3f unrelated cos=%.3f", cosine(v1, para), cosine(v1, other))
-}
-
-// TestEmbedLongInputNoCrash guards #82: a sequence longer than the model's
-// 512 position embeddings must be truncated, not fed whole — an untruncated
-// long input overflows the position-embedding get_rows and hard-aborts the
-// native library (SIGABRT), which would take the whole process down. The
-// embed must instead succeed on the truncated prefix and return a valid
-// vector. 700 space-delimited words tokenize well past 512.
-func TestEmbedLongInputNoCrash(t *testing.T) {
-	l := NewEngine(config.Embedding{ModelPath: testModelPath(t)})
-	defer l.Close()
-	ctx := context.Background()
-
-	long := strings.Repeat("word ", 700)
-	// Pre-truncation this aborts the process; post-fix it returns a vector.
-	v, err := l.EmbedText(ctx, long)
-	if err != nil {
-		t.Fatalf("long input should embed after truncation, got error: %v", err)
-	}
-	if len(v) != 384 {
-		t.Errorf("dims = %d, want 384", len(v))
-	}
-
-	// The truncated text alone must tokenize within budget — proves the guard
-	// actually bounded the sequence rather than the embed getting lucky.
-	l.initOnce.Do(l.init)
-	if l.initErr != nil {
-		t.Fatalf("init: %v", l.initErr)
-	}
-	safe := l.truncateToBudget(long)
-	toks, err := l.lctx.Tokenize(safe)
-	if err != nil {
-		t.Fatalf("tokenize truncated: %v", err)
-	}
-	budget := DefaultContextWindow - specialTokenHeadroom
-	if len(toks) > budget {
-		t.Errorf("truncated to %d tokens, want <= %d", len(toks), budget)
-	}
-
-	// A short input is returned unchanged (no needless truncation).
-	short := "permission: edit the config file"
-	if got := l.truncateToBudget(short); got != short {
-		t.Errorf("short input was altered: %q", got)
-	}
-
-	// A pathologically small context window override is floored to
-	// minContextWindow (a window below it can't hold the special tokens and
-	// would SIGABRT). The engine must use the floor, not the raw value, and
-	// still embed the long input on the truncated prefix.
-	tiny := NewEngine(config.Embedding{ModelPath: testModelPath(t), ModelContextWindow: 1})
-	defer tiny.Close()
-	if tiny.ctxWindow != minContextWindow {
-		t.Errorf("ctxWindow = %d, want floored to %d", tiny.ctxWindow, minContextWindow)
-	}
-	tv, err := tiny.EmbedText(ctx, long)
-	if err != nil {
-		t.Fatalf("floored-window embed should succeed on the truncated prefix, got: %v", err)
-	}
-	if len(tv) != 384 {
-		t.Errorf("floored-window dims = %d, want 384", len(tv))
-	}
-}
-
 // TestResolveContextWindowFloor covers the override boundaries — 0/negative
 // fall to the default, and any positive value below the safe minimum (at or
 // below the special-token headroom included) is clamped up so the budget can
-// never go sub-headroom (#82, PR review).
+// never go sub-headroom (#82, PR review). It is engine-independent, so it runs
+// in both the CGO (`cpu`) and stub (`!cpu`) builds.
 func TestResolveContextWindowFloor(t *testing.T) {
 	cases := []struct{ in, want int }{
 		{0, DefaultContextWindow},
@@ -165,33 +26,5 @@ func TestResolveContextWindowFloor(t *testing.T) {
 		if got := ResolveContextWindow(config.Embedding{ModelContextWindow: c.in}); got != c.want {
 			t.Errorf("ResolveContextWindow(%d) = %d, want %d", c.in, got, c.want)
 		}
-	}
-}
-
-func TestEmbedMissingModelDegrades(t *testing.T) {
-	l := NewEngine(config.Embedding{ModelPath: filepath.Join(t.TempDir(), "missing.gguf")})
-	defer l.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	for i := 0; i < maxConsecutiveFailures; i++ {
-		if _, err := l.EmbedText(ctx, "anything"); err == nil {
-			t.Fatal("missing model should error")
-		}
-	}
-	// Latch tripped: fails fast with ErrDegraded.
-	if _, err := l.EmbedText(ctx, "anything"); err != ErrDegraded {
-		t.Errorf("after %d failures err = %v, want ErrDegraded", maxConsecutiveFailures, err)
-	}
-}
-
-func TestModelIDIsBasename(t *testing.T) {
-	l := NewEngine(config.Embedding{ModelPath: "/x/y/custom-model.gguf"})
-	if l.ModelID() != "custom-model.gguf" {
-		t.Errorf("ModelID = %q", l.ModelID())
-	}
-	def := NewEngine(config.Embedding{})
-	if def.ModelID() != DefaultModelFile {
-		t.Errorf("default ModelID = %q, want %q", def.ModelID(), DefaultModelFile)
 	}
 }

--- a/internal/embedder/engine_cpu.go
+++ b/internal/embedder/engine_cpu.go
@@ -1,0 +1,259 @@
+//go:build cpu
+
+// engine_cpu.go is the real, CGO-backed embedding engine: it links llama.cpp
+// through the llama-go bindings. It is gated on the `cpu` build tag — the same
+// tag every production/CI build already passes (see CLAUDE.md: "vectors cpu
+// always"), which also selects llama.cpp's CPU GGML backend so no GPU/Vulkan
+// libraries are linked. A tag-free build gets engine_stub.go instead and needs
+// no native libraries. Adding `cpu` is therefore the single switch that turns
+// the native engine on; nothing else in the tree changes.
+package embedder
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	llama "github.com/tcpipuk/llama-go"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+)
+
+// truncateIters bounds the proportional-cut retry loop so a pathological
+// text→token ratio can never spin; each pass overshoots the cut, so it
+// converges in one or two iterations in practice.
+const truncateIters = 8
+
+// Llama is the production EmbedderPort implementation.
+type Llama struct {
+	modelPath string
+	gpuLayers int
+	ctxWindow int // model position-embedding limit (n_ctx); see DefaultContextWindow
+
+	initOnce sync.Once
+	initErr  error
+	model    *llama.Model
+	lctx     *llama.Context
+
+	mu       sync.Mutex // serializes native embed calls; guards model/lctx
+	dims     atomic.Int32
+	warmed   atomic.Bool // first successful embed done (model loaded)
+	failures atomic.Int32
+	degraded atomic.Bool
+	closed   atomic.Bool
+}
+
+// NewEngine builds the in-process, CGO-backed embedder from config. An empty
+// ModelPath resolves to the bundled model under the plugin root
+// (<root>/models/...).
+//
+// This is the engine that actually links llama.cpp. In production it runs
+// inside the `hap embed-worker` child process (see RunWorker), never in the
+// daemon itself: a native abort in llama.cpp (GGML_ASSERT → SIGABRT) is
+// uncatchable from Go and would take the whole process down, so the daemon
+// drives it out-of-process through Client instead (see New). Direct callers
+// are the worker and the engine's own tests.
+func NewEngine(cfg config.Embedding) *Llama {
+	return &Llama{
+		modelPath: ResolveModelPath(cfg),
+		gpuLayers: cfg.GPULayers,
+		ctxWindow: ResolveContextWindow(cfg),
+	}
+}
+
+// init loads the model and an embeddings context once.
+func (l *Llama) init() {
+	if _, err := os.Stat(l.modelPath); err != nil {
+		l.initErr = fmt.Errorf("embedding model unavailable: %w", err)
+		return
+	}
+	model, err := llama.LoadModel(l.modelPath, llama.WithGPULayers(l.gpuLayers))
+	if err != nil {
+		l.initErr = fmt.Errorf("load embedding model %s: %w", l.modelPath, err)
+		return
+	}
+	// WithContext caps the KV/positional window at the model's limit — defense
+	// in depth alongside truncateToBudget; the truncation is what actually
+	// prevents the >n_ctx position-embedding overflow (#82).
+	lctx, err := model.NewContext(llama.WithEmbeddings(), llama.WithContext(l.ctxWindow))
+	if err != nil {
+		model.Close()
+		l.initErr = fmt.Errorf("create embedding context: %w", err)
+		return
+	}
+	l.model, l.lctx = model, lctx
+}
+
+// EmbedText returns the L2-normalized embedding of text. The first call
+// loads the model (generous timeout); later calls are guarded by a short
+// stall timeout. Consecutive failures latch degraded mode.
+func (l *Llama) EmbedText(ctx context.Context, text string) ([]float32, error) {
+	if l.closed.Load() {
+		return nil, fmt.Errorf("embedder closed")
+	}
+	if l.degraded.Load() {
+		return nil, ErrDegraded
+	}
+
+	timeout := embedTimeout
+	if !l.warmed.Load() { // model load still pending: allow the warm budget
+		timeout = warmTimeout
+	}
+
+	type result struct {
+		vec []float32
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		if l.closed.Load() { // Close won the mutex while we queued
+			ch <- result{nil, fmt.Errorf("embedder closed")}
+			return
+		}
+		l.initOnce.Do(l.init)
+		if l.initErr != nil {
+			ch <- result{nil, l.initErr}
+			return
+		}
+		vec, err := l.lctx.GetEmbeddings(l.truncateToBudget(text))
+		ch <- result{vec, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		// The caller gave up (shutdown, deadline); the embedder itself is
+		// not at fault, so this must not push toward the degraded latch.
+		return nil, ctx.Err()
+	case <-time.After(timeout):
+		l.recordFailure()
+		return nil, fmt.Errorf("embed call exceeded %s stall guard", timeout)
+	case r := <-ch:
+		if r.err != nil {
+			l.recordFailure()
+			return nil, r.err
+		}
+		l.failures.Store(0)
+		normalize(r.vec)
+		l.dims.Store(int32(len(r.vec)))
+		l.warmed.Store(true)
+		return r.vec, nil
+	}
+}
+
+// truncateToBudget shortens text so its tokenization stays within tokenBudget,
+// guaranteeing the sequence GetEmbeddings assembles never exceeds the model's
+// position-embedding limit (which would SIGABRT the native library, #82). It
+// must be called with l.mu held and after init (l.lctx valid).
+//
+// GetEmbeddings tokenizes internally and takes text, not tokens, so the cut is
+// made on the text: tokenize to measure, and if over budget, keep a prefix
+// sized by the current token→rune ratio (overshooting downward), then re-check.
+// The salient content is front-loaded, so a prefix is the right thing to keep.
+// A Tokenize error is non-fatal — fall through to GetEmbeddings, which will
+// surface its own error (degrading, never aborting the daemon).
+func (l *Llama) truncateToBudget(text string) string {
+	budget := l.ctxWindow - specialTokenHeadroom
+	if budget < 1 {
+		budget = 1
+	}
+	toks, err := l.lctx.Tokenize(text)
+	if err != nil || len(toks) <= budget {
+		return text
+	}
+	runes := []rune(text)
+	for i := 0; i < truncateIters && len(toks) > budget; i++ {
+		if len(runes) <= 1 {
+			break // nothing left to trim
+		}
+		// Overshoot by 5% under the proportional target so a sub-linear
+		// token→rune relationship still converges downward each pass.
+		keep := int(float64(len(runes)) * float64(budget) / float64(len(toks)) * 0.95)
+		if keep < 1 {
+			keep = 1
+		}
+		if keep >= len(runes) { // ratio made no progress: force a real cut
+			keep = len(runes) / 2
+		}
+		runes = runes[:keep]
+		toks, err = l.lctx.Tokenize(string(runes))
+		if err != nil {
+			break
+		}
+	}
+	// Guarantee the invariant the whole function exists for: the returned text
+	// must tokenize within budget, or GetEmbeddings SIGABRTs the worker (#82).
+	// The proportional loop can exit still-over-budget — bounded iterations, a
+	// Tokenize error, or an override window set above the model's real limit —
+	// so hard-halve the prefix until it fits. Halving reaches 1 rune, so this
+	// always terminates; a Tokenize error leaves toks stale and stops the loop
+	// (the embed then surfaces its own error and degrades, never aborts).
+	for err == nil && len(toks) > budget && len(runes) > 1 {
+		runes = runes[:len(runes)/2]
+		toks, err = l.lctx.Tokenize(string(runes))
+	}
+	return string(runes)
+}
+
+func (l *Llama) recordFailure() {
+	if l.failures.Add(1) >= maxConsecutiveFailures && !l.degraded.Swap(true) {
+		slog.Warn("embedder degraded; semantic matching falls back to text search",
+			"model", l.modelPath, "consecutive_failures", maxConsecutiveFailures)
+	}
+}
+
+// ModelID identifies the loaded model for persistence scoping.
+func (l *Llama) ModelID() string { return filepath.Base(l.modelPath) }
+
+// Dims is the embedding dimensionality (0 before the first success).
+func (l *Llama) Dims() int { return int(l.dims.Load()) }
+
+// Degraded reports whether the failure latch has tripped (embed calls now
+// short-circuit to text matching). Exposed for the daemon's health heartbeat;
+// callers type-assert this optional accessor rather than widening EmbedderPort.
+func (l *Llama) Degraded() bool { return l.degraded.Load() }
+
+// Close releases the model. It must never block the caller (the daemon
+// select loop calls it on reload/shutdown), so when a native embed call is
+// in flight — possibly hung, which is why the stall guard exists — the
+// model is leaked instead of freed underneath the running call.
+func (l *Llama) Close() error {
+	if l.closed.Swap(true) {
+		return nil
+	}
+	if !l.mu.TryLock() {
+		return nil // in-flight native call owns the model; leak, don't block
+	}
+	defer l.mu.Unlock()
+	if l.lctx != nil {
+		l.lctx.Close()
+		l.lctx = nil
+	}
+	if l.model != nil {
+		l.model.Close()
+		l.model = nil
+	}
+	return nil
+}
+
+// normalize L2-normalizes v in place (no-op for a zero vector).
+func normalize(v []float32) {
+	var norm float64
+	for _, x := range v {
+		norm += float64(x) * float64(x)
+	}
+	if norm == 0 {
+		return
+	}
+	inv := float32(1 / math.Sqrt(norm))
+	for i := range v {
+		v[i] *= inv
+	}
+}

--- a/internal/embedder/engine_cpu_test.go
+++ b/internal/embedder/engine_cpu_test.go
@@ -1,0 +1,178 @@
+//go:build cpu
+
+package embedder
+
+import (
+	"context"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+)
+
+// testModelPath resolves the real gguf for integration-style tests:
+// HAP_TEST_EMBED_MODEL, then <repo>/models/<default>. Tests skip when absent
+// so `go test ./...` stays green on machines without the model. Shared with
+// the CGO-only Client tests (client_cpu_test.go), which run in the same build.
+func testModelPath(t *testing.T) string {
+	t.Helper()
+	if p := os.Getenv("HAP_TEST_EMBED_MODEL"); p != "" {
+		return p
+	}
+	p := filepath.Join("..", "..", "models", DefaultModelFile)
+	if _, err := os.Stat(p); err != nil {
+		t.Skipf("embedding model not present (%s); set HAP_TEST_EMBED_MODEL to run", p)
+	}
+	return p
+}
+
+func cosine(a, b []float32) float64 {
+	var dot float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+	}
+	return dot // inputs are L2-normalized
+}
+
+func TestEmbedTextRealModel(t *testing.T) {
+	l := NewEngine(config.Embedding{ModelPath: testModelPath(t)})
+	defer l.Close()
+	ctx := context.Background()
+
+	v1, err := l.EmbedText(ctx, "permission: edit the configuration file")
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if len(v1) != 384 {
+		t.Errorf("dims = %d, want 384 (MiniLM-L6)", len(v1))
+	}
+	if l.Dims() != len(v1) {
+		t.Errorf("Dims() = %d, want %d", l.Dims(), len(v1))
+	}
+
+	// Output is L2-normalized.
+	var norm float64
+	for _, x := range v1 {
+		norm += float64(x) * float64(x)
+	}
+	if math.Abs(norm-1.0) > 1e-3 {
+		t.Errorf("norm² = %v, want 1.0", norm)
+	}
+
+	// Determinism / self-similarity.
+	again, err := l.EmbedText(ctx, "permission: edit the configuration file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if self := cosine(v1, again); self < 0.999 {
+		t.Errorf("self-similarity = %v, want ≈1.0", self)
+	}
+
+	// A paraphrase lands closer than an unrelated prompt.
+	para, err := l.EmbedText(ctx, "permission: modify the config file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := l.EmbedText(ctx, "error: connection to database refused")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cosine(v1, para) <= cosine(v1, other) {
+		t.Errorf("paraphrase similarity %v should exceed unrelated %v",
+			cosine(v1, para), cosine(v1, other))
+	}
+	t.Logf("paraphrase cos=%.3f unrelated cos=%.3f", cosine(v1, para), cosine(v1, other))
+}
+
+// TestEmbedLongInputNoCrash guards #82: a sequence longer than the model's
+// 512 position embeddings must be truncated, not fed whole — an untruncated
+// long input overflows the position-embedding get_rows and hard-aborts the
+// native library (SIGABRT), which would take the whole process down. The
+// embed must instead succeed on the truncated prefix and return a valid
+// vector. 700 space-delimited words tokenize well past 512.
+func TestEmbedLongInputNoCrash(t *testing.T) {
+	l := NewEngine(config.Embedding{ModelPath: testModelPath(t)})
+	defer l.Close()
+	ctx := context.Background()
+
+	long := strings.Repeat("word ", 700)
+	// Pre-truncation this aborts the process; post-fix it returns a vector.
+	v, err := l.EmbedText(ctx, long)
+	if err != nil {
+		t.Fatalf("long input should embed after truncation, got error: %v", err)
+	}
+	if len(v) != 384 {
+		t.Errorf("dims = %d, want 384", len(v))
+	}
+
+	// The truncated text alone must tokenize within budget — proves the guard
+	// actually bounded the sequence rather than the embed getting lucky.
+	l.initOnce.Do(l.init)
+	if l.initErr != nil {
+		t.Fatalf("init: %v", l.initErr)
+	}
+	safe := l.truncateToBudget(long)
+	toks, err := l.lctx.Tokenize(safe)
+	if err != nil {
+		t.Fatalf("tokenize truncated: %v", err)
+	}
+	budget := DefaultContextWindow - specialTokenHeadroom
+	if len(toks) > budget {
+		t.Errorf("truncated to %d tokens, want <= %d", len(toks), budget)
+	}
+
+	// A short input is returned unchanged (no needless truncation).
+	short := "permission: edit the config file"
+	if got := l.truncateToBudget(short); got != short {
+		t.Errorf("short input was altered: %q", got)
+	}
+
+	// A pathologically small context window override is floored to
+	// minContextWindow (a window below it can't hold the special tokens and
+	// would SIGABRT). The engine must use the floor, not the raw value, and
+	// still embed the long input on the truncated prefix.
+	tiny := NewEngine(config.Embedding{ModelPath: testModelPath(t), ModelContextWindow: 1})
+	defer tiny.Close()
+	if tiny.ctxWindow != minContextWindow {
+		t.Errorf("ctxWindow = %d, want floored to %d", tiny.ctxWindow, minContextWindow)
+	}
+	tv, err := tiny.EmbedText(ctx, long)
+	if err != nil {
+		t.Fatalf("floored-window embed should succeed on the truncated prefix, got: %v", err)
+	}
+	if len(tv) != 384 {
+		t.Errorf("floored-window dims = %d, want 384", len(tv))
+	}
+}
+
+func TestEmbedMissingModelDegrades(t *testing.T) {
+	l := NewEngine(config.Embedding{ModelPath: filepath.Join(t.TempDir(), "missing.gguf")})
+	defer l.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for i := 0; i < maxConsecutiveFailures; i++ {
+		if _, err := l.EmbedText(ctx, "anything"); err == nil {
+			t.Fatal("missing model should error")
+		}
+	}
+	// Latch tripped: fails fast with ErrDegraded.
+	if _, err := l.EmbedText(ctx, "anything"); err != ErrDegraded {
+		t.Errorf("after %d failures err = %v, want ErrDegraded", maxConsecutiveFailures, err)
+	}
+}
+
+func TestModelIDIsBasename(t *testing.T) {
+	l := NewEngine(config.Embedding{ModelPath: "/x/y/custom-model.gguf"})
+	if l.ModelID() != "custom-model.gguf" {
+		t.Errorf("ModelID = %q", l.ModelID())
+	}
+	def := NewEngine(config.Embedding{})
+	if def.ModelID() != DefaultModelFile {
+		t.Errorf("default ModelID = %q, want %q", def.ModelID(), DefaultModelFile)
+	}
+}

--- a/internal/embedder/engine_stub.go
+++ b/internal/embedder/engine_stub.go
@@ -1,0 +1,56 @@
+//go:build !cpu
+
+// engine_stub.go is the no-CGO fallback engine compiled when the binary is
+// built WITHOUT the `cpu` tag (e.g. a plain `go test ./...` on a CPU-only host
+// that has neither the llama.cpp static libs nor the GPU/Vulkan shared libs the
+// GPU GGML backend would otherwise pull in at link time). It links no native
+// code, so such builds need no native libraries at all: every embed reports
+// unavailable and the daemon stays on its BM25/exact fallback path. The real
+// engine is engine_cpu.go, selected by the `cpu` tag every production/CI build
+// already passes.
+package embedder
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+)
+
+// errEngineUnavailable is what every stub embed returns. It names the missing
+// build tag so a surprised operator (embeddings silently off) can see why.
+var errEngineUnavailable = fmt.Errorf("embedder unavailable: built without the %q tag (no native llama.cpp engine linked)", "cpu")
+
+// Llama is the stub engine: same method set as the real engine_cpu.go Llama so
+// worker.go and callers compile unchanged, but it holds no native model and
+// every embed fails. Dims stays 0 so the daemon's Dims()>0 gate never routes
+// an embed through a worker that can't serve one.
+type Llama struct {
+	modelPath string
+}
+
+// NewEngine builds the stub engine. It resolves the model path (so ModelID and
+// diagnostics stay meaningful) but loads nothing — there is no native backend.
+func NewEngine(cfg config.Embedding) *Llama {
+	return &Llama{modelPath: ResolveModelPath(cfg)}
+}
+
+// EmbedText always reports the engine unavailable in a no-CGO build.
+func (l *Llama) EmbedText(_ context.Context, _ string) ([]float32, error) {
+	return nil, errEngineUnavailable
+}
+
+// ModelID identifies the configured model for persistence scoping, matching
+// the real engine, even though nothing is loaded.
+func (l *Llama) ModelID() string { return filepath.Base(l.modelPath) }
+
+// Dims is always 0: no embed ever succeeds, so callers gate matching off.
+func (l *Llama) Dims() int { return 0 }
+
+// Degraded reports true: the engine can never serve an embed, so it is
+// effectively degraded from the start (semantic matching stays on BM25).
+func (l *Llama) Degraded() bool { return true }
+
+// Close is a no-op; the stub owns no native resources.
+func (l *Llama) Close() error { return nil }

--- a/internal/embedder/engine_stub_test.go
+++ b/internal/embedder/engine_stub_test.go
@@ -1,0 +1,35 @@
+//go:build !cpu
+
+package embedder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+)
+
+// TestStubEngineUnavailable exercises the no-CGO fallback engine that the
+// tag-free build (`go test ./...` without `cpu`) compiles. It must construct
+// cleanly and report itself unavailable so the daemon stays on BM25/exact
+// matching: every embed errors, Dims stays 0 (the daemon's embed gate), and
+// Degraded is true. This is the coverage for the CPU-only build path — the one
+// that no longer links llama.cpp / Vulkan.
+func TestStubEngineUnavailable(t *testing.T) {
+	l := NewEngine(config.Embedding{ModelPath: "/x/y/custom-model.gguf"})
+	defer l.Close()
+
+	if _, err := l.EmbedText(context.Background(), "anything"); err == nil {
+		t.Error("stub EmbedText must error (no native engine linked)")
+	}
+	if got := l.Dims(); got != 0 {
+		t.Errorf("Dims() = %d, want 0 so the daemon never routes an embed to the stub", got)
+	}
+	if !l.Degraded() {
+		t.Error("Degraded() = false, want true (the stub can never serve an embed)")
+	}
+	// ModelID still resolves for diagnostics/persistence scoping.
+	if l.ModelID() != "custom-model.gguf" {
+		t.Errorf("ModelID() = %q, want custom-model.gguf", l.ModelID())
+	}
+}


### PR DESCRIPTION
## Problem

`internal/embedder/embedder.go` imported the llama-go (llama.cpp / CGO) bindings **unconditionally**. Every package that links the embedder — `internal/embedder`, `cmd/hap`, `internal/frontend` (and transitively `internal/daemon`) — pulled llama.cpp into its **test binary**, and without the `cpu` tag the bindings add the GPU GGML backend. So a plain `go test ./...` on a CPU-only host failed to **link**:

```
/usr/bin/ld: cannot find -lggml-vulkan: No such file or directory
/usr/bin/ld: cannot find -lvulkan: No such file or directory
```

(The bindings' `zgpu_linux.go` is `//go:build !cpu` and appends `-lggml-vulkan -lvulkan`; the `cpu` tag selects the CPU backend instead.)

## Fix

Split the engine on the **`cpu`** build tag — the tag every production/CI build already passes (`CLAUDE.md`: "vectors cpu always"), which also selects llama.cpp's CPU backend, so **Vulkan is never linked in any supported configuration**. Build commands are unchanged.

- **`engine_cpu.go`** (`//go:build cpu`) — the real llama-linked `Llama` engine, moved **verbatim** out of `embedder.go` (reviewer confirmed an empty diff vs the original).
- **`engine_stub.go`** (`//go:build !cpu`) — a no-CGO `Llama` with the same method set: `EmbedText` reports unavailable, `Dims()==0` (the daemon's embed gate never routes to it), `Degraded()==true`. Links no native code.
- **`embedder.go`** stays tag-free with only the shared constants/helpers (`Resolve*`, `PluginRoot`, `ErrDegraded`) the untagged `Client` and both engines use.

External callers only ever touch `embedder.New` (the untagged out-of-process `Client`), so the split is invisible to them. In a stub build the out-of-process worker returns "unavailable", the `Client` counts it toward the existing degrade-after-N latch, and semantic matching falls back to BM25 — the daemon stays up.

## Tests

- CGO/real-model cases move behind `//go:build cpu` (`engine_cpu_test.go`, `client_cpu_test.go`).
- Engine-independent tests stay untagged so they run in **both** builds: `TestResolveContextWindowFloor`, `TestProtocolRoundTrip`, and the Client supervision tests (`TestClientWorkerCrashDegrades`, `TestClientContextCancelNotCounted`, `TestMain`).
- `engine_stub_test.go` adds coverage for the no-CGO path (unavailable + `Dims()==0` + degraded).

## Verification

- **Tag-free `go test -c ./internal/embedder/` now LINKS with no Vulkan** (was: `cannot find -lggml-vulkan`).
- `go test ./internal/embedder/` (tag-free) — 5 pass, 0 fail, no native-library error.
- `go test -tags "vectors cpu" ./internal/embedder/` — 6 pass, 4 real-model tests skip (model absent).
- `go vet` + `gofmt` clean in both configs.
- With the match fix present too, `cmd/hap`, `internal/frontend`, `internal/daemon` all link tag-free with no Vulkan.

## Note

A fully green tag-free `go test ./...` also needs the Bleve KNN build-tag fix in **#186** (`internal/match`) — the only *other* package that fails to compile tag-free. The two are independent (Vulkan vs Bleve) and complementary; once both merge, `go test ./...` builds on a CPU-only host with no native GPU libraries.

https://claude.ai/code/session_01FKbYWbyEGhsT8iGnbyBJgr