### PR TITLE
#1 fix: drain daemon background goroutines/timers before closing store and matcher

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -526,6 +526,23 @@ func (d *Daemon) Run(ctx context.Context) error {
 		defer func() { _ = daemonhealth.Remove(d.opt.StateDir) }()
 	}
 
+	// Background drain + native-resource release, registered BEFORE any fallible
+	// setup so they run on EVERY Run return — including an early error return
+	// below (e.g. control-socket setup). New() has already spawned initSemantic
+	// via reloadEmbedder, so a bare early return would otherwise leave that
+	// tracked goroutine touching the store/matcher while the caller closes them.
+	// LIFO: shutdownBackground (drain) is registered last so it runs FIRST, then
+	// the matcher/embedder Close.
+	defer func() {
+		if emb := d.embedderPort(); emb != nil {
+			emb.Close()
+		}
+		if d.matcher != nil {
+			d.matcher.Close()
+		}
+	}()
+	defer d.shutdownBackground()
+
 	// Control socket: reload/wake nudges from front-ends and mcp.
 	var ctl *control.Server
 	if d.opt.ControlSocketPath != "" {
@@ -541,21 +558,6 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 		defer ctl.Close()
 	}
-
-	// Release native resources (embedding model, match index) on exit — but
-	// ONLY after every background goroutine/timer has drained, so nothing can
-	// touch the matcher/embedder (or the store the caller closes next) after
-	// close. This defer is registered AFTER the Close defer so LIFO runs the
-	// drain FIRST.
-	defer func() {
-		if emb := d.embedderPort(); emb != nil {
-			emb.Close()
-		}
-		if d.matcher != nil {
-			d.matcher.Close()
-		}
-	}()
-	defer d.shutdownBackground()
 
 	// Event subscription with reconnect/backoff lives in its own goroutine.
 	d.spawn(func() {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -169,6 +169,24 @@ type Daemon struct {
 	// background refreshes per pane.
 	paneCwds          map[string]paneCwdEntry
 	paneCwdRefreshing map[string]bool
+
+	// Background lifecycle. bg tracks every goroutine and AfterFunc callback
+	// the daemon spawns via spawn/afterFunc; Run awaits it (shutdownBackground)
+	// before its deferred matcher/embedder Close — and before the caller closes
+	// the Store — so no background work can touch a store or matcher after it is
+	// closed (the source of the "database is closed" warnings and capture
+	// flakiness). lifeMu guards closing + timers. closing latches at shutdown so
+	// no new background work is scheduled. timers holds pending (unfired)
+	// AfterFunc timers so shutdown can Stop them. shutdownCtx is cancelled at
+	// shutdown for background work that must outlive a single pipeline ctx yet
+	// still stop on daemon teardown (verify-unblock and semantic-init, which
+	// previously rooted at context.Background() and so ignored shutdown).
+	lifeMu         sync.Mutex
+	closing        bool
+	timers         map[*time.Timer]struct{}
+	bg             sync.WaitGroup
+	shutdownCtx    context.Context
+	cancelShutdown context.CancelFunc
 }
 
 // paneCwdEntry is one cached pane working directory with its capture time.
@@ -278,14 +296,108 @@ func New(opt Options) (*Daemon, error) {
 		paneCwds:             map[string]paneCwdEntry{},
 		paneCwdRefreshing:    map[string]bool{},
 		embedder:             opt.Embedder,
+		timers:               map[*time.Timer]struct{}{},
 	}
+	// The shutdown context must exist before reload(): reload spawns the
+	// semantic-init goroutine, which roots at shutdownCtx so daemon teardown
+	// stops it. It is a child of Background (not a Run ctx, which does not yet
+	// exist) and is cancelled by shutdownBackground.
+	d.shutdownCtx, d.cancelShutdown = context.WithCancel(context.Background())
 	if opt.MatchIndexDir != "" {
 		d.matcher = match.New(opt.MatchIndexDir)
 	}
 	if err := d.reload(); err != nil {
+		d.cancelShutdown()
 		return nil, err
 	}
 	return d, nil
+}
+
+// spawn runs fn on a tracked background goroutine so shutdownBackground can
+// await it. A spawn after shutdown has begun is dropped (fn never runs): the
+// daemon is tearing down and nothing new may touch the store/matcher. Callers
+// that reserve d.mu-guarded state before spawning and release it in fn's defer
+// (sweepInFlight, paneCwdRefreshing) must tolerate that release being skipped
+// on a dropped spawn — harmless here, since it only happens once closing has
+// latched and no further deliveries run.
+func (d *Daemon) spawn(fn func()) {
+	d.lifeMu.Lock()
+	if d.closing {
+		d.lifeMu.Unlock()
+		return
+	}
+	d.bg.Add(1)
+	d.lifeMu.Unlock()
+	go func() {
+		defer d.bg.Done()
+		fn()
+	}()
+}
+
+// afterFunc schedules fn after delay on a tracked timer so shutdownBackground
+// can Stop still-pending ones and await any already-firing callback. It returns
+// the timer for callers that supersede it (stopTimer), or nil if the daemon is
+// already shutting down (fn is never scheduled). The callback removes itself
+// from the registry before running so a concurrent stopTimer/shutdown does not
+// double-count its WaitGroup slot.
+func (d *Daemon) afterFunc(delay time.Duration, fn func()) *time.Timer {
+	d.lifeMu.Lock()
+	if d.closing {
+		d.lifeMu.Unlock()
+		return nil
+	}
+	d.bg.Add(1)
+	var t *time.Timer
+	t = time.AfterFunc(delay, func() {
+		d.lifeMu.Lock()
+		delete(d.timers, t)
+		d.lifeMu.Unlock()
+		defer d.bg.Done()
+		fn()
+	})
+	d.timers[t] = struct{}{}
+	d.lifeMu.Unlock()
+	return t
+}
+
+// stopTimer cancels a tracked timer scheduled by afterFunc (used to supersede a
+// pending capture, and by shutdownBackground to drain unfired timers). If Stop
+// wins the race — the callback had not started — it releases that timer's
+// WaitGroup slot, since the callback will never run to release it itself. A
+// callback already past its own registry-delete releases its own slot.
+func (d *Daemon) stopTimer(t *time.Timer) {
+	if t == nil {
+		return
+	}
+	d.lifeMu.Lock()
+	_, tracked := d.timers[t]
+	if tracked {
+		delete(d.timers, t)
+	}
+	d.lifeMu.Unlock()
+	if tracked && t.Stop() {
+		d.bg.Done()
+	}
+}
+
+// shutdownBackground latches closing, cancels shutdownCtx, drains pending
+// timers, and awaits every tracked goroutine/callback. Run calls it before its
+// deferred matcher/embedder Close (and hence before the caller's Store.Close),
+// so teardown never races live background work against a closed store or index.
+func (d *Daemon) shutdownBackground() {
+	d.lifeMu.Lock()
+	d.closing = true
+	pending := make([]*time.Timer, 0, len(d.timers))
+	for t := range d.timers {
+		pending = append(pending, t)
+	}
+	d.lifeMu.Unlock()
+
+	d.cancelShutdown() // stop shutdownCtx-rooted work (verify-unblock, semantic-init)
+	for _, t := range pending {
+		d.stopTimer(t)
+	}
+	d.bg.Wait()
 }
 
 // reload re-reads TOML config and rebuilds derived state (classifier,
@@ -430,7 +542,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 		defer ctl.Close()
 	}
 
