### PR TITLE
#1 fix: dedup resolved-escalation re-fires and near-identical captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ herdr plugin install 0xGosu/herdr-auto-pilot --ref v0.4.0
 herdr plugin install 0xGosu/herdr-auto-pilot --yes
 ```
 
+### Update to the latest version
+
+Re-run the install command to upgrade an existing install to the newest
+release. `--yes` skips the interactive confirmation.
+
+```sh
+herdr plugin install 0xGosu/herdr-auto-pilot --yes   # download & install the latest release
+hap daemon --ensure                                  # recommended: hot-swap the running daemon now
+```
+
+`hap daemon --ensure` is optional but recommended — it swaps the running
+daemon for the new build immediately, so you don't have to wait for the next
+automatic restart.
+
+For a clean reinstall, uninstall first, then install:
+
+```sh
+herdr plugin uninstall herd-auto-prompter            # optional: only for a clean reinstall
+herdr plugin install 0xGosu/herdr-auto-pilot --yes
+hap daemon --ensure
+```
+
 The monitoring daemon starts automatically when an agent appears in the herd.
 Use the following recommended setup to make the **Auto Prompter** pane (TUI)
 and its CLI convenient to access from the host machine.
@@ -1043,6 +1065,19 @@ Two levels, depending on how much you want gone:
 
 Prefer `clear-data` unless you also want your config gone; it's the only
 path that keeps the daemon running through the wipe.
+
+## Roadmap
+
+Planned features for future releases:
+
+- **Full-Self Prompting mode (FSP)** — a fully autonomous mode where the plugin
+  drives agents end-to-end with zero operator involvement.
+- **OpenCode support** — extend LLM-consult and agent monitoring to the
+  OpenCode CLI alongside the current Claude Code / Codex integrations.
+- **HAP Cloud** — optional sync of local data (rules, signatures, audit) to the
+  cloud for backup and cross-machine storage.
+- **HAP Web — Remote Control** — a web UI to monitor and remotely control the
+  herd from anywhere.
 
 ## Development
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -851,8 +851,9 @@ func printConfig(out io.Writer, cfg config.Config) {
 		cfg.ConfidenceThresholds.Minimum, cfg.ConfidenceThresholds.Idle, cfg.ConfidenceThresholds.Approval,
 		cfg.ConfidenceThresholds.Choice, cfg.ConfidenceThresholds.Error)
 	fmt.Fprintf(out, "learning:   graduation_n=%d confirmation_weight=%g\n", cfg.Learning.GraduationN, cfg.Learning.ConfirmationWeight)
-	fmt.Fprintf(out, "limits:     consecutive=%d per_minute=%d error_retries=%d\n",
-		cfg.Limits.MaxConsecutiveAutoPrompts, cfg.Limits.MaxAutoPromptsPerMinute, cfg.Limits.MaxErrorRetries)
+	fmt.Fprintf(out, "limits:     consecutive=%d per_minute=%d error_retries=%d dedup_window=%ds dedup_jitter=%d%%\n",
+		cfg.Limits.MaxConsecutiveAutoPrompts, cfg.Limits.MaxAutoPromptsPerMinute, cfg.Limits.MaxErrorRetries,
+		cfg.Limits.EscalationDedupWindowSeconds, cfg.Limits.EscalationDedupJitterPercent)
 	fmt.Fprintf(out, "llm:        configured=%v timeout=%ds auto_act_confidence_threshold=%d\n",
 		len(cfg.LLM.Command) > 0, cfg.LLM.TimeoutSeconds, cfg.LLM.AutoActConfidenceThreshold)
 	seedCount := domain.SeedNeverAutoRuleCount()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,6 +81,22 @@ type Limits struct {
 	MaxConsecutiveAutoPrompts int `toml:"max_consecutive_auto_prompts"`
 	MaxAutoPromptsPerMinute   int `toml:"max_auto_prompts_per_minute"`
 	MaxErrorRetries           int `toml:"max_error_retries"`
+	// EscalationDedupWindowSeconds is how long a just-resolved escalation still
+	// suppresses a duplicate re-fire of the same situation. Herdr re-delivers an
+	// attention event for one agent after a delay (the agent flips done->idle
+	// when the operator reads the pane); once the operator accepts the first
+	// escalation it leaves the still-pending set, so without this window the
+	// re-fire would raise a second, duplicate escalation. Measured from when the
+	// escalation was raised. `<= 0` falls back to the default. Still-pending
+	// escalations dedup regardless of age — only resolved ones are time-gated.
+	EscalationDedupWindowSeconds int `toml:"escalation_dedup_window_seconds"`
+	// EscalationDedupJitterPercent is how much two large pane captures may differ
+	// (0-100) and still count as the same screen for the duplicate-ask check —
+	// absorbing residual TUI jitter the normalizer misses. It applies ONLY to
+	// large tail-window captures (>= half the snapshot cap); small captures still
+	// require an exact match so two short but distinct questions never collapse.
+	// `0` disables the tolerance (exact match only); values are clamped to 0-100.
+	EscalationDedupJitterPercent int `toml:"escalation_dedup_jitter_percent"`
 }
 
 // LLM configures the optional local LLM/agent CLI fallback (FR-010, IR-005).
@@ -365,9 +381,11 @@ func Default() Config {
 		// literal here so config stays decoupled from the domain package).
 		Learning: Learning{GraduationN: 2, ConfirmationWeight: 3.0},
 		Limits: Limits{
-			MaxConsecutiveAutoPrompts: 10,
-			MaxAutoPromptsPerMinute:   5,
-			MaxErrorRetries:           2,
+			MaxConsecutiveAutoPrompts:    10,
+			MaxAutoPromptsPerMinute:      5,
+			MaxErrorRetries:              2,
+			EscalationDedupWindowSeconds: 300,
+			EscalationDedupJitterPercent: 5,
 		},
 		LLM: LLM{TimeoutSeconds: 60, PaneExcerptChars: 5000, AutoActConfidenceThreshold: 99},
 		Embedding: Embedding{
@@ -743,6 +761,17 @@ func (c *Config) fillZeroes() {
 	}
 	if c.Limits.MaxErrorRetries <= 0 {
 		c.Limits.MaxErrorRetries = d.Limits.MaxErrorRetries
+	}
+	if c.Limits.EscalationDedupWindowSeconds <= 0 {
+		c.Limits.EscalationDedupWindowSeconds = d.Limits.EscalationDedupWindowSeconds
+	}
+	// 0 is a valid "exact match only" setting, so only a negative (invalid,
+	// SetField rejects it too) falls back to the default; an over-100 value
+	// clamps to a full 100% tolerance.
+	if c.Limits.EscalationDedupJitterPercent < 0 {
+		c.Limits.EscalationDedupJitterPercent = d.Limits.EscalationDedupJitterPercent
+	} else if c.Limits.EscalationDedupJitterPercent > 100 {
+		c.Limits.EscalationDedupJitterPercent = 100
 	}
 	if c.LLM.TimeoutSeconds <= 0 {
 		c.LLM.TimeoutSeconds = d.LLM.TimeoutSeconds

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,6 +65,50 @@ func TestLoadPartialConfigFillsDefaults(t *testing.T) {
 	}
 }
 
+func TestEscalationDedupLimitsDefaultsAndOverrides(t *testing.T) {
+	// Unset → defaults applied.
+	unset := filepath.Join(t.TempDir(), "config.toml")
+	os.WriteFile(unset, []byte("[limits]\nmax_error_retries = 4\n"), 0o600)
+	cfg, err := Load(unset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Limits.EscalationDedupWindowSeconds != Default().Limits.EscalationDedupWindowSeconds {
+		t.Errorf("unset dedup window should default to %d, got %d",
+			Default().Limits.EscalationDedupWindowSeconds, cfg.Limits.EscalationDedupWindowSeconds)
+	}
+	if cfg.Limits.EscalationDedupJitterPercent != Default().Limits.EscalationDedupJitterPercent {
+		t.Errorf("unset dedup jitter should default to %d, got %d",
+			Default().Limits.EscalationDedupJitterPercent, cfg.Limits.EscalationDedupJitterPercent)
+	}
+
+	// Explicit values honored; a 0 jitter is a valid "exact match only" setting
+	// and must NOT be overwritten by the default.
+	set := filepath.Join(t.TempDir(), "config.toml")
+	os.WriteFile(set, []byte("[limits]\nescalation_dedup_window_seconds = 120\nescalation_dedup_jitter_percent = 0\n"), 0o600)
+	cfg, err = Load(set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Limits.EscalationDedupWindowSeconds != 120 {
+		t.Errorf("explicit dedup window lost: %d", cfg.Limits.EscalationDedupWindowSeconds)
+	}
+	if cfg.Limits.EscalationDedupJitterPercent != 0 {
+		t.Errorf("explicit 0 jitter (disable) must be preserved, got %d", cfg.Limits.EscalationDedupJitterPercent)
+	}
+
+	// Out-of-range jitter clamps to 100; a negative falls back to the default.
+	clamp := filepath.Join(t.TempDir(), "config.toml")
+	os.WriteFile(clamp, []byte("[limits]\nescalation_dedup_jitter_percent = 250\n"), 0o600)
+	cfg, err = Load(clamp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Limits.EscalationDedupJitterPercent != 100 {
+		t.Errorf("over-100 jitter should clamp to 100, got %d", cfg.Limits.EscalationDedupJitterPercent)
+	}
+}
+
 func TestDeprecatedVerifyUnblockMsIgnoredAndDroppedOnSave(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	os.WriteFile(path, []byte("[limits]\nverify_unblock_ms = 0\nmax_error_retries = 4\n"), 0o600)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -824,14 +824,18 @@ func (d *Daemon) hasOpenEscalation(ctx context.Context, agentID string) bool {
 // re-processing one, so on doubt the event proceeds to escalate rather than
 // being ignored (the "never a silent drop" architecture rule).
 func (d *Daemon) duplicatePendingEscalation(ctx context.Context, s domain.Situation) bool {
-	pending, err := d.opt.Store.PendingEscalationExcerpts(ctx, s.AgentID, s.AgentType)
+	cfg, _, _ := d.snapshot()
+	window := time.Duration(cfg.Limits.EscalationDedupWindowSeconds) * time.Second
+	resolvedSince := d.opt.Clock.Now().Add(-window)
+	pending, err := d.opt.Store.PendingEscalationExcerpts(ctx, s.AgentID, s.AgentType, resolvedSince)
 	if err != nil {
 		slog.Warn("duplicate-escalation check failed; processing event",
 			"agent", s.AgentID, "pane", s.PaneID, "error", err)
 		return false
 	}
 	return domain.DuplicatesPendingEscalation(s.Type,
-		truncateTailRunes(s.Content, snapshotMaxRunes), snapshotMaxRunes, pending)
+		truncateTailRunes(s.Content, snapshotMaxRunes), snapshotMaxRunes,
+		cfg.Limits.EscalationDedupJitterPercent, pending)
 }
 
 // ignoreDuplicate audits a no-op for an event whose situation already has a

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -454,14 +454,14 @@ func (f *failingStore) HasPendingLLMConsult(ctx context.Context, agentID string)
 	return f.StorePort.HasPendingLLMConsult(ctx, agentID)
 }
 
-func (f *failingStore) PendingEscalationExcerpts(ctx context.Context, agentID, agentType string) ([]domain.PendingEscalation, error) {
+func (f *failingStore) PendingEscalationExcerpts(ctx context.Context, agentID, agentType string, resolvedSince time.Time) ([]domain.PendingEscalation, error) {
 	f.mu.Lock()
 	fail := f.failDedup
 	f.mu.Unlock()
 	if fail {
 		return nil, errors.New("induced dedup-check failure")
 	}
-	return f.StorePort.PendingEscalationExcerpts(ctx, agentID, agentType)
+	return f.StorePort.PendingEscalationExcerpts(ctx, agentID, agentType, resolvedSince)
 }
 
 // --- harness ---
@@ -1522,6 +1522,62 @@ func TestPipelineIgnoresDuplicateEvent(t *testing.T) {
 	})
 	if got := len(ignoredRows(t, h)); got != 1 {
 		t.Fatalf("new situation was wrongly ignored: %d ignored rows, want 1", got)
+	}
+}
+
+// TestPipelineDedupAfterResolveWithinWindow covers the reported bug: an
+// escalation is accepted (escalated -> resolved, leaving the pending set), yet
+// herdr re-delivers the same screen shortly after. Within the dedup window the
+// just-resolved escalation must still suppress the re-fire — otherwise a second,
+// duplicate escalation is raised for a question the operator already handled.
+func TestPipelineDedupAfterResolveWithinWindow(t *testing.T) {
+	h := newHarness(t, "")
+	ctx := context.Background()
+	h.herdr.setPane(approvalPane)
+
+	// First blocked event with no learned rule escalates.
+	h.push("agent-resolve-dup", "blocked")
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+
+	// The operator accepts it AND the answer is delivered: a correction is
+	// recorded and marked sent, then the row flips escalated -> resolved and
+	// leaves the still-pending set. The delivered (sent=1) correction is what
+	// makes the resolved row a dedup candidate — a learn-only confirm would not,
+	// so the shadow-learning re-escalation loop stays intact (covered by
+	// TestConfirmDrivenShadowToAutoPromotion).
+	esc, _ := h.raw.PendingEscalations(ctx)
+	corrID, err := h.raw.InsertCorrection(ctx, domain.CorrectionRecord{
+		AuditID: esc[0].ID, CorrectedAction: "respond: Yes", Author: "test", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.raw.MarkCorrectionSent(ctx, corrID); err != nil {
+		t.Fatal(err)
+	}
+	claimed, err := h.raw.ResolveEscalation(ctx, esc[0].ID)
+	if err != nil || !claimed {
+		t.Fatalf("resolve escalation: claimed=%v err=%v", claimed, err)
+	}
+	if p, _ := h.raw.PendingEscalations(ctx); len(p) != 0 {
+		t.Fatalf("escalation not resolved: %d still pending", len(p))
+	}
+
+	// Herdr re-delivers the same screen (done->idle when the operator read the
+	// pane). The default window is 5 minutes, so this immediate re-fire is well
+	// inside it: no new escalation, and one ignored audit row.
+	h.herdr.setPane(approvalPane)
+	h.push("agent-resolve-dup", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(ignoredRows(t, h)) == 1 })
+
+	if p, _ := h.raw.PendingEscalations(ctx); len(p) != 0 {
+		t.Fatalf("re-delivery after resolve raised a duplicate ask: got %d, want 0", len(p))
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Fatal("duplicate escalation must not send input")
 	}
 }
 

--- a/internal/domain/dedup.go
+++ b/internal/domain/dedup.go
@@ -268,25 +268,29 @@ func DuplicatesPendingEscalation(sitType SituationType, excerpt string, snapshot
 			}
 			return true
 		}
-		// Both fuzzy paths (suffix shift, jitter tolerance) require two large tail
-		// windows whose first lines do NOT discriminate. A differing first line is
-		// a different question, not jitter: the classic approval shape puts the
-		// command ("Bash(npm install)") on the first line above an otherwise
-		// identical menu/body, and over a large body two such screens are >95%
-		// similar — so without this guard the jitter path would silently collapse
-		// two genuinely different approvals. firstLineExplained is the same guard
-		// the suffix path has always used; it holds for real jitter (matching or
-		// head-shifted first lines) and refuses for a discriminating command line.
-		bothLargeTailWindows := freshWindowed &&
-			utf8.RuneCountInString(p.PaneExcerpt)*2 >= snapshotCap &&
-			firstLineExplained(excerpt, p.PaneExcerpt)
-		if !bothLargeTailWindows {
+		// Both fuzzy paths require two large tail windows.
+		bothLarge := freshWindowed && utf8.RuneCountInString(p.PaneExcerpt)*2 >= snapshotCap
+		if !bothLarge {
 			continue
 		}
-		if suffixDuplicate(suffixKey, NormalizeForDedup(dropFirstLine(p.PaneExcerpt))) {
+		// Suffix path (head-shift tolerant): the first line may be a truncation
+		// fragment, so it uses firstLineExplained (fragment-of-the-other) and an
+		// EXACT suffix match, which is order-sensitive and safe.
+		if firstLineExplained(excerpt, p.PaneExcerpt) &&
+			suffixDuplicate(suffixKey, NormalizeForDedup(dropFirstLine(p.PaneExcerpt))) {
 			return true
 		}
-		if jitterPct > 0 && shingleSimilar(keyShingles, keyRunes, pKey, jitterPct) {
+		// Jitter path: trigram-set Jaccard is ORDER-INSENSITIVE, so it demands a
+		// STRONGER first-line guarantee than the suffix path — the first lines must
+		// be IDENTICAL, not merely substring-explained. A substring match is not
+		// enough here: two distinct approval headers ("Bash(npm install)" vs
+		// "Bash(go test ./...)") can each appear in the OTHER capture's scrollback,
+		// passing firstLineExplained, and the order-insensitive set compare would
+		// then collapse two genuinely different approvals — a silent drop. Real
+		// jitter (residual chrome the normalizer missed) is mid-screen and leaves
+		// the first line untouched, so requiring equality costs nothing legitimate.
+		if jitterPct > 0 && firstLinesEqual(excerpt, p.PaneExcerpt) &&
+			shingleSimilar(keyShingles, keyRunes, pKey, jitterPct) {
 			return true
 		}
 	}
@@ -394,6 +398,16 @@ func firstLineIn(src, other string) bool {
 	first, _, _ := strings.Cut(src, "\n")
 	first = strings.TrimSpace(first)
 	return first == "" || strings.Contains(other, first)
+}
+
+// firstLinesEqual reports whether the two captures' trimmed first lines are
+// identical — the strict gate the order-insensitive jitter path uses in place of
+// firstLineExplained, so a discriminating first line (a different command over an
+// otherwise similar body) can never be waved through by a mere substring match.
+func firstLinesEqual(a, b string) bool {
+	fa, _, _ := strings.Cut(a, "\n")
+	fb, _, _ := strings.Cut(b, "\n")
+	return strings.TrimSpace(fa) == strings.TrimSpace(fb)
 }
 
 // dropFirstLine removes the first line of a tail-windowed capture: both the

--- a/internal/domain/dedup.go
+++ b/internal/domain/dedup.go
@@ -238,25 +238,138 @@ type PendingEscalation struct {
 // which is what a genuinely head-shifted window looks like and what two
 // first-line-discriminated questions never do. See suffixDuplicate for the
 // degenerate-length guard.
-func DuplicatesPendingEscalation(sitType SituationType, excerpt string, snapshotCap int, pending []PendingEscalation) bool {
+// jitterPct (0-100) widens the content compare to absorb residual TUI jitter the
+// normalizer misses: two captures that differ by no more than jitterPct% of their
+// character trigrams count as the same screen. It is applied ONLY to large
+// tail-window captures (the same half-cap gate the suffix compare uses), so two
+// short but DISTINCT questions — whose only difference may be a handful of
+// characters — never collapse into one, which would silently strand the second
+// agent. jitterPct <= 0 disables the tolerance, preserving the exact-match
+// behavior.
+func DuplicatesPendingEscalation(sitType SituationType, excerpt string, snapshotCap, jitterPct int, pending []PendingEscalation) bool {
 	key := NormalizeForDedup(excerpt)
 	freshWindowed := snapshotCap > 0 && utf8.RuneCountInString(excerpt)*2 >= snapshotCap
 	suffixKey := NormalizeForDedup(dropFirstLine(excerpt))
+	// The incoming excerpt's shingle set is invariant across the loop, so build it
+	// once (only when the jitter path can run) instead of rebuilding it for every
+	// pending candidate.
+	var keyShingles map[string]struct{}
+	var keyRunes int
+	if jitterPct > 0 {
+		keyShingles = shingles(key)
+		keyRunes = utf8.RuneCountInString(key)
+	}
 	for _, p := range pending {
-		if NormalizeForDedup(p.PaneExcerpt) == key {
+		pKey := NormalizeForDedup(p.PaneExcerpt)
+		if pKey == key {
 			// No content to discriminate on: fall back to the situation type.
 			if key == "" && p.SituationType != sitType {
 				continue
 			}
 			return true
 		}
-		if freshWindowed && utf8.RuneCountInString(p.PaneExcerpt)*2 >= snapshotCap &&
-			firstLineExplained(excerpt, p.PaneExcerpt) &&
-			suffixDuplicate(suffixKey, NormalizeForDedup(dropFirstLine(p.PaneExcerpt))) {
+		// Both fuzzy paths (suffix shift, jitter tolerance) require two large tail
+		// windows whose first lines do NOT discriminate. A differing first line is
+		// a different question, not jitter: the classic approval shape puts the
+		// command ("Bash(npm install)") on the first line above an otherwise
+		// identical menu/body, and over a large body two such screens are >95%
+		// similar — so without this guard the jitter path would silently collapse
+		// two genuinely different approvals. firstLineExplained is the same guard
+		// the suffix path has always used; it holds for real jitter (matching or
+		// head-shifted first lines) and refuses for a discriminating command line.
+		bothLargeTailWindows := freshWindowed &&
+			utf8.RuneCountInString(p.PaneExcerpt)*2 >= snapshotCap &&
+			firstLineExplained(excerpt, p.PaneExcerpt)
+		if !bothLargeTailWindows {
+			continue
+		}
+		if suffixDuplicate(suffixKey, NormalizeForDedup(dropFirstLine(p.PaneExcerpt))) {
+			return true
+		}
+		if jitterPct > 0 && shingleSimilar(keyShingles, keyRunes, pKey, jitterPct) {
 			return true
 		}
 	}
 	return false
+}
+
+// SimilarWithin reports whether two already-normalized captures are within
+// jitterPct% of each other by character-trigram (shingle) Jaccard similarity:
+// sim = |A∩B| / |A∪B| >= (100-jitterPct)/100. Trigram Jaccard is O(n) — unlike
+// Levenshtein's O(n·m), which is far too slow to run per pending escalation on
+// the daemon's synchronous event loop for multi-kilobyte captures — and is a
+// standard near-duplicate metric: a few changed lines in a large screen move sim
+// only slightly, while two genuinely different screens fall well below the
+// threshold. jitterPct <= 0 requires an exact match; jitterPct >= 100 matches
+// anything.
+func SimilarWithin(a, b string, jitterPct int) bool {
+	if a == b {
+		return true
+	}
+	if jitterPct <= 0 {
+		return false
+	}
+	if jitterPct >= 100 {
+		return true
+	}
+	return shingleSimilar(shingles(a), utf8.RuneCountInString(a), b, jitterPct)
+}
+
+// shingleSimilar is the trigram-Jaccard core of SimilarWithin, taking the first
+// capture's precomputed shingle set (and its rune count) so a caller comparing
+// one incoming excerpt against many candidates builds that set only once.
+// jitterPct is assumed already normalized to (0,100) by the caller.
+func shingleSimilar(sa map[string]struct{}, ra int, b string, jitterPct int) bool {
+	rb := utf8.RuneCountInString(b)
+	shorter, longer := ra, rb
+	if shorter > longer {
+		shorter, longer = longer, shorter
+	}
+	if longer == 0 {
+		return true // both empty
+	}
+	// Cheap length pre-filter: for non-degenerate (low-repetition) content the
+	// shingle-count ratio does not exceed the rune-count ratio, so a shorter
+	// capture too small a fraction of the longer cannot clear the threshold —
+	// skip building b's set. Its only failure mode is on highly repetitive text
+	// (e.g. a pane of identical separator runes at differing lengths), where it
+	// may skip a pair the full metric would accept; that direction is safe — a
+	// redundant escalation, never a silent drop of a distinct question.
+	if shorter*100 < (100-jitterPct)*longer {
+		return false
+	}
+	sb := shingles(b)
+	inter := 0
+	for k := range sa {
+		if _, ok := sb[k]; ok {
+			inter++
+		}
+	}
+	union := len(sa) + len(sb) - inter
+	if union == 0 {
+		return true
+	}
+	// sim = inter/union >= (100-jitterPct)/100, kept in integer arithmetic.
+	return inter*100 >= (100-jitterPct)*union
+}
+
+// shingles is the set of overlapping character trigrams of s. A string shorter
+// than 3 runes has no trigram, so it is represented by itself (an empty string
+// yields the empty set) — enough for the exact/near-empty cases the caller feeds
+// it; the real work is on multi-kilobyte captures.
+func shingles(s string) map[string]struct{} {
+	r := []rune(s)
+	m := make(map[string]struct{}, len(r))
+	if len(r) < 3 {
+		if len(r) > 0 {
+			m[string(r)] = struct{}{}
+		}
+		return m
+	}
+	for i := 0; i+3 <= len(r); i++ {
+		m[string(r[i:i+3])] = struct{}{}
+	}
+	return m
 }
 
 // firstLineExplained reports whether either capture's first line — the line

--- a/internal/domain/dedup_test.go
+++ b/internal/domain/dedup_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -296,8 +297,123 @@ func TestDuplicatesPendingEscalation(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := DuplicatesPendingEscalation(tc.sit, tc.excerpt, tc.cap, tc.pending); got != tc.want {
+			// jitter 0: every case here pins the exact/suffix behavior, which the
+			// tolerance path must leave untouched.
+			if got := DuplicatesPendingEscalation(tc.sit, tc.excerpt, tc.cap, 0, tc.pending); got != tc.want {
 				t.Errorf("DuplicatesPendingEscalation = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// bigVariedBody builds a large, NON-repeating body: shingle (trigram) sets
+// collapse repeated text into few unique entries, so identical filler would make
+// a tiny edit a large fraction of the set. Distinct numbered lines give a large
+// unique-trigram set, the realistic case for a full pane of build output.
+func bigVariedBody(n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString("line ")
+		b.WriteString(strconv.Itoa(i))
+		b.WriteString(": build output token alpha")
+		b.WriteString(strconv.Itoa(i * 7))
+		b.WriteString(" beta")
+		b.WriteString(strconv.Itoa(i * 13))
+		b.WriteString(" gamma done\n")
+	}
+	return b.String()
+}
+
+func TestDuplicatesPendingEscalationJitter(t *testing.T) {
+	const cap = 200 // half-cap gate = 100 runes; the big screens clear it, short ones don't.
+	body := bigVariedBody(40)
+	// base and nearDup are the same large standing screen; nearDup changes a few
+	// characters DEEP IN THE BODY (residual jitter the normalizer missed) — a
+	// tiny fraction of a large, varied trigram set. The change is mid-body on
+	// purpose: a head-only difference would be absorbed by the suffix compare, so
+	// a mid-body edit is what isolates the jitter path (it breaks the exact and
+	// suffix compares, leaving only the tolerance).
+	base := "● Working on it\n" + body + "❯ \nstatus bar"
+	nearDup := "● Working on it\n" + strings.Replace(body, "line 20:", "line 20: (retry)", 1) + "❯ \nstatus bar"
+	// A genuinely different large screen (different body + question).
+	veryDifferent := "● Deploy to production?\n" + strings.ReplaceAll(bigVariedBody(40), "build output", "deploy step") + "❯ 1. Yes\n  2. No\nstatus bar"
+
+	tests := []struct {
+		name    string
+		excerpt string
+		jitter  int
+		pending []PendingEscalation
+		want    bool
+	}{
+		{
+			"large near-identical captures dedup within 5% jitter",
+			nearDup, 5, []PendingEscalation{pend(SituationIdle, base)}, true,
+		},
+		{
+			"large near-identical captures do NOT dedup with jitter disabled",
+			nearDup, 0, []PendingEscalation{pend(SituationIdle, base)}, false,
+		},
+		{
+			"genuinely different large captures are NOT a duplicate under 5% jitter",
+			veryDifferent, 5, []PendingEscalation{pend(SituationIdle, base)}, false,
+		},
+		{
+			// Safety: two large approvals with an identical body but a DIFFERENT
+			// first command line are >95% similar as text, yet they are different
+			// questions. firstLineExplained must refuse before the jitter path runs
+			// — otherwise the second approval is silently dropped.
+			"large panes differing only in the first command line are NOT collapsed by jitter",
+			"Bash(npm install)\n" + body + "❯ 1. Yes\n  2. No\nstatus bar", 5,
+			[]PendingEscalation{pend(SituationApproval,
+				"Bash(go test ./...)\n"+body+"❯ 1. Yes\n  2. No\nstatus bar")}, false,
+		},
+		{
+			// Safety: two SHORT distinct commands are below the half-cap gate, so
+			// the jitter path never sees them and they stay separate escalations —
+			// never a silent drop. (Belt and suspenders: at short lengths the
+			// trigram metric already keeps them apart too; see TestSimilarWithin.)
+			"short distinct commands are NOT collapsed by jitter",
+			"Bash(rm -rf /tmp/foo)?", 5,
+			[]PendingEscalation{pend(SituationApproval, "Bash(rm -rf /tmp/bar)?")}, false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DuplicatesPendingEscalation(SituationIdle, tc.excerpt, cap, tc.jitter, tc.pending); got != tc.want {
+				t.Errorf("DuplicatesPendingEscalation = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSimilarWithin(t *testing.T) {
+	body := bigVariedBody(40) // large, varied → a small edit is a small fraction
+	tests := []struct {
+		name   string
+		a, b   string
+		jitter int
+		want   bool
+	}{
+		{"identical strings always match", body, body, 5, true},
+		{"identical strings match even at jitter 0", body, body, 0, true},
+		{"empty strings match", "", "", 5, true},
+		{"tiny change in a large body is within 5%", body + "x", body + "yz", 5, true},
+		{"jitter 0 requires exact match", body + "x", body + "yz", 0, false},
+		{"jitter 100 matches anything", "totally", "different", 100, true},
+		{"very different strings miss at 5%", body, "a completely unrelated short line", 5, false},
+		{
+			// At short lengths a single differing token is already a large
+			// fraction of the trigram set, so distinct short commands fall well
+			// below 95% similar — the metric itself keeps them apart, on top of
+			// the half-cap gate in the caller.
+			"short distinct commands are NOT similar under trigram Jaccard",
+			"Bash(rm -rf /tmp/foo)?", "Bash(rm -rf /tmp/bar)?", 5, false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SimilarWithin(tc.a, tc.b, tc.jitter); got != tc.want {
+				t.Errorf("SimilarWithin(%q, %q, %d) = %v, want %v", tc.a, tc.b, tc.jitter, got, tc.want)
 			}
 		})
 	}

--- a/internal/domain/dedup_test.go
+++ b/internal/domain/dedup_test.go
@@ -360,12 +360,23 @@ func TestDuplicatesPendingEscalationJitter(t *testing.T) {
 		{
 			// Safety: two large approvals with an identical body but a DIFFERENT
 			// first command line are >95% similar as text, yet they are different
-			// questions. firstLineExplained must refuse before the jitter path runs
-			// — otherwise the second approval is silently dropped.
+			// questions. Requiring EQUAL first lines refuses before the jitter path
+			// runs — otherwise the second approval is silently dropped.
 			"large panes differing only in the first command line are NOT collapsed by jitter",
 			"Bash(npm install)\n" + body + "❯ 1. Yes\n  2. No\nstatus bar", 5,
 			[]PendingEscalation{pend(SituationApproval,
 				"Bash(go test ./...)\n"+body+"❯ 1. Yes\n  2. No\nstatus bar")}, false,
+		},
+		{
+			// Safety (the order-insensitive trap): the discriminating first-line
+			// commands ALSO appear in each other's scrollback, so the weaker
+			// firstLineExplained (substring) guard would pass and the trigram SET
+			// compare — which ignores order — would collapse two DIFFERENT
+			// approvals. firstLinesEqual (identity, not substring) refuses.
+			"large panes whose distinct headers appear in each other's body are NOT collapsed",
+			"Bash(npm install)\nnote: earlier Bash(go test ./...) passed\n" + body + "❯ 1. Yes\n  2. No\nstatus bar", 5,
+			[]PendingEscalation{pend(SituationApproval,
+				"Bash(go test ./...)\nnote: earlier Bash(npm install) passed\n"+body+"❯ 1. Yes\n  2. No\nstatus bar")}, false,
 		},
 		{
 			// Safety: two SHORT distinct commands are below the half-cap gate, so

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -1011,11 +1011,12 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	// declared task list. Best-effort: the escalation is already resolved and
 	// the source established, so a failed learning write must not fail the
 	// confirm — it only skips a learning event.
-	if _, err := a.Store.InsertCorrection(ctx, domain.CorrectionRecord{
+	corrID, corrErr := a.Store.InsertCorrection(ctx, domain.CorrectionRecord{
 		AuditID: audit.ID, CorrectedAction: domain.ActionNextDeclaredTask,
 		Author: a.Author, CreatedAt: time.Now(),
-	}); err != nil {
-		slog.Warn("recording generated-task confirmation correction failed", "audit", audit.ID, "error", err)
+	})
+	if corrErr != nil {
+		slog.Warn("recording generated-task confirmation correction failed", "audit", audit.ID, "error", corrErr)
 	}
 
 	if send && a.Herdr != nil {
@@ -1049,6 +1050,16 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 					"it stays [-] and no agent will pick it up until you clear it", err, pos, rbErr)
 			}
 			return fmt.Errorf("task source created, but sending the task to the agent failed: %w", err)
+		}
+		// The task was delivered, so flag the correction sent — the same
+		// "answer reached the agent" signal the pane-send path records. Idle is
+		// not a verifyunblock situation, so this arms no self-check; it only
+		// lets the recently-resolved dedup window recognize this delivered
+		// confirm. Best-effort: delivery already succeeded.
+		if corrErr == nil {
+			if err := a.Store.MarkCorrectionSent(ctx, corrID); err != nil {
+				slog.Warn("marking generated-task correction sent failed", "audit", audit.ID, "error", err)
+			}
 		}
 	}
 	return a.nudge(ctx, control.KindReload)
@@ -1448,11 +1459,12 @@ func (a *App) appendGeneratedTasks(ctx context.Context, audit *domain.AuditRecor
 
 	// Record the correction so the idle signature learns to drive from its
 	// declared task list. Best-effort, as in the bootstrap path.
-	if _, err := a.Store.InsertCorrection(ctx, domain.CorrectionRecord{
+	corrID, corrErr := a.Store.InsertCorrection(ctx, domain.CorrectionRecord{
 		AuditID: audit.ID, CorrectedAction: domain.ActionNextDeclaredTask,
 		Author: a.Author, CreatedAt: time.Now(),
-	}); err != nil {
-		slog.Warn("recording generated-task confirmation correction failed", "audit", audit.ID, "error", err)
+	})
+	if corrErr != nil {
+		slog.Warn("recording generated-task confirmation correction failed", "audit", audit.ID, "error", corrErr)
 	}
 
 	if send && a.Herdr != nil {
@@ -1478,6 +1490,14 @@ func (a *App) appendGeneratedTasks(ctx context.Context, audit *domain.AuditRecor
 					"it stays [-] and no agent will pick it up until you clear it", err, firstIndex, rbErr)
 			}
 			return fmt.Errorf("tasks appended to %s, but sending the task to the agent failed: %w", path, err)
+		}
+		// Delivered — flag the correction sent so the recently-resolved dedup
+		// window recognizes this confirm (see the bootstrap path for why this is
+		// safe: idle is not a verifyunblock situation). Best-effort.
+		if corrErr == nil {
+			if err := a.Store.MarkCorrectionSent(ctx, corrID); err != nil {
+				slog.Warn("marking generated-task correction sent failed", "audit", audit.ID, "error", err)
+			}
 		}
 	}
 	return a.nudge(ctx, control.KindReload)

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -1735,6 +1735,8 @@ var ConfigFields = []ConfigFieldDef{
 	{Key: "limits.max_consecutive_auto_prompts", TUIEditable: true},
 	{Key: "limits.max_auto_prompts_per_minute", TUIEditable: true},
 	{Key: "limits.max_error_retries", TUIEditable: true},
+	{Key: "limits.escalation_dedup_window_seconds", TUIEditable: true},
+	{Key: "limits.escalation_dedup_jitter_percent", TUIEditable: true},
 	{Key: "safety.disable_never_auto_seed_patterns", TUIEditable: true},
 	{Key: "llm.command"},       // argv template
 	{Key: "llm.command_start"}, // argv template (first consult; inherits command)
@@ -1814,6 +1816,10 @@ func FieldValue(cfg config.Config, key string) string {
 		return strconv.Itoa(cfg.Limits.MaxAutoPromptsPerMinute)
 	case "limits.max_error_retries":
 		return strconv.Itoa(cfg.Limits.MaxErrorRetries)
+	case "limits.escalation_dedup_window_seconds":
+		return strconv.Itoa(cfg.Limits.EscalationDedupWindowSeconds)
+	case "limits.escalation_dedup_jitter_percent":
+		return strconv.Itoa(cfg.Limits.EscalationDedupJitterPercent)
 	case "llm.command":
 		if len(cfg.LLM.Command) == 0 {
 			return "(disabled)"
@@ -1951,6 +1957,17 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 			return setInt(&cfg.Limits.MaxAutoPromptsPerMinute)
 		case "limits.max_error_retries":
 			return setInt(&cfg.Limits.MaxErrorRetries)
+		case "limits.escalation_dedup_window_seconds":
+			return setInt(&cfg.Limits.EscalationDedupWindowSeconds)
+		case "limits.escalation_dedup_jitter_percent":
+			// 0-100; 0 disables the tolerance (exact match only), so unlike
+			// setInt this accepts 0 but rejects negatives and values over 100.
+			v, err := strconv.Atoi(value)
+			if err != nil || v < 0 || v > 100 {
+				return fmt.Errorf("limits.escalation_dedup_jitter_percent must be an integer between 0 and 100 (0 = exact match only), got %q", value)
+			}
+			cfg.Limits.EscalationDedupJitterPercent = v
+			return nil
 		case "llm.timeout_seconds":
 			return setInt(&cfg.LLM.TimeoutSeconds)
 		case "llm.auto_act_confidence_threshold":

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -2070,6 +2070,12 @@ func TestSetFieldValidatesAndPersists(t *testing.T) {
 		{"learning.graduation_n", "11", true},
 		{"learning.graduation_n", "7", false},
 		{"limits.max_error_retries", "3", false},
+		{"limits.escalation_dedup_window_seconds", "180", false},
+		{"limits.escalation_dedup_window_seconds", "0", true}, // window must be positive
+		{"limits.escalation_dedup_jitter_percent", "10", false},
+		{"limits.escalation_dedup_jitter_percent", "0", false},  // 0 = exact match only
+		{"limits.escalation_dedup_jitter_percent", "-1", true},  // negative rejected
+		{"limits.escalation_dedup_jitter_percent", "101", true}, // over 100 rejected
 		{"llm.timeout_seconds", "90", false},
 		{"llm.auto_act_confidence_threshold", "70", false},
 		{"llm.auto_act_confidence_threshold", "-1", true},
@@ -2153,6 +2159,8 @@ func TestConfigFieldRegistryParity(t *testing.T) {
 		"limits.max_consecutive_auto_prompts":     "5",
 		"limits.max_auto_prompts_per_minute":      "10",
 		"limits.max_error_retries":                "2",
+		"limits.escalation_dedup_window_seconds":  "180",
+		"limits.escalation_dedup_jitter_percent":  "10",
 		"safety.disable_never_auto_seed_patterns": "true",
 		"llm.command":                             `claude -p "decide"`,
 		"llm.command_start":                       `claude -p "first: decide"`,

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -287,11 +287,13 @@ type ReadStore interface {
 	// CountPendingEscalations counts pending escalations without fetching
 	// the (pane-excerpt-heavy) rows.
 	CountPendingEscalations(ctx context.Context) (int64, error)
-	// PendingEscalationExcerpts returns the pane excerpts of every escalation
-	// still awaiting the operator for this agent + agent type (any age) — the
-	// candidate set for the daemon's duplicate-ask check. The excerpt
-	// comparison itself lives in domain.DuplicatesPendingEscalation.
-	PendingEscalationExcerpts(ctx context.Context, agentID, agentType string) ([]domain.PendingEscalation, error)
+	// PendingEscalationExcerpts returns the pane excerpts of the escalations that
+	// dedup a re-fire for this agent + agent type: every still-pending one (any
+	// age) plus every one resolved at or after resolvedSince WHOSE answer was
+	// delivered (so a genuinely-answered escalation suppresses its own stale
+	// re-delivery, while a learn-only shadow confirmation still re-escalates). The
+	// excerpt comparison itself lives in domain.DuplicatesPendingEscalation.
+	PendingEscalationExcerpts(ctx context.Context, agentID, agentType string, resolvedSince time.Time) ([]domain.PendingEscalation, error)
 	UnprocessedCorrections(ctx context.Context) ([]domain.CorrectionRecord, error)
 	// UnprocessedLLMRetries returns queued LLM-retry requests in order.
 	UnprocessedLLMRetries(ctx context.Context) ([]domain.LLMRetry, error)

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -289,9 +289,11 @@ type ReadStore interface {
 	CountPendingEscalations(ctx context.Context) (int64, error)
 	// PendingEscalationExcerpts returns the pane excerpts of the escalations that
 	// dedup a re-fire for this agent + agent type: every still-pending one (any
-	// age) plus every one resolved at or after resolvedSince WHOSE answer was
-	// delivered (so a genuinely-answered escalation suppresses its own stale
-	// re-delivery, while a learn-only shadow confirmation still re-escalates). The
+	// age) plus every originally-escalated ask whose answer was DELIVERED
+	// (correction sent=1) at or after resolvedSince (measured from delivery time,
+	// not raise time). So a genuinely-answered escalation suppresses its own stale
+	// re-delivery, while a learn-only shadow confirmation still re-escalates and a
+	// post-hoc correction of an autonomous action does not masquerade as one. The
 	// excerpt comparison itself lives in domain.DuplicatesPendingEscalation.
 	PendingEscalationExcerpts(ctx context.Context, agentID, agentType string, resolvedSince time.Time) ([]domain.PendingEscalation, error)
 	UnprocessedCorrections(ctx context.Context) ([]domain.CorrectionRecord, error)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1236,32 +1236,60 @@ func (s *Store) PendingEscalations(ctx context.Context) ([]domain.AuditRecord, e
 // worst case is one redundant operator ask, never a silent drop.
 const PendingEscalationDedupLimit = 128
 
-// PendingEscalationExcerpts returns the pane excerpts of the most recent pending
-// escalations awaiting the operator for this agent + agent type (newest first,
-// capped at PendingEscalationDedupLimit) — the candidate set for the daemon's
-// duplicate-ask check. It is NOT scoped by situation_type: that field is DERIVED
-// from the agent status (the classifier gates the approval/choice rules on herdr
-// reporting "blocked"), so one standing screen re-fired as idle reclassifies,
-// and scoping by it would miss the very re-delivery this dedups. The excerpt
-// comparison, which is the real key, happens in
-// domain.DuplicatesPendingEscalation.
+// PendingEscalationExcerpts returns the pane excerpts of the escalations that
+// dedup a re-fire for this agent + agent type (newest first, capped at
+// PendingEscalationDedupLimit) — the candidate set for the daemon's
+// duplicate-ask check. Two groups qualify:
+//   - every still-pending ('escalated') escalation, ANY age — a menu awaiting
+//     the operator from an hour ago must still dedup its re-delivery;
+//   - every 'resolved' escalation raised at or after resolvedSince WHOSE answer
+//     was actually DELIVERED (a correction with sent=1). Once the operator
+//     answers and the keystroke lands, the agent is unblocked, so herdr's
+//     re-delivered event (the same screen replayed after the pane was read) is a
+//     stale duplicate; without this recently-resolved window it would raise a
+//     second, duplicate ask.
 //
-// The status='escalated' filter is served by idx_audit_status, and pending
-// escalations are globally few (the dedup prevents identical ones from
-// stacking), so the scan stays bounded; the LIMIT additionally caps the Go-side
-// normalization.
+// The sent=1 requirement is load-bearing, not cosmetic: a LEARN-ONLY shadow
+// confirmation (`hap confirm`, send=false) also resolves the escalation but
+// delivers NOTHING, so the agent stays blocked and MUST re-escalate to
+// accumulate confirmations toward graduation (TestConfirmDrivenShadowToAutoPromotion).
+// Keying the window on a delivered answer suppresses genuine stale duplicates
+// while leaving the shadow-learning re-escalation loop intact.
+//
+// created_at (when the escalation was RAISED) is the window reference rather
+// than a resolved-at timestamp: escalations resolve within seconds of being
+// raised, so it is an adequate proxy and avoids a schema migration. The caller
+// derives resolvedSince as now-window.
+//
+// It is NOT scoped by situation_type: that field is DERIVED from the agent
+// status (the classifier gates the approval/choice rules on herdr reporting
+// "blocked"), so one standing screen re-fired as idle reclassifies, and scoping
+// by it would miss the very re-delivery this dedups. The excerpt comparison,
+// which is the real key, happens in domain.DuplicatesPendingEscalation.
+//
+// The agent_id filter is served by idx_audit_agent and the newest-first LIMIT
+// caps the returned rows and the Go-side normalization. The resolved branch's
+// created_at window and the per-row corrections EXISTS are NOT index-served
+// (matching the pre-existing llm_retries EXISTS), so the planner examines this
+// agent's audit rows to satisfy the ORDER BY; that stays cheap in practice
+// because one agent's rows are few and corrections is a small table, but it is
+// not a hard index-bounded scan.
 //
 // Escalations with an unprocessed LLM retry are excluded: the retry explicitly
 // asks to re-evaluate this exact content, so its source row must not suppress
 // the recapture (mirrors the pre-existing dedup query).
-func (s *Store) PendingEscalationExcerpts(ctx context.Context, agentID, agentType string) ([]domain.PendingEscalation, error) {
+func (s *Store) PendingEscalationExcerpts(ctx context.Context, agentID, agentType string, resolvedSince time.Time) ([]domain.PendingEscalation, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT situation_type, pane_excerpt FROM audit_log a
-			WHERE a.status = 'escalated' AND a.agent_id = ? AND a.agent_type = ?
+			WHERE a.agent_id = ? AND a.agent_type = ?
+			  AND ( a.status = 'escalated'
+			        OR (a.status = 'resolved' AND a.created_at >= ?
+			            AND EXISTS (SELECT 1 FROM corrections c
+			                  WHERE c.audit_id = a.id AND c.sent = 1)) )
 			  AND NOT EXISTS (SELECT 1 FROM llm_retries r
 					WHERE r.audit_id = a.id AND r.processed = 0)
 			ORDER BY a.id DESC LIMIT ?`,
