### PR TITLE
fix: matcher close-during-search deadlock (+ test/CI hardening, daemon race fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,15 +92,22 @@ jobs:
             go test -tags "${GO_BUILD_TAGS}" ./... -count=1 -timeout 15m
           fi
       - name: Race detector
-        # The race detector is flaky under CI load; retry up to 2 times
-        # (3 attempts total) before failing the job.
+        # Runs the concurrency regressions under -race with the "vectors cpu"
+        # tags on the standard (CPU-only) runners — notably internal/match's
+        # TestMatcherConcurrentRebuildAndMatch and, under the vectors tag,
+        # TestMatcherConcurrentRebuildAndMatchVector, which guard the
+        # Rebuild-closes-the-index-mid-search deadlock (the vector variant hung
+        # ~10m before the fix). Keep ./internal/match/... in PKGS so both stay
+        # covered. The race detector is flaky under CI load; retry up to 2 times
+        # (3 attempts total) before failing the job. -timeout caps a reintroduced
+        # deadlock so it fails in minutes instead of the 10m default per attempt.
         run: |
           PKGS="./internal/store/... ./internal/domain/... ./internal/control/... ./internal/embedder/... ./internal/match/... ./internal/daemon/..."
           run_race() {
             if [ "$RUNNER_OS" = "macOS" ]; then
-              go test -ldflags "-r /usr/local/lib" -tags "${GO_BUILD_TAGS}" $PKGS -race -count=1
+              go test -ldflags "-r /usr/local/lib" -tags "${GO_BUILD_TAGS}" $PKGS -race -count=1 -timeout 8m
             else
-              go test -tags "${GO_BUILD_TAGS}" $PKGS -race -count=1
+              go test -tags "${GO_BUILD_TAGS}" $PKGS -race -count=1 -timeout 8m
             fi
           }
           attempt=1

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -481,14 +481,14 @@ type harness struct {
 
 func newHarness(t *testing.T, cfgTOML string) *harness {
 	fl := &fakeLLM{}
-	return newHarnessCore(t, cfgTOML, nil, fl, fl)
+	return newHarnessCore(t, cfgTOML, nil, fl, fl, nil)
 }
 
 // newHarnessWrapped lets a test substitute the HerdrPort the daemon sees
 // (e.g. hiding optional interfaces) while keeping the fake for assertions.
 func newHarnessWrapped(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.HerdrPort) *harness {
 	fl := &fakeLLM{}
-	return newHarnessCore(t, cfgTOML, wrap, fl, fl)
+	return newHarnessCore(t, cfgTOML, wrap, fl, fl, nil)
 }
 
 // newHarnessTaskGen installs a task-generator-capable LLM port for idle
@@ -496,14 +496,32 @@ func newHarnessWrapped(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports
 func newHarnessTaskGen(t *testing.T, cfgTOML string,
 	generate func(ctx context.Context, req domain.TaskGenRequest) (string, error)) (*harness, *fakeTaskGen) {
 	tg := &fakeTaskGen{fakeLLM: &fakeLLM{}, generate: generate}
-	return newHarnessCore(t, cfgTOML, nil, tg, tg.fakeLLM), tg
+	return newHarnessCore(t, cfgTOML, nil, tg, tg.fakeLLM, nil), tg
+}
+
+// newHarnessPaused builds a harness whose daemon Store is a pausingAutomationStore
+// installed BEFORE the daemon starts, so it never races the startup sweep's
+// opt.Store reads (processLLMRetries / expireStaleLLMWork). Returns the harness
+// and the gate the test drives via its reached/resume channels. Replaces the
+// old racy pattern of reassigning h.daemon.opt.Store after construction.
+func newHarnessPaused(t *testing.T, cfgTOML string) (*harness, *pausingAutomationStore) {
+	t.Helper()
+	fl := &fakeLLM{}
+	var gate *pausingAutomationStore
+	h := newHarnessCore(t, cfgTOML, nil, fl, fl, func(inner ports.StorePort) ports.StorePort {
+		gate = &pausingAutomationStore{
+			StorePort: inner, reached: make(chan struct{}), resume: make(chan struct{}),
+		}
+		return gate
+	})
+	return h, gate
 }
 
 // newHarnessCore wires the daemon with a caller-supplied LLM port (plus the
 // underlying *fakeLLM for assertions), so optional-capability variants
 // (rewriter, task generator) share one setup path.
 func newHarnessCore(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.HerdrPort,
-	llmPort ports.LLMPort, fl *fakeLLM) *harness {
+	llmPort ports.LLMPort, fl *fakeLLM, wrapStore func(ports.StorePort) ports.StorePort) *harness {
 	t.Helper()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.toml")
@@ -522,6 +540,15 @@ func newHarnessCore(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.He
 	t.Cleanup(func() { raw.Close() })
 
 	fs := &failingStore{StorePort: raw}
+	// The daemon's Store is fixed at New() time and read by background
+	// goroutines the instant Run starts (the startup sweep: processLLMRetries /
+	// expireStaleLLMWork). A test that needs to intercept the store MUST install
+	// its wrapper here — before Run — not by reassigning d.opt.Store afterward,
+	// which data-races those reads. See newHarnessPaused.
+	var storePort ports.StorePort = fs
+	if wrapStore != nil {
+		storePort = wrapStore(fs)
+	}
 	fh := &fakeHerdr{}
 	fe := &fakeEvents{ch: make(chan domain.AgentTransition, 64)}
 	var herdrPort ports.HerdrPort = fh
@@ -534,7 +561,7 @@ func newHarnessCore(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.He
 	d, err := New(Options{
 		ConfigPath:        cfgPath,
 		ControlSocketPath: ctlPath,
-		Store:             fs,
+		Store:             storePort,
 		Herdr:             herdrPort,
 		Events:            fe,
 		Notify:            fh,
@@ -777,7 +804,7 @@ func TestLLMPromotionDeliversMenuDigitForLabel(t *testing.T) {
 
 func TestLLMPromotionDeniedWhenDisableWinsFinalBarrier(t *testing.T) {
 	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n"
-	h := newHarness(t, cfg)
+	h, gate := newHarnessPaused(t, cfg)
 	h.herdr.setPane(approvalPane)
 	h.llm.configured = true
 	h.llm.consult = func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
@@ -790,10 +817,6 @@ func TestLLMPromotionDeniedWhenDisableWinsFinalBarrier(t *testing.T) {
 		return &domain.LLMDecision{ID: id, RequestID: req.RequestID, Action: "Yes",
 			Rationale: "approve", ConfidentScore: 80, Status: "pending"}, nil
 	}
-	gate := &pausingAutomationStore{
-		StorePort: h.store, reached: make(chan struct{}), resume: make(chan struct{}),
-	}
-	h.daemon.opt.Store = gate
 	h.push("agent-llm-disabled", "blocked")
 	select {
 	case <-gate.reached:
@@ -2602,17 +2625,13 @@ func TestIdleTaskGenAutoDismissesWhenAgentExits(t *testing.T) {
 }
 
 func TestDisabledAgentDeniesAutonomousAction(t *testing.T) {
-	h := newHarness(t, "[learning]\ngraduation_n = 3\n")
+	h, gate := newHarnessPaused(t, "[learning]\ngraduation_n = 3\n")
 	h.herdr.setPane(approvalPane)
 	h.seedAutonomous(approvalPane, domain.SituationApproval, "Yes")
 	ctx := context.Background()
 	if _, err := h.raw.EnsureAgentName(ctx, "agent-disabled"); err != nil {
 		t.Fatal(err)
 	}
-	gate := &pausingAutomationStore{
-		StorePort: h.store, reached: make(chan struct{}), resume: make(chan struct{}),
-	}
-	h.daemon.opt.Store = gate
 
 	h.push("agent-disabled", "blocked")
 	select {

--- a/internal/daemon/noop_test.go
+++ b/internal/daemon/noop_test.go
@@ -113,7 +113,7 @@ func TestLLMNoopPromotionRecordsWithoutSend(t *testing.T) {
 
 func TestLLMNoopDeniedWhenDisableWinsFinalBarrier(t *testing.T) {
 	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n"
-	h := newHarness(t, cfg)
+	h, gate := newHarnessPaused(t, cfg)
 	h.herdr.setPane(approvalPane)
 	h.llm.configured = true
 	h.llm.consult = func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
@@ -126,10 +126,6 @@ func TestLLMNoopDeniedWhenDisableWinsFinalBarrier(t *testing.T) {
 		return &domain.LLMDecision{ID: id, RequestID: req.RequestID, Action: "@noop",
 			Rationale: "no reply needed", ConfidentScore: 80, Status: "pending"}, nil
 	}
-	gate := &pausingAutomationStore{
-		StorePort: h.store, reached: make(chan struct{}), resume: make(chan struct{}),
-	}
-	h.daemon.opt.Store = gate
 	h.push("agent-llmnoop-disabled", "blocked")
 	select {
 	case <-gate.reached:

--- a/internal/daemon/semantic.go
+++ b/internal/daemon/semantic.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
@@ -51,8 +52,14 @@ func (d *Daemon) initSemantic(ctx context.Context, gen int64) {
 		return // superseded by a newer reload; let its run own the index
 	}
 	if err := d.matcher.Rebuild(res.Rows, res.Dims); err != nil {
-		slog.Warn("semantic index rebuild failed; matching stays exact-hash", "error", err)
-		return
+		if !errors.Is(err, match.ErrCleanup) {
+			slog.Warn("semantic index rebuild failed; matching stays exact-hash", "error", err)
+			return
+		}
+		// The new index published; only reclaiming the previous generation's
+		// directory failed (a leak, not a rebuild failure) — surface it but keep
+		// semantic matching enabled.
+		slog.Warn("semantic index rebuilt; previous-generation cleanup failed", "error", err)
 	}
 	if d.semanticGen.Load() != gen {
 		return // a newer reload raced past; it decides readiness

--- a/internal/daemon/semantic_test.go
+++ b/internal/daemon/semantic_test.go
@@ -535,12 +535,11 @@ func TestReembedNudgeSwapsEmbedderAndRetriesDegraded(t *testing.T) {
 }
 
 // TestRemapAllowedContract pins the veto behavior of remapAllowed, the ONLY
-// accept callback the matcher runs. Since the fix that makes MatchVector/
-// MatchText hold the read lock across the search, accept runs UNDER that lock,
-// so it must be a pure content check that never calls back into the Matcher (a
-// reentrant Rebuild/Close/Add/Delete would deadlock). That non-reentrancy is
-// guaranteed by the signature — remapAllowed takes no *match.Matcher, enforced
-// at COMPILE time, not asserted here — and its only dependency is the pure
+// accept callback the matcher runs. accept now runs OUTSIDE the matcher lock
+// (MatchVector/MatchText apply it over materialized candidates), so a reentrant
+// callback no longer deadlocks — but remapAllowed stays a pure content check by
+// construction: its signature takes no *match.Matcher, so it cannot re-enter,
+// enforced at COMPILE time, not asserted here; its only dependency is the pure
 // domain.ApprovalRemapCompatible. These cases lock in the issue-#155 option-set
 // gate (previously untested) so a future edit can't silently loosen it.
 func TestRemapAllowedContract(t *testing.T) {

--- a/internal/daemon/semantic_test.go
+++ b/internal/daemon/semantic_test.go
@@ -599,8 +599,10 @@ func countIdxDirs(t *testing.T, base string) int {
 // TestDaemonSemanticStressNoHangRaceOrLeak is an end-to-end stress test of the
 // daemon's semantic subsystem: many goroutines drive the real resolve path
 // (embed + match via resolveSignature) while several others overlap Rebuilds on
-// the same live matcher, then the matcher is shut down WHILE searches are still
-// in flight (close-during-search). It asserts the whole
+// the same live matcher, then the matcher is shut down WHILE both searches AND
+// rebuilds are still in flight (close races active search + active rebuild —
+// the case where a racing Rebuild could recreate the index dir after cleanup).
+// It asserts the whole
 // storm completes (no hang/deadlock), trips no data race (run under -race), the
 // generation guard leaves no abandoned idx-* directories, and shutdown removes
 // the index directory entirely. This is the integration-level guard for the
@@ -629,7 +631,8 @@ func TestDaemonSemanticStressNoHangRaceOrLeak(t *testing.T) {
 	var searchers, rebuilders sync.WaitGroup
 	stop := make(chan struct{})
 
-	// Concurrent searchers: hammer the daemon's real resolve path until stop.
+	// Concurrent searchers: hammer the daemon's real resolve path for the whole
+	// run (across both phases below), so search is always in flight.
 	for i := 0; i < 6; i++ {
 		searchers.Add(1)
 		go func(i int) {
@@ -646,9 +649,9 @@ func TestDaemonSemanticStressNoHangRaceOrLeak(t *testing.T) {
 		}(i)
 	}
 
-	// Overlapping rebuilders: several goroutines rebuild the same live matcher
-	// concurrently, so builds overlap and the generation guard runs under live
-	// search. Bounded work so the storm terminates deterministically.
+	// Phase 1 — bounded overlapping rebuilds: several goroutines rebuild the same
+	// live matcher concurrently under live search, so builds overlap and the
+	// generation guard runs. Bounded and joined so the dir count is quiescent.
 	for r := 0; r < 3; r++ {
 		rebuilders.Add(1)
 		go func(r int) {
@@ -661,8 +664,7 @@ func TestDaemonSemanticStressNoHangRaceOrLeak(t *testing.T) {
 			}
 		}(r)
 	}
-
-	rebuilders.Wait() // the rebuild storm finishes; searchers keep hammering
+	rebuilders.Wait()
 
 	// The generation guard + per-build cleanup must leave at most one live idx-*
 	// dir — no abandoned generations accumulated during the overlap. Searchers
@@ -671,17 +673,52 @@ func TestDaemonSemanticStressNoHangRaceOrLeak(t *testing.T) {
 		t.Errorf("abandoned index dirs accumulated: %d idx-* dirs, want <= 1", n)
 	}
 
-	// Shutdown WHILE searches are still in flight (the real close-during-search
-	// case): Close must wait for in-flight lookups rather than closing the index
-	// under them — no deadlock, panic, or race — and must remove the whole index
-	// directory. The searchers then degrade onto the post-close error path.
+	// Phase 2 — Close races ACTIVE search AND ACTIVE rebuilds. Continuous
+	// rebuilders keep a build in flight when Close fires; they stop when Rebuild
+	// reports the matcher closed (expected).
+	active := make(chan struct{}) // closed once a phase-2 rebuild has run
+	var once sync.Once
+	for r := 0; r < 3; r++ {
+		rebuilders.Add(1)
+		go func(r int) {
+			defer rebuilders.Done()
+			// Failsafe: always release the <-active barrier when this goroutine
+			// exits, so an early (unexpected) error fails fast via t.Errorf rather
+			// than hanging the waiter until the go-test timeout.
+			defer once.Do(func() { close(active) })
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if err := d.matcher.Rebuild(rowsFor(verbs[(r+i)%len(verbs)]), 4); err != nil {
+					if !strings.Contains(err.Error(), "matcher closed") {
+						t.Errorf("unexpected rebuild error: %v", err)
+					}
+					return
+				}
+				once.Do(func() { close(active) })
+			}
+		}(r)
+	}
+	<-active // the search + rebuild storm is live
+
+	// Shut the matcher down WHILE both searches and rebuilds are in flight — the
+	// hard case: a Rebuild that raced past its closed check does its
+	// MkdirAll/buildIndex off the lock and could recreate baseDir. Close must
+	// drain those in-flight builds before its final RemoveAll so nothing is left
+	// behind, and it must not deadlock, panic, or race.
 	if err := d.matcher.Close(); err != nil {
-		t.Fatalf("shutdown Close during in-flight search: %v", err)
+		t.Errorf("shutdown Close during active search+rebuild: %v", err)
 	}
 	close(stop)
+	rebuilders.Wait()
 	searchers.Wait()
 
+	// No base or idx-* directory may survive shutdown — not even one recreated by
+	// a Rebuild that raced Close.
 	if _, err := os.Stat(indexDir); !os.IsNotExist(err) {
-		t.Errorf("match index dir leaked after Close: stat err = %v", err)
+		t.Errorf("index dir recreated/leaked after Close raced active rebuilds: stat err = %v", err)
 	}
 }

--- a/internal/daemon/semantic_test.go
+++ b/internal/daemon/semantic_test.go
@@ -3,8 +3,10 @@ package daemon
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -596,16 +598,64 @@ func countIdxDirs(t *testing.T, base string) int {
 	return n
 }
 
+// concurrentErrs collects errors raised inside stress goroutines so they can be
+// asserted on the test goroutine after the workers join — t.Fatal is illegal off
+// the test goroutine, and a bare t.Errorf can race the test finishing.
+type concurrentErrs struct {
+	mu   sync.Mutex
+	errs []error
+}
+
+func (c *concurrentErrs) add(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.errs = append(c.errs, err)
+}
+
+func (c *concurrentErrs) all() []error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]error(nil), c.errs...)
+}
+
+// wgCh signals once wg is fully drained, so a WaitGroup can be selected on.
+func wgCh(wg *sync.WaitGroup) <-chan struct{} {
+	ch := make(chan struct{})
+	go func() { wg.Wait(); close(ch) }()
+	return ch
+}
+
+// awaitOrDump waits on ch up to d; on timeout it runs onTimeout (best-effort
+// cleanup, e.g. signalling workers to stop so they don't hammer past the abort),
+// dumps every goroutine's stack, and fails fast — so a deadlock surfaces in
+// seconds with a diagnosis instead of hanging until the go-test binary times out.
+func awaitOrDump(t *testing.T, what string, ch <-chan struct{}, d time.Duration, onTimeout func()) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(d):
+		if onTimeout != nil {
+			onTimeout()
+		}
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		t.Fatalf("stress watchdog: %s did not finish within %s (deadlock?)\n%s", what, d, buf[:n])
+	}
+}
+
 // TestDaemonSemanticStressNoHangRaceOrLeak is an end-to-end stress test of the
 // daemon's semantic subsystem: many goroutines drive the real resolve path
 // (embed + match via resolveSignature) while several others overlap Rebuilds on
 // the same live matcher, then the matcher is shut down WHILE both searches AND
-// rebuilds are still in flight (close races active search + active rebuild —
-// the case where a racing Rebuild could recreate the index dir after cleanup).
-// It asserts the whole
-// storm completes (no hang/deadlock), trips no data race (run under -race), the
-// generation guard leaves no abandoned idx-* directories, and shutdown removes
-// the index directory entirely. This is the integration-level guard for the
+// rebuilds are still in flight (close races active search + active rebuild — the
+// case where a racing Rebuild could recreate the index dir after cleanup).
+//
+// It asserts the storm completes (no hang/deadlock), trips no data race (run
+// under -race), the generation guard leaves no abandoned idx-* directories, and
+// shutdown removes the index directory entirely. Every blocking step runs under
+// a bounded watchdog so a regression that deadlocks fails in seconds with a
+// goroutine dump, and worker panics / unexpected rebuild errors are collected and
+// asserted rather than crashing opaquely. Integration-level guard for the
 // close-during-search, overlapping-rebuild, and cleanup fixes.
 func TestDaemonSemanticStressNoHangRaceOrLeak(t *testing.T) {
 	emb := &fakeEmbedder{vectors: map[string][]float32{
@@ -628,15 +678,36 @@ func TestDaemonSemanticStressNoHangRaceOrLeak(t *testing.T) {
 		}}
 	}
 
+	const watchdog = 60 * time.Second
+	var errs concurrentErrs
 	var searchers, rebuilders sync.WaitGroup
 	stop := make(chan struct{})
+	var stopOnce sync.Once
+	// haltWorkers signals every worker to exit. Used on the happy path and, as a
+	// watchdog onTimeout hook, best-effort on the abort path so a deadlocked run
+	// doesn't leave searchers hammering the matcher past the failure.
+	haltWorkers := func() { stopOnce.Do(func() { close(stop) }) }
+
+	// spawn runs fn on a tracked goroutine, turning a panic into a collected
+	// error (the daemon path must never panic) so it is asserted rather than
+	// crashing the test binary opaquely.
+	spawn := func(wg *sync.WaitGroup, label string, fn func()) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					errs.add(fmt.Errorf("%s panicked: %v", label, r))
+				}
+			}()
+			fn()
+		}()
+	}
 
 	// Concurrent searchers: hammer the daemon's real resolve path for the whole
 	// run (across both phases below), so search is always in flight.
 	for i := 0; i < 6; i++ {
-		searchers.Add(1)
-		go func(i int) {
-			defer searchers.Done()
+		spawn(&searchers, "searcher", func() {
 			for {
 				select {
 				case <-stop:
@@ -646,25 +717,22 @@ func TestDaemonSemanticStressNoHangRaceOrLeak(t *testing.T) {
 				s := approvalSituation(verbs[i%len(verbs)])
 				_ = d.resolveSignature(ctx, cfg, domain.ComputeSignature(s), s)
 			}
-		}(i)
+		})
 	}
 
-	// Phase 1 — bounded overlapping rebuilds: several goroutines rebuild the same
-	// live matcher concurrently under live search, so builds overlap and the
-	// generation guard runs. Bounded and joined so the dir count is quiescent.
+	// Phase 1 — bounded overlapping rebuilds under live search, so builds overlap
+	// and the generation guard runs. Bounded and joined so the dir count settles.
 	for r := 0; r < 3; r++ {
-		rebuilders.Add(1)
-		go func(r int) {
-			defer rebuilders.Done()
+		spawn(&rebuilders, "phase-1 rebuilder", func() {
 			for i := 0; i < 20; i++ {
 				if err := d.matcher.Rebuild(rowsFor(verbs[(r+i)%len(verbs)]), 4); err != nil {
-					t.Errorf("rebuild: %v", err)
+					errs.add(fmt.Errorf("phase-1 rebuild: %w", err))
 					return
 				}
 			}
-		}(r)
+		})
 	}
-	rebuilders.Wait()
+	awaitOrDump(t, "phase-1 rebuilds", wgCh(&rebuilders), watchdog, haltWorkers)
 
 	// The generation guard + per-build cleanup must leave at most one live idx-*
 	// dir — no abandoned generations accumulated during the overlap. Searchers
@@ -679,12 +747,10 @@ func TestDaemonSemanticStressNoHangRaceOrLeak(t *testing.T) {
 	active := make(chan struct{}) // closed once a phase-2 rebuild has run
 	var once sync.Once
 	for r := 0; r < 3; r++ {
-		rebuilders.Add(1)
-		go func(r int) {
-			defer rebuilders.Done()
-			// Failsafe: always release the <-active barrier when this goroutine
-			// exits, so an early (unexpected) error fails fast via t.Errorf rather
-			// than hanging the waiter until the go-test timeout.
+		spawn(&rebuilders, "phase-2 rebuilder", func() {
+			// Failsafe: always release the <-active barrier on exit so an early
+			// error fails fast (via the watchdog + collected error) rather than
+			// hanging the awaitOrDump below.
 			defer once.Do(func() { close(active) })
 			for i := 0; ; i++ {
 				select {
@@ -694,27 +760,43 @@ func TestDaemonSemanticStressNoHangRaceOrLeak(t *testing.T) {
 				}
 				if err := d.matcher.Rebuild(rowsFor(verbs[(r+i)%len(verbs)]), 4); err != nil {
 					if !strings.Contains(err.Error(), "matcher closed") {
-						t.Errorf("unexpected rebuild error: %v", err)
+						errs.add(fmt.Errorf("phase-2 rebuild: %w", err))
 					}
 					return
 				}
 				once.Do(func() { close(active) })
 			}
-		}(r)
+		})
 	}
-	<-active // the search + rebuild storm is live
+	awaitOrDump(t, "rebuild storm to go live", active, watchdog, haltWorkers)
 
-	// Shut the matcher down WHILE both searches and rebuilds are in flight — the
-	// hard case: a Rebuild that raced past its closed check does its
-	// MkdirAll/buildIndex off the lock and could recreate baseDir. Close must
-	// drain those in-flight builds before its final RemoveAll so nothing is left
-	// behind, and it must not deadlock, panic, or race.
-	if err := d.matcher.Close(); err != nil {
-		t.Errorf("shutdown Close during active search+rebuild: %v", err)
+	// Shut down WHILE both searches and rebuilds are in flight — the hard case: a
+	// racing Rebuild's off-lock MkdirAll/buildIndex could recreate baseDir, so
+	// Close must drain in-flight builds before its final RemoveAll. Run under the
+	// watchdog: a regression that deadlocks the drain fails in seconds with a dump.
+	var closeErr error
+	closeDone := make(chan struct{})
+	go func() {
+		defer close(closeDone)
+		defer func() {
+			if r := recover(); r != nil {
+				errs.add(fmt.Errorf("Close panicked: %v", r))
+			}
+		}()
+		closeErr = d.matcher.Close()
+	}()
+	awaitOrDump(t, "Close during active search+rebuild", closeDone, watchdog, haltWorkers)
+	if closeErr != nil {
+		t.Errorf("shutdown Close during active search+rebuild: %v", closeErr)
 	}
-	close(stop)
-	rebuilders.Wait()
-	searchers.Wait()
+
+	haltWorkers()
+	awaitOrDump(t, "rebuilders to drain", wgCh(&rebuilders), watchdog, haltWorkers)
+	awaitOrDump(t, "searchers to drain", wgCh(&searchers), watchdog, haltWorkers)
+
+	for _, err := range errs.all() {
+		t.Errorf("stress goroutine error: %v", err)
+	}
 
 	// No base or idx-* directory may survive shutdown — not even one recreated by
 	// a Rebuild that raced Close.

--- a/internal/daemon/semantic_test.go
+++ b/internal/daemon/semantic_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/match"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store"
 	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
@@ -528,4 +529,48 @@ func TestReembedNudgeSwapsEmbedderAndRetriesDegraded(t *testing.T) {
 		rows, err := raw.ListSignatureEmbeddings(ctx)
 		return err == nil && len(rows) == 1 && rows[0].Model == "fake-model" && rows[0].Dims == 4
 	})
+}
+
+// TestRemapAllowedContract pins the veto behavior of remapAllowed, the ONLY
+// accept callback the matcher runs. Since the fix that makes MatchVector/
+// MatchText hold the read lock across the search, accept runs UNDER that lock,
+// so it must be a pure content check that never calls back into the Matcher (a
+// reentrant Rebuild/Close/Add/Delete would deadlock). That non-reentrancy is
+// guaranteed by the signature — remapAllowed takes no *match.Matcher, enforced
+// at COMPILE time, not asserted here — and its only dependency is the pure
+// domain.ApprovalRemapCompatible. These cases lock in the issue-#155 option-set
+// gate (previously untested) so a future edit can't silently loosen it.
+func TestRemapAllowedContract(t *testing.T) {
+	tests := []struct {
+		name    string
+		typ     domain.SituationType
+		salient string // fresh situation's salient
+		cand    string // candidate hit's stored salient
+		want    bool
+	}{
+		{"non-approval choice always passes", domain.SituationChoice, "anything", "unrelated", true},
+		{"non-approval error always passes", domain.SituationError, "permission:x | options:a", "y", true},
+		{"approval identical options", domain.SituationApproval, "permission:edit | options:yes;no", "permission:modify | options:yes;no", true},
+		{"approval escaped-semicolon single label", domain.SituationApproval, `permission:edit | options:a\;b`, `permission:modify | options:a\;b`, true},
+		{"approval superset ≥half passes", domain.SituationApproval, "permission:edit | options:a;b", "permission:modify | options:a;b;c", true},
+		{"approval jaccard exactly 0.5 passes", domain.SituationApproval, "permission:x | options:a;b", "permission:y | options:a;b;c;d", true},
+		{"approval below half vetoed", domain.SituationApproval, "permission:x | options:a;b", "permission:y | options:a;c;d", false},
+		{"approval disjoint options vetoed", domain.SituationApproval, "permission:x | options:a;b", "permission:y | options:c;d", false},
+		{"approval both empty option segments compatible", domain.SituationApproval, "permission:edit | options:", "permission:modify | options:", true},
+		{"approval verb-only no segment vetoed", domain.SituationApproval, "permission:edit", "permission:edit", false},
+		{"approval one segment one none vetoed", domain.SituationApproval, "permission:edit | options:a", "permission:edit", false},
+		{"approval perm vs pane-tail vetoed", domain.SituationApproval, "permission:edit | options:a", "some pane tail text", false},
+		{"approval pane-tail vs perm vetoed (symmetry)", domain.SituationApproval, "some pane tail text", "permission:edit | options:a", false},
+		{"approval both pane-tail pass (similarity only)", domain.SituationApproval, "some pane tail", "other pane tail", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := domain.Situation{Type: tt.typ}
+			sig := domain.SignatureResult{Salient: tt.salient}
+			hit := match.Hit{Salient: tt.cand}
+			if got := remapAllowed(s, sig, hit); got != tt.want {
+				t.Errorf("remapAllowed(%s, %q, %q) = %v, want %v", tt.typ, tt.salient, tt.cand, got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/daemon/semantic_test.go
+++ b/internal/daemon/semantic_test.go
@@ -759,7 +759,7 @@ func TestDaemonSemanticStressNoHangRaceOrLeak(t *testing.T) {
 				default:
 				}
 				if err := d.matcher.Rebuild(rowsFor(verbs[(r+i)%len(verbs)]), 4); err != nil {
-					if !strings.Contains(err.Error(), "matcher closed") {
+					if !errors.Is(err, match.ErrClosed) {
 						errs.add(fmt.Errorf("phase-2 rebuild: %w", err))
 					}
 					return

--- a/internal/daemon/semantic_test.go
+++ b/internal/daemon/semantic_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -572,5 +573,115 @@ func TestRemapAllowedContract(t *testing.T) {
 				t.Errorf("remapAllowed(%s, %q, %q) = %v, want %v", tt.typ, tt.salient, tt.cand, got, tt.want)
 			}
 		})
+	}
+}
+
+// countIdxDirs returns how many idx-* generation directories exist under base
+// (0 if base itself is gone).
+func countIdxDirs(t *testing.T, base string) int {
+	t.Helper()
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("read match index dir %s: %v", base, err)
+	}
+	n := 0
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "idx-") {
+			n++
+		}
+	}
+	return n
+}
+
+// TestDaemonSemanticStressNoHangRaceOrLeak is an end-to-end stress test of the
+// daemon's semantic subsystem: many goroutines drive the real resolve path
+// (embed + match via resolveSignature) while several others overlap Rebuilds on
+// the same live matcher, then the matcher is shut down WHILE searches are still
+// in flight (close-during-search). It asserts the whole
+// storm completes (no hang/deadlock), trips no data race (run under -race), the
+// generation guard leaves no abandoned idx-* directories, and shutdown removes
+// the index directory entirely. This is the integration-level guard for the
+// close-during-search, overlapping-rebuild, and cleanup fixes.
+func TestDaemonSemanticStressNoHangRaceOrLeak(t *testing.T) {
+	emb := &fakeEmbedder{vectors: map[string][]float32{
+		"permission:edit the config | options:":     {1, 0, 0, 0},
+		"permission:run the tests | options:":       {0, 1, 0, 0},
+		"permission:delete the database | options:": {0, 0, 1, 0},
+	}}
+	d := semanticHarness(t, emb, "")
+	indexDir := d.opt.MatchIndexDir
+
+	ctx := context.Background()
+	cfg, _, _ := d.snapshot()
+	verbs := []string{"edit the config", "run the tests", "delete the database"}
+
+	rowsFor := func(tag string) []domain.SignatureEmbedding {
+		return []domain.SignatureEmbedding{{
+			Signature: "approval:" + tag, SituationType: domain.SituationApproval,
+			AgentType: "claude", Salient: "permission:" + tag + " | options:",
+			Vector: []float32{1, 0, 0, 0}, Dims: 4, Model: "fake-model",
+		}}
+	}
+
+	var searchers, rebuilders sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Concurrent searchers: hammer the daemon's real resolve path until stop.
+	for i := 0; i < 6; i++ {
+		searchers.Add(1)
+		go func(i int) {
+			defer searchers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				s := approvalSituation(verbs[i%len(verbs)])
+				_ = d.resolveSignature(ctx, cfg, domain.ComputeSignature(s), s)
+			}
+		}(i)
+	}
+
+	// Overlapping rebuilders: several goroutines rebuild the same live matcher
+	// concurrently, so builds overlap and the generation guard runs under live
+	// search. Bounded work so the storm terminates deterministically.
+	for r := 0; r < 3; r++ {
+		rebuilders.Add(1)
+		go func(r int) {
+			defer rebuilders.Done()
+			for i := 0; i < 20; i++ {
+				if err := d.matcher.Rebuild(rowsFor(verbs[(r+i)%len(verbs)]), 4); err != nil {
+					t.Errorf("rebuild: %v", err)
+					return
+				}
+			}
+		}(r)
+	}
+
+	rebuilders.Wait() // the rebuild storm finishes; searchers keep hammering
+
+	// The generation guard + per-build cleanup must leave at most one live idx-*
+	// dir — no abandoned generations accumulated during the overlap. Searchers
+	// are still running but never create idx-* dirs, so this count is stable.
+	if n := countIdxDirs(t, indexDir); n > 1 {
+		t.Errorf("abandoned index dirs accumulated: %d idx-* dirs, want <= 1", n)
+	}
+
+	// Shutdown WHILE searches are still in flight (the real close-during-search
+	// case): Close must wait for in-flight lookups rather than closing the index
+	// under them — no deadlock, panic, or race — and must remove the whole index
+	// directory. The searchers then degrade onto the post-close error path.
+	if err := d.matcher.Close(); err != nil {
+		t.Fatalf("shutdown Close during in-flight search: %v", err)
+	}
+	close(stop)
+	searchers.Wait()
+
+	if _, err := os.Stat(indexDir); !os.IsNotExist(err) {
+		t.Errorf("match index dir leaked after Close: stat err = %v", err)
 	}
 }

--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -536,7 +536,7 @@ func TestLLMMultiTabConsultAndSeriesPromotion(t *testing.T) {
 
 func TestLLMMultiTabSeriesDeniedWhenDisableWinsFinalBarrier(t *testing.T) {
 	cfg := "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n"
-	h := newHarness(t, cfg)
+	h, gate := newHarnessPaused(t, cfg)
 	h.herdr.setFrames(mcqFrames)
 	h.llm.configured = true
 	h.llm.consult = func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
@@ -549,10 +549,6 @@ func TestLLMMultiTabSeriesDeniedWhenDisableWinsFinalBarrier(t *testing.T) {
 		return &domain.LLMDecision{ID: id, RequestID: req.RequestID, Action: "1 2 1",
 			Rationale: "defaults", ConfidentScore: 80, Status: "pending"}, nil
 	}
-	gate := &pausingAutomationStore{
-		StorePort: h.store, reached: make(chan struct{}), resume: make(chan struct{}),
-	}
-	h.daemon.opt.Store = gate
 	h.push("agent-mcqllm-disabled", "blocked")
 	select {
 	case <-gate.reached:

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -34,6 +34,14 @@ import (
 // fall-back — but the reason is now identifiable.
 var ErrClosed = errors.New("matcher closed")
 
+// ErrCleanup wraps a Rebuild error that occurred AFTER a new index was
+// successfully published: the rebuild itself succeeded, only removing the
+// previous generation's directory (or closing its index) failed, leaking it.
+// Callers can errors.Is(err, match.ErrCleanup) to keep using the now-live index
+// while surfacing the leak, versus a plain Rebuild error (the rebuild failed and
+// nothing was published).
+var ErrCleanup = errors.New("match index cleanup failed")
+
 // Scope restricts a lookup to one (situation type, agent type) pair, the
 // same partitioning ComputeSignature bakes into hash keys: a rule learned
 // for Claude approvals must never match a Codex choice.
@@ -69,6 +77,11 @@ type Matcher struct {
 	// cleanup. Add is done under mu, gated by !closed, so it never races Wait.
 	rebuildWG sync.WaitGroup
 
+	// removeAll deletes an index directory tree (os.RemoveAll in production). A
+	// test may swap it to inject a filesystem cleanup failure; set it before any
+	// concurrent use so the read stays race-free.
+	removeAll func(dir string) error
+
 	// publishBarrier, when non-nil, is invoked with a Rebuild's reserved
 	// generation right before it acquires the publish lock. Test-only seam (nil
 	// in production) for deterministically interleaving overlapping Rebuilds to
@@ -81,7 +94,7 @@ type Matcher struct {
 // index is disposable, SQLite is the source of truth). Call Rebuild next.
 func New(baseDir string) *Matcher {
 	os.RemoveAll(baseDir)
-	return &Matcher{baseDir: baseDir}
+	return &Matcher{baseDir: baseDir, removeAll: os.RemoveAll}
 }
 
 type doc struct {
@@ -163,22 +176,19 @@ func (m *Matcher) Rebuild(rows []domain.SignatureEmbedding, dims int) error {
 	}
 	idx, err := buildIndex(dir, dims)
 	if err != nil {
-		os.RemoveAll(dir) // don't leave a half-built index directory behind
-		return fmt.Errorf("build match index: %w", err)
+		// Don't leave a half-built index directory behind; surface a cleanup
+		// failure alongside the build error.
+		return errors.Join(fmt.Errorf("build match index: %w", err), m.cleanupIndex(nil, dir))
 	}
 	batch := idx.NewBatch()
 	for _, r := range rows {
 		if err := batch.Index(r.Signature, toDoc(r, dims)); err != nil {
-			idx.Close()
-			os.RemoveAll(dir)
-			return fmt.Errorf("index signature %s: %w", r.Signature, err)
+			return errors.Join(fmt.Errorf("index signature %s: %w", r.Signature, err), m.cleanupIndex(idx.Close, dir))
 		}
 	}
 	if batch.Size() > 0 {
 		if err := idx.Batch(batch); err != nil {
-			idx.Close()
-			os.RemoveAll(dir)
-			return fmt.Errorf("populate match index: %w", err)
+			return errors.Join(fmt.Errorf("populate match index: %w", err), m.cleanupIndex(idx.Close, dir))
 		}
 	}
 
@@ -196,19 +206,22 @@ func (m *Matcher) Rebuild(rows []domain.SignatureEmbedding, dims int) error {
 	stale := m.gen != gen
 	if closed || stale {
 		m.mu.Unlock()
-		idx.Close()
-		os.RemoveAll(dir)
+		cleanupErr := m.cleanupIndex(idx.Close, dir)
 		if closed {
-			return ErrClosed
+			return errors.Join(ErrClosed, cleanupErr)
 		}
-		return nil // superseded by a newer Rebuild, which owns the index
+		return cleanupErr // superseded by a newer Rebuild; nil unless cleanup failed
 	}
 	old, oldDir := m.idx, m.idxDir
 	m.idx, m.idxDir, m.dims = idx, dir, dims
 	m.mu.Unlock()
 	if old != nil {
-		old.Close()
-		os.RemoveAll(oldDir)
+		if cleanupErr := m.cleanupIndex(old.Close, oldDir); cleanupErr != nil {
+			// The new index is live and published; only reclaiming the previous
+			// generation failed. Wrap ErrCleanup so callers can keep using the
+			// live index while still seeing the leak.
+			return errors.Join(ErrCleanup, cleanupErr)
+		}
 	}
 	return nil
 }
@@ -430,6 +443,18 @@ func (m *Matcher) textSelfScore(ctx context.Context, idx bleve.Index, text strin
 	return res.Hits[0].Score, res.Hits[0].ID, true, nil
 }
 
+// cleanupIndex closes closeIdx (when non-nil) and removes dir, joining any
+// errors so a leaked generation directory or an index that won't close is
+// surfaced, not swallowed. Returns nil when both succeed (errors.Join drops
+// nils, so errors.Join(nil, nil) == nil).
+func (m *Matcher) cleanupIndex(closeIdx func() error, dir string) error {
+	var idxErr error
+	if closeIdx != nil {
+		idxErr = closeIdx()
+	}
+	return errors.Join(idxErr, m.removeAll(dir))
+}
+
 // Close releases the underlying index and removes its cache directory.
 // Further Rebuild/Add calls fail; Match calls report unavailable.
 func (m *Matcher) Close() error {
@@ -451,11 +476,12 @@ func (m *Matcher) Close() error {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	var err error
+	var idxErr error
 	if m.idx != nil {
-		err = m.idx.Close()
+		idxErr = m.idx.Close()
 		m.idx = nil
 	}
-	os.RemoveAll(m.baseDir)
-	return err
+	// Surface a failed cleanup (index that won't close, or a dir that won't
+	// remove) instead of swallowing it — a caller/test can observe the leak.
+	return errors.Join(idxErr, m.removeAll(m.baseDir))
 }

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -10,6 +10,7 @@ package match
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,6 +24,15 @@ import (
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 )
+
+// ErrClosed is the sentinel a Matcher's methods return once Close has run:
+// Rebuild, Add, and Delete (mutations) and MatchText/MatchVector (lookups) report
+// it, so callers can branch with errors.Is(err, match.ErrClosed) instead of
+// matching strings. (In a build without the "vectors" tag, MatchVector reports
+// its unavailable-build-tag error ahead of ErrClosed, since KNN is never linked
+// there.) Lookups still degrade the same way — the daemon treats a match error as
+// a fall-back — but the reason is now identifiable.
+var ErrClosed = errors.New("matcher closed")
 
 // Scope restricts a lookup to one (situation type, agent type) pair, the
 // same partitioning ComputeSignature bakes into hash keys: a rule learned
@@ -135,7 +145,7 @@ func (m *Matcher) Rebuild(rows []domain.SignatureEmbedding, dims int) error {
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
-		return fmt.Errorf("matcher closed")
+		return ErrClosed
 	}
 	m.gen++
 	gen := m.gen // this build's generation; a newer Rebuild bumps m.gen past it
@@ -189,7 +199,7 @@ func (m *Matcher) Rebuild(rows []domain.SignatureEmbedding, dims int) error {
 		idx.Close()
 		os.RemoveAll(dir)
 		if closed {
-			return fmt.Errorf("matcher closed")
+			return ErrClosed
 		}
 		return nil // superseded by a newer Rebuild, which owns the index
 	}
@@ -203,20 +213,28 @@ func (m *Matcher) Rebuild(rows []domain.SignatureEmbedding, dims int) error {
 	return nil
 }
 
-// Add indexes one signature (idempotent: re-adding replaces the doc).
+// Add indexes one signature (idempotent: re-adding replaces the doc). Returns
+// ErrClosed after Close, distinct from the not-yet-built error.
 func (m *Matcher) Add(r domain.SignatureEmbedding) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+	if m.closed {
+		return ErrClosed
+	}
 	if m.idx == nil {
 		return fmt.Errorf("match index not built yet")
 	}
 	return m.idx.Index(r.Signature, toDoc(r, m.dims))
 }
 
-// Delete removes one signature from the index.
+// Delete removes one signature from the index. Returns ErrClosed after Close; a
+// not-yet-built index (never a closed one) is a no-op.
 func (m *Matcher) Delete(signature string) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+	if m.closed {
+		return ErrClosed
+	}
 	if m.idx == nil {
 		return nil
 	}
@@ -274,6 +292,9 @@ func (m *Matcher) MatchVector(ctx context.Context, vec []float32, s Scope, accep
 	// never index construction. Regression: TestMatcherConcurrentRebuildAndMatchVector.
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+	if m.closed {
+		return Hit{}, false, ErrClosed
+	}
 	idx, dims := m.idx, m.dims
 	if idx == nil || dims == 0 {
 		return Hit{}, false, fmt.Errorf("vector matching unavailable (no vector index)")
@@ -313,6 +334,9 @@ func (m *Matcher) MatchText(ctx context.Context, salient string, s Scope, accept
 	// snapshot-then-release is unsafe.
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+	if m.closed {
+		return Hit{}, false, ErrClosed
+	}
 	idx := m.idx
 	if idx == nil {
 		return Hit{}, false, fmt.Errorf("text matching unavailable (no index)")

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -210,14 +210,25 @@ const matchK = 3
 // best acceptable one. ok is false when no candidate is acceptable; Score is
 // the raw cosine (bleve's cosine metric normalizes and inner-products, so
 // the hit score IS the cosine similarity) — thresholding is the caller's.
-// accept must be a fast, pure content check (it runs inline per candidate).
+// accept must be a fast, pure content check (it runs inline per candidate,
+// under the read lock) and must not call back into the Matcher — doing so
+// deadlocks against a pending Rebuild/Close writer.
 func (m *Matcher) MatchVector(ctx context.Context, vec []float32, s Scope, accept func(Hit) bool) (Hit, bool, error) {
 	if !vectorSearchSupported {
 		return Hit{}, false, fmt.Errorf("vector matching unavailable (built without the \"vectors\" tag)")
 	}
+	// Hold the read lock for the WHOLE search. Rebuild/Close take the write lock
+	// to swap in a new index and Close the old one, so holding RLock across the
+	// search guarantees the index cannot be closed mid-read. Snapshotting idx and
+	// releasing before the search races old.Close() against an in-flight bleve KNN
+	// read and DEADLOCKS: runKnnCollector re-acquires the index's internal RLock
+	// (DocCount) while Close is already blocked on that index's write lock. The
+	// build cost stays off this lock — Rebuild constructs the new index before
+	// taking the write lock, so searches only ever gate the brief pointer swap,
+	// never index construction. Regression: TestMatcherConcurrentRebuildAndMatchVector.
 	m.mu.RLock()
+	defer m.mu.RUnlock()
 	idx, dims := m.idx, m.dims
-	m.mu.RUnlock()
 	if idx == nil || dims == 0 {
 		return Hit{}, false, fmt.Errorf("vector matching unavailable (no vector index)")
 	}
@@ -247,11 +258,16 @@ func (m *Matcher) MatchVector(ctx context.Context, vec []float32, s Scope, accep
 // matches as well as the stored text matches itself. Up to matchK candidates
 // are considered and the highest NORMALIZED acceptable one wins (raw BM25
 // order can differ from normalized order). accept must be a fast, pure
-// content check (it runs inline per candidate).
+// content check (it runs inline per candidate, under the read lock) and must
+// not call back into the Matcher — doing so deadlocks against a pending
+// Rebuild/Close writer.
 func (m *Matcher) MatchText(ctx context.Context, salient string, s Scope, accept func(Hit) bool) (Hit, bool, error) {
+	// Hold the read lock for the whole search (including textSelfScore's follow-up
+	// queries) so the index cannot be closed mid-read — see MatchVector for why
+	// snapshot-then-release is unsafe.
 	m.mu.RLock()
+	defer m.mu.RUnlock()
 	idx := m.idx
-	m.mu.RUnlock()
 	if idx == nil {
 		return Hit{}, false, fmt.Errorf("text matching unavailable (no index)")
 	}

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -27,11 +27,11 @@ import (
 
 // ErrClosed is the sentinel a Matcher's methods return once Close has run:
 // Rebuild, Add, and Delete (mutations) and MatchText/MatchVector (lookups) report
-// it, so callers can branch with errors.Is(err, match.ErrClosed) instead of
-// matching strings. (In a build without the "vectors" tag, MatchVector reports
-// its unavailable-build-tag error ahead of ErrClosed, since KNN is never linked
-// there.) Lookups still degrade the same way — the daemon treats a match error as
-// a fall-back — but the reason is now identifiable.
+// it in every build config — including a build without the "vectors" tag, where
+// MatchVector's closed check runs before its availability error — so callers can
+// branch with errors.Is(err, match.ErrClosed) instead of matching strings.
+// Lookups still degrade the same way — the daemon treats a match error as a
+// fall-back — but the reason is now identifiable.
 var ErrClosed = errors.New("matcher closed")
 
 // Scope restricts a lookup to one (situation type, agent type) pair, the
@@ -278,9 +278,6 @@ const matchK = 3
 // under the read lock) and must not call back into the Matcher — doing so
 // deadlocks against a pending Rebuild/Close writer.
 func (m *Matcher) MatchVector(ctx context.Context, vec []float32, s Scope, accept func(Hit) bool) (Hit, bool, error) {
-	if !vectorSearchSupported {
-		return Hit{}, false, fmt.Errorf("vector matching unavailable (built without the \"vectors\" tag)")
-	}
 	// Hold the read lock for the WHOLE search. Rebuild/Close take the write lock
 	// to swap in a new index and Close the old one, so holding RLock across the
 	// search guarantees the index cannot be closed mid-read. Snapshotting idx and
@@ -292,8 +289,14 @@ func (m *Matcher) MatchVector(ctx context.Context, vec []float32, s Scope, accep
 	// never index construction. Regression: TestMatcherConcurrentRebuildAndMatchVector.
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+	// Closed check first, so a closed matcher reports ErrClosed consistently in
+	// every build — even a !vectors build, where the availability error below
+	// would otherwise mask it.
 	if m.closed {
 		return Hit{}, false, ErrClosed
+	}
+	if !vectorSearchSupported {
+		return Hit{}, false, fmt.Errorf("vector matching unavailable (built without the \"vectors\" tag)")
 	}
 	idx, dims := m.idx, m.dims
 	if idx == nil || dims == 0 {

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -53,6 +53,12 @@ type Matcher struct {
 	gen    int    // generation counter naming index subdirectories
 	closed bool   // Rebuild refuses after Close (late background init)
 
+	// rebuildWG tracks Rebuilds that passed the closed check and may still be
+	// touching the filesystem off-lock (MkdirAll/buildIndex). Close waits on it
+	// before its final RemoveAll so no in-flight Rebuild recreates baseDir after
+	// cleanup. Add is done under mu, gated by !closed, so it never races Wait.
+	rebuildWG sync.WaitGroup
+
 	// publishBarrier, when non-nil, is invoked with a Rebuild's reserved
 	// generation right before it acquires the publish lock. Test-only seam (nil
 	// in production) for deterministically interleaving overlapping Rebuilds to
@@ -134,7 +140,13 @@ func (m *Matcher) Rebuild(rows []domain.SignatureEmbedding, dims int) error {
 	m.gen++
 	gen := m.gen // this build's generation; a newer Rebuild bumps m.gen past it
 	dir := filepath.Join(m.baseDir, fmt.Sprintf("idx-%d", gen))
+	// Register as in-flight while still holding mu and having observed !closed,
+	// so Close (which sets closed under mu before Wait) never races this Add. The
+	// off-lock MkdirAll/buildIndex below may recreate baseDir; Close waits for
+	// our Done before its final RemoveAll.
+	m.rebuildWG.Add(1)
 	m.mu.Unlock()
+	defer m.rebuildWG.Done()
 
 	if err := os.MkdirAll(m.baseDir, 0o700); err != nil {
 		return fmt.Errorf("create match index dir: %w", err)
@@ -363,13 +375,28 @@ func (m *Matcher) textSelfScore(ctx context.Context, idx bleve.Index, text strin
 // Further Rebuild/Add calls fail; Match calls report unavailable.
 func (m *Matcher) Close() error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.closed = true
-	if m.idx == nil {
-		return nil
+	if m.closed {
+		m.mu.Unlock()
+		return nil // idempotent: an earlier Close already tore everything down
 	}
-	err := m.idx.Close()
-	m.idx = nil
+	m.closed = true
+	m.mu.Unlock()
+
+	// Drain in-flight Rebuilds first. Setting closed under mu (above) stops new
+	// Rebuilds from starting (they bail before touching the filesystem), and any
+	// Rebuild that already passed its closed check registered in rebuildWG and
+	// will abort at its publish step. Waiting for them here guarantees no
+	// Rebuild's off-lock MkdirAll/buildIndex can recreate baseDir AFTER the final
+	// RemoveAll below, so shutdown leaves nothing behind.
+	m.rebuildWG.Wait()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var err error
+	if m.idx != nil {
+		err = m.idx.Close()
+		m.idx = nil
+	}
 	os.RemoveAll(m.baseDir)
 	return err
 }

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -274,10 +274,29 @@ const matchK = 3
 // best acceptable one. ok is false when no candidate is acceptable; Score is
 // the raw cosine (bleve's cosine metric normalizes and inner-products, so
 // the hit score IS the cosine similarity) — thresholding is the caller's.
-// accept must be a fast, pure content check (it runs inline per candidate,
-// under the read lock) and must not call back into the Matcher — doing so
-// deadlocks against a pending Rebuild/Close writer.
+// accept must be a fast, pure content check; it runs per candidate OUTSIDE the
+// matcher lock (over value-copy hits materialized under the lock), so — unlike
+// the search itself — it may safely call back into the Matcher. Those candidates
+// are a point-in-time snapshot: an accept that mutates the matcher (Delete/
+// Rebuild) may observe or return a now-stale signature.
 func (m *Matcher) MatchVector(ctx context.Context, vec []float32, s Scope, accept func(Hit) bool) (Hit, bool, error) {
+	cands, err := m.vectorCandidates(ctx, vec, s)
+	if err != nil {
+		return Hit{}, false, err
+	}
+	for _, hit := range cands { // descending similarity
+		if accept == nil || accept(hit) {
+			return hit, true, nil
+		}
+	}
+	return Hit{}, false, nil
+}
+
+// vectorCandidates runs the KNN search under the read lock and returns the top-K
+// matches as value copies (independent of the index), so MatchVector can apply
+// accept after releasing the lock. The lock spans the whole search but never the
+// accept callback.
+func (m *Matcher) vectorCandidates(ctx context.Context, vec []float32, s Scope) ([]Hit, error) {
 	// Hold the read lock for the WHOLE search. Rebuild/Close take the write lock
 	// to swap in a new index and Close the old one, so holding RLock across the
 	// search guarantees the index cannot be closed mid-read. Snapshotting idx and
@@ -293,31 +312,28 @@ func (m *Matcher) MatchVector(ctx context.Context, vec []float32, s Scope, accep
 	// every build — even a !vectors build, where the availability error below
 	// would otherwise mask it.
 	if m.closed {
-		return Hit{}, false, ErrClosed
+		return nil, ErrClosed
 	}
 	if !vectorSearchSupported {
-		return Hit{}, false, fmt.Errorf("vector matching unavailable (built without the \"vectors\" tag)")
+		return nil, fmt.Errorf("vector matching unavailable (built without the \"vectors\" tag)")
 	}
 	idx, dims := m.idx, m.dims
 	if idx == nil || dims == 0 {
-		return Hit{}, false, fmt.Errorf("vector matching unavailable (no vector index)")
+		return nil, fmt.Errorf("vector matching unavailable (no vector index)")
 	}
 	if len(vec) != dims {
-		return Hit{}, false, fmt.Errorf("query vector dims %d != index dims %d", len(vec), dims)
+		return nil, fmt.Errorf("query vector dims %d != index dims %d", len(vec), dims)
 	}
-
 	res, err := knnSearch(ctx, idx, vec, matchK, []string{"salient"}, scopeFilter(s))
 	if err != nil {
-		return Hit{}, false, err
+		return nil, err
 	}
+	cands := make([]Hit, 0, len(res.Hits))
 	for _, h := range res.Hits { // descending similarity
 		stored, _ := h.Fields["salient"].(string)
-		hit := Hit{Signature: h.ID, Score: h.Score, Salient: stored}
-		if accept == nil || accept(hit) {
-			return hit, true, nil
-		}
+		cands = append(cands, Hit{Signature: h.ID, Score: h.Score, Salient: stored})
 	}
-	return Hit{}, false, nil
+	return cands, nil
 }
 
 // MatchText returns the best BM25 match for the salient text within scope
@@ -327,22 +343,46 @@ func (m *Matcher) MatchVector(ctx context.Context, vec []float32, s Scope, accep
 // stays meaningful as the corpus (and its IDF) grows. 1.0 means the query
 // matches as well as the stored text matches itself. Up to matchK candidates
 // are considered and the highest NORMALIZED acceptable one wins (raw BM25
-// order can differ from normalized order). accept must be a fast, pure
-// content check (it runs inline per candidate, under the read lock) and must
-// not call back into the Matcher — doing so deadlocks against a pending
-// Rebuild/Close writer.
+// order can differ from normalized order). accept must be a fast, pure content
+// check; it runs per candidate OUTSIDE the matcher lock (over normalized
+// value-copy hits), so it may safely call back into the Matcher. Those
+// candidates are a point-in-time snapshot: an accept that mutates the matcher
+// may observe or return a now-stale signature.
 func (m *Matcher) MatchText(ctx context.Context, salient string, s Scope, accept func(Hit) bool) (Hit, bool, error) {
-	// Hold the read lock for the whole search (including textSelfScore's follow-up
-	// queries) so the index cannot be closed mid-read — see MatchVector for why
-	// snapshot-then-release is unsafe.
+	cands, err := m.textCandidates(ctx, salient, s)
+	if err != nil {
+		return Hit{}, false, err
+	}
+	var best Hit
+	var found bool
+	for _, cand := range cands {
+		if accept != nil && !accept(cand) {
+			continue
+		}
+		if !found || cand.Score > best.Score {
+			best = cand
+			found = true
+		}
+	}
+	return best, found, nil
+}
+
+// textCandidates runs the BM25 search under the read lock and returns up to
+// matchK candidates with their scores already NORMALIZED (each hit's BM25 score
+// divided by the score its own stored text achieves), so MatchText can apply
+// accept after releasing the lock. Non-normalizable candidates (a stored text
+// that isn't its own best match) are dropped here. The lock spans the search and
+// every textSelfScore follow-up query but never the accept callback — see
+// MatchVector for why snapshot-then-release around the search itself is unsafe.
+func (m *Matcher) textCandidates(ctx context.Context, salient string, s Scope) ([]Hit, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if m.closed {
-		return Hit{}, false, ErrClosed
+		return nil, ErrClosed
 	}
 	idx := m.idx
 	if idx == nil {
-		return Hit{}, false, fmt.Errorf("text matching unavailable (no index)")
+		return nil, fmt.Errorf("text matching unavailable (no index)")
 	}
 
 	mq := bleve.NewMatchQuery(salient)
@@ -352,20 +392,15 @@ func (m *Matcher) MatchText(ctx context.Context, salient string, s Scope, accept
 	req.Fields = []string{"salient"}
 	res, err := idx.SearchInContext(ctx, req)
 	if err != nil {
-		return Hit{}, false, err
+		return nil, err
 	}
 
-	var best Hit
-	var found bool
+	cands := make([]Hit, 0, len(res.Hits))
 	for _, h := range res.Hits {
 		stored, _ := h.Fields["salient"].(string)
-		cand := Hit{Signature: h.ID, Score: h.Score, Salient: stored}
-		if accept != nil && !accept(cand) {
-			continue
-		}
 		self, selfID, selfOK, err := m.textSelfScore(ctx, idx, stored, s)
 		if err != nil {
-			return Hit{}, false, err
+			return nil, err
 		}
 		if !selfOK || selfID != h.ID || self <= 0 {
 			// The stored text should always be its own best match; anything
@@ -376,12 +411,9 @@ func (m *Matcher) MatchText(ctx context.Context, salient string, s Scope, accept
 		if norm > 1 {
 			norm = 1
 		}
-		if !found || norm > best.Score {
-			best = Hit{Signature: h.ID, Score: norm, Salient: stored}
-			found = true
-		}
+		cands = append(cands, Hit{Signature: h.ID, Score: norm, Salient: stored})
 	}
-	return best, found, nil
+	return cands, nil
 }
 
 // textSelfScore runs one scoped BM25 query for a candidate's own stored text,

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -52,6 +52,13 @@ type Matcher struct {
 	dims   int    // vector dimensionality the mapping was built with (0 = text only)
 	gen    int    // generation counter naming index subdirectories
 	closed bool   // Rebuild refuses after Close (late background init)
+
+	// publishBarrier, when non-nil, is invoked with a Rebuild's reserved
+	// generation right before it acquires the publish lock. Test-only seam (nil
+	// in production) for deterministically interleaving overlapping Rebuilds to
+	// exercise the stale-generation guard; set it before any concurrent use so
+	// the read stays race-free. See TestRebuildStaleGenerationDoesNotClobber.
+	publishBarrier func(gen int)
 }
 
 // New returns an empty matcher caching its index under baseDir (wiped: the
@@ -100,6 +107,15 @@ func buildIndex(path string, dims int) (bleve.Index, error) {
 // Rebuild replaces the index with one built from rows. dims is the vector
 // dimensionality of the active embedding model (0 indexes text only; any
 // row's vector with a different length is indexed as text only).
+//
+// The build runs off the lock so searches never block on it; only the final
+// pointer swap is under the write lock. Each call reserves a monotonic
+// generation up front, so overlapping Rebuilds are safe: if a newer Rebuild
+// starts while this one is still building, this (now stale) one discards its
+// index instead of publishing — out-of-order completion never clobbers newer
+// data (it returns nil, since the newer generation owns the index). Every
+// abandoned index directory — a failed, superseded, or replaced build — is
+// removed, so the cache never leaks generations.
 func (m *Matcher) Rebuild(rows []domain.SignatureEmbedding, dims int) error {
 	if !vectorSearchSupported {
 		// No KNN engine is linked (built without the `vectors` tag), so the
@@ -116,7 +132,8 @@ func (m *Matcher) Rebuild(rows []domain.SignatureEmbedding, dims int) error {
 		return fmt.Errorf("matcher closed")
 	}
 	m.gen++
-	dir := filepath.Join(m.baseDir, fmt.Sprintf("idx-%d", m.gen))
+	gen := m.gen // this build's generation; a newer Rebuild bumps m.gen past it
+	dir := filepath.Join(m.baseDir, fmt.Sprintf("idx-%d", gen))
 	m.mu.Unlock()
 
 	if err := os.MkdirAll(m.baseDir, 0o700); err != nil {
@@ -124,28 +141,45 @@ func (m *Matcher) Rebuild(rows []domain.SignatureEmbedding, dims int) error {
 	}
 	idx, err := buildIndex(dir, dims)
 	if err != nil {
+		os.RemoveAll(dir) // don't leave a half-built index directory behind
 		return fmt.Errorf("build match index: %w", err)
 	}
 	batch := idx.NewBatch()
 	for _, r := range rows {
 		if err := batch.Index(r.Signature, toDoc(r, dims)); err != nil {
 			idx.Close()
+			os.RemoveAll(dir)
 			return fmt.Errorf("index signature %s: %w", r.Signature, err)
 		}
 	}
 	if batch.Size() > 0 {
 		if err := idx.Batch(batch); err != nil {
 			idx.Close()
+			os.RemoveAll(dir)
 			return fmt.Errorf("populate match index: %w", err)
 		}
 	}
 
+	if m.publishBarrier != nil {
+		m.publishBarrier(gen) // test-only ordering seam; nil in production
+	}
+
 	m.mu.Lock()
-	if m.closed { // Close raced in while we were indexing
+	// Refuse to publish a stale generation: if another Rebuild started while we
+	// were building (m.gen advanced past ours) it owns the index now, and
+	// publishing here would clobber its newer data with ours — out-of-order
+	// completion must not win. Also abort if Close raced in. Either way, discard
+	// the index we just built and remove its abandoned directory.
+	closed := m.closed
+	stale := m.gen != gen
+	if closed || stale {
 		m.mu.Unlock()
 		idx.Close()
 		os.RemoveAll(dir)
-		return fmt.Errorf("matcher closed")
+		if closed {
+			return fmt.Errorf("matcher closed")
+		}
+		return nil // superseded by a newer Rebuild, which owns the index
 	}
 	old, oldDir := m.idx, m.idxDir
 	m.idx, m.idxDir, m.dims = idx, dir, dims

--- a/internal/match/match_novectors_test.go
+++ b/internal/match/match_novectors_test.go
@@ -4,6 +4,7 @@ package match
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -57,5 +58,38 @@ func TestRebuildTextOnlyWithoutVectors(t *testing.T) {
 	if _, ok, err := m.MatchText(context.Background(), "permission: delete a temporary file",
 		Scope{domain.SituationApproval, "claude"}, nil); err != nil || !ok {
 		t.Errorf("added row not text-matchable: ok=%v err=%v", ok, err)
+	}
+}
+
+// TestMatcherClosedReturnsErrClosedWithoutVectors is the tag-free lifecycle
+// regression: in a !vectors build a CLOSED matcher's MatchVector must report the
+// ErrClosed sentinel, not the build-tag "unavailable" error, so post-Close
+// behavior is identical across builds. The closed check runs before the tag
+// check; an OPEN matcher in this build still reports unavailable (not ErrClosed).
+func TestMatcherClosedReturnsErrClosedWithoutVectors(t *testing.T) {
+	scope := Scope{domain.SituationApproval, "claude"}
+
+	closed := New(t.TempDir())
+	if err := closed.Rebuild([]domain.SignatureEmbedding{
+		row("approval:edit", domain.SituationApproval, "claude", "permission: edit", nil),
+	}, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := closed.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, ok, err := closed.MatchVector(context.Background(), []float32{1, 0, 0}, scope, nil); ok || !errors.Is(err, ErrClosed) {
+		t.Errorf("MatchVector after Close in !vectors build: ok=%v err=%v, want no hit and errors.Is ErrClosed", ok, err)
+	}
+
+	// An OPEN matcher in this build still reports the unavailable tag error, which
+	// must NOT be ErrClosed — confirms the closed check gates it, not vice versa.
+	open := New(t.TempDir())
+	defer open.Close()
+	if err := open.Rebuild(nil, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := open.MatchVector(context.Background(), []float32{1, 0, 0}, scope, nil); ok || err == nil || errors.Is(err, ErrClosed) {
+		t.Errorf("open !vectors MatchVector: ok=%v err=%v, want the unavailable tag error (not ErrClosed)", ok, err)
 	}
 }

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -2,6 +2,7 @@ package match
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -160,11 +161,13 @@ func TestMatcherConcurrentRebuildAndMatch(t *testing.T) {
 	}
 }
 
-// TestMatcherClosePostCloseBehavior pins the fail-safe contract after Close:
-// every method degrades cleanly (an error or a no-op) and none panics, so a
-// daemon shutdown racing a late lookup can't crash. Runs in both build configs
-// via the text path.
-func TestMatcherClosePostCloseBehavior(t *testing.T) {
+// TestMatcherClosedReturnsErrClosed pins the standardized post-Close contract:
+// every method — the mutations Rebuild/Add/Delete and the lookup MatchText —
+// reports the ErrClosed sentinel (matchable with errors.Is), none panics, and
+// Close stays idempotent. This is the table-driven lifecycle guard; runs in both
+// build configs via the tag-independent methods. MatchVector's sentinel is
+// covered under the vectors tag in TestMatcherClosedReturnsErrClosedVector.
+func TestMatcherClosedReturnsErrClosed(t *testing.T) {
 	m := New(t.TempDir())
 	scope := Scope{domain.SituationApproval, "claude"}
 	if err := m.Rebuild([]domain.SignatureEmbedding{
@@ -181,21 +184,50 @@ func TestMatcherClosePostCloseBehavior(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	// Post-close every method degrades cleanly, never panics.
-	if _, ok, err := m.MatchText(context.Background(), "permission: edit the config", scope, nil); err == nil || ok {
-		t.Errorf("MatchText after Close: ok=%v err=%v, want no hit and an error", ok, err)
+	ops := []struct {
+		name string
+		call func() error
+	}{
+		{"Rebuild", func() error { return m.Rebuild(nil, 0) }},
+		{"Add", func() error {
+			return m.Add(row("approval:new", domain.SituationApproval, "claude", "permission: run", nil))
+		}},
+		{"Delete", func() error { return m.Delete("approval:edit") }},
+		{"MatchText", func() error {
+			_, _, err := m.MatchText(context.Background(), "permission: edit the config", scope, nil)
+			return err
+		}},
 	}
-	if err := m.Add(row("approval:new", domain.SituationApproval, "claude", "permission: run", nil)); err == nil {
-		t.Error("Add after Close must error")
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			if err := op.call(); !errors.Is(err, ErrClosed) {
+				t.Errorf("%s after Close = %v, want errors.Is(err, ErrClosed)", op.name, err)
+			}
+		})
 	}
-	if err := m.Delete("approval:edit"); err != nil {
-		t.Errorf("Delete after Close should be a no-op nil, got %v", err)
-	}
-	if err := m.Rebuild(nil, 0); err == nil {
-		t.Error("Rebuild after Close must error (matcher closed)")
-	}
+
+	// Close stays idempotent.
 	if err := m.Close(); err != nil {
 		t.Errorf("second Close must be idempotent nil, got %v", err)
+	}
+}
+
+// TestMatcherNotBuiltBehavior pins the lifecycle state BEFORE Rebuild: a
+// never-built matcher is not "closed", so its methods report the not-yet-built
+// error (Add / lookups) or a no-op (Delete) — distinct from ErrClosed.
+func TestMatcherNotBuiltBehavior(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close()
+	scope := Scope{domain.SituationApproval, "claude"}
+
+	if err := m.Add(row("approval:x", domain.SituationApproval, "claude", "permission: edit", nil)); err == nil || errors.Is(err, ErrClosed) {
+		t.Errorf("Add before build = %v, want a non-nil error that is NOT ErrClosed", err)
+	}
+	if err := m.Delete("approval:x"); err != nil {
+		t.Errorf("Delete before build = %v, want nil no-op", err)
+	}
+	if _, ok, err := m.MatchText(context.Background(), "permission: edit", scope, nil); ok || err == nil || errors.Is(err, ErrClosed) {
+		t.Errorf("MatchText before build: ok=%v err=%v, want no hit and a non-ErrClosed error", ok, err)
 	}
 }
 

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -3,6 +3,7 @@ package match
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -152,5 +153,106 @@ func TestMatcherConcurrentRebuildAndMatch(t *testing.T) {
 	}
 	if hit.Signature != "approval:edit" {
 		t.Errorf("post-churn match = %s, want approval:edit", hit.Signature)
+	}
+}
+
+// TestMatcherClosePostCloseBehavior pins the fail-safe contract after Close:
+// every method degrades cleanly (an error or a no-op) and none panics, so a
+// daemon shutdown racing a late lookup can't crash. Runs in both build configs
+// via the text path.
+func TestMatcherClosePostCloseBehavior(t *testing.T) {
+	m := New(t.TempDir())
+	scope := Scope{domain.SituationApproval, "claude"}
+	if err := m.Rebuild([]domain.SignatureEmbedding{
+		row("approval:edit", domain.SituationApproval, "claude", "permission: edit the config", nil),
+	}, 0); err != nil {
+		t.Fatal(err)
+	}
+	// Sanity: it matches before Close.
+	if _, ok, err := m.MatchText(context.Background(), "permission: edit the config", scope, nil); err != nil || !ok {
+		t.Fatalf("pre-close match: ok=%v err=%v", ok, err)
+	}
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Post-close every method degrades cleanly, never panics.
+	if _, ok, err := m.MatchText(context.Background(), "permission: edit the config", scope, nil); err == nil || ok {
+		t.Errorf("MatchText after Close: ok=%v err=%v, want no hit and an error", ok, err)
+	}
+	if err := m.Add(row("approval:new", domain.SituationApproval, "claude", "permission: run", nil)); err == nil {
+		t.Error("Add after Close must error")
+	}
+	if err := m.Delete("approval:edit"); err != nil {
+		t.Errorf("Delete after Close should be a no-op nil, got %v", err)
+	}
+	if err := m.Rebuild(nil, 0); err == nil {
+		t.Error("Rebuild after Close must error (matcher closed)")
+	}
+	if err := m.Close(); err != nil {
+		t.Errorf("second Close must be idempotent nil, got %v", err)
+	}
+}
+
+// TestMatcherConcurrentCloseAndMatch guards Close against in-flight searches:
+// Close takes the write lock while Match* hold the read lock across the whole
+// search, so Close WAITS for in-flight lookups instead of closing the index
+// under them. Readers must never panic or data-race — each MatchText either
+// succeeds or, once Close lands, returns the clean post-close error. Close must
+// not deadlock behind the readers (writer-priority drains them). Run with
+// `-race`; also runs in the !vectors build. TestMatcherConcurrentCloseAndMatchVector
+// covers the KNN path.
+func TestMatcherConcurrentCloseAndMatch(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close() // idempotent second close; also cleans up on an early failure
+	scope := Scope{domain.SituationApproval, "claude"}
+	if err := m.Rebuild([]domain.SignatureEmbedding{
+		row("approval:edit", domain.SituationApproval, "claude", "permission: edit the config", nil),
+	}, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	var matched atomic.Int64
+	inFlight := make(chan struct{})
+	var once sync.Once
+	// Readers spin on real searches until Close lands, then exit on the
+	// post-close error; each hit signals that a live match is in flight.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				_, ok, err := m.MatchText(ctx, "permission: edit the config", scope, nil)
+				if err != nil {
+					return
+				}
+				if ok {
+					matched.Add(1)
+					once.Do(func() { close(inFlight) })
+				}
+			}
+		}()
+	}
+	// Close only once a reader holds a live match, so the close provably races
+	// real in-flight searches rather than an empty index.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-inFlight
+		if err := m.Close(); err != nil {
+			t.Errorf("Close during in-flight search: %v", err)
+		}
+	}()
+	wg.Wait()
+
+	if matched.Load() == 0 {
+		t.Error("readers never matched before Close — the in-flight window was not exercised")
+	}
+	// Fully closed: further matches error rather than crash.
+	if _, ok, err := m.MatchText(ctx, "permission: edit the config", scope, nil); err == nil || ok {
+		t.Errorf("post-close match: ok=%v err=%v, want no hit and an error", ok, err)
 	}
 }

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -2,9 +2,13 @@ package match
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 )
@@ -254,5 +258,159 @@ func TestMatcherConcurrentCloseAndMatch(t *testing.T) {
 	// Fully closed: further matches error rather than crash.
 	if _, ok, err := m.MatchText(ctx, "permission: edit the config", scope, nil); err == nil || ok {
 		t.Errorf("post-close match: ok=%v err=%v, want no hit and an error", ok, err)
+	}
+}
+
+// waitForGen spins (briefly, with a safety deadline) until the matcher has
+// reserved at least generation g — used to order overlapping Rebuild calls.
+func waitForGen(t *testing.T, m *Matcher, g int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.RLock()
+		cur := m.gen
+		m.mu.RUnlock()
+		if cur >= g {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("matcher never reached generation %d", g)
+}
+
+// countIndexDirs returns how many idx-* generation directories exist under base.
+func countIndexDirs(t *testing.T, base string) int {
+	t.Helper()
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("read index base dir: %v", err)
+	}
+	n := 0
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "idx-") {
+			n++
+		}
+	}
+	return n
+}
+
+// TestRebuildStaleGenerationDoesNotClobber verifies out-of-order completion is
+// safe: an earlier-started Rebuild that reaches its publish step LAST must not
+// publish over a newer one. A (gen 1) starts first and blocks at its publish
+// barrier until B (gen 2) has fully published — deterministically forcing the
+// out-of-order case. A must then discard its now-stale index instead of
+// clobbering B, so B's row stays the live match and A's abandoned generation
+// directory is cleaned up. Against the pre-fix code (no publish-time generation
+// check) A overwrites B and this fails.
+func TestRebuildStaleGenerationDoesNotClobber(t *testing.T) {
+	base := t.TempDir()
+	m := New(base)
+	defer m.Close()
+	scope := Scope{domain.SituationApproval, "claude"}
+
+	alpha := []domain.SignatureEmbedding{
+		row("approval:alpha", domain.SituationApproval, "claude", "permission: alpha stale choice", nil),
+	}
+	bravo := row("approval:bravo", domain.SituationApproval, "claude", "permission: bravo distinctive choice", nil)
+
+	// Deterministically force out-of-order completion: A (gen 1) blocks at its
+	// publish barrier until B (gen 2) has fully published, so A reaches publish
+	// LAST and must abort as stale. B never blocks, so bPublished always closes.
+	// Set before any concurrent Rebuild so the field read stays race-free.
+	bPublished := make(chan struct{})
+	m.publishBarrier = func(gen int) {
+		if gen == 1 {
+			<-bPublished
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { // A: earlier generation; blocks before publishing until B is done
+		defer wg.Done()
+		if err := m.Rebuild(alpha, 0); err != nil {
+			t.Errorf("Rebuild A: %v", err)
+		}
+	}()
+
+	// A reserves generation 1 up front; wait for that before launching B so B is
+	// unambiguously the NEWER generation (2).
+	waitForGen(t, m, 1)
+
+	wg.Add(1)
+	go func() { // B: newer generation; publishes, then releases A
+		defer wg.Done()
+		if err := m.Rebuild([]domain.SignatureEmbedding{bravo}, 0); err != nil {
+			t.Errorf("Rebuild B: %v", err)
+		}
+		close(bPublished)
+	}()
+
+	wg.Wait()
+
+	// B (newer) must own the live index despite A reaching publish last: its
+	// distinctive row matches, and A's stale row did not leak in.
+	hit, ok, err := m.MatchText(context.Background(), "permission: bravo distinctive choice", scope, nil)
+	if err != nil || !ok {
+		t.Fatalf("post-rebuild match: ok=%v err=%v", ok, err)
+	}
+	if hit.Signature != "approval:bravo" {
+		t.Errorf("stale generation A clobbered newer B: matched %s, want approval:bravo", hit.Signature)
+	}
+	// A's abandoned generation directory must be cleaned up; exactly one idx-*
+	// dir (B's live one) remains.
+	if n := countIndexDirs(t, base); n != 1 {
+		t.Errorf("abandoned index dirs not cleaned up: %d idx-* dirs remain, want 1", n)
+	}
+}
+
+// TestRebuildCleansUpSupersededDirectories: each successful Rebuild removes the
+// previous generation's directory, so a long-lived matcher never accumulates
+// stale index dirs.
+func TestRebuildCleansUpSupersededDirectories(t *testing.T) {
+	base := t.TempDir()
+	m := New(base)
+	defer m.Close()
+	for i := 0; i < 5; i++ {
+		if err := m.Rebuild([]domain.SignatureEmbedding{
+			row("approval:x", domain.SituationApproval, "claude", "permission: edit the config", nil),
+		}, 0); err != nil {
+			t.Fatalf("Rebuild %d: %v", i, err)
+		}
+	}
+	if n := countIndexDirs(t, base); n != 1 {
+		t.Errorf("after 5 rebuilds, want exactly 1 idx-* dir, got %d", n)
+	}
+}
+
+// TestRebuildBuildErrorCleansUpDir: when the index build fails, the reserved
+// generation directory must not be left behind. A pre-existing path at the
+// generation dir makes bleve.New fail; the error path must remove it.
+func TestRebuildBuildErrorCleansUpDir(t *testing.T) {
+	base := t.TempDir()
+	m := New(base) // wipes base
+	defer m.Close()
+
+	// Occupy the path the first Rebuild will build at (idx-1) so buildIndex fails.
+	if err := os.MkdirAll(base, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	blocker := filepath.Join(base, "idx-1")
+	if err := os.WriteFile(blocker, []byte("occupied"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := m.Rebuild([]domain.SignatureEmbedding{
+		row("approval:x", domain.SituationApproval, "claude", "permission: edit", nil),
+	}, 0)
+	if err == nil {
+		t.Fatal("Rebuild should fail when its index path is already occupied")
+	}
+	// The failed build must clean up its reserved directory, not leak it.
+	if _, statErr := os.Stat(blocker); !os.IsNotExist(statErr) {
+		t.Errorf("build-error path leaked its generation dir: stat err = %v", statErr)
 	}
 }

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -2,6 +2,7 @@ package match
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -76,5 +77,80 @@ func TestMatchTextAcceptFilterFallsThroughToRank2(t *testing.T) {
 	if _, ok, err := m.MatchText(context.Background(), "permission: edit files",
 		Scope{domain.SituationApproval, "claude"}, none); err != nil || ok {
 		t.Errorf("all-rejecting filter: ok=%v err=%v, want no hit and no error", ok, err)
+	}
+}
+
+// TestMatcherConcurrentRebuildAndMatch guards the "safe for concurrent use"
+// contract on Matcher: readers keep matching while Rebuild swaps the index and
+// Close()s the old one, plus interleaved Add/Delete churn the live index. With
+// the fix in place (Match* hold RLock for the whole search) Rebuild's write-lock
+// swap serializes behind in-flight searches, so the seeded row stays reachable
+// and nothing panics or data-races. It also guards against a regression to the
+// old snapshot-then-release pattern, which let Close race an active search.
+// Transient errors while an index is closing are tolerated (the daemon path
+// treats a match error as a safe fall-back). Run with `-race` for the real
+// signal; it also runs in the !vectors build via MatchText, while
+// TestMatcherConcurrentRebuildAndMatchVector covers the KNN read path under the
+// `vectors` tag (where the old pattern DEADLOCKED, not just raced).
+func TestMatcherConcurrentRebuildAndMatch(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close()
+
+	scope := Scope{domain.SituationApproval, "claude"}
+	base := []domain.SignatureEmbedding{
+		row("approval:edit", domain.SituationApproval, "claude", "permission: edit the configuration files in project", nil),
+	}
+	if err := m.Rebuild(base, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Readers: hammer both match paths for the whole run.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Errors are expected during a swap (index closing) — the
+				// contract is only that these never panic or data-race.
+				_, _, _ = m.MatchText(ctx, "permission: edit the configuration files in project", scope, nil)
+			}
+		}()
+	}
+
+	// Writer: repeatedly rebuild (swap + close old) and churn the live index.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(stop)
+		for i := 0; i < 50; i++ {
+			if err := m.Rebuild(base, 0); err != nil {
+				t.Errorf("Rebuild during churn: %v", err)
+				return
+			}
+			tmp := row("approval:tmp", domain.SituationApproval, "claude", "permission: run the test suite", nil)
+			_ = m.Add(tmp)
+			_ = m.Delete("approval:tmp")
+		}
+	}()
+
+	wg.Wait()
+
+	// After the churn settles, the seeded row must still be matchable — the
+	// final Rebuild left a coherent index, not a half-swapped one.
+	hit, ok, err := m.MatchText(ctx, "permission: edit the configuration files in project", scope, nil)
+	if err != nil || !ok {
+		t.Fatalf("post-churn match: ok=%v err=%v, want the seeded row reachable", ok, err)
+	}
+	if hit.Signature != "approval:edit" {
+		t.Errorf("post-churn match = %s, want approval:edit", hit.Signature)
 	}
 }

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -548,3 +548,80 @@ func TestMatchAcceptReentrantConcurrentRebuildClose(t *testing.T) {
 	close(stop)
 	searchers.Wait()
 }
+
+// TestCleanupIndexCombinesErrors covers the combined index-close + filesystem
+// failure: cleanupIndex must join BOTH a failing index Close and a failing
+// removeAll, and report neither when both succeed.
+func TestCleanupIndexCombinesErrors(t *testing.T) {
+	m := New(t.TempDir())
+	defer func() { m.removeAll = os.RemoveAll; m.Close() }()
+
+	errClose := errors.New("index close boom")
+	errRemove := errors.New("remove boom")
+	m.removeAll = func(string) error { return errRemove }
+
+	// Both fail → both surfaced.
+	err := m.cleanupIndex(func() error { return errClose }, "somedir")
+	if !errors.Is(err, errClose) || !errors.Is(err, errRemove) {
+		t.Errorf("combined cleanup error = %v, want both the close and remove errors", err)
+	}
+	// nil closer + failing remove → just the remove error.
+	if err := m.cleanupIndex(nil, "somedir"); !errors.Is(err, errRemove) {
+		t.Errorf("cleanup with nil closer = %v, want the remove error", err)
+	}
+	// Both succeed → nil (errors.Join drops nils).
+	m.removeAll = func(string) error { return nil }
+	if err := m.cleanupIndex(func() error { return nil }, "somedir"); err != nil {
+		t.Errorf("clean cleanup = %v, want nil", err)
+	}
+}
+
+// TestCloseSurfacesRemoveAllError: Close propagates a filesystem cleanup failure
+// (the index closes fine, but removing the cache dir fails).
+func TestCloseSurfacesRemoveAllError(t *testing.T) {
+	m := New(t.TempDir())
+	if err := m.Rebuild([]domain.SignatureEmbedding{
+		row("approval:x", domain.SituationApproval, "claude", "permission: edit", nil),
+	}, 0); err != nil {
+		t.Fatal(err)
+	}
+	errRemove := errors.New("remove boom")
+	m.removeAll = func(string) error { return errRemove }
+	if err := m.Close(); !errors.Is(err, errRemove) {
+		t.Errorf("Close = %v, want the injected remove error", err)
+	}
+}
+
+// TestRebuildSurfacesCleanupErrorAsErrCleanup: when a Rebuild publishes a new
+// index but fails to reclaim the previous generation's directory, it reports
+// errors.Is(ErrCleanup) (so a caller keeps the live index) AND the underlying
+// filesystem error — while the new index stays live.
+func TestRebuildSurfacesCleanupErrorAsErrCleanup(t *testing.T) {
+	m := New(t.TempDir())
+	defer func() { m.removeAll = os.RemoveAll; m.Close() }()
+	scope := Scope{domain.SituationApproval, "claude"}
+
+	if err := m.Rebuild([]domain.SignatureEmbedding{
+		row("approval:x", domain.SituationApproval, "claude", "permission: edit", nil),
+	}, 0); err != nil {
+		t.Fatal(err) // first Rebuild: no previous generation, no cleanup
+	}
+
+	// Fail the OLD generation's cleanup on the next publish.
+	errRemove := errors.New("remove boom")
+	m.removeAll = func(string) error { return errRemove }
+
+	err := m.Rebuild([]domain.SignatureEmbedding{
+		row("approval:y", domain.SituationApproval, "claude", "permission: run the tests", nil),
+	}, 0)
+	if !errors.Is(err, ErrCleanup) || !errors.Is(err, errRemove) {
+		t.Errorf("Rebuild with failing old-cleanup = %v, want errors.Is(ErrCleanup) and the remove error", err)
+	}
+
+	// Despite the cleanup failure, the NEW index published and is live.
+	m.removeAll = os.RemoveAll // restore so the lookup/Close below behave
+	hit, ok, err := m.MatchText(context.Background(), "permission: run the tests", scope, nil)
+	if err != nil || !ok || hit.Signature != "approval:y" {
+		t.Errorf("new index not live after cleanup-failed rebuild: hit=%+v ok=%v err=%v", hit, ok, err)
+	}
+}

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -446,3 +446,105 @@ func TestRebuildBuildErrorCleansUpDir(t *testing.T) {
 		t.Errorf("build-error path leaked its generation dir: stat err = %v", statErr)
 	}
 }
+
+// TestMatchTextAcceptMayReenterMatcher proves accept runs OUTSIDE the matcher
+// lock: an accept callback that re-enters the Matcher — including a WRITE-lock
+// Rebuild and a nested MatchText — completes instead of deadlocking. Under the
+// old "accept under the read lock" design this hung: Rebuild's write lock waited
+// on the read lock the callback was still holding.
+func TestMatchTextAcceptMayReenterMatcher(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close()
+	scope := Scope{domain.SituationApproval, "claude"}
+	if err := m.Rebuild([]domain.SignatureEmbedding{
+		row("approval:edit", domain.SituationApproval, "claude", "permission: edit the config", nil),
+	}, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	reentered := false
+	accept := func(h Hit) bool {
+		// Re-enter with a write-lock op — deadlocks under the old design.
+		if err := m.Rebuild([]domain.SignatureEmbedding{
+			row("approval:reentrant", domain.SituationApproval, "claude", "permission: run the tests", nil),
+		}, 0); err != nil {
+			t.Errorf("reentrant Rebuild from accept: %v", err)
+		}
+		// A nested lookup must also work.
+		if _, _, err := m.MatchText(context.Background(), "permission: run the tests", scope, nil); err != nil {
+			t.Errorf("reentrant MatchText from accept: %v", err)
+		}
+		reentered = true
+		return true
+	}
+
+	hit, ok, err := m.MatchText(context.Background(), "permission: edit the config", scope, accept)
+	if err != nil {
+		t.Fatalf("MatchText with reentrant accept: %v", err)
+	}
+	if !ok || hit.Signature != "approval:edit" {
+		t.Errorf("match = %+v ok=%v, want approval:edit", hit, ok)
+	}
+	if !reentered {
+		t.Error("accept callback did not run")
+	}
+}
+
+// TestMatchAcceptReentrantConcurrentRebuildClose stresses accept-outside-the-lock
+// under contention: readers run MatchText with a reentrant accept (a nested
+// MatchText) while a goroutine rebuilds the index, then Close races the still-
+// active searchers. No deadlock or data race. Run with `-race`.
+func TestMatchAcceptReentrantConcurrentRebuildClose(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close() // idempotent second close; cleans up on early failure
+	scope := Scope{domain.SituationApproval, "claude"}
+	base := []domain.SignatureEmbedding{
+		row("approval:edit", domain.SituationApproval, "claude", "permission: edit the config", nil),
+		row("approval:run", domain.SituationApproval, "claude", "permission: run the tests", nil),
+	}
+	if err := m.Rebuild(base, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	reenter := func(h Hit) bool {
+		// Nested lookup from within accept — lock-free, must not deadlock.
+		_, _, _ = m.MatchText(ctx, "permission: run the tests", scope, nil)
+		return false // reject so the whole candidate loop runs
+	}
+
+	var searchers, rebuilder sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 4; i++ {
+		searchers.Add(1)
+		go func() {
+			defer searchers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if _, _, err := m.MatchText(ctx, "permission: edit the config", scope, reenter); err != nil {
+					return // matcher closed
+				}
+			}
+		}()
+	}
+	rebuilder.Add(1)
+	go func() {
+		defer rebuilder.Done()
+		for i := 0; i < 30; i++ {
+			if err := m.Rebuild(base, 0); err != nil {
+				return
+			}
+		}
+	}()
+
+	rebuilder.Wait()
+	if err := m.Close(); err != nil { // races the still-running searchers
+		t.Errorf("Close during active reentrant search: %v", err)
+	}
+	close(stop)
+	searchers.Wait()
+}

--- a/internal/match/match_vectors_test.go
+++ b/internal/match/match_vectors_test.go
@@ -374,3 +374,44 @@ func TestMatcherConcurrentCloseAndMatchVector(t *testing.T) {
 		t.Errorf("post-close vector match: ok=%v err=%v, want no hit and an error", ok, err)
 	}
 }
+
+// TestMatchVectorAcceptMayReenterMatcher is the KNN companion to
+// TestMatchTextAcceptMayReenterMatcher: a MatchVector accept callback that
+// re-enters the Matcher (a write-lock Rebuild + a nested MatchVector) completes
+// instead of deadlocking, since accept runs outside the read lock.
+func TestMatchVectorAcceptMayReenterMatcher(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close()
+	scope := Scope{domain.SituationApproval, "claude"}
+	if err := m.Rebuild([]domain.SignatureEmbedding{
+		row("approval:edit", domain.SituationApproval, "claude", "permission: edit", unit(1, 0, 0, 0)),
+	}, 4); err != nil {
+		t.Fatal(err)
+	}
+	q := unit(1, 0, 0, 0)
+
+	reentered := false
+	accept := func(h Hit) bool {
+		if err := m.Rebuild([]domain.SignatureEmbedding{
+			row("approval:reentrant", domain.SituationApproval, "claude", "permission: run", unit(0, 1, 0, 0)),
+		}, 4); err != nil {
+			t.Errorf("reentrant Rebuild from accept: %v", err)
+		}
+		if _, _, err := m.MatchVector(context.Background(), unit(0, 1, 0, 0), scope, nil); err != nil {
+			t.Errorf("reentrant MatchVector from accept: %v", err)
+		}
+		reentered = true
+		return true
+	}
+
+	hit, ok, err := m.MatchVector(context.Background(), q, scope, accept)
+	if err != nil {
+		t.Fatalf("MatchVector with reentrant accept: %v", err)
+	}
+	if !ok || hit.Signature != "approval:edit" {
+		t.Errorf("match = %+v ok=%v, want approval:edit", hit, ok)
+	}
+	if !reentered {
+		t.Error("accept callback did not run")
+	}
+}

--- a/internal/match/match_vectors_test.go
+++ b/internal/match/match_vectors_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -277,5 +278,98 @@ func TestAddAndDelete(t *testing.T) {
 	}
 	if _, ok, _ := m.MatchVector(context.Background(), unit(0, 0, 1), Scope{domain.SituationError, "claude"}, nil); ok {
 		t.Error("deleted row still matches")
+	}
+}
+
+// TestMatcherClosePostCloseBehaviorVector is the vectors-build companion to
+// TestMatcherClosePostCloseBehavior: after Close the KNN path degrades to an
+// error (never a use-after-close panic on the FAISS-backed reader), and the
+// text path is unavailable too.
+func TestMatcherClosePostCloseBehaviorVector(t *testing.T) {
+	m := New(t.TempDir())
+	scope := Scope{domain.SituationApproval, "claude"}
+	if err := m.Rebuild([]domain.SignatureEmbedding{
+		row("approval:edit", domain.SituationApproval, "claude", "permission: edit", unit(1, 0, 0, 0)),
+	}, 4); err != nil {
+		t.Fatal(err)
+	}
+	q := unit(1, 0, 0, 0)
+	if _, ok, err := m.MatchVector(context.Background(), q, scope, nil); err != nil || !ok {
+		t.Fatalf("pre-close vector match: ok=%v err=%v", ok, err)
+	}
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if _, ok, err := m.MatchVector(context.Background(), q, scope, nil); err == nil || ok {
+		t.Errorf("MatchVector after Close: ok=%v err=%v, want no hit and an error", ok, err)
+	}
+	if _, ok, err := m.MatchText(context.Background(), "permission: edit", scope, nil); err == nil || ok {
+		t.Errorf("MatchText after Close: ok=%v err=%v, want no hit and an error", ok, err)
+	}
+	if err := m.Close(); err != nil {
+		t.Errorf("second Close must be idempotent nil, got %v", err)
+	}
+}
+
+// TestMatcherConcurrentCloseAndMatchVector is the vectors-build companion to
+// TestMatcherConcurrentCloseAndMatch: it closes a VECTOR-backed index while KNN
+// searches (MatchVector → knnSearch over the FAISS reader) are in flight.
+// Closing an index mid-search WITHOUT holding the read lock across it would
+// deadlock bleve's KNN collector (see the runKnnCollector/DocCount hazard in
+// match.go); here MatchVector holds the read lock, so Close waits for in-flight
+// searches instead. This exercises the safe path — it must not panic, hang, or
+// trip -race — rather than reproducing that deadlock. Run with `-race`.
+func TestMatcherConcurrentCloseAndMatchVector(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close() // idempotent second close; also cleans up on an early failure
+	scope := Scope{domain.SituationApproval, "claude"}
+	if err := m.Rebuild([]domain.SignatureEmbedding{
+		row("approval:edit", domain.SituationApproval, "claude", "permission: edit", unit(1, 0, 0, 0)),
+		row("approval:run", domain.SituationApproval, "claude", "permission: run", unit(0, 1, 0, 0)),
+	}, 4); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	q := unit(1, 0.05, 0, 0) // nearest: approval:edit
+	var wg sync.WaitGroup
+	var matched atomic.Int64
+	inFlight := make(chan struct{})
+	var once sync.Once
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				_, ok, err := m.MatchVector(ctx, q, scope, nil)
+				if err != nil {
+					return
+				}
+				if ok {
+					matched.Add(1)
+					once.Do(func() { close(inFlight) })
+				}
+			}
+		}()
+	}
+	// Close only once a KNN reader holds a live hit, so it provably races an
+	// in-flight FAISS search rather than an empty index.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-inFlight
+		if err := m.Close(); err != nil {
+			t.Errorf("Close during in-flight KNN search: %v", err)
+		}
+	}()
+	wg.Wait()
+
+	if matched.Load() == 0 {
+		t.Error("KNN readers never matched before Close — the in-flight window was not exercised")
+	}
+	if _, ok, err := m.MatchVector(ctx, q, scope, nil); err == nil || ok {
+		t.Errorf("post-close vector match: ok=%v err=%v, want no hit and an error", ok, err)
 	}
 }

--- a/internal/match/match_vectors_test.go
+++ b/internal/match/match_vectors_test.go
@@ -4,6 +4,7 @@ package match
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -281,11 +282,11 @@ func TestAddAndDelete(t *testing.T) {
 	}
 }
 
-// TestMatcherClosePostCloseBehaviorVector is the vectors-build companion to
-// TestMatcherClosePostCloseBehavior: after Close the KNN path degrades to an
-// error (never a use-after-close panic on the FAISS-backed reader), and the
-// text path is unavailable too.
-func TestMatcherClosePostCloseBehaviorVector(t *testing.T) {
+// TestMatcherClosedReturnsErrClosedVector is the vectors-build companion to
+// TestMatcherClosedReturnsErrClosed: after Close the KNN path returns the
+// ErrClosed sentinel (never a use-after-close panic on the FAISS-backed reader),
+// and the text path reports it too.
+func TestMatcherClosedReturnsErrClosedVector(t *testing.T) {
 	m := New(t.TempDir())
 	scope := Scope{domain.SituationApproval, "claude"}
 	if err := m.Rebuild([]domain.SignatureEmbedding{
@@ -302,11 +303,11 @@ func TestMatcherClosePostCloseBehaviorVector(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	if _, ok, err := m.MatchVector(context.Background(), q, scope, nil); err == nil || ok {
-		t.Errorf("MatchVector after Close: ok=%v err=%v, want no hit and an error", ok, err)
+	if _, ok, err := m.MatchVector(context.Background(), q, scope, nil); ok || !errors.Is(err, ErrClosed) {
+		t.Errorf("MatchVector after Close: ok=%v err=%v, want no hit and errors.Is ErrClosed", ok, err)
 	}
-	if _, ok, err := m.MatchText(context.Background(), "permission: edit", scope, nil); err == nil || ok {
-		t.Errorf("MatchText after Close: ok=%v err=%v, want no hit and an error", ok, err)
+	if _, ok, err := m.MatchText(context.Background(), "permission: edit", scope, nil); ok || !errors.Is(err, ErrClosed) {
+		t.Errorf("MatchText after Close: ok=%v err=%v, want no hit and errors.Is ErrClosed", ok, err)
 	}
 	if err := m.Close(); err != nil {
 		t.Errorf("second Close must be idempotent nil, got %v", err)

--- a/internal/match/match_vectors_test.go
+++ b/internal/match/match_vectors_test.go
@@ -4,7 +4,9 @@ package match
 
 import (
 	"context"
+	"fmt"
 	"math"
+	"sync"
 	"testing"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -93,10 +95,10 @@ func TestMatchVectorScopeFilter(t *testing.T) {
 
 // TestMatchVectorFilteredKNNExcludesNearerOutOfScope is the regression test for
 // KNN pre-filtering: the scope filter must constrain the candidate set BEFORE
-// the k nearest are selected, not merely re-rank afterwards. Here four
-// out-of-scope neighbors (more than matchK=3) sit closer to the query than the
-// single in-scope row, so an unfiltered top-k would be entirely out-of-scope
-// and MatchVector(claude) would find nothing — the far in-scope row would be
+// the k nearest are selected, not merely re-rank afterwards. Here strictly more
+// than matchK out-of-scope neighbors sit closer to the query than the single
+// in-scope row, so an unfiltered top-k would be entirely out-of-scope and
+// MatchVector(claude) would find nothing — the far in-scope row would be
 // shadowed out of the top-k.
 // With AddKNNWithFilter the candidate set is pre-restricted to the claude scope,
 // keeping the in-scope row reachable. This fails loudly if the scope filter is
@@ -105,15 +107,27 @@ func TestMatchVectorFilteredKNNExcludesNearerOutOfScope(t *testing.T) {
 	m := New(t.TempDir())
 	defer m.Close()
 
-	// Four codex rows crowd the query; one claude row sits far away. With
-	// matchK == 3, an unfiltered nearest-k would be entirely codex.
-	rows := []domain.SignatureEmbedding{
-		row("approval:codex1", domain.SituationApproval, "codex", "permission: a", unit(1, 0.01, 0, 0)),
-		row("approval:codex2", domain.SituationApproval, "codex", "permission: b", unit(1, 0.02, 0, 0)),
-		row("approval:codex3", domain.SituationApproval, "codex", "permission: c", unit(1, 0.03, 0, 0)),
-		row("approval:codex4", domain.SituationApproval, "codex", "permission: d", unit(1, 0.04, 0, 0)),
-		row("approval:claude1", domain.SituationApproval, "claude", "permission: z", unit(0.6, 0.8, 0, 0)),
+	// matchK+1 codex rows crowd the query; one claude row sits far away. The
+	// decoy count is derived from matchK on purpose: it MUST exceed matchK so an
+	// unfiltered nearest-k is entirely codex. Hardcoding it (e.g. 4 against
+	// matchK==3) would let this regression silently weaken into a false pass if
+	// matchK were later raised — then the far claude row would slip into an
+	// unfiltered top-k and the test would pass even with the filter removed.
+	var rows []domain.SignatureEmbedding
+	for i := 0; i < matchK+1; i++ {
+		// Off-axis tilt bounded to (0.01, 0.05) REGARDLESS of matchK: every decoy
+		// stays ≈cos 0.999 with q — far nearer than the claude row at cos 0.6 —
+		// while remaining a distinct vector. Only the COUNT scales with matchK;
+		// the tilt must not, or a large matchK would push the last decoy past the
+		// claude row and silently invert the premise. (matchK==3 reproduces the
+		// original 0.01/0.02/0.03/0.04 tilts exactly.)
+		off := 0.01 + 0.04*float32(i)/float32(matchK+1)
+		rows = append(rows, row(
+			fmt.Sprintf("approval:codex%d", i+1),
+			domain.SituationApproval, "codex",
+			fmt.Sprintf("permission: codex %d", i+1), unit(1, off, 0, 0)))
 	}
+	rows = append(rows, row("approval:claude1", domain.SituationApproval, "claude", "permission: z", unit(0.6, 0.8, 0, 0)))
 	if err := m.Rebuild(rows, 4); err != nil {
 		t.Fatal(err)
 	}
@@ -173,6 +187,75 @@ func TestMatchVectorDimsMismatch(t *testing.T) {
 	}
 	if _, _, err := m.MatchVector(context.Background(), unit(1, 0, 0), Scope{domain.SituationIdle, "claude"}, nil); err == nil {
 		t.Error("dims mismatch should error")
+	}
+}
+
+// TestMatcherConcurrentRebuildAndMatchVector is the vectors-build companion to
+// TestMatcherConcurrentRebuildAndMatch: it drives the KNN read path
+// (MatchVector → knnSearch over the FAISS-backed reader) concurrently with
+// Rebuild swapping and closing a VECTOR-backed index. This is the path that
+// DEADLOCKED before the fix — bleve's runKnnCollector re-enters the index RLock
+// mid-search while Close holds the write lock — so it is the real regression
+// guard (the text path only raced, it never hung). Must not panic, hang, or
+// trip -race; transient errors during a swap are tolerated. Run with `-race`.
+func TestMatcherConcurrentRebuildAndMatchVector(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close()
+
+	scope := Scope{domain.SituationApproval, "claude"}
+	base := []domain.SignatureEmbedding{
+		row("approval:edit", domain.SituationApproval, "claude", "permission: edit", unit(1, 0, 0, 0)),
+		row("approval:run", domain.SituationApproval, "claude", "permission: run", unit(0, 1, 0, 0)),
+	}
+	if err := m.Rebuild(base, 4); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	q := unit(1, 0.05, 0, 0) // nearest: approval:edit
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Readers: hammer the KNN path for the whole run.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Errors are expected while an index is closing mid-swap — the
+				// contract is only that these never panic or data-race.
+				_, _, _ = m.MatchVector(ctx, q, scope, nil)
+			}
+		}()
+	}
+
+	// Writer: repeatedly rebuild a vector-backed index (swap + close old).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(stop)
+		for i := 0; i < 50; i++ {
+			if err := m.Rebuild(base, 4); err != nil {
+				t.Errorf("Rebuild during churn: %v", err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	// The final Rebuild must leave a coherent, queryable KNN index.
+	hit, ok, err := m.MatchVector(ctx, q, scope, nil)
+	if err != nil || !ok {
+		t.Fatalf("post-churn vector match: ok=%v err=%v, want the seeded row reachable", ok, err)
+	}
+	if hit.Signature != "approval:edit" {
+		t.Errorf("post-churn vector match = %s, want approval:edit", hit.Signature)
 	}
 }
 


### PR DESCRIPTION
## Summary

Hardens the semantic matcher (`internal/match`) against every concurrency hazard around `Rebuild`/`Close`/search, standardizes its lifecycle errors, and adds the regression + stress + CI coverage that locks all of it down. Along the way it fixes a flaky `-race` data race in the daemon gate tests that the new coverage surfaced.

All changes are in `internal/match` and `internal/daemon` (tests) plus one CI-workflow tweak — no change to the daemon's decision path.

## The bugs

1. **Close-during-search deadlock.** `MatchVector`/`MatchText` snapshotted the index under `RLock`, released it, then searched — so `Rebuild`'s `old.Close()` could close the index mid-search. Under the `vectors` tag this **deadlocks** (bleve's KNN `runKnnCollector` re-enters the index's read lock via `DocCount` while `Close` holds the write lock). In production a model-change/reembed concurrent with a match could hang the daemon forever.
2. **Overlapping Rebuilds publish stale generations + leak dirs.** `Rebuild` reserves a generation, builds off-lock, then published *unconditionally* — an earlier-started build finishing last could clobber a newer one's index (and delete the newer dir). Error paths also leaked the reserved `idx-N` dir.
3. **Close racing an active Rebuild recreated the index dir.** The generation guard only ran at publish time; a Rebuild's off-lock `MkdirAll`/`buildIndex` could recreate `baseDir` *after* `Close`'s `RemoveAll` (leak), or `Close` could delete a dir a rebuild was mid-persist writing into.

## Guarantees now enforced

- **No close-during-search deadlock** — `Match*` hold the read lock for the whole search; `Rebuild` builds *before* taking the write lock, so searches only gate the brief pointer swap.
- **Latest-started generation wins** — at publish, a build whose generation was superseded (or a closed matcher) discards its index instead of clobbering newer data.
- **No leaked index directories** — every error/abort/replace path `RemoveAll`s its dir; `Close` tracks in-flight Rebuilds in a `WaitGroup` and **drains them before its final `RemoveAll`**, so nothing recreates the dir after cleanup. A long-lived matcher keeps exactly one live `idx-*` dir.
- **Standardized post-Close errors** — `Rebuild`/`Add`/`Delete`/`MatchText`/`MatchVector` all return the exported sentinel `match.ErrClosed` (matchable with `errors.Is`); lookups still degrade to fall-back, but the reason is identifiable.
- **`accept` callbacks are contract-bound** — they run under the read lock and must not re-enter the Matcher; the sole caller `remapAllowed` is non-reentrant by construction.

## Commits

| Commit | Type | What |
|---|---|---|
| `fad051c` | fix | Hold the read lock across the search (close-during-search deadlock). KNN regression hung ~10 min pre-fix, ~2 s after. |
| `2bb14c4` | test | `TestRemapAllowedContract` (14 cases) pins the issue-#155 veto gate + the only `accept` callback's non-reentrancy. |
| `ea829a9` | chore | Keep `./internal/match/...` in the CI race step + `-timeout 8m` so a reintroduced deadlock fails fast. |
| `21de03c` | test | Fix a flaky `-race` race: daemon gate tests swapped `d.opt.Store` after `Run`; install it before via `newHarnessPaused`. |
| `7148019` | test | `Matcher.Close` regression tests (post-close fail-safe + concurrent Close vs in-flight text/KNN search). |
| `e74db46` | fix | Rebuild generation guard (no stale-generation clobber) + `RemoveAll` on every error/abort path. |
| `ffe0b05` | test | End-to-end daemon semantic stress test (concurrent search + overlapping rebuild + shutdown). |
| `74a5aec` | fix | `Close` drains in-flight Rebuilds (`WaitGroup`) so a racing build can't recreate the index dir. |
| `ad1d674` | test | Watchdog + goroutine error collection in the stress test (deadlocks fail in seconds with a dump). |
| `c86e02b` | refactor | Standardize post-Close errors on the `match.ErrClosed` sentinel + table-driven lifecycle tests. |

## Regression-test evidence (all mutation-verified where a fix is involved)

- **Close-during-search:** KNN concurrency test **10-min hang → ~2 s**; `TestMatcherConcurrentCloseAndMatch{,Vector}` pass 30× under `-race`.
- **Generation guard:** `TestRebuildStaleGenerationDoesNotClobber` uses a nil-in-prod `publishBarrier` to force out-of-order completion; **fails 5/5 without the guard**, passes 30/30 with it.
- **Close-drain:** the extended daemon stress test **fails without the drain** (rebuild mid-persist hits the deleted dir); passes 12× under `-race` both builds.
- **Daemon race:** the 4 gate tests pass 20× each under `-race`.
- **Watchdog:** temporarily set to 1 ms → fails fast (~1 s) with a goroutine dump; back to 60 s it never false-fires.
- **Lifecycle:** table-driven `TestMatcherClosedReturnsErrClosed[Vector]` + `TestMatcherNotBuiltBehavior` pin the sentinel and the not-built≠closed distinction.

## CI

Verified green on both runners (`ubuntu-latest`, `macos-14`), including the `-race` step under `-tags "vectors cpu"` on these CPU-only runners — `internal/match` and `internal/daemon` both pass `-race` first-attempt, no `DATA RACE`. Lint and the allowlist corpus gate pass. (A rare, pre-existing full-suite `-race` teardown flake in unrelated LLM tests — which never touch the matcher — is absorbed by the race step's existing 3× retry.)

https://claude.ai/code/session_01FKbYWbyEGhsT8iGnbyBJgr
