### PR TITLE
#1 fix: cap generated-task confirms at max_tasks and default auto-act to 99

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,8 +659,10 @@ irreversible heuristic, rate limits):
   task, or *no reply* for a decline), and the **original** queued task and the
   LLM's reasoning appear in the escalation detail.
 
-Because the default threshold is `999` (never auto-act), every review is
-surfaced for confirmation until you lower `auto_act_confidence_threshold`.
+The default threshold is `99`, so a review auto-acts only when the LLM is
+near-certain (score ≥ 99); anything less confident is surfaced for confirmation.
+Raise `auto_act_confidence_threshold` above 100 (e.g. `999`) to never auto-act,
+or lower it to auto-act more readily.
 
 For learning, every accepted task-review send is stored symbolically as
 `@next_task:declared`, whether the LLM approved the queued task verbatim,
@@ -796,7 +798,7 @@ command = [
   "--allowedTools", "mcp__hap__get_context,mcp__hap__submit_decision",
 ]
 timeout_seconds = 120
-auto_act_confidence_threshold = 999   # auto-act only when the LLM's confidence (0-100) is >= this; 999 = never (surface for your confirmation)
+auto_act_confidence_threshold = 99   # auto-act only when the LLM's confidence (0-100) is >= this; default 99 (near-certain only); >100 e.g. 999 = never (surface for your confirmation)
 pane_excerpt_chars = 5000   # pane excerpt size in the consult context (default 5000)
 ```
 
@@ -894,7 +896,7 @@ launch (claude/agy: prompt moved next to `-p`/`--print`; codex: missing
 `exec` inserted) — an unrecognized shape is left untouched. Every LLM
 suggestion is re-gated through the same never-auto patterns, kill switch, and rate
 guards; it auto-acts only when the LLM's self-reported confidence meets
-`auto_act_confidence_threshold` (0-100; default 999 = never) and the action
+`auto_act_confidence_threshold` (0-100; default 99, >100 e.g. 999 = never) and the action
 doesn't contradict your learned history — otherwise the suggestion is surfaced
 for you to confirm. On timeout, CLI failure, or no submission the situation
 escalates. For a retryable failed/timed-out consult, press `l` on its TUI

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,9 +100,10 @@ type LLM struct {
 	// AutoActConfidenceThreshold gates acting on an LLM suggestion
 	// automatically (subject to every safety control and the learned-history
 	// gate): the daemon auto-acts only when the LLM's self-reported
-	// confidence score (0-100) is at or above this threshold. A value above
-	// 100 — the default 999 — never auto-acts (LLM suggestions are surfaced
-	// as escalations for the operator to confirm); 0 acts on any reported
+	// confidence score (0-100) is at or above this threshold. The default is
+	// 99, so out of the box the daemon auto-acts only on a near-certain
+	// (>= 99) score and surfaces everything less confident as an escalation.
+	// A value above 100 (e.g. 999) never auto-acts; 0 acts on any reported
 	// score. A decision with no reported score (-1) always escalates.
 	AutoActConfidenceThreshold int `toml:"auto_act_confidence_threshold"`
 	// DeprecatedAutoAct is the removed boolean `auto_act` key, kept only to
@@ -368,7 +369,7 @@ func Default() Config {
 			MaxAutoPromptsPerMinute:   5,
 			MaxErrorRetries:           2,
 		},
-		LLM: LLM{TimeoutSeconds: 60, PaneExcerptChars: 5000, AutoActConfidenceThreshold: 999},
+		LLM: LLM{TimeoutSeconds: 60, PaneExcerptChars: 5000, AutoActConfidenceThreshold: 99},
 		Embedding: Embedding{
 			SimilarityThreshold: 0.90,
 			BM25MinScore:        0.35,
@@ -625,13 +626,13 @@ func Load(path string) (Config, error) {
 			"path", path, "configured_value", *inferredBarProbe.ConfidenceThresholds.InferredTaskBar)
 	}
 	// Deprecated boolean `auto_act`: migrate to the confidence threshold only
-	// when the new key was NOT explicitly set. A magic-number check on the
-	// default (999) can't tell an explicit "never" from the default — 999 is
-	// also the value operators write to disable auto-act — so probe the raw
-	// file for the new key's presence: an explicit new key always wins. true →
-	// 0 (act on any reported score) is the closest equivalent, not identical:
-	// unreported-confidence decisions now escalate. Clearing the pointer makes
-	// the next Save drop the old key.
+	// when the new key was NOT explicitly set. Comparing the loaded value to
+	// the default can't tell an explicit setting from the default — an operator
+	// may write the default value on purpose — so probe the raw file for the
+	// new key's presence: an explicit new key always wins. auto_act=false → 999
+	// (never); true → 0 (act on any reported score) is the closest equivalent,
+	// not identical: unreported-confidence decisions now escalate. Clearing the
+	// pointer makes the next Save drop the old key.
 	if cfg.LLM.DeprecatedAutoAct != nil {
 		var probe struct {
 			LLM struct {
@@ -750,8 +751,9 @@ func (c *Config) fillZeroes() {
 		c.LLM.PaneExcerptChars = d.LLM.PaneExcerptChars
 	}
 	// A hand-edited negative threshold is invalid (SetField rejects it too):
-	// fall back to the never-default, never a value below 0 that would let an
-	// unreported (-1) score auto-act. 0 stays valid (act on any reported score).
+	// fall back to the default threshold, never a value below 0 that would let
+	// an unreported (-1) score auto-act. 0 stays valid (act on any reported
+	// score).
 	if c.LLM.AutoActConfidenceThreshold < 0 {
 		c.LLM.AutoActConfidenceThreshold = d.LLM.AutoActConfidenceThreshold
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1101,9 +1101,10 @@ func TestDisableNeverAutoSeedPatternsMigration(t *testing.T) {
 }
 
 func TestAutoActConfidenceThresholdDefault(t *testing.T) {
-	// Omitted key keeps the never-auto default (999).
-	if got := Default().LLM.AutoActConfidenceThreshold; got != 999 {
-		t.Fatalf("default threshold = %d, want 999", got)
+	// Omitted key keeps the near-certain default (99): auto-act only on a
+	// >= 99 LLM score, surface everything less confident for confirmation.
+	if got := Default().LLM.AutoActConfidenceThreshold; got != 99 {
+		t.Fatalf("default threshold = %d, want 99", got)
 	}
 	path := filepath.Join(t.TempDir(), "config.toml")
 	if err := os.WriteFile(path, []byte("[llm]\ntimeout_seconds = 30\n"), 0o600); err != nil {
@@ -1113,8 +1114,8 @@ func TestAutoActConfidenceThresholdDefault(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.LLM.AutoActConfidenceThreshold != 999 {
-		t.Errorf("omitted key should default to 999, got %d", cfg.LLM.AutoActConfidenceThreshold)
+	if cfg.LLM.AutoActConfidenceThreshold != 99 {
+		t.Errorf("omitted key should default to 99, got %d", cfg.LLM.AutoActConfidenceThreshold)
 	}
 }
 
@@ -1175,7 +1176,7 @@ func TestDeprecatedAutoActMigrates(t *testing.T) {
 
 func TestDeprecatedAutoActYieldsToExplicitNewKey(t *testing.T) {
 	// When both keys are present, the explicit new key wins over the old bool —
-	// including when it equals the default sentinel 999 (an operator who set it
+	// including when it equals the never sentinel 999 (an operator who set it
 	// explicitly to "never" must not be flipped to 0 by a stale auto_act=true).
 	cases := []struct {
 		name string
@@ -1206,7 +1207,8 @@ func TestDeprecatedAutoActYieldsToExplicitNewKey(t *testing.T) {
 
 func TestAutoActConfidenceThresholdNegativeClamped(t *testing.T) {
 	// A hand-edited negative threshold is invalid and must not let an
-	// unreported (-1) score auto-act: it falls back to the never-default.
+	// unreported (-1) score auto-act: it falls back to the default (99), which
+	// still escalates an unreported score since -1 < 99.
 	path := filepath.Join(t.TempDir(), "config.toml")
 	if err := os.WriteFile(path, []byte("[llm]\nauto_act_confidence_threshold = -5\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -1215,8 +1217,8 @@ func TestAutoActConfidenceThresholdNegativeClamped(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.LLM.AutoActConfidenceThreshold != 999 {
-		t.Errorf("negative threshold must clamp to the never-default 999, got %d", cfg.LLM.AutoActConfidenceThreshold)
+	if cfg.LLM.AutoActConfidenceThreshold != 99 {
+		t.Errorf("negative threshold must clamp to the default 99, got %d", cfg.LLM.AutoActConfidenceThreshold)
 	}
 }
 

--- a/internal/daemon/actionreview_test.go
+++ b/internal/daemon/actionreview_test.go
@@ -355,10 +355,10 @@ func TestActionReviewTaskSentinelOutsideTaskReviewDegrades(t *testing.T) {
 }
 
 func TestActionReviewLowConfidenceStillDelivers(t *testing.T) {
-	// The consult confidence gate does NOT apply to action reviews: a low
-	// (or default-unreachable-threshold) score still delivers the adapted
-	// text — the learned rule already earned the send.
-	h := approvalReviewHarness(t, "") // auto_act_confidence_threshold stays 999
+	// The consult confidence gate does NOT apply to action reviews: even a
+	// score below the threshold still delivers the adapted text — the learned
+	// rule already earned the send.
+	h := approvalReviewHarness(t, "") // default auto_act_confidence_threshold (99)
 	var calls atomic.Int32
 	respondReview(h, &calls, 5, func(domain.LLMRequest) (string, error) {
 		return "y — confirmed after review", nil

--- a/internal/daemon/command_start_test.go
+++ b/internal/daemon/command_start_test.go
@@ -18,9 +18,9 @@ import (
 )
 
 func TestConsultFirstFlagPerAgent(t *testing.T) {
-	// Default confidence threshold (999) means every consult escalates, which
-	// leaves nothing sent and no rate/learning side effects — a clean way to
-	// drive repeated consults for one agent.
+	// The consult returns an error, so every consult escalates regardless of
+	// the confidence threshold, which leaves nothing sent and no rate/learning
+	// side effects — a clean way to drive repeated consults for one agent.
 	h := newHarness(t, "[llm]\ncommand = [\"fake\"]\ntimeout_seconds = 5\n")
 	h.llm.configured = true
 	var mu sync.Mutex

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2921,9 +2921,10 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 	}
 	// Confidence gate: auto-act only when the LLM's self-reported confidence
 	// meets the operator's threshold. A missing score (-1) is below any
-	// threshold >= 0, so it always escalates; the default threshold (999) is
-	// unreachable on the 0-100 scale, i.e. never auto-act. The reject closure
-	// surfaces the score ("llm confidence N/100") on the escalation.
+	// threshold >= 0, so it always escalates; the default threshold (99) auto-
+	// acts only on a near-certain score, and a threshold above 100 (e.g. 999)
+	// never auto-acts. The reject closure surfaces the score ("llm confidence
+	// N/100") on the escalation.
 	if llmDec.ConfidentScore < cfg.LLM.AutoActConfidenceThreshold {
 		reject(domain.ReasonLLMLowConfidence, "")
 		return

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2988,7 +2988,7 @@ func TestLLMFallbackStagingRegateAndPromotion(t *testing.T) {
 func TestLLMConfidentScoreShownOnEscalation(t *testing.T) {
 	// The agent's self-reported confident_score (0-100) must reach the
 	// escalation entry the operator sees; without one (-1) nothing is added.
-	cfg := "[llm]\ncommand = [\"fake\"]\ntimeout_seconds = 5\n" // threshold defaults to 999: 62 < 999 → escalate
+	cfg := "[llm]\ncommand = [\"fake\"]\ntimeout_seconds = 5\n" // threshold defaults to 99: 62 < 99 → escalate
 	h := newHarness(t, cfg)
 	h.herdr.setPane(approvalPane)
 	h.llm.configured = true

--- a/internal/daemon/noop_test.go
+++ b/internal/daemon/noop_test.go
@@ -160,11 +160,11 @@ func TestLLMNoopDeniedWhenDisableWinsFinalBarrier(t *testing.T) {
 	}
 }
 
-// Below the confidence threshold (default 999 = never), an LLM @noop surfaces
-// as a human-readable suggestion; confirming it records the @noop as a
+// Below the confidence threshold (score 0 < the default 99), an LLM @noop
+// surfaces as a human-readable suggestion; confirming it records the @noop as a
 // learning event (end-to-end: accepted noop escalation becomes learned history).
 func TestLLMNoopEscalatesBelowConfidenceThreshold(t *testing.T) {
-	cfg := "[llm]\ncommand = [\"fake\"]\ntimeout_seconds = 5\n" // threshold defaults to 999 (never)
+	cfg := "[llm]\ncommand = [\"fake\"]\ntimeout_seconds = 5\n" // threshold defaults to 99
 	h := newHarness(t, cfg)
 	h.herdr.setPane(approvalPane)
 	h.llm.configured = true

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -1117,12 +1117,17 @@ func ensureGeneratedTaskFile(path, name string, tasks []string, limit int) ([]st
 		// freshly rendered "[ ]" line.
 		content = carryOverChecklistMarks(existing, content)
 	}
-	// Enforce the cap on the growing list: existing count + genuinely-new count.
-	// uniqueExisting collapses any duplicate identities so the reported "new"
-	// matches what mergeGeneratedTasks actually appended.
-	if limit > 0 && len(merged) > limit {
-		uniqueExisting := len(mergeGeneratedTasks(existing, nil))
-		return nil, taskCapExceededError(path, uniqueExisting, len(merged)-uniqueExisting, limit)
+	// Enforce the cap only when this confirm actually ADDS a task. uniqueExisting
+	// collapses the file's identities the same way merged does, so `adding` is
+	// the genuinely-new count that mergeGeneratedTasks appended — keying on it
+	// (not on sameChecklistTexts, which also trips on a mere reorder/renumber of
+	// the same items) means a no-growth re-confirm of an already-over-cap file
+	// is never refused, so a pre-fix or hand-edited over-cap file keeps its
+	// escalation retryable instead of being stranded.
+	uniqueExisting := len(mergeGeneratedTasks(existing, nil))
+	adding := len(merged) - uniqueExisting
+	if limit > 0 && adding > 0 && len(merged) > limit {
+		return nil, taskCapExceededError(path, uniqueExisting, adding, limit)
 	}
 	if err := writeFileAtomic(path, []byte(content), 0o600); err != nil {
 		return nil, err

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -978,8 +978,14 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	// tasks not already present — it never drops or reorders the agent's list
 	// (issue #183). `merged` is that combined list, so the send reservation
 	// below can locate the first suggested task by its real position.
-	merged, err := ensureGeneratedTaskFile(path, name, tasks)
+	// A bootstrap always registers a fresh source, which carries no explicit
+	// max_tasks, so the default cap applies — the same limit a later append or
+	// `task add` would enforce once the source is declared.
+	merged, err := ensureGeneratedTaskFile(path, name, tasks, config.DefaultMaxTasks)
 	if err != nil {
+		if errors.Is(err, errTaskCapExceeded) {
+			return err
+		}
 		return fmt.Errorf("write tasks file: %w", err)
 	}
 	// Register the file as this agent's task source (writes config.toml and
@@ -1048,6 +1054,25 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	return a.nudge(ctx, control.KindReload)
 }
 
+// errTaskCapExceeded flags a refusal to add generated tasks because the
+// source's max_tasks cap would be exceeded. Both generated-task confirm paths
+// return it — the bootstrap path (ensureGeneratedTaskFile) unwrapped, the
+// append path (appendGeneratedTasks) wrapped with its own retry context — so
+// the bootstrap caller can detect it with errors.Is and surface the
+// operator-facing "clean up the task list" guidance in place of its own generic
+// "write tasks file:" prefix. (The manual `task add` path enforces the same cap
+// but builds its own CLI-worded message; it does not carry this sentinel.)
+var errTaskCapExceeded = errors.New("maximum number of tasks reached")
+
+// taskCapExceededError formats the shared cap-exceeded refusal: how many tasks
+// the list already holds, how many the confirm would add, and the cap — with
+// the actionable "clean up ... then confirm again" the operator needs. It wraps
+// errTaskCapExceeded so callers can detect it with errors.Is.
+func taskCapExceededError(path string, existing, adding, limit int) error {
+	return fmt.Errorf("%w for %s: %d existing + %d new = %d exceeds cap %d — clean up the task list to make room, then confirm again",
+		errTaskCapExceeded, path, existing, adding, existing+adding, limit)
+}
+
 // ensureGeneratedTaskFile writes the agent's generated-task checklist to path
 // as ONE locked read-merge-write, under the same per-path lock mutateTaskFile
 // takes — an unlocked check-then-write could land after a concurrent confirm's
@@ -1056,10 +1081,14 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 // from `tasks` not already present are added at the end — a later generation
 // never drops or reorders the agent's list (issue #183). A file already
 // carrying exactly the merged items is left untouched (a stale re-confirm must
-// not clobber markers or operator edits). The write is atomic because the
-// daemon reads this file without the lock. Returns the merged task list (raw,
-// unnumbered) so the caller can locate a task's rendered position.
-func ensureGeneratedTaskFile(path, name string, tasks []string) ([]string, error) {
+// not clobber markers or operator edits). When adding tasks would push the
+// merged list past `limit` (the new source's max_tasks cap; <= 0 disables the
+// check), it refuses with errTaskCapExceeded rather than growing an unbounded
+// list — a re-confirm that adds nothing is exempt so a pre-cap file can still
+// be re-confirmed idempotently. The write is atomic because the daemon reads
+// this file without the lock. Returns the merged task list (raw, unnumbered) so
+// the caller can locate a task's rendered position.
+func ensureGeneratedTaskFile(path, name string, tasks []string, limit int) ([]string, error) {
 	lockPath := taskLockPath(path)
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
 		return nil, err
@@ -1078,12 +1107,22 @@ func ensureGeneratedTaskFile(path, name string, tasks []string) ([]string, error
 	content := domain.RenderGeneratedTaskList(name, merged)
 	if existing != "" {
 		if sameChecklistTexts(existing, content) {
+			// Idempotent re-confirm: no task is added, so the cap check is
+			// skipped — an already-over-cap file (a pre-fix write, or a manual
+			// edit) stays re-confirmable instead of stranding its escalation.
 			return merged, nil
 		}
 		// merged lists every existing task, so carry-over drops nothing — it
 		// only restores each preserved item's "[-]"/"[x]" marker onto its
 		// freshly rendered "[ ]" line.
 		content = carryOverChecklistMarks(existing, content)
+	}
+	// Enforce the cap on the growing list: existing count + genuinely-new count.
+	// uniqueExisting collapses any duplicate identities so the reported "new"
+	// matches what mergeGeneratedTasks actually appended.
+	if limit > 0 && len(merged) > limit {
+		uniqueExisting := len(mergeGeneratedTasks(existing, nil))
+		return nil, taskCapExceededError(path, uniqueExisting, len(merged)-uniqueExisting, limit)
 	}
 	if err := writeFileAtomic(path, []byte(content), 0o600); err != nil {
 		return nil, err
@@ -1326,11 +1365,11 @@ func (a *App) appendGeneratedTasks(ctx context.Context, audit *domain.AuditRecor
 
 	// ONE locked compare-append: skip already-present tasks (a retry after a
 	// failed claim, or the loser of a concurrent double-confirm, must not
-	// duplicate them), enforce the max_tasks cap on what is actually missing,
-	// and record where the first task lives for the reservation below. The cap
-	// is the same limit the daemon's generation gate and manual `task add`
-	// enforce; refusing here — pre-claim — lets the operator prune the list
-	// and confirm again.
+	// duplicate them), enforce the max_tasks cap on existing + genuinely-new
+	// tasks (any overflow refuses — no partial truncation), and record where
+	// the first task lives for the reservation below. The cap is the same limit
+	// the daemon's generation gate and manual `task add` enforce; refusing here
+	// — pre-claim — lets the operator prune the list and confirm again.
 	firstText := domain.EncodeTaskNewlines(tasks[0])
 	firstIndex := 0
 	if _, err := mutateTaskFile(path, func(content string) (string, error) {
@@ -1365,16 +1404,12 @@ func (a *App) appendGeneratedTasks(ctx context.Context, audit *domain.AuditRecor
 				present[text] = -1
 			}
 		}
-		if len(missing) > 0 {
-			room := limit - len(items)
-			if room <= 0 {
-				return "", fmt.Errorf("maximum number of tasks reached for %s (%d items, cap %d) — clean up the task list to make room, then confirm again", path, len(items), limit)
-			}
-			if room < len(missing) {
-				slog.Warn("truncating generated tasks to the source's max_tasks cap",
-					"path", path, "cap", limit, "dropped", len(missing)-room)
-				missing = missing[:room]
-			}
+		// Enforce the cap on the whole would-be list: existing items plus the
+		// tasks actually missing. Any overflow refuses outright (no silent
+		// truncation) so the operator sees the full suggestion and prunes the
+		// list — confirming half of it and dropping the rest would hide work.
+		if len(missing) > 0 && len(items)+len(missing) > limit {
+			return "", taskCapExceededError(path, len(items), len(missing), limit)
 		}
 		out := content
 		for _, text := range missing {

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -1280,7 +1280,11 @@ func TestConfirmGeneratedTaskAppendRespectsMaxTasks(t *testing.T) {
 			t.Errorf("the retried confirm must send exactly once, got %d sends", len(fake.inputs))
 		}
 	})
-	t.Run("partial room truncates the appended set", func(t *testing.T) {
+	t.Run("partial overflow refuses without truncating", func(t *testing.T) {
+		// 1 existing + 3 new = 4 exceeds the cap of 3. Rather than silently
+		// appending only the 2 that fit and dropping "third", the confirm
+		// refuses the whole set so the operator sees every suggested task and
+		// prunes the list — hiding work would be worse than refusing.
 		app, st, fake, _, path := declaredSourceApp(t, "w1:p1", "- [x] 1. a\n")
 		ctx := context.Background()
 		if err := app.UpdateConfig(ctx, func(cfg *config.Config) error {
@@ -1291,18 +1295,108 @@ func TestConfirmGeneratedTaskAppendRespectsMaxTasks(t *testing.T) {
 		}
 		id := generatedEscalation(t, st, "w1:p1", "- [ ] first\n- [ ] second\n- [ ] third")
 
-		if err := app.Confirm(ctx, id, true); err != nil {
+		err := app.Confirm(ctx, id, true)
+		if err == nil || !strings.Contains(err.Error(), "maximum number of tasks") {
+			t.Fatalf("a would-be-over-cap append must refuse with the cap error, got %v", err)
+		}
+		body, _ := os.ReadFile(path)
+		if string(body) != "- [x] 1. a\n" {
+			t.Errorf("nothing may be appended on a refused confirm, got %q", body)
+		}
+		if len(fake.inputs) != 0 {
+			t.Errorf("nothing may be sent on a refused confirm, got %v", fake.inputs)
+		}
+		audit, _ := st.GetAudit(ctx, id)
+		if audit.Status != "escalated" {
+			t.Errorf("escalation must stay pending so the operator can prune and retry, got %q", audit.Status)
+		}
+	})
+	t.Run("append that fits the cap exactly succeeds", func(t *testing.T) {
+		// 1 existing + 2 new = 3 == cap: the boundary is inclusive, so this must
+		// go through (the refusal is for exceeding, not reaching, the cap).
+		app, st, fake, _, path := declaredSourceApp(t, "w1:p1", "- [x] 1. a\n")
+		ctx := context.Background()
+		if err := app.UpdateConfig(ctx, func(cfg *config.Config) error {
+			cfg.TaskSources[0].MaxTasks = 3
+			return nil
+		}); err != nil {
 			t.Fatal(err)
+		}
+		id := generatedEscalation(t, st, "w1:p1", "- [ ] first\n- [ ] second")
+
+		if err := app.Confirm(ctx, id, true); err != nil {
+			t.Fatalf("an append that exactly fills the cap must succeed, got %v", err)
 		}
 		body, _ := os.ReadFile(path)
 		want := "- [x] 1. a\n- [-] first\n- [ ] second\n"
 		if string(body) != want {
-			t.Errorf("declared file = %q, want the set truncated to the cap %q", body, want)
+			t.Errorf("declared file = %q, want both tasks appended %q", body, want)
 		}
 		if len(fake.inputs) != 1 {
-			t.Errorf("the first task must still be sent, got %v", fake.inputs)
+			t.Errorf("the first task must be sent, got %v", fake.inputs)
 		}
 	})
+}
+
+func TestConfirmGeneratedTaskBootstrapRespectsMaxTasks(t *testing.T) {
+	// The bootstrap path (no declared source yet) also honors the default
+	// max_tasks cap: a file already holding DefaultMaxTasks items refuses one
+	// more generated task instead of growing an unbounded list. Regression for
+	// the gap where only the append + `task add` paths enforced the cap.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w1:p1")
+	// Pre-seed the bootstrap file AT the cap without registering a source, so
+	// the confirm takes the bootstrap branch (not the declared-source append).
+	path := filepath.Join(stateDir, "tasks", name+".md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	b.WriteString("# Tasks for " + name + "\n\n")
+	for i := 1; i <= config.DefaultMaxTasks; i++ {
+		fmt.Fprintf(&b, "- [ ] %d. task %d\n", i, i)
+	}
+	seeded := b.String()
+	if err := os.WriteFile(path, []byte(seeded), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:p1", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "one more task", CreatedAt: time.Now(),
+	})
+
+	err := app.Confirm(ctx, id, true)
+	if err == nil || !strings.Contains(err.Error(), "maximum number of tasks") {
+		t.Fatalf("a bootstrap confirm over the default cap must refuse, got %v", err)
+	}
+	body, _ := os.ReadFile(path)
+	if string(body) != seeded {
+		t.Errorf("a refused bootstrap confirm must not change the file, got %q", body)
+	}
+	if len(fake.inputs) != 0 {
+		t.Errorf("nothing may be sent on a refused confirm, got %v", fake.inputs)
+	}
+	// The refusal happens before source registration, so the operator can prune
+	// the file and retry the same escalation.
+	cfg, err := config.Load(app.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 0 {
+		t.Errorf("a refused confirm must not register a source, got %+v", cfg.TaskSources)
+	}
+	audit, _ := st.GetAudit(ctx, id)
+	if audit.Status != "escalated" {
+		t.Errorf("escalation must stay pending so the operator can prune and retry, got %q", audit.Status)
+	}
 }
 
 // sendHookHerdr wraps fakeHerdr to observe on-disk state at the exact moment
@@ -2061,11 +2155,17 @@ func TestConfigFieldRegistryParity(t *testing.T) {
 }
 
 func TestAutoActConfidenceThresholdFieldDisplay(t *testing.T) {
-	// The default (999) renders with a "never" label, not a bare number.
+	// The default (99) is a reachable 0-100 threshold, so it renders as a bare
+	// number, not the "never" label.
 	def := config.Default()
 	got := frontend.FieldValue(def, "llm.auto_act_confidence_threshold")
-	if !strings.Contains(got, "never") || !strings.Contains(got, "999") {
-		t.Errorf("default threshold should show a never label, got %q", got)
+	if got != "99" {
+		t.Errorf("default threshold display = %q, want a bare 99", got)
+	}
+	// A value above 100 still renders with the "never" label.
+	def.LLM.AutoActConfidenceThreshold = 999
+	if got := frontend.FieldValue(def, "llm.auto_act_confidence_threshold"); !strings.Contains(got, "never") || !strings.Contains(got, "999") {
+		t.Errorf("over-100 threshold should show a never label, got %q", got)
 	}
 	// A reachable 0-100 threshold renders plainly.
 	def.LLM.AutoActConfidenceThreshold = 70

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -1399,6 +1399,61 @@ func TestConfirmGeneratedTaskBootstrapRespectsMaxTasks(t *testing.T) {
 	}
 }
 
+func TestConfirmGeneratedTaskBootstrapOverCapNoGrowthNotRefused(t *testing.T) {
+	// An already-over-cap bootstrap file (a pre-fix write or a hand edit) with
+	// NON-canonical numbering re-confirmed with only already-present tasks adds
+	// nothing, so it must NOT be refused — the cap gate keys on genuinely-new
+	// tasks, not on a text/numbering match. Regression: keying the exemption on
+	// sameChecklistTexts stranded the escalation of a reordered over-cap file.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w1:p1")
+	path := filepath.Join(stateDir, "tasks", name+".md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// One MORE than the cap, numbered in REVERSE so the file's rendered text
+	// differs from RenderGeneratedTaskList's canonical 1..N — this makes
+	// sameChecklistTexts return false and exercises the cap gate directly.
+	n := config.DefaultMaxTasks + 1
+	var b strings.Builder
+	b.WriteString("# Tasks for " + name + "\n\n")
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&b, "- [ ] %d. task %d\n", n+1-i, i)
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// The suggestion is an item ALREADY present (identity "task 1"), so the
+	// merge adds no new task. send=false keeps the assertion on the refusal
+	// gate, not on delivery.
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:p1", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.SuggestTaskPrefix + "task 1", CreatedAt: time.Now(),
+	})
+
+	if err := app.Confirm(ctx, id, false); err != nil {
+		t.Fatalf("a no-growth re-confirm of an over-cap file must not be refused, got %v", err)
+	}
+	// The list neither grew nor shrank — still n items, just renumbered.
+	body, _ := os.ReadFile(path)
+	if got := len(domain.ParseChecklist(string(body))); got != n {
+		t.Errorf("over-cap file must be preserved at %d items, got %d: %q", n, got, body)
+	}
+	// The escalation resolved (not stranded).
+	audit, _ := st.GetAudit(ctx, id)
+	if audit.Status == "escalated" {
+		t.Errorf("a no-growth confirm must resolve the escalation, got %q", audit.Status)
+	}
+}
+
 // sendHookHerdr wraps fakeHerdr to observe on-disk state at the exact moment
 // Send runs — the only way to assert reserve-BEFORE-send ordering, since the
 // final file state after a rollback is identical to never having reserved.

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -89,7 +89,7 @@ command = [
 # ]
 
 timeout_seconds = 120              # codex is slower to start; 180 is a safer value there
-auto_act_confidence_threshold = 999  # auto-act only when the LLM confidence (0-100) is >= this; 999 = never (surface for confirmation)
+auto_act_confidence_threshold = 99  # auto-act only when the LLM confidence (0-100) is >= this; default 99 (near-certain only); set >100 (e.g. 999) to never auto-act and always surface for confirmation
 pane_excerpt_chars = 5000          # pane context included in the consult
 
 # ── Outbound action review (optional) ──
@@ -220,7 +220,9 @@ terminal_bell = true       # ring the terminal bell (\a) on new escalations and 
 # hold before LLM task generation stops refilling it: once the file has MORE
 # than max_tasks items and its pending items are exhausted, the daemon logs a
 # warning and skips generation instead of piling more onto an already-long list
-# — prune the checklist to make room. Default: 20 when unset.
+# — prune the checklist to make room. Confirming generated tasks whose count
+# would push the list past the cap is likewise REFUSED (no partial truncation),
+# as is a manual `hap task add`. Default: 20 when unset.
 # max_tasks = 20
 
 # ── Custom classifier rules (repeatable, extend the built-ins) ──────


### PR DESCRIPTION
## Summary

Two related task-generation / LLM-action safety changes (originally a verification of whether generated-task adds honor `max_tasks`, which surfaced a real gap).

### 1. Enforce `max_tasks` on LLM-generated task confirms

Confirming LLM-generated tasks had two holes vs. the intended "existing + new tasks over the cap → fail and tell the operator to clean up":

- **Declared-source append path** silently **truncated** the new tasks to fit the cap and only logged a warning — hiding suggested work.
- **Bootstrap path** (`ensureGeneratedTaskFile`, used when no source is declared yet) had **no cap check at all**.

Now both refuse with a shared `errTaskCapExceeded` sentinel when `existing + new > cap`, with an actionable "clean up the task list to make room, then confirm again" message. Details:

- Boundary is inclusive: `existing + new == cap` still **succeeds**; only `> cap` refuses (no partial truncation).
- A pure idempotent re-confirm (same items already present) is **exempt** from the cap check, so an already-over-cap file (a pre-fix write or manual edit) never strands its escalation.
- The refusal happens **pre-claim**, so the escalation stays pending and retryable after the operator prunes the list.
- The manual `hap task add` path already enforced the cap (unchanged).

### 2. Default `auto_act_confidence_threshold` 999 → 99

`999` (>100) meant "never auto-act" and was easy to misread. The default is now **99**: the daemon auto-acts only when the LLM is near-certain (score ≥ 99) and surfaces everything less confident for confirmation.

- The deprecated `auto_act = false → 999` migration and the `>100` "never" sentinel are **unchanged** (write `999` to opt back into never).
- A hand-edited negative threshold now clamps to `99`; an unreported score (`-1`) still escalates since `-1 < 99`.

## Testing

- New/updated unit tests: append cap (`full list refuses`, `partial overflow refuses without truncating`, `append that fits the cap exactly succeeds`), new `TestConfirmGeneratedTaskBootstrapRespectsMaxTasks`, and updated `auto_act` default/clamp/display tests.
- `go test -tags "vectors cpu"` green for `internal/frontend`, `internal/daemon`, `internal/config`.
- `gofmt`, `go vet`, and `golangci-lint` clean on the changed packages.
- Code-reviewed via subagent; the one doc-accuracy note it raised was fixed.

https://claude.ai/code/session_0162qGzBfdPGLgrbUfV8osks