-	// Release native resources (embedding model, match index) on exit.
+	// Release native resources (embedding model, match index) on exit — but
+	// ONLY after every background goroutine/timer has drained, so nothing can
+	// touch the matcher/embedder (or the store the caller closes next) after
+	// close. This defer is registered AFTER the Close defer so LIFO runs the
+	// drain FIRST.
 	defer func() {
 		if emb := d.embedderPort(); emb != nil {
 			emb.Close()
@@ -439,16 +555,17 @@ func (d *Daemon) Run(ctx context.Context) error {
 			d.matcher.Close()
 		}
 	}()
+	defer d.shutdownBackground()
 
 	// Event subscription with reconnect/backoff lives in its own goroutine.
-	go func() {
+	d.spawn(func() {
 		err := logging.Guard("event-subscriber", func() error {
 			return d.opt.Events.Subscribe(ctx, d.transitions)
 		})
 		if err != nil && ctx.Err() == nil {
 			slog.Error("event subscriber terminated", "error", err)
 		}
-	}()
+	})
 
 	// Consume corrections that accumulated while the daemon was down (a
 	// failed front-end nudge is non-fatal by design), and keep a slow
@@ -653,7 +770,7 @@ func (d *Daemon) handleTransition(ctx context.Context, tr domain.AgentTransition
 func (d *Daemon) cancelCapture(paneID string) {
 	d.mu.Lock()
 	if p := d.pendingCapture[paneID]; p != nil {
-		p.timer.Stop()
+		d.stopTimer(p.timer) // release the tracked bg slot, not a bare Stop
 		delete(d.pendingCapture, paneID)
 	}
 	d.mu.Unlock()
@@ -673,7 +790,7 @@ func (d *Daemon) scheduleCapture(ctx context.Context, tr domain.AgentTransition)
 	cfg, _, _ := d.snapshot()
 	d.mu.Lock()
 	if p := d.pendingCapture[tr.PaneID]; p != nil {
-		p.timer.Stop()
+		d.stopTimer(p.timer)
 		// A regular attention event may arrive while an operator-requested
 		// retry is settling. Coalescing must not erase the retry intent, or
 		// the resulting high-confidence decision could be auto-promoted.
@@ -685,7 +802,7 @@ func (d *Daemon) scheduleCapture(ctx context.Context, tr domain.AgentTransition)
 	// fires — a burst of events during startup keeps the longer settle.
 	delay := cfg.CaptureDelay(tr.AgentType, !d.captureStarted[tr.PaneID])
 	entry := &captureEntry{retryAuditID: tr.RetryAuditID}
-	entry.timer = time.AfterFunc(delay, func() {
+	entry.timer = d.afterFunc(delay, func() {
 		d.mu.Lock()
 		current := d.pendingCapture[tr.PaneID] == entry
 		if current {
@@ -704,6 +821,12 @@ func (d *Daemon) scheduleCapture(ctx context.Context, tr domain.AgentTransition)
 		case <-ctx.Done():
 		}
 	})
+	if entry.timer == nil {
+		// Daemon shutting down: drop this capture rather than leak an entry
+		// whose timer will never fire (afterFunc refused to schedule).
+		d.mu.Unlock()
+		return
+	}
 	d.pendingCapture[tr.PaneID] = entry
 	d.mu.Unlock()
 }
@@ -1407,9 +1530,12 @@ func (d *Daemon) scheduleUnblockCheck(p verifyunblock.Params) {
 	if delay <= 0 {
 		delay = unblockCheckDelay
 	}
-	time.AfterFunc(delay, func() {
+	d.afterFunc(delay, func() {
 		_ = logging.Guard("verify-unblock", func() error {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			// Root the check at shutdownCtx (not context.Background) so daemon
+			// teardown cancels an in-flight self-check instead of letting it
+			// read a store the caller is about to close.
+			ctx, cancel := context.WithTimeout(d.shutdownCtx, 10*time.Second)
 			defer cancel()
 			blocked, _, err := verifyunblock.Check(ctx, d.opt.Herdr, d.opt.Store, p, d.opt.Clock.Now())
 			if err != nil {
@@ -1729,7 +1855,7 @@ func (d *Daemon) consultLLM(ctx context.Context, cfg config.Config, s domain.Sit
 		AgentID: s.AgentID, Status: "pending", CreatedAt: now, First: first,
 		RetryAuditID: s.RetryAuditID,
 	}
-	go func() {
+	d.spawn(func() {
 		outcome := llmOutcome{situation: s, sig: sig, request: req}
 		err := logging.Guard("llm-consult", func() error {
 			// The short name rides on the request ({agent_name}) and the
@@ -1753,7 +1879,7 @@ func (d *Daemon) consultLLM(ctx context.Context, cfg config.Config, s domain.Sit
 		case d.llmResults <- outcome:
 		case <-ctx.Done():
 		}
-	}()
+	})
 }
 
 // taskReviewContext carries the extra get_context fields for a pre-send
@@ -1818,7 +1944,7 @@ func (d *Daemon) consultDeclaredTask(ctx context.Context, cfg config.Config, s d
 		return
 	}
 
-	go func() {
+	d.spawn(func() {
 		outcome := llmOutcome{situation: s, sig: sig, request: req}
 		err := logging.Guard("llm-task-review", func() error {
 			agentName, nerr := d.opt.Store.EnsureAgentName(ctx, s.AgentID)
@@ -1855,7 +1981,7 @@ func (d *Daemon) consultDeclaredTask(ctx context.Context, cfg config.Config, s d
 		case d.llmResults <- outcome:
 		case <-ctx.Done():
 		}
-	}()
+	})
 }
 
 // taskGenPort returns the LLM adapter as a TaskGeneratorPort when a
@@ -1960,7 +2086,7 @@ func (d *Daemon) generateTask(ctx context.Context, cfg config.Config, s domain.S
 		return
 	}
 
-	go func() {
+	d.spawn(func() {
 		outcome := taskGenOutcome{situation: s, sig: sig, tr: tr, request: req, reason: reason}
 		err := logging.Guard("generate-task", func() error {
 			agentName, nerr := d.opt.Store.EnsureAgentName(ctx, s.AgentID)
@@ -1994,7 +2120,7 @@ func (d *Daemon) generateTask(ctx context.Context, cfg config.Config, s domain.S
 		case d.taskGenResults <- outcome:
 		case <-ctx.Done():
 		}
-	}()
+	})
 }
 
 // handleTaskGenOutcome surfaces a finished idle task generation as an
@@ -2365,7 +2491,7 @@ func (d *Daemon) startActionReview(ctx context.Context, s domain.Situation,
 	}
 	d.mu.Unlock()
 
-	go func() {
+	d.spawn(func() {
 		// The short name rides on the request ({agent_name}) and is reused
 		// for the fallback template if the review degrades; degrade to "".
 		agentName, err := d.opt.Store.EnsureAgentName(rctx, s.AgentID)
@@ -2392,7 +2518,7 @@ func (d *Daemon) startActionReview(ctx context.Context, s domain.Situation,
 		case d.actionReviewResults <- outcome:
 		case <-ctx.Done():
 		}
-	}()
+	})
 }
 
 // actionReviewSuggestion formats the original action as an escalation
@@ -3778,7 +3904,7 @@ func (d *Daemon) refreshPaneCwd(ctx context.Context, paneID string) {
 	}
 	d.paneCwdRefreshing[paneID] = true
 	d.mu.Unlock()
-	go func() {
+	d.spawn(func() {
 		defer func() {
 			d.mu.Lock()
 			delete(d.paneCwdRefreshing, paneID)
@@ -3796,7 +3922,7 @@ func (d *Daemon) refreshPaneCwd(ctx context.Context, paneID string) {
 		d.mu.Lock()
 		d.paneCwds[paneID] = paneCwdEntry{cwd: cwd, at: d.opt.Clock.Now()}
 		d.mu.Unlock()
-	}()
+	})
 }
 
 func (d *Daemon) audit(ctx context.Context, rec domain.AuditRecord) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -477,6 +477,21 @@ type harness struct {
 	cfgPath string
 	ctlPath string
 	cancel  context.CancelFunc
+	runDone chan struct{} // closed when d.Run returns (after background drain)
+}
+
+// stop cancels the daemon and blocks until Run has fully returned — i.e. until
+// shutdownBackground has drained every background goroutine/timer. Tests use it
+// to close the shutdown→store-close race deterministically; it is idempotent
+// and also runs automatically at t.Cleanup.
+func (h *harness) stop() {
+	h.t.Helper()
+	h.cancel()
+	select {
+	case <-h.runDone:
+	case <-time.After(5 * time.Second):
+		h.t.Error("daemon Run did not return within 5s of cancel (background goroutine/timer leak?)")
+	}
 }
 
 func newHarness(t *testing.T, cfgTOML string) *harness {
@@ -572,8 +587,24 @@ func newHarnessCore(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.He
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	go d.Run(ctx)
+	runDone := make(chan struct{})
+	go func() {
+		d.Run(ctx)
+		close(runDone)
+	}()
+	// Await Run's full return (background drain) BEFORE the store closes. The
+	// store's raw.Close() cleanup was registered earlier, so LIFO runs this
+	// one first — cancel, then drain, then close. Without the drain, timers
+	// and goroutines the daemon spawned would race raw.Close ("database is
+	// closed" warnings, capture flakiness).
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runDone:
+		case <-time.After(5 * time.Second):
+			t.Error("daemon Run did not return within 5s of cancel (background goroutine/timer leak?)")
+		}
+	})
 	// Give the control socket a moment to come up.
 	waitFor(t, time.Second, func() bool {
 		_, err := os.Stat(ctlPath)
@@ -582,7 +613,7 @@ func newHarnessCore(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.He
 
 	return &harness{
 		t: t, daemon: d, store: fs, raw: raw, herdr: fh, events: fe, llm: fl,
-		cfgPath: cfgPath, ctlPath: ctlPath, cancel: cancel,
+		cfgPath: cfgPath, ctlPath: ctlPath, cancel: cancel, runDone: runDone,
 	}
 }
 

--- a/internal/daemon/semantic.go
+++ b/internal/daemon/semantic.go
@@ -232,8 +232,12 @@ func (d *Daemon) reloadEmbedder(prev, next config.Config, first bool) {
 
 	d.semanticReady.Store(false)
 	gen := d.semanticGen.Add(1)
-	go logging.Guard("semantic-init", func() error {
-		d.initSemantic(context.Background(), gen)
-		return nil
+	// Tracked + rooted at shutdownCtx so daemon teardown cancels the reembed /
+	// index rebuild and awaits it before the matcher (and store) close.
+	d.spawn(func() {
+		_ = logging.Guard("semantic-init", func() error {
+			d.initSemantic(d.shutdownCtx, gen)
+			return nil
+		})
 	})
 }

--- a/internal/daemon/shutdown_test.go
+++ b/internal/daemon/shutdown_test.go
@@ -1,0 +1,209 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
+)
+
+// logCapture is a slog.Handler that records every emitted record's message and
+// attribute values, so a test can assert whether a particular string (e.g. the
+// SQLite "database is closed" error) ever surfaced.
+type logCapture struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (c *logCapture) Enabled(context.Context, slog.Level) bool { return true }
+
+func (c *logCapture) Handle(_ context.Context, r slog.Record) error {
+	var b strings.Builder
+	b.WriteString(r.Message)
+	r.Attrs(func(a slog.Attr) bool {
+		b.WriteByte(' ')
+		b.WriteString(a.Value.String())
+		return true
+	})
+	c.mu.Lock()
+	c.lines = append(c.lines, b.String())
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *logCapture) WithAttrs([]slog.Attr) slog.Handler { return c }
+func (c *logCapture) WithGroup(string) slog.Handler      { return c }
+
+// matching returns every captured line containing sub.
+func (c *logCapture) matching(sub string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []string
+	for _, l := range c.lines {
+		if strings.Contains(l, sub) {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// TestShutdownStopsPendingCaptureTimer proves the daemon drains a still-pending
+// capture timer at shutdown instead of leaving it to fire later against a
+// closed store (the "capture flakiness"). With a 10s capture delay the timer
+// cannot fire during the test, so if shutdown awaited it (or leaked it) Run
+// would take ~10s to return; the fix Stop()s it and returns promptly.
+func TestShutdownStopsPendingCaptureTimer(t *testing.T) {
+	// A long capture delay that outlives the test window; first match wins, so
+	// this rule beats the harness's appended tiny wildcard rule.
+	h := newHarness(t, "[[capture_delay]]\nagent_type = \"*\"\nstart_ms = 10000\nevent_ms = 10000\n")
+	h.herdr.setPane(approvalPane)
+
+	// A blocked transition arms the pane's 10s capture timer (pending).
+	h.push("agent-1", "blocked")
+	// Let the transition reach the loop and schedule the timer before we stop.
+	waitFor(t, 2*time.Second, func() bool {
+		h.daemon.mu.Lock()
+		_, armed := h.daemon.pendingCapture["agent-1"]
+		h.daemon.mu.Unlock()
+		return armed
+	})
+
+	start := time.Now()
+	h.stop() // cancel + await Run's full background drain
+	if el := time.Since(start); el > 3*time.Second {
+		t.Fatalf("shutdown took %v with a pending 10s capture timer — pending timers were not stopped/drained", el)
+	}
+}
+
+// TestShutdownDrainsVerifyUnblockBeforeStoreClose proves the post-action
+// verify-unblock self-check (a background timer that reads the store) is drained
+// before the store closes, so it can never touch a closed database. Before the
+// fix the check rooted at context.Background() and was untracked: it fired after
+// Run returned and raced the store's Close(), logging "database is closed".
+func TestShutdownDrainsVerifyUnblockBeforeStoreClose(t *testing.T) {
+	cap := &logCapture{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(cap))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(tinyCaptureDelay), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := store.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fh := &fakeHerdr{}
+	fh.setPane(approvalPane)
+	// Pin the agent as still blocked so verify-unblock's ListAgents reports
+	// "still blocked" and proceeds to the store write (AppendAudit) — the store
+	// touch we must not let race Close().
+	fh.setAgents([]domain.AgentTransition{
+		{AgentID: "a1", PaneID: "a1", AgentType: "claude", Status: "blocked"},
+	})
+	fe := &fakeEvents{ch: make(chan domain.AgentTransition, 64)}
+	ctlPath := filepath.Join(testutil.SocketDir(t), "control.sock")
+
+	d, err := New(Options{
+		ConfigPath:        cfgPath,
+		ControlSocketPath: ctlPath,
+		Store:             raw,
+		Herdr:             fh,
+		Events:            fe,
+		Notify:            fh,
+		LLM:               &fakeLLM{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Fire the self-check quickly so it is in flight around shutdown. Set before
+	// Run starts (the go statement synchronizes the write to the daemon loop).
+	d.verifyUnblockDelay = 20 * time.Millisecond
+
+	// Seed an autonomous approval rule so the blocked event auto-answers and
+	// schedules the verify-unblock check. Written before Run to avoid racing the
+	// startup sweep's reads.
+	seedAutonomousRule(t, raw, approvalPane, domain.SituationApproval, "1")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	go func() {
+		d.Run(ctx)
+		close(runDone)
+	}()
+	waitFor(t, time.Second, func() bool {
+		_, err := os.Stat(ctlPath)
+		return err == nil
+	})
+
+	fe.ch <- domain.AgentTransition{AgentID: "a1", PaneID: "a1", AgentType: "claude", Status: "blocked"}
+	waitFor(t, 3*time.Second, func() bool { return len(fh.sentInputs()) == 1 })
+
+	// Shut down and await the full background drain.
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("daemon Run did not return within 5s of cancel (background goroutine/timer leak?)")
+	}
+
+	// Run has drained every background goroutine/timer, so closing the store now
+	// cannot race one. Close, then give any regressed leaked timer a window to
+	// fire against the closed DB.
+	if err := raw.Close(); err != nil {
+		t.Fatalf("store close: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	if hits := cap.matching("database is closed"); len(hits) > 0 {
+		t.Fatalf("background work touched the store after Close (not drained): %v", hits)
+	}
+}
+
+// seedAutonomousRule installs a graduated (autonomous) rule directly in the
+// store so a matching situation auto-answers. It mirrors harness.seedAutonomous
+// but targets a raw store for tests that build the daemon by hand.
+func seedAutonomousRule(t *testing.T, raw *store.Store, pane string, situationType domain.SituationType, action string) string {
+	t.Helper()
+	ctx := context.Background()
+	status := "blocked"
+	if situationType == domain.SituationIdle {
+		status = "idle"
+	}
+	s := classifierForTest().Classify("claude", status, pane)
+	if s.Type != situationType {
+		t.Fatalf("fixture classifies as %v, expected %v", s.Type, situationType)
+	}
+	sig := domain.ComputeSignature(s)
+	if sig.Verdict != domain.GuardOK {
+		t.Fatalf("seed situation over-masked: %q", sig.Salient)
+	}
+	for i := 0; i < 8; i++ {
+		if _, err := raw.RecordDecision(ctx, domain.DecisionRecord{
+			Signature: sig.Signature, SituationType: situationType, AgentType: "claude",
+			ChosenAction: action, Source: domain.SourceOperator,
+			CreatedAt: time.Now().Add(-time.Duration(8-i) * time.Minute),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := raw.UpsertSignature(ctx, domain.SignatureState{
+		Signature: sig.Signature, SituationType: situationType, AgentType: "claude",
+		Mode: domain.ModeAutonomous, ConsecutiveConfirmations: 8,
+		CachedConfidence: 1.0, UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return sig.Signature
+}

--- a/internal/daemon/shutdown_test.go
+++ b/internal/daemon/shutdown_test.go
@@ -171,6 +171,69 @@ func TestShutdownDrainsVerifyUnblockBeforeStoreClose(t *testing.T) {
 	}
 }
 
+// TestRunDrainsBackgroundOnEarlyControlSocketFailure covers the early-return
+// path: New() spawns the semantic-init goroutine (matcher configured), then Run
+// fails fast setting up the control socket. The drain barrier must still run on
+// that return — otherwise the tracked semantic-init goroutine keeps touching the
+// store/matcher while the caller (cmd/hap) closes them. We assert Run returns
+// the error AND that shutdownBackground ran (shutdownCtx cancelled + bg drained),
+// then close the store; under -race a leaked goroutine would be flagged.
+func TestRunDrainsBackgroundOnEarlyControlSocketFailure(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(tinyCaptureDelay), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := store.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fh := &fakeHerdr{}
+	fe := &fakeEvents{ch: make(chan domain.AgentTransition, 8)}
+	d, err := New(Options{
+		ConfigPath: cfgPath,
+		// Parent directory does not exist, so control.NewServer fails and Run
+		// returns before its own event/loop setup.
+		ControlSocketPath: filepath.Join(dir, "no-such-dir", "control.sock"),
+		// A configured match index makes New() spawn initSemantic via spawn(),
+		// so there is a real tracked background goroutine to drain.
+		MatchIndexDir: filepath.Join(dir, "match"),
+		Store:         raw,
+		Herdr:         fh,
+		Events:        fe,
+		Notify:        fh,
+		LLM:           &fakeLLM{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- d.Run(context.Background()) }()
+
+	select {
+	case err := <-runErr:
+		if err == nil {
+			t.Fatal("expected a control-socket setup error from Run")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return within 5s on early control-socket failure (drain barrier not on the early path?)")
+	}
+
+	// shutdownBackground must have run on the early return: it cancels
+	// shutdownCtx and drains bg. Before the fix this defer was registered after
+	// the failing control-socket setup, so it never ran here.
+	if d.shutdownCtx.Err() == nil {
+		t.Fatal("shutdownBackground did not run on early return: shutdownCtx not cancelled — background work can outlive Run and race the store/matcher close")
+	}
+
+	// Draining happened before Run returned, so this close cannot race it.
+	if err := raw.Close(); err != nil {
+		t.Fatalf("store close: %v", err)
+	}
+}
+
 // seedAutonomousRule installs a graduated (autonomous) rule directly in the
 // store so a matching situation auto-answers. It mirrors harness.seedAutonomous
 // but targets a raw store for tests that build the daemon by hand.

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -98,7 +98,7 @@ func (d *Daemon) startSweep(ctx context.Context, ks ports.KeystrokeSender,
 		return
 	}
 
-	go func() {
+	d.spawn(func() {
 		outcome := sweepOutcome{situation: s, tr: tr, agentName: agentName}
 		logging.Guard("mcq-sweep", func() error {
 			swept, err := d.sweepFrames(ctx, ks, s)
@@ -116,7 +116,7 @@ func (d *Daemon) startSweep(ctx context.Context, ks ports.KeystrokeSender,
 		case d.sweepResults <- outcome:
 		case <-ctx.Done():
 		}
-	}()
+	})
 }
 
 // sweepFrames drives the Right-arrow capture protocol: read the visible
@@ -369,7 +369,7 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 		return
 	}
 
-	go func() {
+	d.spawn(func() {
 		defer d.releasePane(s.AgentID)
 		logging.Guard("series-delivery", func() error {
 			d.withAgentAutomation(ctx, s, sig, tr, dec.Input, dec.Confidence, nil, "", now, func() {
@@ -424,7 +424,7 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 			})
 			return nil
 		})
-	}()
+	})
 }
 
 // deliverSeriesLLM is the promotion-path twin of deliverSeries. Its final
@@ -435,7 +435,7 @@ func (d *Daemon) deliverSeriesLLM(ctx context.Context, ks ports.KeystrokeSender,
 	llmDec *domain.LLMDecision, groups [][]string, confidence float64,
 	llmConfidence *int, now time.Time) {
 
-	go func() {
+	d.spawn(func() {
 		defer d.releasePane(s.AgentID)
 		logging.Guard("series-delivery-llm", func() error {
 			executed := d.withAgentAutomation(ctx, s, sig, tr, llmDec.Action,
@@ -497,7 +497,7 @@ func (d *Daemon) deliverSeriesLLM(ctx context.Context, ks ports.KeystrokeSender,
 			}
 			return nil
 		})
-	}()
+	})
 }
 
 // deliverRemoteEnv answers Claude's standing "Select remote environment"
@@ -523,7 +523,7 @@ func (d *Daemon) deliverRemoteEnv(ctx context.Context, ks ports.KeystrokeSender,
 		return
 	}
 
-	go func() {
+	d.spawn(func() {
 		defer d.releasePane(s.AgentID)
 		logging.Guard("remote-env-delivery", func() error {
 			d.withAgentAutomation(ctx, s, sig, tr, dec.Input, dec.Confidence, nil, "", now, func() {
@@ -571,7 +571,7 @@ func (d *Daemon) deliverRemoteEnv(ctx context.Context, ks ports.KeystrokeSender,
 			})
 			return nil
 		})
-	}()
+	})
 }
 
 // deliverRemoteEnvLLM is the promotion-path twin of deliverRemoteEnv (same
@@ -581,7 +581,7 @@ func (d *Daemon) deliverRemoteEnvLLM(ctx context.Context, ks ports.KeystrokeSend
 	s domain.Situation, sig domain.SignatureResult, tr domain.AgentTransition,
 	llmDec *domain.LLMDecision, confidence float64, llmConfidence *int, now time.Time) {
 
-	go func() {
+	d.spawn(func() {
 		defer d.releasePane(s.AgentID)
 		logging.Guard("remote-env-delivery-llm", func() error {
 			executed := d.withAgentAutomation(ctx, s, sig, tr, llmDec.Action,
@@ -636,7 +636,7 @@ func (d *Daemon) deliverRemoteEnvLLM(ctx context.Context, ks ports.KeystrokeSend
 			}
 			return nil
 		})
-	}()
+	})
 }
 
 // sendRemoteEnvSelection answers the standing remote-environment picker via


### PR DESCRIPTION
## Problem

The daemon's post-action **verify-unblock** self-check and the **semantic-init** goroutine rooted at `context.Background()`, and every background goroutine / `time.AfterFunc` timer was untracked. On shutdown they raced the deferred matcher/embedder `Close()` and the caller's `Store.Close()` — surfacing as `sql: database is closed` warnings and capture-timer flakiness (visible as `-race` flakiness in the daemon suite).

## Fix

- **Lifecycle registry** on `Daemon`: a `sync.WaitGroup` (`bg`), a tracked-timer set + `closing` flag guarded by `lifeMu`, and a `shutdownCtx` cancelled at teardown.
- Every `go func` now routes through `spawn()`; both delivered `AfterFunc` timers through `afterFunc()`/`stopTimer()`. **verify-unblock** and **semantic-init** root at `shutdownCtx` instead of `context.Background()`.
- `Run()` defers `shutdownBackground()` (cancel `shutdownCtx` → stop pending timers → `bg.Wait()`) **before** its matcher/embedder `Close` defer, so background work always drains before any store/matcher closes (and before the caller closes the store).
- `cancelCapture()` releases its timer via `stopTimer()` so a working-transition cancel no longer leaks a WaitGroup slot.
- Test harness (`newHarnessCore`) now awaits `Run`'s full return before closing the store (deterministic cancel → drain → close).

## Tests

- `TestShutdownStopsPendingCaptureTimer` — a pending long-delay capture timer is Stop()ped on shutdown (proves no capture leak / hang).
- `TestShutdownDrainsVerifyUnblockBeforeStoreClose` — an in-flight verify-unblock store touch is drained before `Close()`; asserts no `database is closed` (the DB-closed-warning coverage).
- Both pass under `-race`. Full non-race suite green across all packages (the CI gate).

## Notes

The daemon suite has **pre-existing** `-race`-only flakiness in unrelated tests (e.g. escalation-dedup / consult ordering producing extra audit rows) — they pass without `-race` on clean `main` and are out of scope here. This change removes the shutdown-race source of `database is closed` warnings that contributed to that noise.

https://claude.ai/code/session_0162qGzBfdPGLgrbUfV8osks