-		agentID, agentType, PendingEscalationDedupLimit)
+		agentID, agentType, unix(resolvedSince), PendingEscalationDedupLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1237,59 +1237,85 @@ func (s *Store) PendingEscalations(ctx context.Context) ([]domain.AuditRecord, e
 const PendingEscalationDedupLimit = 128
 
 // PendingEscalationExcerpts returns the pane excerpts of the escalations that
-// dedup a re-fire for this agent + agent type (newest first, capped at
-// PendingEscalationDedupLimit) — the candidate set for the daemon's
-// duplicate-ask check. Two groups qualify:
+// dedup a re-fire for this agent + agent type — the candidate set for the
+// daemon's duplicate-ask check. Two groups qualify, fetched as SEPARATE queries
+// so a burst of recent resolved rows can never crowd the still-pending rows out
+// of a single shared LIMIT:
 //   - every still-pending ('escalated') escalation, ANY age — a menu awaiting
 //     the operator from an hour ago must still dedup its re-delivery;
-//   - every 'resolved' escalation raised at or after resolvedSince WHOSE answer
-//     was actually DELIVERED (a correction with sent=1). Once the operator
-//     answers and the keystroke lands, the agent is unblocked, so herdr's
-//     re-delivered event (the same screen replayed after the pane was read) is a
-//     stale duplicate; without this recently-resolved window it would raise a
-//     second, duplicate ask.
+//   - every recently-DELIVERED, originally-escalated ask: an audit whose action
+//     is AuditActionEscalated (a genuine escalation, not a corrected autonomous
+//     action) that is now 'resolved' and carries a correction delivered
+//     (sent=1) at or after resolvedSince. Once the operator answers and the
+//     keystroke lands, the agent is unblocked, so herdr's re-delivered event
+//     (the same screen replayed after the pane was read) is a stale duplicate;
+//     without this window it would raise a second, duplicate ask.
 //
-// The sent=1 requirement is load-bearing, not cosmetic: a LEARN-ONLY shadow
-// confirmation (`hap confirm`, send=false) also resolves the escalation but
-// delivers NOTHING, so the agent stays blocked and MUST re-escalate to
-// accumulate confirmations toward graduation (TestConfirmDrivenShadowToAutoPromotion).
-// Keying the window on a delivered answer suppresses genuine stale duplicates
-// while leaving the shadow-learning re-escalation loop intact.
+// Three predicates on the resolved group are each load-bearing:
+//   - sent=1: a LEARN-ONLY shadow confirmation (`hap confirm`, send=false) also
+//     resolves the escalation but delivers NOTHING, so the agent stays blocked
+//     and MUST re-escalate to graduate (TestConfirmDrivenShadowToAutoPromotion).
+//   - the window is measured from the correction's delivery time, NOT the
+//     audit's raise time: an escalation can sit pending far longer than the
+//     window before the operator answers, so keying on raise time would exclude
+//     it the instant it resolved and defeat the fix exactly in the away-operator
+//     case this exists for.
+//   - action = AuditActionEscalated: `hap resolve --send` can post-hoc correct
+//     an AUTONOMOUS action, which also lands at status='resolved' with a sent
+//     correction; without this filter such a never-escalated row would suppress
+//     a later genuine escalation (a silent drop). Delivery-failed escalations
+//     (an auto row flipped to 'escalated', so action stays "auto:…") fall out of
+//     this filter too and simply re-escalate a redundant ask — the safe direction.
 //
-// created_at (when the escalation was RAISED) is the window reference rather
-// than a resolved-at timestamp: escalations resolve within seconds of being
-// raised, so it is an adequate proxy and avoids a schema migration. The caller
-// derives resolvedSince as now-window.
-//
-// It is NOT scoped by situation_type: that field is DERIVED from the agent
-// status (the classifier gates the approval/choice rules on herdr reporting
+// Neither group is scoped by situation_type: that field is DERIVED from the
+// agent status (the classifier gates approval/choice on herdr reporting
 // "blocked"), so one standing screen re-fired as idle reclassifies, and scoping
 // by it would miss the very re-delivery this dedups. The excerpt comparison,
-// which is the real key, happens in domain.DuplicatesPendingEscalation.
+// the real key, happens in domain.DuplicatesPendingEscalation.
 //
-// The agent_id filter is served by idx_audit_agent and the newest-first LIMIT
-// caps the returned rows and the Go-side normalization. The resolved branch's
-// created_at window and the per-row corrections EXISTS are NOT index-served
-// (matching the pre-existing llm_retries EXISTS), so the planner examines this
-// agent's audit rows to satisfy the ORDER BY; that stays cheap in practice
-// because one agent's rows are few and corrections is a small table, but it is
-// not a hard index-bounded scan.
+// The agent_id filter is served by idx_audit_agent and each newest-first LIMIT
+// caps the returned rows and the Go-side normalization. The resolved query's
+// window and per-row corrections EXISTS are not index-served (matching the
+// pre-existing llm_retries EXISTS), but one agent's rows are few and corrections
+// is small, so the scan stays cheap.
 //
-// Escalations with an unprocessed LLM retry are excluded: the retry explicitly
-// asks to re-evaluate this exact content, so its source row must not suppress
-// the recapture (mirrors the pre-existing dedup query).
+// Escalations with an unprocessed LLM retry are excluded from both groups: the
+// retry explicitly asks to re-evaluate this exact content, so its source row
+// must not suppress the recapture (mirrors the pre-existing dedup query).
 func (s *Store) PendingEscalationExcerpts(ctx context.Context, agentID, agentType string, resolvedSince time.Time) ([]domain.PendingEscalation, error) {
-	rows, err := s.db.QueryContext(ctx,
+	// Group 1: all still-pending escalations, unbounded in time.
+	pending, err := s.scanEscalationExcerpts(ctx,
 		`SELECT situation_type, pane_excerpt FROM audit_log a
-			WHERE a.agent_id = ? AND a.agent_type = ?
-			  AND ( a.status = 'escalated'
-			        OR (a.status = 'resolved' AND a.created_at >= ?
-			            AND EXISTS (SELECT 1 FROM corrections c
-			                  WHERE c.audit_id = a.id AND c.sent = 1)) )
+			WHERE a.agent_id = ? AND a.agent_type = ? AND a.status = 'escalated'
 			  AND NOT EXISTS (SELECT 1 FROM llm_retries r
 					WHERE r.audit_id = a.id AND r.processed = 0)
 			ORDER BY a.id DESC LIMIT ?`,
-		agentID, agentType, unix(resolvedSince), PendingEscalationDedupLimit)
+		agentID, agentType, PendingEscalationDedupLimit)
+	if err != nil {
+		return nil, err
+	}
+	// Group 2: recently-delivered, originally-escalated resolved asks.
+	resolved, err := s.scanEscalationExcerpts(ctx,
+		`SELECT a.situation_type, a.pane_excerpt FROM audit_log a
+			WHERE a.agent_id = ? AND a.agent_type = ? AND a.status = 'resolved'
+			  AND a.action_or_escalation = ?
+			  AND EXISTS (SELECT 1 FROM corrections c
+					WHERE c.audit_id = a.id AND c.sent = 1 AND c.created_at >= ?)
+			  AND NOT EXISTS (SELECT 1 FROM llm_retries r
+					WHERE r.audit_id = a.id AND r.processed = 0)
+			ORDER BY a.id DESC LIMIT ?`,
+		agentID, agentType, domain.AuditActionEscalated, unix(resolvedSince), PendingEscalationDedupLimit)
+	if err != nil {
+		return nil, err
+	}
+	return append(pending, resolved...), nil
+}
+
+// scanEscalationExcerpts runs a (situation_type, pane_excerpt) query and maps the
+// rows to PendingEscalation — the shared body of the two PendingEscalationExcerpts
+// candidate queries.
+func (s *Store) scanEscalationExcerpts(ctx context.Context, query string, args ...any) ([]domain.PendingEscalation, error) {
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -388,21 +388,70 @@ func TestPendingEscalationExcerpts(t *testing.T) {
 		return id
 	}
 
+	// The daemon derives this as now-window; here a 5-minute window.
+	resolvedSince := now.Add(-5 * time.Minute)
+
+	// resolveSent marks an escalation resolved with a DELIVERED answer (the
+	// operator accepted it and the keystroke landed), the shape that makes a
+	// recently-resolved row a dedup candidate.
+	resolveSent := func(auditID int64, at time.Time) {
+		corrID, err := s.InsertCorrection(ctx, domain.CorrectionRecord{
+			AuditID: auditID, CorrectedAction: "respond: Yes", Author: "op", CreatedAt: at,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.MarkCorrectionSent(ctx, corrID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.ResolveEscalation(ctx, auditID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// resolveUnsent reproduces a LEARN-ONLY shadow confirm faithfully: the
+	// front-end DOES record a correction, but with sent=0 (never MarkCorrectionSent
+	// because nothing was delivered). Seeding a real sent=0 correction — rather
+	// than a bare resolved row with no correction — is what makes the `sent = 1`
+	// clause the SOLE reason this row is excluded, so a regression that matched
+	// any correction would be caught.
+	resolveUnsent := func(auditID int64, at time.Time) {
+		if _, err := s.InsertCorrection(ctx, domain.CorrectionRecord{
+			AuditID: auditID, CorrectedAction: "respond: Yes", Author: "op", CreatedAt: at,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.ResolveEscalation(ctx, auditID); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	// A pending escalation, however old, is a candidate (unbounded in time).
 	pendingID = seed("agent-1", "claude", domain.SituationApproval, "escalated", "allow bash?", now.Add(-10*time.Minute))
 	// A different situation_type escalation for the same agent is ALSO returned
 	// (the query is deliberately not type-scoped).
 	seed("agent-1", "claude", domain.SituationError, "escalated", "some error", now.Add(-20*time.Second))
-	// Non-escalated rows are never candidates.
+	// A recently-resolved escalation WITH a delivered answer is a candidate: it
+	// dedups the agent's own stale re-delivery after being unblocked.
+	recentSent := seed("agent-1", "claude", domain.SituationApproval, "escalated", "a recent answered ask", now.Add(-1*time.Minute))
+	resolveSent(recentSent, now.Add(-1*time.Minute))
+	// A recently-resolved escalation with a learn-only (sent=0) correction is NOT
+	// a candidate — the agent is still blocked and must re-escalate to keep
+	// graduating. This pins the load-bearing `sent = 1` predicate.
+	recentUnsent := seed("agent-1", "claude", domain.SituationApproval, "escalated", "a recent learn-only ask", now.Add(-1*time.Minute))
+	resolveUnsent(recentUnsent, now.Add(-1*time.Minute))
+	// A resolved+answered escalation raised OUTSIDE the window is not a candidate.
+	oldSent := seed("agent-1", "claude", domain.SituationApproval, "escalated", "an old answered ask", now.Add(-10*time.Minute))
+	resolveSent(oldSent, now.Add(-10*time.Minute))
+	// Non-escalated, non-resolved rows are never candidates (auto sends, and
+	// dismissals are not time-windowed).
 	seed("agent-1", "claude", domain.SituationIdle, "auto", "an auto send", now)
-	seed("agent-1", "claude", domain.SituationApproval, "resolved", "a resolved ask", now)
 	seed("agent-1", "claude", domain.SituationApproval, "dismissed", "a dismissed ask", now)
 	// A different agent / agent_type is out of scope.
 	seed("agent-2", "claude", domain.SituationApproval, "escalated", "other agent", now)
 	seed("agent-1", "codex", domain.SituationApproval, "escalated", "other type", now)
 
 	excerpts := func() map[string]bool {
-		got, err := s.PendingEscalationExcerpts(ctx, "agent-1", "claude")
+		got, err := s.PendingEscalationExcerpts(ctx, "agent-1", "claude", resolvedSince)
 		if err != nil {
 			t.Fatalf("PendingEscalationExcerpts: %v", err)
 		}
@@ -414,13 +463,14 @@ func TestPendingEscalationExcerpts(t *testing.T) {
 	}
 
 	got := excerpts()
-	for _, w := range []string{"allow bash?", "some error"} {
+	for _, w := range []string{"allow bash?", "some error", "a recent answered ask"} {
 		if !got[w] {
 			t.Errorf("expected pending escalation %q, got %v", w, got)
 		}
 	}
 	for _, unwanted := range []string{
-		"an auto send", "a resolved ask", "a dismissed ask", "other agent", "other type",
+		"a recent learn-only ask", "an old answered ask", "an auto send",
+		"a dismissed ask", "other agent", "other type",
 	} {
 		if got[unwanted] {
 			t.Errorf("did not expect candidate %q", unwanted)
@@ -467,7 +517,7 @@ func TestPendingEscalationExcerptsBounded(t *testing.T) {
 		}
 	}
 
-	got, err := s.PendingEscalationExcerpts(ctx, "agent-1", "claude")
+	got, err := s.PendingEscalationExcerpts(ctx, "agent-1", "claude", now.Add(-5*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -434,14 +434,43 @@ func TestPendingEscalationExcerpts(t *testing.T) {
 	// dedups the agent's own stale re-delivery after being unblocked.
 	recentSent := seed("agent-1", "claude", domain.SituationApproval, "escalated", "a recent answered ask", now.Add(-1*time.Minute))
 	resolveSent(recentSent, now.Add(-1*time.Minute))
+	// The window is measured from DELIVERY, not raise: an escalation raised long
+	// ago (well before the window) but answered just now is STILL a candidate.
+	// This is the away-operator case the fix exists for.
+	lateAnswered := seed("agent-1", "claude", domain.SituationApproval, "escalated", "raised long ago, answered now", now.Add(-30*time.Minute))
+	resolveSent(lateAnswered, now.Add(-1*time.Minute))
 	// A recently-resolved escalation with a learn-only (sent=0) correction is NOT
 	// a candidate — the agent is still blocked and must re-escalate to keep
 	// graduating. This pins the load-bearing `sent = 1` predicate.
 	recentUnsent := seed("agent-1", "claude", domain.SituationApproval, "escalated", "a recent learn-only ask", now.Add(-1*time.Minute))
 	resolveUnsent(recentUnsent, now.Add(-1*time.Minute))
-	// A resolved+answered escalation raised OUTSIDE the window is not a candidate.
+	// A resolved+answered escalation whose answer was DELIVERED outside the
+	// window (delivery time, not raise time) is not a candidate.
 	oldSent := seed("agent-1", "claude", domain.SituationApproval, "escalated", "an old answered ask", now.Add(-10*time.Minute))
 	resolveSent(oldSent, now.Add(-10*time.Minute))
+	// A post-hoc correction of an AUTONOMOUS action (action="auto:…") that lands
+	// at status=resolved with a recent sent correction is NOT a candidate — it
+	// was never an escalation, so it must not suppress a later genuine one.
+	autoID, err := s.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "agent-1", AgentType: "claude", Trigger: "x",
+		SituationType: domain.SituationApproval, Action: domain.AuditActionAutoPrefix + "respond: Yes",
+		Status: "auto", PaneExcerpt: "a corrected auto action", CreatedAt: now.Add(-1 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	autoCorr, err := s.InsertCorrection(ctx, domain.CorrectionRecord{
+		AuditID: autoID, CorrectedAction: "respond: No", Author: "op", CreatedAt: now.Add(-1 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkCorrectionSent(ctx, autoCorr); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateAuditStatus(ctx, autoID, "resolved"); err != nil {
+		t.Fatal(err)
+	}
 	// Non-escalated, non-resolved rows are never candidates (auto sends, and
 	// dismissals are not time-windowed).
 	seed("agent-1", "claude", domain.SituationIdle, "auto", "an auto send", now)
@@ -463,14 +492,14 @@ func TestPendingEscalationExcerpts(t *testing.T) {
 	}
 
 	got := excerpts()
-	for _, w := range []string{"allow bash?", "some error", "a recent answered ask"} {
+	for _, w := range []string{"allow bash?", "some error", "a recent answered ask", "raised long ago, answered now"} {
 		if !got[w] {
 			t.Errorf("expected pending escalation %q, got %v", w, got)
 		}
 	}
 	for _, unwanted := range []string{
-		"a recent learn-only ask", "an old answered ask", "an auto send",
-		"a dismissed ask", "other agent", "other type",
+		"a recent learn-only ask", "an old answered ask", "a corrected auto action",
+		"an auto send", "a dismissed ask", "other agent", "other type",
 	} {
 		if got[unwanted] {
 			t.Errorf("did not expect candidate %q", unwanted)
@@ -536,6 +565,66 @@ func TestPendingEscalationExcerptsBounded(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("newest pending escalation %q missing from the bounded window", newest)
+	}
+}
+
+// TestPendingEscalationExcerptsPendingNotCrowdedOut pins that a burst of recent
+// resolved-and-delivered escalations can never displace a still-pending one from
+// the candidate set. The two groups are fetched by separate queries with
+// independent LIMITs, so an old low-id pending row is always returned even when
+// far more than the cap of newer resolved rows exist — a single shared
+// ORDER BY ... LIMIT over both would drop it and let its re-fire duplicate.
+func TestPendingEscalationExcerptsPendingNotCrowdedOut(t *testing.T) {
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// One old still-pending escalation (lowest id).
+	if _, err := s.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "agent-1", AgentType: "claude", Trigger: "x",
+		SituationType: domain.SituationApproval, Action: "escalated", Status: "escalated",
+		PaneExcerpt: "old pending screen", CreatedAt: now.Add(-1 * time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// More than the cap of newer resolved-and-delivered escalations.
+	for i := 0; i < PendingEscalationDedupLimit+10; i++ {
+		id, err := s.AppendAudit(ctx, domain.AuditRecord{
+			AgentID: "agent-1", AgentType: "claude", Trigger: "x",
+			SituationType: domain.SituationApproval, Action: domain.AuditActionEscalated, Status: "escalated",
+			PaneExcerpt: fmt.Sprintf("resolved screen %d", i),
+			CreatedAt:   now.Add(time.Duration(i) * time.Millisecond),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		corrID, err := s.InsertCorrection(ctx, domain.CorrectionRecord{
+			AuditID: id, CorrectedAction: "respond: Yes", Author: "op", CreatedAt: now,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.MarkCorrectionSent(ctx, corrID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.ResolveEscalation(ctx, id); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := s.PendingEscalationExcerpts(ctx, "agent-1", "claude", now.Add(-5*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, p := range got {
+		if p.PaneExcerpt == "old pending screen" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("a still-pending escalation was crowded out of the candidate set by recent resolved rows")
 	}
 }
 

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -37,6 +37,14 @@ disable_never_auto_seed_patterns = false  # keep all shipped strict + heuristic 
 max_consecutive_auto_prompts = 10  # per agent, without human interaction
 max_auto_prompts_per_minute = 5    # per agent
 max_error_retries = 2              # per error signature
+# Suppress a duplicate escalation when the same situation re-fires shortly after
+# the first was accepted. A just-resolved escalation still dedups for this long
+# (measured from when it was raised); still-pending ones dedup regardless of age.
+escalation_dedup_window_seconds = 300
+# How much two large pane captures may differ (0-100%) and still count as the
+# same screen, absorbing residual TUI jitter. Applies only to large captures;
+# small ones require an exact match. 0 = exact match only.
+escalation_dedup_jitter_percent = 5
 
 # ── Operator LLM (consulted on unknown situations) ──────────────────
 # Omit this whole section to escalate unknown situations directly to you.


### PR DESCRIPTION
## Summary

Fixes duplicate escalations that appeared after an operator had already handled one, and adds the README docs requested alongside.

### Escalation de-duplication (the fix)
Two independent gaps, each behind a new `[limits]` config knob (TUI/CLI-editable, documented in `sample/config.toml`):

- **Recently-resolved window** — `escalation_dedup_window_seconds` (default `300`). Once an escalation was accepted it flipped `escalated → resolved` and left the dedup candidate set, so herdr's delayed re-delivery of the same screen re-escalated as a duplicate. The candidate set now also includes recently-resolved escalations **whose answer was actually delivered** (`corrections.sent = 1`).
  - **Why `sent = 1` is load-bearing:** a learn-only shadow confirm (`hap confirm`, `send=false`) also resolves the escalation but delivers nothing, so the agent stays blocked and *must* re-escalate to accumulate confirmations toward graduation. Keying the window on a delivered answer suppresses genuine stale duplicates while leaving the shadow-learning loop intact.

- **Content jitter tolerance** — `escalation_dedup_jitter_percent` (default `5`, `0` = exact-only). Near-identical captures now dedup via character-trigram (shingle) Jaccard similarity (`domain.SimilarWithin`), applied **only to large tail-window captures** behind the existing `firstLineExplained` guard, so two distinct commands sharing a large identical body can never silently collapse (the "never a silent drop" rule).

### README (docs)
- Quickstart **"Update to the latest version"** — `herdr plugin install … --yes` + `hap daemon --ensure`, plus the optional clean reinstall.
- **Roadmap** — Full-Self Prompting (FSP), OpenCode support, HAP Cloud, HAP Web (remote control).

## Testing
- Full suite green: `go test -tags "vectors cpu" ./internal/...` — 1,526 tests across 22 packages, 0 failures.
- New/updated coverage: store window (sent vs learn-only vs out-of-window), `SimilarWithin`, jitter gating (incl. the first-line safety case), config defaults/validation + field-registry parity, and an end-to-end `TestPipelineDedupAfterResolveWithinWindow`. `TestConfirmDrivenShadowToAutoPromotion` (shadow graduation) still passes.
- `gofmt` clean, `go vet` clean, `golangci-lint` 0 issues.

https://claude.ai/code/session_01FKbYWbyEGhsT8iGnbyBJgr