### PR TITLE
#1 fix: detect one-question Claude tab forms so they reach the verified deliverer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,23 @@ whose manifest carries exactly that version).
   touching these must keep/extend the safety-invariant tests; new destructive-command shapes
   go in `internal/domain/testdata/irreversible_corpus.txt` (CI fails if seed patterns miss a
   corpus entry).
+- **A checkbox tab is answered by TOGGLING, so its baseline is a safety control** — a digit
+  flips a `[ ]`/`[✔]` box rather than selecting it, so pressing one blind is not idempotent:
+  over a pane already carrying an attempt's toggles it CLEARS them and the advance submits an
+  empty answer. The rule is `checked ⊆ chosen`, enforced at DELIVERY (`domain.CheckedOutside`
+  in `daemon.reverifyMultiSelect`, `frontend.verifyTabBaseline`, and again per keystroke in
+  `mcqdeliver.toggleTab`, which presses only the missing boxes): hap's own boxes may already
+  be set, anything else is the operator's and is never cleared. CAPTURE only records — refusing
+  there would strand every form hap itself half-answered, since the next attention event
+  re-captures that pane. The signature folds the checkbox state away
+  (`domain.NormalizedOptionSet`) so a half-delivered form still matches the rule learned for
+  the untouched one. **The widened baseline needs evidence**: it applies only when this daemon
+  recorded its own attempt at this pane+signature (`markToggleAttempt`, in-memory, cleared on
+  a completed delivery and lost across restarts — both fail safe). Without it a tab must be
+  completely clean, because "checked ⊆ chosen" alone would also accept an operator halfway
+  through ticking that very form. Keep all three invariant tests when touching this
+  (`TestMultiTabSweepMultiSelectOwnTogglesComplete` / `…ForeignSelectionEscalates` /
+  `…UnattributedTogglesEscalate`).
 - **Don't stall the main loop** — the daemon's select loop handles all agents; anything that
   shells out repeatedly (LLM CLI, deep pane reads) belongs in a goroutine that funnels
   results back through a channel (see `consultLLM` / `llmResults`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ absent, so these are safe to run anywhere:
 
 ```sh
 go test -tags integration ./test/integration/ -v                    # from inside herdr, or set HERDR_BIN_PATH
-HAP_ITEST_CLAUDE=1 go test -tags integration ./test/integration/ -v # also drive a real claude (spends tokens)
+HAP_ITEST_CLAUDE=1 go test -tags integration ./test/integration/ -v -timeout 20m # also drive a real claude (spends tokens; several real-claude cases can exceed the 10m default)
 go test -tags "integration vectors cpu" ./test/integration/ -v      # include the real-model semantic case
 ```
 
@@ -65,7 +65,12 @@ go test -tags "integration vectors cpu" ./test/integration/ -v      # include th
   (cosine ≥ 0.90) and leaves an unrelated one alone — skips without the model;
   `TestRealClaudePreviewMCQDelivery` (needs `HAP_ITEST_CLAUDE=1`) drives a real
   AskUserQuestion form whose options carry PREVIEWS and asserts the answers actually land —
-  the rendering where a digit only moves the caret, which blind digit delivery no-oped on.
+  the rendering where a digit only moves the caret, which blind digit delivery no-oped on;
+  `TestRealClaudeOneQuestionMultiSelectMCQDelivery` (needs `HAP_ITEST_CLAUDE=1`) drives a real
+  ONE-question multi-select form — the shape whose footer carries no tab hint, so it read as a
+  plain menu and got a bare digit that only toggled its checkbox — and asserts the answer
+  toggles, advances to Submit, and commits. It FAILS (does not skip) when a form is on screen
+  but `MultiTabForm` misses it, so the detection regression can never pass silently.
 
 **Recommended: run the integration suite once after finishing any feature**, before the
 PR — the unit suite fakes herdr, so only this catches real CLI-shape drift (e.g.

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -272,6 +272,29 @@ func TestClaudeMCQMultiTabV2FooterReportsTabCount(t *testing.T) {
 	}
 }
 
+func TestClaudeMCQOneQuestionTabFormReportsTabCount(t *testing.T) {
+	// Live capture (2026-07-20): a form with ONE question tab plus Submit
+	// carries the tab header but the plain selection footer — there is no
+	// sibling question to switch to. It was classified as a plain menu, so
+	// delivery sent the bare digit, which only toggled the option's checkbox
+	// and left the agent blocked on the Submit tab.
+	c := New(nil)
+	data, err := os.ReadFile(filepath.Join("testdata", "transcripts", "choice_claude_mcq_tabs_one_question.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := c.Classify("claude", "blocked", string(data))
+	if s.Type != domain.SituationChoice {
+		t.Fatalf("type = %q, want choice", s.Type)
+	}
+	if s.MCQKind != domain.MCQClaudeTabs {
+		t.Errorf("form kind = %q, want %q", s.MCQKind, domain.MCQClaudeTabs)
+	}
+	if s.TabCount != 2 {
+		t.Errorf("tab count = %d, want 2 (1 question + Submit)", s.TabCount)
+	}
+}
+
 func TestNarratedNumberedListNotChoice(t *testing.T) {
 	// A narrated markdown list whose first item wraps into a long indented
 	// continuation block (> 4 lines, no MCQ footer) must NOT classify as a

--- a/internal/classify/testdata/classifications.golden
+++ b/internal/classify/testdata/classifications.golden
@@ -5,6 +5,7 @@ approval_permission.txt status=blocked type=approval verb=proceed options=3
 approval_yn.txt status=blocked type=approval verb= options=0
 choice_claude_mcq.txt status=blocked type=choice verb= options=5
 choice_claude_mcq_tabs.txt status=blocked type=choice verb= options=5
+choice_claude_mcq_tabs_one_question.txt status=blocked type=choice verb= options=6
 choice_claude_mcq_tabs_v2.txt status=blocked type=choice verb= options=3
 choice_codex_mcq.txt status=blocked type=choice verb= options=3
 choice_library.txt status=blocked type=choice verb= options=3

--- a/internal/classify/testdata/transcripts/choice_claude_mcq_tabs_one_question.txt
+++ b/internal/classify/testdata/transcripts/choice_claude_mcq_tabs_one_question.txt
@@ -1,0 +1,33 @@
+● I'll explore how the task source parser works today.
+
+● Explore(Find task_source parsing code)
+  ⎿  Backgrounded agent (↓ to manage · ctrl+o to expand)
+
+  Searched for 6 patterns, read 7 files, listed 2 directories, ran 2 shell commands
+  ⎿  Loaded ../../vscode/home/root/.claude/rules/go.md
+
+❯ its ok to for the tasks.md file to contain more than 20 tasks if the user explictly update it manualy via file editing. (the 20 limit is applied to hap TUI/CLI create task and LLM generate tasks only)
+
+● Agent "Find task_source parsing code" finished · 1m 48s
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Planning: /root/.claude/plans/make-sure-the-task-source-melodic-backus.md
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+←  ☐ Scope  ✔ Submit  →
+
+Parsing already works — I verified this exact file shape parses cleanly (headings/prose skipped, all 50 `- [ ] N.M ...` items found, no false positives). The real gaps are addressing and context. Which should I fix?
+
+❯ 1. [ ] Hierarchical task IDs (Recommended)
+  `hap task <agent> done 3.4` currently errors (Atoi fails), and `done 3` silently marks positional item #3 — the wrong task. Add: a dotted ref like "3.4" resolves by the item's own leading ID label; plain integers stay positional (fully
+  backward compatible).
+  2. [ ] Section heading context
+  Add a `{task_section}` template placeholder carrying the item's nearest `##` heading (e.g. "5. Webapp UI — Share flow (`app/routes/...`)"), so the sent prompt keeps the section's file-path context. Default template unchanged.
+  3. [ ] Regression test only
+  Add this exact tasks.md as a testdata fixture with a test pinning parse/numbering/next-task behavior. No behavior change.
+  4. [ ] Show IDs in `hap task list`
+  Render the positional number alongside the file's own ID so an agent reading "3.4 …" can see it is task #23 before running a command.
+  5. [ ] Type something
+     Submit
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  6. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -161,6 +161,19 @@ type Daemon struct {
 	// (guarded by mu); outcomes return through sweepResults.
 	sweepInFlight map[string]bool
 
+	// toggleAttempt records, per agent, the signature of the multi-select form
+	// this daemon last started answering — the evidence that lets a later
+	// delivery accept a tab whose boxes are ALREADY ticked. Without it,
+	// "checked ⊆ chosen" is only an inference: an operator halfway through
+	// ticking a form, having chosen a subset of what the rule chose, would
+	// pass it and have their form completed and submitted for them. With it,
+	// hap widens the baseline only where it can point at its own abandoned
+	// attempt. Cleared once a delivery completes, so the NEXT form on that
+	// agent starts from the strict baseline again. Deliberately in-memory:
+	// after a restart hap can no longer prove the ticks are its own, and
+	// falling back to "escalate" is the safe direction. Guarded by mu.
+	toggleAttempt map[string]string
+
 	// idleSince tracks how long each agent has been continuously parked at a
 	// non-busy status, for the auto-send-when-idle poll. Refreshed from the
 	// sweep's agent listing: an agent that is still parked on the SAME pane
@@ -347,6 +360,7 @@ func New(opt Options) (*Daemon, error) {
 		lastAutoNoop:         map[string]time.Time{},
 		actionReviewInFlight: map[string]actionReviewFlight{},
 		sweepInFlight:        map[string]bool{},
+		toggleAttempt:        map[string]string{},
 		idleSince:            map[string]idleMark{},
 		autoTaskClaim:        map[string]taskClaim{},
 		snapshotSaved:        map[string]bool{},
@@ -2494,7 +2508,8 @@ func (d *Daemon) consultContext(ctx context.Context, cfg config.Config, s domain
 		}
 		if kinds, anyMulti := tabSelectKinds(s.EffectiveAnswerMultiSelect()); anyMulti {
 			fields["tab_select_kinds"] = kinds
-			answer += ". Some tabs are MULTI-SELECT (tab_select_kinds marks each tab \"single\" or \"multi\"; a multi-select question shows `[ ]` checkboxes on its options): for a multi-select tab pass an ARRAY of the option numbers to toggle instead of a single integer, e.g. [1, [1, 3], 2] chooses option 1 on tab 1, toggles options 1 and 3 on tab 2, and option 2 on tab 3"
+			answer += ". Some tabs are MULTI-SELECT (tab_select_kinds marks each tab \"single\" or \"multi\"; a multi-select question shows `[ ]` checkboxes on its options): for a multi-select tab pass an ARRAY of the option numbers to toggle instead of a single integer, e.g. [1, [1, 3], 2] chooses option 1 on tab 1, toggles options 1 and 3 on tab 2, and option 2 on tab 3" +
+				". An option already rendered `[✔]` is ALREADY ticked (a previous, unfinished delivery): still list every option you want selected — the complete desired set for that tab, not the difference — because the keys are pressed only for the boxes that are not already ticked, and any box you leave out is never cleared"
 		}
 		fields["answer_format"] = answer
 	} else if len(s.Options) > 0 {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -177,8 +178,21 @@ func (f *fakeHerdr) pressMCQDigit(key string) {
 	if len(f.mcqAnswered) < len(f.frames) {
 		f.mcqAnswered = make([]bool, len(f.frames))
 	}
-	// A multi-select tab toggles a checkbox: no answer, no advance.
-	if domain.MultiSelectTab(f.frames[f.frameIdx]) {
+	// A multi-select tab toggles a checkbox: no answer, no advance — but the
+	// box DOES flip, and delivery verifies exactly that before advancing, so
+	// the flip has to be modelled or a correct delivery would read as one that
+	// never landed. Ticking the first box ALSO flips that tab's header mark to
+	// ☒ while the form still stands and still owes an answer (verified live
+	// 2026-07-20, Claude Code v2.1.215), and the header is drawn on every tab.
+	if domain.MultiSelectTab(domain.ExtractMCQForm(f.frames[f.frameIdx])) {
+		f.frames[f.frameIdx] = toggleFakeCheckbox(f.frames[f.frameIdx], key)
+		checked := false
+		for _, on := range domain.OptionCheckStates(domain.ExtractMCQForm(f.frames[f.frameIdx])) {
+			checked = checked || on
+		}
+		for i := range f.frames {
+			f.frames[i] = markFakeTabAnswered(f.frames[i], f.frameIdx, checked)
+		}
 		return
 	}
 	// The last frame is the Submit tab: its digit submits the form away.
@@ -189,6 +203,45 @@ func (f *fakeHerdr) pressMCQDigit(key string) {
 	f.mcqAnswered[f.frameIdx] = true
 	f.frameIdx++
 }
+
+// toggleFakeCheckbox flips the `[ ]`/`[x]` box on the option line numbered
+// digit, the way a real multi-select tab re-renders after its digit press.
+func toggleFakeCheckbox(frame, digit string) string {
+	re := regexp.MustCompile(`(?m)^([ \t]*(?:[❯›>][ \t]*)?` + regexp.QuoteMeta(digit) + `[.)][ \t]+)\[[ xX✔✓]\]`)
+	return re.ReplaceAllStringFunc(frame, func(m string) string {
+		box := "[ ]"
+		if strings.HasSuffix(m, "[ ]") {
+			box = "[✔]" // the glyph Claude actually renders when checked
+		}
+		return m[:strings.LastIndex(m, "[")] + box
+	})
+}
+
+// markFakeTabAnswered sets the tab-th question mark in the frame's tab header
+// to ☒ (answered) or ☐, mirroring how the real header tracks a tab that now
+// carries a selection. The trailing ✔ Submit entry is never a question, so
+// only the ☐/☒ marks are counted.
+func markFakeTabAnswered(frame string, tab int, answered bool) string {
+	header, ok := domain.MCQTabHeaderLine(frame)
+	if !ok {
+		return frame
+	}
+	want := "☐"
+	if answered {
+		want = "☒"
+	}
+	seen := 0
+	updated := questionMarkRE.ReplaceAllStringFunc(header, func(m string) string {
+		defer func() { seen++ }()
+		if seen == tab {
+			return want
+		}
+		return m
+	})
+	return strings.Replace(frame, header, updated, 1)
+}
+
+var questionMarkRE = regexp.MustCompile(`[☐☒]`)
 
 func (f *fakeHerdr) SendKeys(ctx context.Context, paneID string, keys ...string) error {
 	for _, key := range keys {
@@ -208,7 +261,9 @@ func (f *fakeHerdr) keysSent() []string {
 func (f *fakeHerdr) setFrames(frames []string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.frames = frames
+	// Copied: a digit press mutates the frame it lands on (checkbox toggles),
+	// and the fixtures are package-level slices shared by every test.
+	f.frames = append([]string(nil), frames...)
 	f.frameIdx = 0
 }
 

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -102,7 +102,7 @@ func (d *Daemon) startSweep(ctx context.Context, ks ports.KeystrokeSender,
 	d.spawn(func() {
 		outcome := sweepOutcome{situation: s, tr: tr, agentName: agentName}
 		logging.Guard("mcq-sweep", func() error {
-			swept, err := d.sweepFrames(ctx, ks, s, nil)
+			swept, err := d.sweepFrames(ctx, ks, s, checkBaseline{})
 			if err != nil {
 				slog.Warn("multi-tab sweep failed; degrading to single-frame capture",
 					"agent", s.AgentID, "error", err)
@@ -126,13 +126,19 @@ func (d *Daemon) startSweep(ctx context.Context, ks ports.KeystrokeSender,
 // is back on the first question. A failed reset fails the whole sweep —
 // otherwise a later answer series would start on the wrong tab.
 //
-// chosen carries the answer's per-tab selections when one is already decided
-// (the pre-delivery re-verification), and is nil at CAPTURE time. It only
-// widens the multi-select baseline below: with no answer yet, a checked box
-// means someone else touched the form; with an answer, the boxes that answer
-// itself chose may already be set by its own earlier, unverified attempt.
+// checkBaseline decides how the multi-select checkbox baseline is judged.
+// enforce is false only on the CAPTURE path, which records what it finds;
+// when it is true a checked box must be one this answer chose (chosen), and a
+// nil chosen therefore demands a completely clean tab.
+type checkBaseline struct {
+	chosen  [][]string
+	enforce bool
+}
+
+// baseline is how the multi-select checkbox state is judged on this pass: see
+// checkBaseline. Nothing else in the sweep depends on it.
 func (d *Daemon) sweepFrames(ctx context.Context, ks ports.KeystrokeSender,
-	s domain.Situation, chosen [][]string) (domain.Situation, error) {
+	s domain.Situation, baseline checkBaseline) (domain.Situation, error) {
 
 	answerCount := s.EffectiveAnswerCount()
 	frames := make([]string, 0, answerCount)
@@ -167,26 +173,28 @@ func (d *Daemon) sweepFrames(ctx context.Context, ks ports.KeystrokeSender,
 		}
 		// A multi-select tab is answered by toggling checkboxes, which is a
 		// RELATIVE flip, so what is already checked decides what may be pressed.
+		// That question is settled at DELIVERY (enforce), where an answer
+		// exists to compare against: the boxes IT chose may already be set by
+		// its own earlier, unverified attempt, and delivery presses only the
+		// missing ones (mcqdeliver.toggleTab), while anything checked outside
+		// that set refuses — it is not hap's to clear.
 		//
-		// At CAPTURE (chosen == nil) the tab must be all-unchecked. No answer
-		// exists yet, so there is nothing to compare a checked box against and
-		// no way to tell hap's own abandoned toggle from an operator's
-		// selection: escalate the whole form. A form that is already toggled
-		// when hap first sees it therefore always reaches a human — including a
-		// re-capture after hap's own attempt died mid-toggle.
+		// CAPTURE (enforce == false) only records. Refusing here would strand
+		// every form hap itself had half-answered: an attempt that dies
+		// mid-toggle leaves ticks behind, and the next attention event
+		// re-captures that pane, so a capture-time refusal made the agent
+		// permanently un-answerable without a human. Nothing is pressed on the
+		// capture path, and the signature folds the checkbox state away
+		// (NormalizedOptionSet), so a half-delivered form still resolves to the
+		// rule learned for the untouched one and reaches the same delivery gate.
 		//
-		// At DELIVERY (chosen != nil) the answer is known, so the boxes IT chose
-		// may already be set by its own earlier, unverified attempt in the
-		// window since capture; delivery presses only the missing ones
-		// (mcqdeliver.toggleTab). Anything checked outside that set still
-		// escalates — it is not hap's to clear.
 		// Scoped to the LIVE render: a visible read carries earlier renders
 		// above the form, and an older render of an already-toggled tab would
 		// otherwise contribute checkboxes the live tab does not have.
 		liveFrame := domain.ExtractMCQForm(frame)
 		multi := s.MCQKind == domain.MCQClaudeTabs && domain.MultiSelectTab(liveFrame)
-		if multi {
-			if foreign := domain.CheckedOutside(liveFrame, tabChoice(chosen, tab)); len(foreign) > 0 {
+		if multi && baseline.enforce {
+			if foreign := domain.CheckedOutside(liveFrame, tabChoice(baseline.chosen, tab)); len(foreign) > 0 {
 				sweepErr = fmt.Errorf("answer %d/%d already has option(s) %s selected, which this answer did not choose; cannot auto-toggle safely",
 					tab+1, answerCount, strings.Join(foreign, ", "))
 				break
@@ -288,18 +296,30 @@ func anyMultiSelect(flags []bool) bool {
 // tab count and a baseline carrying nothing this answer did not choose. A
 // no-op for forms with no multi-select tab.
 //
-// groups is the answer about to be delivered: it widens the baseline to this
-// answer's OWN boxes (an earlier attempt may have set them before dying) and,
-// for the same reason, the content comparison ignores the checkbox marks —
-// CheckedOutside inside sweepFrames is what governs which boxes may be set, so
-// the normalized compare hides nothing that decides safety.
+// groups is the answer about to be delivered. It widens the baseline to this
+// answer's OWN boxes — but ONLY once this daemon has recorded an attempt at
+// this very form (toggleAttempt), because "checked ⊆ chosen" is otherwise just
+// an inference: an operator halfway through ticking the form, having chosen a
+// subset of what the rule chose, would pass it and get their form completed and
+// submitted for them. With no such evidence the strict all-unchecked baseline
+// applies and a pre-ticked form escalates, as it always did.
+//
+// The content comparison ignores the checkbox marks for the same reason the
+// baseline widens: CheckedOutside inside sweepFrames is what governs which
+// boxes may be set, so the normalized compare hides nothing that decides
+// safety.
 func (d *Daemon) reverifyMultiSelect(ctx context.Context, ks ports.KeystrokeSender,
-	s domain.Situation, groups [][]string) error {
+	s domain.Situation, signature string, groups [][]string) error {
 
 	if !anyMultiSelect(s.EffectiveAnswerMultiSelect()) {
 		return nil
 	}
-	reswept, err := d.sweepFrames(ctx, ks, s, groups)
+	baseline := checkBaseline{chosen: groups, enforce: true}
+	if !d.hasToggleAttempt(s.AgentID, signature) {
+		// No attempt of ours can explain a tick: demand a completely clean tab.
+		baseline.chosen = nil
+	}
+	reswept, err := d.sweepFrames(ctx, ks, s, baseline)
 	if err != nil {
 		return err
 	}
@@ -312,9 +332,42 @@ func (d *Daemon) reverifyMultiSelect(ctx context.Context, ks ports.KeystrokeSend
 	return nil
 }
 
+// escalateAudit demotes an already-written "auto" audit row to escalated and
+// records WHY plus a confirmable suggestion. Flipping only the status leaves
+// the rule's own rationale and an empty suggestion on the row, so the operator
+// gets a queue entry that neither explains itself nor can be confirmed.
+func (d *Daemon) escalateAudit(ctx context.Context, auditID int64, rationale, suggestion string) {
+	if err := d.opt.Store.EscalateAudit(ctx, auditID, rationale, suggestion); err != nil {
+		slog.Error("audit escalation write failed", "audit_id", auditID, "error", err)
+	}
+}
+
+// markToggleAttempt records that this daemon is about to press toggles into
+// agentID's form, so a later delivery can tell its own abandoned ticks from an
+// operator's selection. clearToggleAttempt drops that evidence once a delivery
+// finishes: the next form starts from the strict baseline.
+func (d *Daemon) markToggleAttempt(agentID, signature string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.toggleAttempt[agentID] = signature
+}
+
+func (d *Daemon) clearToggleAttempt(agentID string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.toggleAttempt, agentID)
+}
+
+func (d *Daemon) hasToggleAttempt(agentID, signature string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return signature != "" && d.toggleAttempt[agentID] == signature
+}
+
 // tabChoice returns the selections a decided answer makes on one tab, or nil
-// when no answer is decided yet (capture time) or the series is shorter than
-// the form — nil demands an all-unchecked tab, the strict baseline.
+// when the series is shorter than the form — nil then demands an all-unchecked
+// tab, so a series that does not reach this tab can never license a checkbox
+// on it. (The capture path passes no answer at all and skips the check.)
 func tabChoice(chosen [][]string, tab int) []string {
 	if tab < 0 || tab >= len(chosen) {
 		return nil
@@ -412,20 +465,29 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 						"An automated action was blocked because its audit record could not be written.")
 					return
 				}
-				if err := d.reverifyMultiSelect(ctx, ks, s, groups); err != nil {
+				if err := d.reverifyMultiSelect(ctx, ks, s, sig.Signature, groups); err != nil {
 					slog.Warn("multi-select baseline moved before delivery; refusing", "pane", s.PaneID, "error", err)
-					d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
+					d.escalateAudit(ctx, auditID, err.Error(), "answer series: "+dec.Input)
 					d.notify(ctx, "Herd Auto Prompter: action delivery skipped",
 						fmt.Sprintf("Agent %s: the multi-select form changed before the answer could be delivered (%v); please review it.", s.AgentID, err))
 					return
 				}
+				// Recorded BEFORE the first keystroke: a delivery that dies
+				// mid-toggle must still leave the evidence that explains the
+				// ticks it left behind.
+				d.markToggleAttempt(s.AgentID, sig.Signature)
 				if err := d.sendTabSelections(ctx, ks, s, groups); err != nil {
 					slog.Error("answer series delivery failed", "pane", s.PaneID, "error", err)
-					d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
+					// The attempt marker STAYS: a delivery that died mid-toggle
+					// is exactly what licenses the next one to complete it.
+					d.escalateAudit(ctx, auditID, err.Error(), "answer series: "+dec.Input)
 					d.notify(ctx, "Herd Auto Prompter: action delivery failed",
 						fmt.Sprintf("Agent %s: multi-tab answer series failed mid-delivery (%v); please review the form.", s.AgentID, err))
 					return
 				}
+				// Answered and submitted: the form is gone, so the next one on
+				// this agent starts from the strict baseline again.
+				d.clearToggleAttempt(s.AgentID)
 				d.mu.Lock()
 				d.lastAutoSend[s.AgentID] = now
 				d.mu.Unlock()
@@ -480,19 +542,21 @@ func (d *Daemon) deliverSeriesLLM(ctx context.Context, ks ports.KeystrokeSender,
 							"An LLM-derived action was blocked because its audit record could not be written.")
 						return
 					}
-					if err := d.reverifyMultiSelect(ctx, ks, s, groups); err != nil {
+					if err := d.reverifyMultiSelect(ctx, ks, s, sig.Signature, groups); err != nil {
 						slog.Warn("multi-select baseline moved before LLM delivery; refusing", "pane", s.PaneID, "error", err)
-						d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
+						d.escalateAudit(ctx, auditID, err.Error(), "answer series: "+llmDec.Action)
 						d.notify(ctx, "Herd Auto Prompter: action delivery skipped",
 							fmt.Sprintf("Agent %s: the multi-select form changed before the answer could be delivered (%v); please review it.", s.AgentID, err))
 						return
 					}
+					d.markToggleAttempt(s.AgentID, sig.Signature)
 					if err := d.sendTabSelections(ctx, ks, s, groups); err != nil {
 						slog.Error("LLM answer series delivery failed", "pane", s.PaneID, "error", err)
-						d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
+						d.escalateAudit(ctx, auditID, err.Error(), "answer series: "+llmDec.Action)
 						d.notify(ctx, "Herd Auto Prompter: action delivery failed", err.Error())
 						return
 					}
+					d.clearToggleAttempt(s.AgentID)
 					if err := d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "accepted"); err != nil {
 						slog.Error("llm decision status update failed", "error", err)
 					}

--- a/internal/daemon/sweep.go
+++ b/internal/daemon/sweep.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -101,7 +102,7 @@ func (d *Daemon) startSweep(ctx context.Context, ks ports.KeystrokeSender,
 	d.spawn(func() {
 		outcome := sweepOutcome{situation: s, tr: tr, agentName: agentName}
 		logging.Guard("mcq-sweep", func() error {
-			swept, err := d.sweepFrames(ctx, ks, s)
+			swept, err := d.sweepFrames(ctx, ks, s, nil)
 			if err != nil {
 				slog.Warn("multi-tab sweep failed; degrading to single-frame capture",
 					"agent", s.AgentID, "error", err)
@@ -124,8 +125,14 @@ func (d *Daemon) startSweep(ctx context.Context, ks ports.KeystrokeSender,
 // SAME form shape, then reset with a fixed burst of Left arrows so the form
 // is back on the first question. A failed reset fails the whole sweep —
 // otherwise a later answer series would start on the wrong tab.
+//
+// chosen carries the answer's per-tab selections when one is already decided
+// (the pre-delivery re-verification), and is nil at CAPTURE time. It only
+// widens the multi-select baseline below: with no answer yet, a checked box
+// means someone else touched the form; with an answer, the boxes that answer
+// itself chose may already be set by its own earlier, unverified attempt.
 func (d *Daemon) sweepFrames(ctx context.Context, ks ports.KeystrokeSender,
-	s domain.Situation) (domain.Situation, error) {
+	s domain.Situation, chosen [][]string) (domain.Situation, error) {
 
 	answerCount := s.EffectiveAnswerCount()
 	frames := make([]string, 0, answerCount)
@@ -159,14 +166,29 @@ func (d *Daemon) sweepFrames(ctx context.Context, ks ports.KeystrokeSender,
 			break
 		}
 		// A multi-select tab is answered by toggling checkboxes, which is a
-		// RELATIVE flip. We can only reason about the keystrokes if the tab
-		// starts all-unchecked (the observed default); any pre-selected option
-		// means an operator (or a default) already touched it, so escalate the
-		// whole form rather than blind-toggle into the wrong set.
-		multi := s.MCQKind == domain.MCQClaudeTabs && domain.MultiSelectTab(frame)
+		// RELATIVE flip, so what is already checked decides what may be pressed.
+		//
+		// At CAPTURE (chosen == nil) the tab must be all-unchecked. No answer
+		// exists yet, so there is nothing to compare a checked box against and
+		// no way to tell hap's own abandoned toggle from an operator's
+		// selection: escalate the whole form. A form that is already toggled
+		// when hap first sees it therefore always reaches a human — including a
+		// re-capture after hap's own attempt died mid-toggle.
+		//
+		// At DELIVERY (chosen != nil) the answer is known, so the boxes IT chose
+		// may already be set by its own earlier, unverified attempt in the
+		// window since capture; delivery presses only the missing ones
+		// (mcqdeliver.toggleTab). Anything checked outside that set still
+		// escalates — it is not hap's to clear.
+		// Scoped to the LIVE render: a visible read carries earlier renders
+		// above the form, and an older render of an already-toggled tab would
+		// otherwise contribute checkboxes the live tab does not have.
+		liveFrame := domain.ExtractMCQForm(frame)
+		multi := s.MCQKind == domain.MCQClaudeTabs && domain.MultiSelectTab(liveFrame)
 		if multi {
-			if n := countChecked(frame); n > 0 {
-				sweepErr = fmt.Errorf("answer %d/%d already has %d option(s) selected; cannot auto-toggle safely", tab+1, answerCount, n)
+			if foreign := domain.CheckedOutside(liveFrame, tabChoice(chosen, tab)); len(foreign) > 0 {
+				sweepErr = fmt.Errorf("answer %d/%d already has option(s) %s selected, which this answer did not choose; cannot auto-toggle safely",
+					tab+1, answerCount, strings.Join(foreign, ", "))
 				break
 			}
 		}
@@ -263,17 +285,25 @@ func anyMultiSelect(flags []bool) bool {
 // decisions (toggling is relative). It re-runs the capture sweep and then fails
 // CLOSED unless the re-swept aggregate content AND per-tab select kinds match
 // the situation being delivered — sweepFrames alone only guarantees the same
-// tab count and an unchecked baseline. A no-op for forms with no multi-select
-// tab.
-func (d *Daemon) reverifyMultiSelect(ctx context.Context, ks ports.KeystrokeSender, s domain.Situation) error {
+// tab count and a baseline carrying nothing this answer did not choose. A
+// no-op for forms with no multi-select tab.
+//
+// groups is the answer about to be delivered: it widens the baseline to this
+// answer's OWN boxes (an earlier attempt may have set them before dying) and,
+// for the same reason, the content comparison ignores the checkbox marks —
+// CheckedOutside inside sweepFrames is what governs which boxes may be set, so
+// the normalized compare hides nothing that decides safety.
+func (d *Daemon) reverifyMultiSelect(ctx context.Context, ks ports.KeystrokeSender,
+	s domain.Situation, groups [][]string) error {
+
 	if !anyMultiSelect(s.EffectiveAnswerMultiSelect()) {
 		return nil
 	}
-	reswept, err := d.sweepFrames(ctx, ks, s)
+	reswept, err := d.sweepFrames(ctx, ks, s, groups)
 	if err != nil {
 		return err
 	}
-	if reswept.Content != s.Content {
+	if domain.ClearCheckboxMarks(reswept.Content) != domain.ClearCheckboxMarks(s.Content) {
 		return fmt.Errorf("form content changed since capture")
 	}
 	if !slices.Equal(reswept.EffectiveAnswerMultiSelect(), s.EffectiveAnswerMultiSelect()) {
@@ -282,17 +312,14 @@ func (d *Daemon) reverifyMultiSelect(ctx context.Context, ks ports.KeystrokeSend
 	return nil
 }
 
-// countChecked reports how many of a frame's checkbox options are already
-// checked (`[x]`). Used to enforce the all-unchecked baseline before an
-// autonomous multi-select toggle.
-func countChecked(frame string) int {
-	n := 0
-	for _, checked := range domain.OptionCheckStates(frame) {
-		if checked {
-			n++
-		}
+// tabChoice returns the selections a decided answer makes on one tab, or nil
+// when no answer is decided yet (capture time) or the series is shorter than
+// the form — nil demands an all-unchecked tab, the strict baseline.
+func tabChoice(chosen [][]string, tab int) []string {
+	if tab < 0 || tab >= len(chosen) {
+		return nil
 	}
-	return n
+	return chosen[tab]
 }
 
 // handleSweepOutcome resumes the decision pipeline with the aggregated
@@ -385,7 +412,7 @@ func (d *Daemon) deliverSeries(ctx context.Context, s domain.Situation, sig doma
 						"An automated action was blocked because its audit record could not be written.")
 					return
 				}
-				if err := d.reverifyMultiSelect(ctx, ks, s); err != nil {
+				if err := d.reverifyMultiSelect(ctx, ks, s, groups); err != nil {
 					slog.Warn("multi-select baseline moved before delivery; refusing", "pane", s.PaneID, "error", err)
 					d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
 					d.notify(ctx, "Herd Auto Prompter: action delivery skipped",
@@ -453,7 +480,7 @@ func (d *Daemon) deliverSeriesLLM(ctx context.Context, ks ports.KeystrokeSender,
 							"An LLM-derived action was blocked because its audit record could not be written.")
 						return
 					}
-					if err := d.reverifyMultiSelect(ctx, ks, s); err != nil {
+					if err := d.reverifyMultiSelect(ctx, ks, s, groups); err != nil {
 						slog.Warn("multi-select baseline moved before LLM delivery; refusing", "pane", s.PaneID, "error", err)
 						d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
 						d.notify(ctx, "Herd Auto Prompter: action delivery skipped",

--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -368,6 +368,37 @@ func TestMultiTabSweepMultiSelectForeignSelectionEscalates(t *testing.T) {
 	}
 }
 
+// A classification that over-claims a multi-tab form must cost nothing but an
+// escalation. The consuming "recent" read the classifier uses can carry an
+// older render, so a stale tab header above an ordinary live menu can make
+// MultiTabForm true there — the text alone can not rule it out. Every path
+// that sends a keystroke re-reads the VISIBLE pane first, and this pins that:
+// the sweep's first frame check runs BEFORE its first arrow, so a pane that no
+// longer shows the form degrades to escalation with nothing pressed.
+//
+// (Verified live 2026-07-21, Claude Code v2.1.215: this pairing does not occur
+// on the visible pane at all — submitting or ESC-cancelling a form replaces the
+// whole widget, header included, and the plain permission menu that follows
+// carries no header. The guard is for the reads that can still see scrollback.)
+func TestSweepFailsClosedWhenVisiblePaneIsNotTheForm(t *testing.T) {
+	h := newHarness(t, "")
+	// Classified as a 2-tab form (a stale header sat above the live menu in the
+	// classification read) — but the live pane is an ordinary permission menu.
+	s := sweptSituationFrom(t, mcqMultiFrames)
+	s.AgentID, s.PaneID = "agent-stale-header", "agent-stale-header"
+	h.herdr.setFrames([]string{
+		"Bash command\n\ntouch /tmp/x\n\nDo you want to proceed?\n❯ 1. Yes\n  2. No\n\n" +
+			"Esc to cancel · Tab to amend · ctrl+e to explain\n",
+	})
+
+	if _, err := h.daemon.sweepFrames(context.Background(), h.herdr, s, checkBaseline{}); err == nil {
+		t.Fatal("the sweep must refuse a pane that no longer shows the form")
+	}
+	if keys := h.herdr.keysSent(); len(keys) != 0 {
+		t.Errorf("no keystroke may reach an ordinary menu misread as a form, got %v", keys)
+	}
+}
+
 // SAFETY INVARIANT: without evidence that the ticks are hap's own, a form
 // carrying a SUBSET of what the answer chose is refused — it may be an
 // operator halfway through ticking that very form, and completing it would

--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -39,7 +39,7 @@ func TestCodexQuestionSweepAndAdaptiveDelivery(t *testing.T) {
 	if s.Type != domain.SituationChoice || s.MCQKind != domain.MCQCodexQuestions || s.EffectiveAnswerCount() != 2 {
 		t.Fatalf("fixture classification = %+v", s)
 	}
-	swept, err := h.daemon.sweepFrames(context.Background(), h.herdr, s)
+	swept, err := h.daemon.sweepFrames(context.Background(), h.herdr, s, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,11 +290,25 @@ func TestReverifyMultiSelectRejectsChangedForm(t *testing.T) {
 	s.TabMultiSelect = []bool{false, true, false}
 	s.PaneID = "w1:p1"
 	ctx := context.Background()
+	groups := [][]string{{"1"}, {"1", "3"}, {"1"}}
 
 	// Unchanged form re-verifies clean.
 	h.herdr.setFrames(mcqMultiFrames)
-	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s); err != nil {
+	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s, groups); err != nil {
 		t.Fatalf("an unchanged multi-select form must re-verify clean, got %v", err)
+	}
+
+	// The same form carrying THIS answer's own toggles re-verifies clean too:
+	// only the checkbox marks differ, and they are the ones it chose.
+	h.herdr.setFrames(mcqMultiOwnToggleFrames)
+	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s, groups); err != nil {
+		t.Fatalf("a form carrying this answer's own toggles must re-verify clean, got %v", err)
+	}
+
+	// A box this answer did not choose is still a refusal.
+	h.herdr.setFrames(mcqMultiPrecheckedFrames)
+	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s, groups); err == nil {
+		t.Fatal("reverify must reject a selection this answer did not choose")
 	}
 
 	// The middle tab now shows a DIFFERENT (still-unchecked, same-count) form.
@@ -304,7 +318,7 @@ func TestReverifyMultiSelectRejectsChangedForm(t *testing.T) {
 		mcqMultiFrames[2],
 	}
 	h.herdr.setFrames(changed)
-	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s); err == nil {
+	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s, groups); err == nil {
 		t.Fatal("reverify must reject a form whose content changed since capture")
 	}
 }
@@ -331,6 +345,46 @@ func TestMultiTabSweepMultiSelectPrecheckedEscalates(t *testing.T) {
 	for _, k := range h.herdr.keysSent() {
 		if k != "right" && k != "left" {
 			t.Errorf("no digit may be pressed when the toggle baseline is unsafe, keys: %v", h.herdr.keysSent())
+		}
+	}
+}
+
+// mcqMultiOwnToggleFrames is mcqMultiFrames with the multi-select tab carrying
+// exactly what the learned answer ("1 1,3 1") chooses — the pane an earlier
+// delivery attempt leaves behind when it dies after toggling but before
+// submitting. It renders what Claude actually draws in that state (verified
+// live 2026-07-20): checked boxes are `[✔]`, and the toggled tab's header mark
+// has flipped to ☒ on EVERY tab even though the form still stands.
+const mcqHeaderTab2Answered = "←  ☐ Q one  ☒ Q two  ✔ Submit  →"
+
+var mcqMultiOwnToggleFrames = []string{
+	"──────\n" + mcqHeaderTab2Answered + "\n\nWhich backend?\n\n❯ 1. sqlite\n  2. postgres\n\n" + mcqFooter + "\n",
+	"──────\n" + mcqHeaderTab2Answered + "\n\nWhich stats to show?\n\n❯ 1. [✔] Auto-sends\n  2. [ ] Escalations\n  3. [✔] Confirmed\n\n" + mcqFooter + "\n",
+	"──────\n" + mcqHeaderTab2Answered + "\n\nReview your answers\n\nReady to submit your answers?\n\n❯ 1. Submit answers\n  2. Cancel\n",
+}
+
+// A form CAPTURED with a checkbox already set still escalates, whatever the
+// learned answer chose. Capture runs before any answer is known, so the
+// "checked ⊆ chosen" rule the delivery-time gates use has nothing to compare
+// against — the strict baseline is the only safe one there. The relaxation
+// therefore only ever applies to a form captured clean whose boxes moved
+// before delivery (see TestReverifyMultiSelectRejectsChangedForm).
+func TestMultiTabSweepMultiSelectPrecheckedEscalatesEvenWhenChosen(t *testing.T) {
+	h := newHarness(t, "")
+	// The rule chooses exactly the options the pane already carries.
+	h.seedSeriesRuleFrom(t, mcqMultiFrames, "1 1,3 1")
+	h.herdr.setFrames(mcqMultiOwnToggleFrames)
+
+	h.push("agent-mcqcaptured", "blocked")
+
+	ctx := context.Background()
+	waitFor(t, 10*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	for _, k := range h.herdr.keysSent() {
+		if k != "right" && k != "left" {
+			t.Errorf("no digit may be pressed when the captured baseline is unsafe, keys: %v", h.herdr.keysSent())
 		}
 	}
 }

--- a/internal/daemon/sweep_test.go
+++ b/internal/daemon/sweep_test.go
@@ -39,7 +39,7 @@ func TestCodexQuestionSweepAndAdaptiveDelivery(t *testing.T) {
 	if s.Type != domain.SituationChoice || s.MCQKind != domain.MCQCodexQuestions || s.EffectiveAnswerCount() != 2 {
 		t.Fatalf("fixture classification = %+v", s)
 	}
-	swept, err := h.daemon.sweepFrames(context.Background(), h.herdr, s, nil)
+	swept, err := h.daemon.sweepFrames(context.Background(), h.herdr, s, checkBaseline{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,23 +291,32 @@ func TestReverifyMultiSelectRejectsChangedForm(t *testing.T) {
 	s.PaneID = "w1:p1"
 	ctx := context.Background()
 	groups := [][]string{{"1"}, {"1", "3"}, {"1"}}
+	sig := domain.ComputeSignature(s).Signature
 
 	// Unchanged form re-verifies clean.
 	h.herdr.setFrames(mcqMultiFrames)
-	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s, groups); err != nil {
+	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s, sig, groups); err != nil {
 		t.Fatalf("an unchanged multi-select form must re-verify clean, got %v", err)
 	}
 
-	// The same form carrying THIS answer's own toggles re-verifies clean too:
-	// only the checkbox marks differ, and they are the ones it chose.
+	// A form carrying ticks that hap can NOT attribute to itself is refused,
+	// even when they are a subset of what this answer chose — it may be an
+	// operator halfway through the same form.
 	h.herdr.setFrames(mcqMultiOwnToggleFrames)
-	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s, groups); err != nil {
+	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s, sig, groups); err == nil {
+		t.Fatal("ticks with no recorded attempt of ours must be refused")
+	}
+
+	// With this daemon's own attempt on record, the same pane re-verifies
+	// clean: those ticks are the answer's own, half delivered.
+	h.daemon.markToggleAttempt(s.AgentID, sig)
+	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s, sig, groups); err != nil {
 		t.Fatalf("a form carrying this answer's own toggles must re-verify clean, got %v", err)
 	}
 
-	// A box this answer did not choose is still a refusal.
+	// A box this answer did not choose is a refusal even then.
 	h.herdr.setFrames(mcqMultiPrecheckedFrames)
-	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s, groups); err == nil {
+	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s, sig, groups); err == nil {
 		t.Fatal("reverify must reject a selection this answer did not choose")
 	}
 
@@ -318,18 +327,19 @@ func TestReverifyMultiSelectRejectsChangedForm(t *testing.T) {
 		mcqMultiFrames[2],
 	}
 	h.herdr.setFrames(changed)
-	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s, groups); err == nil {
+	if err := h.daemon.reverifyMultiSelect(ctx, h.herdr, s, sig, groups); err == nil {
 		t.Fatal("reverify must reject a form whose content changed since capture")
 	}
 }
 
-// A multi-select tab that ALREADY has a selection can not be toggled safely
-// (toggling is relative): the sweep refuses, the form escalates, and no digit
-// is ever pressed.
-func TestMultiTabSweepMultiSelectPrecheckedEscalates(t *testing.T) {
+// SAFETY INVARIANT: a checkbox this answer did not choose is someone else's
+// selection. Capture records it, the rule still resolves (the signature folds
+// the box away), and the DELIVERY gate refuses — no digit is ever pressed, and
+// the operator gets the form.
+func TestMultiTabSweepMultiSelectForeignSelectionEscalates(t *testing.T) {
 	h := newHarness(t, "")
-	h.herdr.setFrames(mcqMultiPrecheckedFrames)
-	h.seedSeriesRuleFrom(t, mcqMultiFrames, "1 1,3 1") // even a graduated rule must not fire
+	h.herdr.setFrames(mcqMultiPrecheckedFrames) // option 2 checked; the rule chooses 1 and 3
+	h.seedSeriesRuleFrom(t, mcqMultiFrames, "1 1,3 1")
 
 	h.push("agent-mcqprechecked", "blocked")
 
@@ -338,14 +348,87 @@ func TestMultiTabSweepMultiSelectPrecheckedEscalates(t *testing.T) {
 		esc, _ := h.raw.PendingEscalations(ctx)
 		return len(esc) == 1
 	})
-	esc, _ := h.raw.PendingEscalations(ctx)
-	if !strings.Contains(esc[0].Rationale, "already has") {
-		t.Errorf("escalation must name the pre-selected baseline: %+v", esc[0])
-	}
 	for _, k := range h.herdr.keysSent() {
 		if k != "right" && k != "left" {
 			t.Errorf("no digit may be pressed when the toggle baseline is unsafe, keys: %v", h.herdr.keysSent())
 		}
+	}
+	audits, _ := h.raw.AuditLog(ctx, 10)
+	if audits[0].Status != "escalated" {
+		t.Errorf("audit status = %q, want escalated: %+v", audits[0].Status, audits[0])
+	}
+	// The queue entry must explain itself and be confirmable: a bare status
+	// flip leaves the rule's own rationale and an empty suggestion behind.
+	esc, _ := h.raw.PendingEscalations(ctx)
+	if !strings.Contains(esc[0].Rationale, "already has option(s) 2") {
+		t.Errorf("escalation must name the foreign selection: %+v", esc[0])
+	}
+	if esc[0].Suggestion == "" {
+		t.Errorf("escalation must carry a confirmable suggestion: %+v", esc[0])
+	}
+}
+
+// SAFETY INVARIANT: without evidence that the ticks are hap's own, a form
+// carrying a SUBSET of what the answer chose is refused — it may be an
+// operator halfway through ticking that very form, and completing it would
+// submit a selection they never finished making.
+func TestMultiTabSweepMultiSelectUnattributedTogglesEscalate(t *testing.T) {
+	h := newHarness(t, "")
+	h.herdr.setFrames(mcqMultiOwnToggleFrames) // exactly the rule's own choices
+	h.seedSeriesRuleFrom(t, mcqMultiFrames, "1 1,3 1")
+	// No markToggleAttempt: this daemon never started answering this form.
+
+	h.push("agent-mcqunattributed", "blocked")
+
+	ctx := context.Background()
+	waitFor(t, 10*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	for _, k := range h.herdr.keysSent() {
+		if k != "right" && k != "left" {
+			t.Errorf("no digit may be pressed without evidence the ticks are ours, keys: %v", h.herdr.keysSent())
+		}
+	}
+}
+
+// SAFETY INVARIANT (the other direction): a form carrying ONLY the boxes this
+// answer chose is hap's own half-delivered attempt. Re-capturing it must not
+// strand the agent — the rule resolves, the delivery gate accepts, and only
+// the MISSING keystrokes go out (option 1 and 3 are already ticked, so tab 2
+// contributes just its advance).
+func TestMultiTabSweepMultiSelectOwnTogglesComplete(t *testing.T) {
+	h := newHarness(t, "")
+	h.herdr.setFrames(mcqMultiOwnToggleFrames)
+	sig := h.seedSeriesRuleFrom(t, mcqMultiFrames, "1 1,3 1")
+	// The evidence a real retry would carry: this daemon already started
+	// answering this form, so the ticks on it are its own.
+	h.daemon.markToggleAttempt("agent-mcqowntoggle", sig)
+
+	h.push("agent-mcqowntoggle", "blocked")
+
+	ctx := context.Background()
+	waitFor(t, 10*time.Second, func() bool {
+		decs, _ := h.raw.DecisionsForSignature(ctx, sig, 10)
+		return len(decs) == 9
+	})
+	esc, _ := h.raw.PendingEscalations(ctx)
+	if len(esc) != 0 {
+		t.Fatalf("hap's own half-delivered form must not escalate: %+v", esc)
+	}
+	// The WHOLE keystroke run, so a stray digit anywhere fails: capture sweep
+	// (2 rights + reset), the pre-delivery re-verification sweep (the same
+	// again), then delivery's own reset, tab 1's digit, tab 2's advance ALONE
+	// — its boxes are already ticked and re-pressing one would clear it — and
+	// Submit.
+	reset := strings.TrimSpace(strings.Repeat("left ", 10))
+	want := "right right " + reset + " right right " + reset + " " + reset + " 1 right 1"
+	if got := strings.Join(h.herdr.keysSent(), " "); got != want {
+		t.Errorf("keystroke protocol mismatch:\n got %s\nwant %s", got, want)
+	}
+	audits, _ := h.raw.AuditLog(ctx, 10)
+	if audits[0].Status != "auto" {
+		t.Errorf("audit status = %q, want auto: %+v", audits[0].Status, audits[0])
 	}
 }
 
@@ -363,29 +446,16 @@ var mcqMultiOwnToggleFrames = []string{
 	"──────\n" + mcqHeaderTab2Answered + "\n\nReview your answers\n\nReady to submit your answers?\n\n❯ 1. Submit answers\n  2. Cancel\n",
 }
 
-// A form CAPTURED with a checkbox already set still escalates, whatever the
-// learned answer chose. Capture runs before any answer is known, so the
-// "checked ⊆ chosen" rule the delivery-time gates use has nothing to compare
-// against — the strict baseline is the only safe one there. The relaxation
-// therefore only ever applies to a form captured clean whose boxes moved
-// before delivery (see TestReverifyMultiSelectRejectsChangedForm).
-func TestMultiTabSweepMultiSelectPrecheckedEscalatesEvenWhenChosen(t *testing.T) {
-	h := newHarness(t, "")
-	// The rule chooses exactly the options the pane already carries.
-	h.seedSeriesRuleFrom(t, mcqMultiFrames, "1 1,3 1")
-	h.herdr.setFrames(mcqMultiOwnToggleFrames)
-
-	h.push("agent-mcqcaptured", "blocked")
-
-	ctx := context.Background()
-	waitFor(t, 10*time.Second, func() bool {
-		esc, _ := h.raw.PendingEscalations(ctx)
-		return len(esc) == 1
-	})
-	for _, k := range h.herdr.keysSent() {
-		if k != "right" && k != "left" {
-			t.Errorf("no digit may be pressed when the captured baseline is unsafe, keys: %v", h.herdr.keysSent())
-		}
+// A half-delivered form must resolve to the SAME signature as the untouched
+// one: the checkbox marks are volatile state, not part of the question. Without
+// that fold the learned rule never matches a re-captured form and the agent is
+// stranded no matter how permissive the gates are.
+func TestPartiallyToggledFormKeepsItsSignature(t *testing.T) {
+	clean := sweptSituationFrom(t, mcqMultiFrames)
+	toggled := sweptSituationFrom(t, mcqMultiOwnToggleFrames)
+	if got, want := domain.ComputeSignature(toggled), domain.ComputeSignature(clean); got.Signature != want.Signature {
+		t.Errorf("signature drifted with the checkbox state:\n toggled %s (%q)\n clean   %s (%q)",
+			got.Signature, got.Salient, want.Signature, want.Salient)
 	}
 }
 

--- a/internal/domain/mcqform.go
+++ b/internal/domain/mcqform.go
@@ -57,6 +57,21 @@ var mcqSubmitScreenRE = regexp.MustCompile(`(?im)^\s*ready to submit your answer
 // MultiTabForm).
 var mcqSingleFooterRE = regexp.MustCompile(`(?im)^.*enter to select.*(·|\bnavigate\b).*$`)
 
+// MCQTabHeaderLine returns the LIVE (last) AskUserQuestion tab header row, if
+// the pane carries one. It reports the header ALONE, without the live-form
+// corroboration MultiTabForm also requires, so a caller can tell "no form is
+// rendered" apart from "a form is rendered but did not qualify" — the
+// integration suite needs that split to fail, rather than skip, when detection
+// regresses. Callers deciding whether to send keystrokes must use
+// MultiTabForm; a bare header can be scrollback.
+func MCQTabHeaderLine(pane string) (string, bool) {
+	headers := mcqTabHeaderRE.FindAllString(pane, -1)
+	if len(headers) == 0 {
+		return "", false
+	}
+	return headers[len(headers)-1], true
+}
+
 // ClaudeMCQForm reports whether pane content shows any of Claude Code's
 // on-screen MCQ selection prompts: the multi-tab AskUserQuestion form (a tab
 // header plus a live-form footer, via MultiTabForm) or the single-question

--- a/internal/domain/mcqform.go
+++ b/internal/domain/mcqform.go
@@ -125,11 +125,21 @@ func ParseMCQForm(agentType, pane string) (MCQFormState, bool) {
 // cannot stand in. ClaudeTabForm and ExtractMCQForm scope to the same region.
 //
 // The plain footer is the weakest of the three signals, because an ordinary
-// single-question menu carries it too: a submitted form's header sitting in
-// scrollback ABOVE such a menu would otherwise borrow it and route the menu
-// into the Right-arrow sweep. So that path also requires an unanswered (☐) tab
-// in the header — a submitted form marks every question ☒, and a live form
-// standing on its Submit tab carries the Submit confirmation body instead.
+// single-question menu carries it too: a submitted form's header left in
+// scrollback ABOVE such a menu would otherwise borrow it and route that menu
+// into the Right-arrow sweep — where a digit COMMITS. So that branch needs a
+// second signal that the header describes what is on screen: either a tab that
+// still owes an answer (☐), or checkbox options in the live region, which a
+// plain menu never renders.
+//
+// Both are needed. A ☐ test alone is wrong — verified live (2026-07-20, Claude
+// Code v2.1.215) a one-question form flips its header to ☒ the moment its
+// first checkbox is ticked while still standing and still owed an answer, and
+// demanding ☐ made delivery lose the form it was mid-way through answering.
+// A checkbox test alone is wrong too: a single-select one-question form has no
+// boxes at all. The pairing still can not separate a stale MULTI-SELECT form's
+// header from a live one below it; that residue is left to the delivery-time
+// tab-count and per-tab question checks.
 func MultiTabForm(pane string) (tabs int, ok bool) {
 	headers := mcqTabHeaderRE.FindAllStringIndex(pane, -1)
 	if len(headers) == 0 {
@@ -140,7 +150,8 @@ func MultiTabForm(pane string) (tabs int, ok bool) {
 	header := pane[last[0]:last[1]]
 	switch {
 	case mcqTabFooterRE.MatchString(live), mcqSubmitScreenRE.MatchString(live):
-	case mcqSingleFooterRE.MatchString(live) && strings.Contains(header, "☐"):
+	case mcqSingleFooterRE.MatchString(live) &&
+		(strings.Contains(header, "☐") || MultiSelectTab(ExtractMCQForm(pane))):
 	default:
 		return 0, false
 	}

--- a/internal/domain/mcqform.go
+++ b/internal/domain/mcqform.go
@@ -137,9 +137,22 @@ func ParseMCQForm(agentType, pane string) (MCQFormState, bool) {
 // first checkbox is ticked while still standing and still owed an answer, and
 // demanding ☐ made delivery lose the form it was mid-way through answering.
 // A checkbox test alone is wrong too: a single-select one-question form has no
-// boxes at all. The pairing still can not separate a stale MULTI-SELECT form's
-// header from a live one below it; that residue is left to the delivery-time
-// tab-count and per-tab question checks.
+// boxes at all.
+//
+// Neither signal proves the header is live — an unanswered form's ☐ header
+// left in scrollback above an ordinary menu would satisfy the first. Measured
+// live (2026-07-21, Claude Code v2.1.215) that pairing does not arise on the
+// VISIBLE pane: submitting a form replaces the whole widget with "User
+// answered Claude's questions", ESC-cancelling it with "User declined to
+// answer questions", and in both cases the header line is gone; the plain
+// permission menu that follows carries no header at all. A consuming "recent"
+// read can still hold an older render, so the guarantee that matters is
+// downstream, not here: every path that sends a keystroke re-reads the visible
+// pane and refuses before pressing anything (daemon.sweepFrames checks its
+// first frame BEFORE its first arrow — see
+// TestSweepFailsClosedWhenVisiblePaneIsNotTheForm — and seriesStale,
+// reverifyMultiSelect, mcqdeliver and the frontend confirm path all re-read
+// too). Over-claiming here therefore costs an escalation, never a keystroke.
 func MultiTabForm(pane string) (tabs int, ok bool) {
 	headers := mcqTabHeaderRE.FindAllStringIndex(pane, -1)
 	if len(headers) == 0 {

--- a/internal/domain/mcqform.go
+++ b/internal/domain/mcqform.go
@@ -12,10 +12,11 @@ import (
 //
 //	←  ☐ New name  ☐ Rename depth  ☐ Config compat  ☐ Conciseness  ✔ Submit  →
 //
-// and a footer that names tab navigation ("Tab/Arrow keys to navigate" on
-// older builds, "Tab to switch questions" since Claude Code v2.1.207). The
-// pane shows ONE question at a time; the header is the only signal that more
-// tabs exist.
+// and — when the form has two or more question tabs — a footer that names tab
+// navigation ("Tab/Arrow keys to navigate" on older builds, "Tab to switch
+// questions" since Claude Code v2.1.207). A ONE-question form has nothing to
+// switch to and renders the plain selection footer instead. The pane shows ONE
+// question at a time; the header is the only signal that more tabs exist.
 var (
 	// The tab header marks each question ☐ (unanswered) or ☒ (answered) plus a
 	// final ✔ Submit. ☒ must be counted too — an operator (or the daemon) may
@@ -51,12 +52,14 @@ var mcqSubmitScreenRE = regexp.MustCompile(`(?im)^\s*ready to submit your answer
 // word "navigate"). The tail keeps an agent merely narrating "press enter to
 // select" (fzf-style help text in dev output) from reading as a live prompt.
 // The single-question form carries no tab header, so this footer is the only
-// structural signal it is a live menu.
+// structural signal it is a live menu — and a ONE-question tab form renders
+// this same footer, where it corroborates the tab header instead (see
+// MultiTabForm).
 var mcqSingleFooterRE = regexp.MustCompile(`(?im)^.*enter to select.*(·|\bnavigate\b).*$`)
 
 // ClaudeMCQForm reports whether pane content shows any of Claude Code's
 // on-screen MCQ selection prompts: the multi-tab AskUserQuestion form (a tab
-// header plus its navigation footer, via MultiTabForm) or the single-question
+// header plus a live-form footer, via MultiTabForm) or the single-question
 // form (an "Enter to select … navigate" footer). This is the choice-
 // classification signal for claude, replacing brittle numbered-line matching
 // that any narrated list would trip.
@@ -87,21 +90,46 @@ func ParseMCQForm(agentType, pane string) (MCQFormState, bool) {
 
 // MultiTabForm reports whether pane content shows the multi-tab MCQ variant
 // and how many tabs it has (checkbox entries plus the Submit entry). The tab
-// header is always required; alongside it the pane must carry EITHER the
-// tab-navigation footer (the question tabs) OR the Submit confirmation body
-// (the final tab drops the footer — issue #95). Requiring one of the two
-// keeps a narrated checkbox list from false-positiving. The LAST header
-// occurrence is the live render: a consuming "recent" read can carry earlier
-// renders (or an older form) above the current one.
+// header is always required; alongside it the pane must carry a live-form
+// signal: the tab-navigation footer (a form with two or more question tabs),
+// the Submit confirmation body (the final tab drops the footer — issue #95),
+// or the plain selection footer.
+//
+// That last case is a ONE-question form (`←  ☐ Scope  ✔ Submit  →`): with no
+// sibling question to switch to, Claude omits the tab hint and renders the
+// same footer as the single-question form. Requiring the header plus SOME
+// live-menu footer still keeps a narrated checkbox list from false-positiving,
+// while routing these forms to the verified tab deliverer — treating one as a
+// plain menu sent a blind digit that only toggled its checkbox and never
+// reached the Submit tab, leaving the agent blocked.
+//
+// The LAST header occurrence is the live render: a consuming "recent" read can
+// carry earlier renders (or an older form) above the current one. The
+// corroborating footer is searched BELOW that header only — a live form always
+// renders its footer under its header, so a footer left in scrollback above it
+// cannot stand in. ClaudeTabForm and ExtractMCQForm scope to the same region.
+//
+// The plain footer is the weakest of the three signals, because an ordinary
+// single-question menu carries it too: a submitted form's header sitting in
+// scrollback ABOVE such a menu would otherwise borrow it and route the menu
+// into the Right-arrow sweep. So that path also requires an unanswered (☐) tab
+// in the header — a submitted form marks every question ☒, and a live form
+// standing on its Submit tab carries the Submit confirmation body instead.
 func MultiTabForm(pane string) (tabs int, ok bool) {
-	headers := mcqTabHeaderRE.FindAllString(pane, -1)
+	headers := mcqTabHeaderRE.FindAllStringIndex(pane, -1)
 	if len(headers) == 0 {
 		return 0, false
 	}
-	if !mcqTabFooterRE.MatchString(pane) && !mcqSubmitScreenRE.MatchString(pane) {
+	last := headers[len(headers)-1]
+	live := pane[last[0]:]
+	header := pane[last[0]:last[1]]
+	switch {
+	case mcqTabFooterRE.MatchString(live), mcqSubmitScreenRE.MatchString(live):
+	case mcqSingleFooterRE.MatchString(live) && strings.Contains(header, "☐"):
+	default:
 		return 0, false
 	}
-	n := len(mcqTabEntryRE.FindAllString(headers[len(headers)-1], -1))
+	n := len(mcqTabEntryRE.FindAllString(header, -1))
 	if n < 2 {
 		return 0, false
 	}

--- a/internal/domain/mcqform_test.go
+++ b/internal/domain/mcqform_test.go
@@ -230,6 +230,22 @@ func TestMultiTabFormRejectsStaleHeaderAboveLiveSingleMenu(t *testing.T) {
 	}
 }
 
+func TestMCQTabHeaderLine(t *testing.T) {
+	// The header alone, uncorroborated: it must find the LIVE (last) header,
+	// and report absence rather than an empty match.
+	line, ok := MCQTabHeaderLine(mcqOneQuestionTabFrame)
+	if !ok || !strings.Contains(line, "☐ Scope") {
+		t.Errorf("MCQTabHeaderLine = (%q,%v), want the live header", line, ok)
+	}
+	stale := "←  ☒ Old  ✔ Submit  →\nsubmitted\n\n←  ☐ New  ✔ Submit  →\n"
+	if line, _ := MCQTabHeaderLine(stale); !strings.Contains(line, "☐ New") {
+		t.Errorf("MCQTabHeaderLine = %q, want the LAST header", line)
+	}
+	if _, ok := MCQTabHeaderLine("no form here\n1. Yes\n"); ok {
+		t.Error("MCQTabHeaderLine reported a header on a pane without one")
+	}
+}
+
 func TestMultiTabFormRejectsSelectionFooterAboveTheHeader(t *testing.T) {
 	// The corroborating footer must sit BELOW the live header. A pane whose
 	// only selection footer belongs to an earlier render is not evidence that

--- a/internal/domain/mcqform_test.go
+++ b/internal/domain/mcqform_test.go
@@ -115,6 +115,167 @@ func TestMultiTabFormRejectsNarratedCheckboxes(t *testing.T) {
 	}
 }
 
+// mcqOneQuestionTabFrame is a LIVE capture (2026-07-20), trimmed from
+// internal/classify/testdata/transcripts/choice_claude_mcq_tabs_one_question.txt
+// (the byte-exact transcript — keep the two in step, they are not identical):
+// a Claude AskUserQuestion form with exactly ONE question tab plus Submit,
+// whose options are MULTI-select (`[ ]` checkboxes). With no sibling question
+// to switch to, the footer carries no tab hint — it is the plain
+// single-question footer — so the tab header was ignored and the form was
+// answered as a plain menu: hap sent the digit alone, which only toggled the
+// option's checkbox, and the agent stayed blocked on the Submit tab.
+const mcqOneQuestionTabFrame = `● I'll explore how the task source parser works today.
+────────────────────────────────────────────────────
+Planning: /root/.claude/plans/make-sure-the-task-source.md
+────────────────────────────────────────────────────
+←  ☐ Scope  ✔ Submit  →
+
+Parsing already works — I verified this exact file shape parses cleanly. The real gaps are addressing and context. Which should I fix?
+
+❯ 1. [ ] Hierarchical task IDs (Recommended)
+  ` + "`hap task <agent> done 3.4`" + ` currently errors (Atoi fails), and ` + "`done 3`" + ` silently marks positional item #3 — the wrong task.
+  2. [ ] Section heading context
+  Add a ` + "`{task_section}`" + ` template placeholder carrying the item's nearest ` + "`##`" + ` heading.
+  3. [ ] Regression test only
+  Add this exact tasks.md as a testdata fixture with a test pinning parse/numbering/next-task behavior.
+  4. [ ] Show IDs in ` + "`hap task list`" + `
+  Render the positional number alongside the file's own ID.
+  5. [ ] Type something
+     Submit
+────────────────────────────────────────────────────
+  6. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel
+`
+
+// mcqOneQuestionSingleChoiceTabFrame is the other one-question shape: the same
+// header + plain footer, but SINGLE-select options (no `[ ]` checkboxes). Both
+// shapes must detect identically — the checkbox only decides how a tab is
+// answered (toggle vs. pick), never whether the form is a tab form.
+const mcqOneQuestionSingleChoiceTabFrame = `● Ready for your call.
+────────────────────────────────────────────────────
+←  ☐ Rollout  ✔ Submit  →
+
+Which rollout order should I take?
+
+❯ 1. Ship the parser fix first (Recommended)
+     Smallest diff, unblocks the rest.
+  2. Ship the CLI change first
+     Bigger blast radius.
+  3. Type something
+     Submit
+────────────────────────────────────────────────────
+  4. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel
+`
+
+func TestMultiTabFormDetectsOneQuestionTabForm(t *testing.T) {
+	// A one-question form renders the tab header but the plain selection
+	// footer. Both select kinds must resolve to their 2 tabs (question +
+	// Submit) so the verified tab deliverer — not blind digit delivery —
+	// answers them.
+	cases := []struct {
+		name        string
+		frame       string
+		multiSelect bool
+	}{
+		{"multi-choice (checkbox options)", mcqOneQuestionTabFrame, true},
+		{"single-choice (plain options)", mcqOneQuestionSingleChoiceTabFrame, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tabs, ok := MultiTabForm(tc.frame)
+			if !ok || tabs != 2 {
+				t.Fatalf("MultiTabForm = (%d,%v), want (2,true)", tabs, ok)
+			}
+			// The select kind drives delivery: a checkbox tab toggles with the
+			// digit and needs Enter to commit, a plain tab commits on the digit.
+			if got := MultiSelectTab(ExtractMCQForm(tc.frame)); got != tc.multiSelect {
+				t.Errorf("MultiSelectTab = %v, want %v", got, tc.multiSelect)
+			}
+		})
+	}
+}
+
+func TestClaudeTabFormReadsOneQuestionSingleChoiceTabForm(t *testing.T) {
+	state, ok := ClaudeTabForm(mcqOneQuestionSingleChoiceTabFrame)
+	if !ok {
+		t.Fatal("ClaudeTabForm(one-question single-choice form) = not a form")
+	}
+	if state.Kind != MCQClaudeTabs || state.AnswerCount != 2 {
+		t.Errorf("kind/answers = %q/%d, want %q/2", state.Kind, state.AnswerCount, MCQClaudeTabs)
+	}
+	if state.Unanswered != 1 {
+		t.Errorf("Unanswered = %d, want 1", state.Unanswered)
+	}
+	if state.SelectedOption != "1" {
+		t.Errorf("SelectedOption = %q, want \"1\"", state.SelectedOption)
+	}
+	if !strings.Contains(state.Question, "Which rollout order") {
+		t.Errorf("Question = %q, want the tab's question line", state.Question)
+	}
+}
+
+func TestMultiTabFormRejectsStaleHeaderAboveLiveSingleMenu(t *testing.T) {
+	// A consuming "recent" read can carry a finished form's header in
+	// scrollback above the live plain menu. The header must not borrow that
+	// menu's footer: doing so would route an ordinary single-question menu
+	// into the Right-arrow sweep and type arrows into it.
+	pane := "←  ☒ Scope  ✔ Submit  →\n\nAnswers submitted.\n\n" +
+		"How do you want to submit?\n❯ 1. All 4\n  2. Hold\n\n" +
+		"Enter to select · ↑/↓ to navigate · Esc to cancel\n"
+	if tabs, ok := MultiTabForm(pane); ok {
+		t.Fatalf("stale header above a live single menu must not detect as multi-tab, got %d tabs", tabs)
+	}
+}
+
+func TestMultiTabFormRejectsSelectionFooterAboveTheHeader(t *testing.T) {
+	// The corroborating footer must sit BELOW the live header. A pane whose
+	// only selection footer belongs to an earlier render is not evidence that
+	// the trailing header is live.
+	pane := "How do you want to submit?\n❯ 1. All 4\n  2. Hold\n\n" +
+		"Enter to select · ↑/↓ to navigate · Esc to cancel\n\n" +
+		"←  ☐ Scope  ✔ Submit  →\n"
+	if tabs, ok := MultiTabForm(pane); ok {
+		t.Fatalf("footer above the header must not corroborate it, got %d tabs", tabs)
+	}
+}
+
+func TestParseMCQFormRoutesOneQuestionTabFormToTabs(t *testing.T) {
+	state, ok := ParseMCQForm("claude", mcqOneQuestionTabFrame)
+	if !ok {
+		t.Fatal("ParseMCQForm(claude, one-question tab form) = not a form")
+	}
+	if state.Kind != MCQClaudeTabs {
+		t.Errorf("Kind = %q, want %q", state.Kind, MCQClaudeTabs)
+	}
+	if state.AnswerCount != 2 {
+		t.Errorf("AnswerCount = %d, want 2", state.AnswerCount)
+	}
+}
+
+func TestClaudeTabFormReadsOneQuestionTabForm(t *testing.T) {
+	state, ok := ClaudeTabForm(mcqOneQuestionTabFrame)
+	if !ok {
+		t.Fatal("ClaudeTabForm(one-question tab form) = not a form")
+	}
+	if state.Unanswered != 1 {
+		t.Errorf("Unanswered = %d, want 1", state.Unanswered)
+	}
+	if state.SelectedOption != "1" {
+		t.Errorf("SelectedOption = %q, want \"1\"", state.SelectedOption)
+	}
+	if !strings.Contains(state.Question, "Which should I fix?") {
+		t.Errorf("Question = %q, want the tab's question line", state.Question)
+	}
+	// The options carry `[ ]` checkboxes: the digit toggles, Enter commits.
+	// Delivery must treat this tab as multi-select.
+	if !MultiSelectTab(ExtractMCQForm(mcqOneQuestionTabFrame)) {
+		t.Error("MultiSelectTab = false, want true for a checkbox question")
+	}
+}
+
 func TestClaudeMCQForm(t *testing.T) {
 	singleQuestion := "How do you want to submit?\n❯ 1. All 4\n  2. Hold\n\nEnter to select · ↑/↓ to navigate · Esc to cancel\n"
 	cases := []struct {

--- a/internal/domain/mcqform_test.go
+++ b/internal/domain/mcqform_test.go
@@ -217,16 +217,24 @@ func TestClaudeTabFormReadsOneQuestionSingleChoiceTabForm(t *testing.T) {
 	}
 }
 
-func TestMultiTabFormRejectsStaleHeaderAboveLiveSingleMenu(t *testing.T) {
-	// A consuming "recent" read can carry a finished form's header in
-	// scrollback above the live plain menu. The header must not borrow that
-	// menu's footer: doing so would route an ordinary single-question menu
-	// into the Right-arrow sweep and type arrows into it.
-	pane := "←  ☒ Scope  ✔ Submit  →\n\nAnswers submitted.\n\n" +
-		"How do you want to submit?\n❯ 1. All 4\n  2. Hold\n\n" +
+func TestMultiTabFormDetectsAnsweredOneQuestionForm(t *testing.T) {
+	// Verified live (2026-07-20, Claude Code v2.1.215): ticking the first
+	// checkbox flips the header to ☒ while the form is STILL STANDING and
+	// still owed an answer, and a checked box renders `[✔]`. Delivery re-reads
+	// between keystrokes, so losing the form here stranded it mid-answer with
+	// one box ticked.
+	answered := "←  ☒ Shape  ✔ Submit  →\n\nWhich shapes do you like?\n\n" +
+		"❯ 1. [✔] Circle\n  2. [ ] Square\n  3. [ ] Triangle\n\n" +
 		"Enter to select · ↑/↓ to navigate · Esc to cancel\n"
-	if tabs, ok := MultiTabForm(pane); ok {
-		t.Fatalf("stale header above a live single menu must not detect as multi-tab, got %d tabs", tabs)
+	tabs, ok := MultiTabForm(answered)
+	if !ok || tabs != 2 {
+		t.Fatalf("MultiTabForm(mid-answer one-question form) = (%d,%v), want (2,true)", tabs, ok)
+	}
+	if !MultiSelectTab(ExtractMCQForm(answered)) {
+		t.Error("a `[✔]`-checked option must still read as multi-select")
+	}
+	if states := OptionCheckStates(ExtractMCQForm(answered)); !states["1"] || states["2"] {
+		t.Errorf("check states = %v, want option 1 checked", states)
 	}
 }
 
@@ -243,6 +251,19 @@ func TestMCQTabHeaderLine(t *testing.T) {
 	}
 	if _, ok := MCQTabHeaderLine("no form here\n1. Yes\n"); ok {
 		t.Error("MCQTabHeaderLine reported a header on a pane without one")
+	}
+}
+
+func TestMultiTabFormRejectsStaleHeaderAboveLivePlainMenu(t *testing.T) {
+	// A finished form's header can sit in scrollback above a live plain menu.
+	// Borrowing that menu's footer would route it into the Right-arrow sweep,
+	// where a digit COMMITS — so the header needs its own live-form evidence:
+	// no unanswered ☐, and the region below it shows no checkbox options.
+	pane := "←  ☒ Scope  ✔ Submit  →\n\nAnswers submitted.\n\n" +
+		"How do you want to submit?\n❯ 1. All 4\n  2. Hold\n\n" +
+		"Enter to select · ↑/↓ to navigate · Esc to cancel\n"
+	if tabs, ok := MultiTabForm(pane); ok {
+		t.Fatalf("stale header above a live plain menu must not detect as multi-tab, got %d tabs", tabs)
 	}
 }
 

--- a/internal/domain/menu.go
+++ b/internal/domain/menu.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -11,11 +12,18 @@ import (
 // menu that starts at 0 or skips a number is honored, not re-indexed).
 var numberedOptionRE = regexp.MustCompile(`(?m)^[ \t]*(?:[❯›>][ \t]*)?(?:(\d+)[.)]|\[(\d+)\])[ \t]+(\S.*?)[ \t]*$`)
 
-// checkboxLabelRE matches the leading `[ ]` / `[x]` checkbox marker that a
-// Claude multi-SELECT question renders in front of each toggleable option
-// (e.g. "1. [ ] Auto-sends" parses to label "[ ] Auto-sends"). The capture
-// group is the box contents: a space (unchecked) or x/X (checked).
-var checkboxLabelRE = regexp.MustCompile(`^\[([ xX])\]`)
+// checkboxLabelRE matches the leading checkbox marker that a Claude
+// multi-SELECT question renders in front of each toggleable option (e.g.
+// "1. [ ] Auto-sends" parses to label "[ ] Auto-sends"). The capture group is
+// the box contents: a space (unchecked) or a check mark (checked).
+//
+// Claude Code renders a CHECKED box as `[✔]` (verified live 2026-07-20,
+// v2.1.215) — matching only `[x]` made every checked option invisible to
+// OptionCheckStates, so the "this tab already carries a selection" gate saw an
+// operator's selection as an empty tab and the toggle verification could not
+// see its own keystroke land. `[x]`/`[X]`/`[✓]` stay accepted: cheap, and the
+// glyph is a rendering detail that has already changed once.
+var checkboxLabelRE = regexp.MustCompile(`^\[([ xX✔✓])\]`)
 
 // NumberedOption pairs a menu option's displayed number with its label.
 type NumberedOption struct {
@@ -44,11 +52,57 @@ func OptionCheckStates(frame string) map[string]bool {
 	states := make(map[string]bool)
 	for _, o := range ParseNumberedOptions(frame) {
 		if m := checkboxLabelRE.FindStringSubmatch(o.Label); m != nil {
-			states[o.Number] = m[1] == "x" || m[1] == "X"
+			states[o.Number] = m[1] != " " // any mark means checked
 		}
 	}
 	return states
 }
+
+// CheckedOutside lists, in option order, the digits a multi-select frame shows
+// as CHECKED that are not in chosen. It is the shared "checked ⊆ chosen" rule
+// for answering a checkbox tab: the boxes an answer means to set are safe to
+// find already set (its own earlier, unverified attempt put them there, and
+// re-pressing one would CLEAR it), while any other checked box belongs to
+// someone else and is never hap's to clear.
+//
+// Pass a nil/empty chosen to demand an all-unchecked frame — the capture-time
+// baseline, where no answer has been decided yet.
+func CheckedOutside(frame string, chosen []string) []string {
+	want := make(map[string]bool, len(chosen))
+	for _, digit := range chosen {
+		want[digit] = true
+	}
+	var foreign []string
+	for digit, checked := range OptionCheckStates(frame) {
+		if checked && !want[digit] {
+			foreign = append(foreign, digit)
+		}
+	}
+	sort.Strings(foreign)
+	return foreign
+}
+
+// ClearCheckboxMarks rewrites a form's selection state back to untouched, so
+// two renders of the same form compare equal regardless of what a partial
+// delivery toggled. That means the option boxes AND the tab header's answered
+// marks: ticking a checkbox flips its tab from ☐ to ☒ while the form still
+// stands (verified live 2026-07-20), so normalizing the boxes alone would
+// still compare unequal and the comparison would reject the very
+// partially-delivered form it exists to accept.
+//
+// Only those marks change — option text, the ✔ Submit entry, and every other
+// line are untouched — and CheckedOutside is what governs which boxes may be
+// set, so nothing that decides safety is hidden by the comparison.
+func ClearCheckboxMarks(content string) string {
+	content = checkedOptionRE.ReplaceAllString(content, "${1}[ ]")
+	return mcqTabHeaderRE.ReplaceAllStringFunc(content, func(header string) string {
+		return strings.ReplaceAll(header, "☒", "☐")
+	})
+}
+
+// checkedOptionRE matches a numbered option line's CHECKED box, capturing
+// everything up to it so the replacement keeps the caret, number and spacing.
+var checkedOptionRE = regexp.MustCompile(`(?m)^([ \t]*(?:[❯›>][ \t]*)?(?:\d+[.)]|\[\d+\])[ \t]+)\[[xX✔✓]\]`)
 
 // ParseNumberedOptions extracts the numbered options from pane content in
 // display order (e.g. "❯ 1. Yes\n  2. No" → [{"1","Yes"},{"2","No"}]).

--- a/internal/domain/menu.go
+++ b/internal/domain/menu.go
@@ -65,8 +65,11 @@ func OptionCheckStates(frame string) map[string]bool {
 // re-pressing one would CLEAR it), while any other checked box belongs to
 // someone else and is never hap's to clear.
 //
-// Pass a nil/empty chosen to demand an all-unchecked frame — the capture-time
-// baseline, where no answer has been decided yet.
+// Pass a nil/empty chosen to demand an all-unchecked frame: every checked box
+// then reads as foreign. Callers with no decided answer (capture) do not ask
+// this question at all — with nothing to compare against, refusing would
+// strand hap's own half-delivered forms; they record and let the delivery-time
+// call decide.
 func CheckedOutside(frame string, chosen []string) []string {
 	want := make(map[string]bool, len(chosen))
 	for _, digit := range chosen {

--- a/internal/domain/menu_test.go
+++ b/internal/domain/menu_test.go
@@ -1,6 +1,9 @@
 package domain
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 const claudeApproval = "Bash(go test ./...)\n\nDo you want to proceed?\n❯ 1. Yes\n  2. No, and tell the agent what to do differently\n"
 
@@ -28,6 +31,71 @@ func TestOptionCheckStates(t *testing.T) {
 	// A frame without checkboxes yields no states.
 	if got := OptionCheckStates(claudeApproval); len(got) != 0 {
 		t.Errorf("non-checkbox options must yield no check states, got %+v", got)
+	}
+}
+
+func TestCheckedOutside(t *testing.T) {
+	// multiSelectFrame has option 2 checked.
+	if got := CheckedOutside(multiSelectFrame, nil); len(got) != 1 || got[0] != "2" {
+		t.Errorf("CheckedOutside(nil) = %v, want [2]: with no answer decided, any checked box is foreign", got)
+	}
+	if got := CheckedOutside(multiSelectFrame, []string{"2"}); len(got) != 0 {
+		t.Errorf("CheckedOutside(chosen 2) = %v, want none: this answer's own box is not foreign", got)
+	}
+	if got := CheckedOutside(multiSelectFrame, []string{"1", "2"}); len(got) != 0 {
+		t.Errorf("CheckedOutside(chosen 1,2) = %v, want none", got)
+	}
+	if got := CheckedOutside(multiSelectFrame, []string{"1", "3"}); len(got) != 1 || got[0] != "2" {
+		t.Errorf("CheckedOutside(chosen 1,3) = %v, want [2]", got)
+	}
+	if got := CheckedOutside(claudeApproval, nil); len(got) != 0 {
+		t.Errorf("a frame without checkboxes has nothing checked, got %v", got)
+	}
+}
+
+func TestClearCheckboxMarks(t *testing.T) {
+	cleared := ClearCheckboxMarks(multiSelectFrame)
+	for digit, checked := range OptionCheckStates(cleared) {
+		if checked {
+			t.Errorf("option %s is still checked after clearing: %q", digit, cleared)
+		}
+	}
+	// Only the box changes: the option set and their labels survive.
+	if len(OptionCheckStates(cleared)) != len(OptionCheckStates(multiSelectFrame)) {
+		t.Error("clearing the marks must not drop options")
+	}
+	if before, after := ParseNumberedOptions(multiSelectFrame), ParseNumberedOptions(cleared); len(before) != len(after) {
+		t.Fatalf("option count changed: %d -> %d", len(before), len(after))
+	}
+	// Two renders of one form differing only in what a partial delivery
+	// toggled must compare equal.
+	if ClearCheckboxMarks(multiSelectFrame) != ClearCheckboxMarks(cleared) {
+		t.Error("normalized renders of the same form must compare equal")
+	}
+	// Prose is untouched — only numbered option lines carry a box.
+	const prose = "the runbook says [x] means done\n"
+	if got := ClearCheckboxMarks(prose); got != prose {
+		t.Errorf("ClearCheckboxMarks rewrote non-option text: %q", got)
+	}
+
+	// The tab header's answered marks normalize too: ticking a box flips its
+	// tab ☐ -> ☒ while the form still stands, so leaving the header alone
+	// would keep two renders of one form comparing unequal — the exact case
+	// the comparison exists to accept.
+	const untouched = "←  ☐ Shape  ✔ Submit  →\n\nWhich?\n\n❯ 1. [ ] Circle\n  2. [ ] Square\n"
+	const midAnswer = "←  ☒ Shape  ✔ Submit  →\n\nWhich?\n\n❯ 1. [✔] Circle\n  2. [ ] Square\n"
+	if ClearCheckboxMarks(untouched) != ClearCheckboxMarks(midAnswer) {
+		t.Errorf("a partially-answered render must normalize to its untouched form:\n%q\n%q",
+			ClearCheckboxMarks(untouched), ClearCheckboxMarks(midAnswer))
+	}
+	// The Submit entry is not a question mark and must survive.
+	if !strings.Contains(ClearCheckboxMarks(midAnswer), "✔ Submit") {
+		t.Error("the ✔ Submit entry must not be normalized away")
+	}
+	// A genuinely different form still compares unequal.
+	const other = "←  ☐ Shape  ✔ Submit  →\n\nWhich?\n\n❯ 1. [ ] Circle\n  2. [ ] Hexagon\n"
+	if ClearCheckboxMarks(untouched) == ClearCheckboxMarks(other) {
+		t.Error("different option text must not normalize to equal")
 	}
 }
 

--- a/internal/domain/signature.go
+++ b/internal/domain/signature.go
@@ -159,6 +159,15 @@ func NormalizedOptionSet(options []string) string {
 	opts := make([]string, len(options))
 	for i, o := range options {
 		o = strings.ToLower(strings.TrimSpace(o))
+		// A multi-select option's checkbox is VOLATILE state, not part of the
+		// question's identity: "[✔] Auto-sends" is the same option as
+		// "[ ] Auto-sends", just already ticked. Folding it to the unchecked
+		// spelling is what lets a form carrying a half-delivered answer still
+		// resolve to the rule learned for the untouched form — and folding TO
+		// "[ ]" (rather than dropping the box) keeps every signature already
+		// learned from an untouched form byte-identical, so nothing needs a
+		// migration.
+		o = checkboxLabelRE.ReplaceAllString(o, "[ ]")
 		o = strings.ReplaceAll(o, `\`, `\\`)
 		opts[i] = strings.ReplaceAll(o, ";", `\;`)
 	}

--- a/internal/domain/signature_test.go
+++ b/internal/domain/signature_test.go
@@ -101,6 +101,35 @@ func TestSignatureOptionSets(t *testing.T) {
 	}
 }
 
+func TestSignatureFoldsCheckboxState(t *testing.T) {
+	mk := func(opts ...string) Situation {
+		return Situation{Type: SituationChoice, AgentType: "claude",
+			Content: "Pick the stats to show", Options: opts}
+	}
+	// A ticked box is volatile state, not a different question: a form
+	// carrying a half-delivered answer must resolve to the rule learned for
+	// the untouched one.
+	unchecked := ComputeSignature(mk("[ ] Auto-sends", "[ ] Escalations"))
+	for _, mark := range []string{"[✔]", "[x]", "[X]", "[✓]"} {
+		got := ComputeSignature(mk(mark+" Auto-sends", "[ ] Escalations"))
+		if got.Signature != unchecked.Signature {
+			t.Errorf("%s drifted the signature: %q vs %q", mark, got.Salient, unchecked.Salient)
+		}
+	}
+	// It must not over-collapse: only the BOX is folded, never the label.
+	if near := ComputeSignature(mk("[✔] Auto-send", "[ ] Escalations")); near.Signature == unchecked.Signature {
+		t.Errorf("labels differing outside the box must not collapse: %q", near.Salient)
+	}
+	// The fold rewrites a checked box to the UNCHECKED spelling rather than
+	// dropping it, so every signature learned before this existed stays
+	// byte-identical — no stored row needs a migration. This pins the salient
+	// an untouched form produces; changing it invalidates every learned rule.
+	if want := "options:[ ] auto-sends;[ ] escalations"; unchecked.Salient != want {
+		t.Errorf("untouched salient = %q, want %q (a change here invalidates stored rules)",
+			unchecked.Salient, want)
+	}
+}
+
 func TestOverMaskingFloor(t *testing.T) {
 	// FR-003a acceptance: a prompt reduced almost entirely to placeholders
 	// is unclassifiable rather than matched on a degenerate signature.

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -57,7 +57,7 @@ func (a *App) deliverTabSeries(ctx context.Context, ks ports.KeystrokeSender, au
 		return a.deliverCodexSeries(ctx, ks, audit, groups)
 	}
 	agentID := audit.AgentID
-	multi, err := a.verifyTabBaseline(ctx, ks, agentID, len(groups))
+	multi, err := a.verifyTabBaseline(ctx, ks, agentID, groups)
 	if err != nil {
 		return err
 	}
@@ -212,10 +212,17 @@ func (a *App) resetCodexForm(ctx context.Context, ks ports.KeystrokeSender,
 
 // verifyTabBaseline walks the form read-only (reset, then one Right per tab)
 // and returns each tab's multi-select flag, erroring if the form drifted or a
-// multi-select tab already carries a selection. It toggles nothing, so the
-// caller can refuse before any answer keystroke — an all-or-nothing baseline
-// check that mirrors the daemon's capture-time refusal.
-func (a *App) verifyTabBaseline(ctx context.Context, ks ports.KeystrokeSender, agentID string, tabCount int) ([]bool, error) {
+// multi-select tab carries a selection this answer did not choose. It toggles
+// nothing, so the caller can refuse before any answer keystroke — the same
+// "checked ⊆ chosen" rule the daemon applies before delivery, and that
+// mcqdeliver enforces again at the keystroke: a box THIS answer chose may
+// already be set by an earlier attempt that died before submitting (pressing
+// it again would clear it), while anything else on the tab is the operator's
+// and is never cleared.
+func (a *App) verifyTabBaseline(ctx context.Context, ks ports.KeystrokeSender,
+	agentID string, groups [][]string) ([]bool, error) {
+
+	tabCount := len(groups)
 	if err := a.resetForm(ctx, ks, agentID); err != nil {
 		return nil, err
 	}
@@ -234,12 +241,14 @@ func (a *App) verifyTabBaseline(ctx context.Context, ks ports.KeystrokeSender, a
 		if tabs, ok := domain.MultiTabForm(frame); !ok || tabs != tabCount {
 			return nil, fmt.Errorf("the pane no longer shows the %d-tab form at tab %d; answer in the pane", tabCount, tab+1)
 		}
-		if domain.MultiSelectTab(frame) {
+		// Scoped to the live render — scrollback above it can carry an earlier,
+		// already-toggled render of this or another form.
+		liveFrame := domain.ExtractMCQForm(frame)
+		if domain.MultiSelectTab(liveFrame) {
 			multi[tab] = true
-			for digit, checked := range domain.OptionCheckStates(frame) {
-				if checked {
-					return nil, fmt.Errorf("tab %d already has option %s selected; answer in the pane", tab+1, digit)
-				}
+			if foreign := domain.CheckedOutside(liveFrame, groups[tab]); len(foreign) > 0 {
+				return nil, fmt.Errorf("tab %d already has option(s) %s selected, which this answer did not choose; answer in the pane",
+					tab+1, strings.Join(foreign, ", "))
 			}
 		}
 	}

--- a/internal/mcqdeliver/mcqdeliver.go
+++ b/internal/mcqdeliver/mcqdeliver.go
@@ -8,6 +8,7 @@ package mcqdeliver
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -77,20 +78,7 @@ func (c Config) answerTab(ctx context.Context, i, n int, group []string, multi b
 	// AskUserQuestion contract, so a multi-select tab is always the plain
 	// digit-toggling rendering and keeps its original protocol.
 	if multi {
-		for j, digit := range group {
-			if j > 0 {
-				time.Sleep(c.KeyDelay)
-			}
-			if err := c.Keys.SendKey(ctx, c.PaneID, digit); err != nil {
-				return fmt.Errorf("tab %d/%d toggle %s: %w", i+1, n, digit, err)
-			}
-		}
-		time.Sleep(c.KeyDelay)
-		if err := c.Keys.SendKey(ctx, c.PaneID, domain.MCQAdvanceKey); err != nil {
-			return fmt.Errorf("tab %d/%d advance: %w", i+1, n, err)
-		}
-		time.Sleep(c.KeyDelay)
-		return nil
+		return c.toggleTab(ctx, i, n, group)
 	}
 
 	if len(group) != 1 {
@@ -188,12 +176,161 @@ func (c Config) answerTab(ctx context.Context, i, n int, group []string, multi b
 	return nil
 }
 
+// toggleTab answers a MULTI-SELECT tab: it presses only the checkboxes that
+// are not already in the wanted state, verifies the resulting selection, and
+// only then advances.
+//
+// A digit TOGGLES here — it does not select. Pressing one blind is therefore
+// not idempotent: a retry over a pane that already carries the previous
+// attempt's toggles CLEARS them, and the advance then commits an empty answer
+// while every keystroke looks delivered. That is what stranded a live agent
+// (audit #41-#44, 2026-07-20): two delivery attempts, the second undoing the
+// first, the screen ending up exactly as it started.
+//
+// So the baseline is read first and drives the presses. It also fails CLOSED on
+// a selection this answer did not ask for: someone else's checkbox is not ours
+// to clear, and re-pressing it to "fix" the state would be the same blind
+// toggle. The frontend refuses such a tab at capture time; this is the same
+// rule enforced at the keystroke, where the state can have moved on.
+func (c Config) toggleTab(ctx context.Context, i, n int, group []string) error {
+	want := make(map[string]bool, len(group))
+	for _, digit := range group {
+		want[digit] = true
+	}
+
+	before, frame, ok, err := c.stateFrame(ctx)
+	if err != nil {
+		return fmt.Errorf("tab %d/%d pre-toggle read: %w", i+1, n, err)
+	}
+	if !ok {
+		return fmt.Errorf("tab %d/%d is no longer showing a multi-tab form", i+1, n)
+	}
+	if before.AnswerCount != n {
+		return fmt.Errorf("the form now has %d tabs, not the %d this answer was built for",
+			before.AnswerCount, n)
+	}
+	states := domain.OptionCheckStates(frame)
+	if len(states) == 0 {
+		return fmt.Errorf("tab %d/%d shows no checkbox options; it is not multi-select", i+1, n)
+	}
+	for _, digit := range group {
+		if _, offered := states[digit]; !offered {
+			return fmt.Errorf("tab %d/%d does not offer option %s", i+1, n, digit)
+		}
+	}
+	if foreign := domain.CheckedOutside(frame, group); len(foreign) > 0 {
+		return fmt.Errorf("tab %d/%d already has option(s) %s selected, which this answer did not choose; not clearing them",
+			i+1, n, strings.Join(foreign, ", "))
+	}
+
+	var pressed []string
+	for _, digit := range group {
+		if states[digit] {
+			continue // already checked — pressing it again would clear it
+		}
+		if len(pressed) > 0 {
+			time.Sleep(c.KeyDelay)
+		}
+		if err := c.Keys.SendKey(ctx, c.PaneID, digit); err != nil {
+			return fmt.Errorf("tab %d/%d toggle %s: %w%s", i+1, n, digit, err, residue(pressed))
+		}
+		pressed = append(pressed, digit)
+	}
+
+	if len(pressed) > 0 {
+		time.Sleep(c.KeyDelay)
+		after, frame, ok, err := c.stateFrame(ctx)
+		if err != nil {
+			return fmt.Errorf("tab %d/%d post-toggle read: %w%s", i+1, n, err, residue(pressed))
+		}
+		if !ok {
+			return fmt.Errorf("the form disappeared while toggling tab %d/%d%s", i+1, n, residue(pressed))
+		}
+		// A multi-select digit must not move off the tab; if it did, the tab is
+		// not the toggling rendering this branch assumes.
+		if after.Question != before.Question {
+			return fmt.Errorf("tab %d/%d moved to another question while toggling (%q -> %q)%s",
+				i+1, n, before.Question, after.Question, residue(pressed))
+		}
+		// Verify against the SAME option set that was read before the presses.
+		// Ranging over the post-read alone would fail OPEN: an option the
+		// re-render drops (a scrolling list, a truncated read window) would
+		// simply not be checked, and delivery would advance having pressed a
+		// toggle it never verified — the silent no-op this branch exists to
+		// prevent.
+		got := domain.OptionCheckStates(frame)
+		if len(got) != len(states) {
+			return fmt.Errorf("tab %d/%d now shows %d checkbox options, not the %d read before toggling; can not verify the selection%s",
+				i+1, n, len(got), len(states), residue(pressed))
+		}
+		for digit := range states {
+			checked, readable := got[digit]
+			if !readable {
+				return fmt.Errorf("tab %d/%d option %s is no longer readable after toggling; can not verify the selection%s",
+					i+1, n, digit, residue(pressed))
+			}
+			if checked != want[digit] {
+				return fmt.Errorf("tab %d/%d option %s is %s after toggling; the keystrokes did not land as chosen%s",
+					i+1, n, digit, checkedWord(checked), residue(pressed))
+			}
+		}
+	}
+
+	if err := c.Keys.SendKey(ctx, c.PaneID, domain.MCQAdvanceKey); err != nil {
+		return fmt.Errorf("tab %d/%d advance: %w%s", i+1, n, err, residue(pressed))
+	}
+	time.Sleep(c.KeyDelay)
+	// The Submit tab is never multi-select, so a multi-select tab always has a
+	// tab after it: the form must still be standing, on a different question.
+	moved, _, ok, err := c.stateFrame(ctx)
+	if err != nil {
+		return fmt.Errorf("tab %d/%d post-advance read: %w%s", i+1, n, err, residue(pressed))
+	}
+	if !ok {
+		return fmt.Errorf("the form disappeared after advancing past tab %d/%d%s", i+1, n, residue(pressed))
+	}
+	if moved.Question == before.Question {
+		return fmt.Errorf("tab %d/%d did not advance; it still shows %q%s",
+			i+1, n, before.Question, residue(pressed))
+	}
+	return nil
+}
+
+// residue names the boxes this delivery pressed, for errors raised after a
+// press went out. It deliberately does NOT claim they are still checked: the
+// verification that just failed may have proved the opposite (a tab that
+// swallowed its digits), and a capture that finds ANY selection escalates the
+// whole form, so the operator needs to know where to look, not a guess at the
+// state.
+func residue(pressed []string) string {
+	if len(pressed) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("; option(s) %s were pressed — check the pane before retrying",
+		strings.Join(pressed, ", "))
+}
+
+func checkedWord(checked bool) string {
+	if checked {
+		return "checked"
+	}
+	return "unchecked"
+}
+
 // state reads the pane and parses the live Claude multi-tab form.
 func (c Config) state(ctx context.Context) (domain.MCQFormState, bool, error) {
+	st, _, ok, err := c.stateFrame(ctx)
+	return st, ok, err
+}
+
+// stateFrame is state plus the live form region, for callers that must inspect
+// the options themselves (checkbox states). The region is scoped to the live
+// render, so scrollback above it can not supply stale checkboxes.
+func (c Config) stateFrame(ctx context.Context) (domain.MCQFormState, string, bool, error) {
 	pane, err := c.Read(ctx, c.PaneID, c.ReadLines)
 	if err != nil {
-		return domain.MCQFormState{}, false, err
+		return domain.MCQFormState{}, "", false, err
 	}
 	st, ok := domain.ClaudeTabForm(pane)
-	return st, ok, nil
+	return st, domain.ExtractMCQForm(pane), ok, nil
 }

--- a/internal/mcqdeliver/mcqdeliver_test.go
+++ b/internal/mcqdeliver/mcqdeliver_test.go
@@ -52,6 +52,27 @@ type fakeForm struct {
 	// submitStuck models a Submit tab that will not submit, so the fail-closed
 	// guard for that state is reachable.
 	submitStuck bool
+	// toggleDeaf models a multi-select tab that swallows its digits (a build
+	// with a different checkbox binding), so the toggle verification is
+	// reachable. Without it, a delivery that changes nothing on screen would
+	// still advance and submit an empty answer.
+	toggleDeaf bool
+	// hideAfterToggle drops the trailing options from a multi-select tab once
+	// it has been toggled, modelling a re-render whose option list scrolls (or
+	// a read window that truncates it). Verification must refuse rather than
+	// skip the options it can no longer see.
+	hideAfterToggle int
+	// stuckTab keeps the advance key from leaving the multi-select tab.
+	stuckTab bool
+}
+
+// check pre-checks a multi-select tab's option, modelling a pane that already
+// carries an earlier delivery attempt's toggles.
+func (f *fakeForm) check(tab, option int) {
+	if f.checked[tab] == nil {
+		f.checked[tab] = map[int]bool{}
+	}
+	f.checked[tab][option] = true
 }
 
 func newFakeForm(binding digitBinding, questions, options int) *fakeForm {
@@ -88,6 +109,9 @@ func (f *fakeForm) SendKey(_ context.Context, _, key string) error {
 			f.caret = 1
 		}
 	case "right":
+		if f.stuckTab && !f.onSubmitTab() && f.multiTabs[f.current] {
+			break // the advance does not leave a multi-select tab
+		}
 		if f.current < f.questions {
 			f.current++
 			f.caret = 1
@@ -102,6 +126,9 @@ func (f *fakeForm) SendKey(_ context.Context, _, key string) error {
 		// A multi-select tab's digit toggles a checkbox: no caret move, no
 		// commit, no advance.
 		if !f.onSubmitTab() && f.multiTabs[f.current] {
+			if f.toggleDeaf {
+				break
+			}
 			if f.checked[f.current] == nil {
 				f.checked[f.current] = map[int]bool{}
 			}
@@ -167,6 +194,12 @@ func (f *fakeForm) Read(_ context.Context, _ string, _ int) (string, error) {
 			continue
 		}
 		labels[i] = fmt.Sprintf("Option %d", i+1)
+	}
+	// A re-render that scrolls (or a truncated read) can show fewer options
+	// than the pre-toggle read did.
+	if f.hideAfterToggle > 0 && f.multiTabs[f.current] && len(f.checked[f.current]) > 0 &&
+		f.hideAfterToggle < len(labels) {
+		labels = labels[:f.hideAfterToggle]
 	}
 	b.WriteString(f.renderOptions(labels))
 	b.WriteString("\n" + f.footer())
@@ -321,6 +354,186 @@ func TestClaudeTabsTogglesAndAdvancesMultiSelectTab(t *testing.T) {
 	}
 	if !form.submitted {
 		t.Error("the form should still have been submitted after the multi-select tab")
+	}
+}
+
+// The retry regression (audit #41-#44, 2026-07-20): a digit TOGGLES a checkbox,
+// so a second delivery attempt over a pane that already carries the first
+// attempt's toggles must not press it again — that would CLEAR the selection
+// and submit an empty answer while every keystroke looked delivered. A retry
+// has to be idempotent: press nothing, verify, advance.
+func TestClaudeTabsDoesNotRetoggleAlreadyChosenOptions(t *testing.T) {
+	form := newFakeForm(digitCommits, 1, 3)
+	form.multiTabs[0] = true
+	form.check(0, 1) // the previous attempt already checked option 1
+	form.check(0, 3)
+
+	err := ClaudeTabs(context.Background(), form.config(),
+		[][]string{{"1", "3"}, {"1"}}, []bool{true, false})
+	if err != nil {
+		t.Fatalf("ClaudeTabs returned error: %v", err)
+	}
+	tail := form.keys[MCQResetKeysForTest:]
+	want := []string{"right", "1"} // no toggles: advance, then Submit
+	if strings.Join(tail, ",") != strings.Join(want, ",") {
+		t.Errorf("keys = %v, want %v (the chosen options must not be re-pressed)", tail, want)
+	}
+	if got := form.checked[0]; !got[1] || !got[3] {
+		t.Errorf("checked = %v, want options 1 and 3 still checked", got)
+	}
+	if !form.submitted {
+		t.Error("the retry should have submitted the form")
+	}
+}
+
+// A partially-delivered tab (the first attempt died between its two toggles)
+// must be completed, not restarted: press only the missing option.
+func TestClaudeTabsPressesOnlyTheMissingOptions(t *testing.T) {
+	form := newFakeForm(digitCommits, 1, 3)
+	form.multiTabs[0] = true
+	form.check(0, 1)
+
+	err := ClaudeTabs(context.Background(), form.config(),
+		[][]string{{"1", "3"}, {"1"}}, []bool{true, false})
+	if err != nil {
+		t.Fatalf("ClaudeTabs returned error: %v", err)
+	}
+	tail := form.keys[MCQResetKeysForTest:]
+	want := []string{"3", "right", "1"}
+	if strings.Join(tail, ",") != strings.Join(want, ",") {
+		t.Errorf("keys = %v, want %v", tail, want)
+	}
+	if got := form.checked[0]; !got[1] || !got[3] {
+		t.Errorf("checked = %v, want options 1 and 3 checked", got)
+	}
+	if !form.submitted {
+		t.Error("the form should have been submitted")
+	}
+}
+
+// A checkbox this answer did not choose is someone else's selection. Clearing
+// it would be the same blind toggle, so delivery refuses before pressing
+// anything — the frontend's capture-time rule, enforced at the keystroke.
+func TestClaudeTabsRefusesForeignSelection(t *testing.T) {
+	form := newFakeForm(digitCommits, 1, 3)
+	form.multiTabs[0] = true
+	form.check(0, 2)
+
+	err := ClaudeTabs(context.Background(), form.config(),
+		[][]string{{"1"}, {"1"}}, []bool{true, false})
+	if err == nil {
+		t.Fatal("ClaudeTabs accepted a tab carrying a selection it did not choose")
+	}
+	if !strings.Contains(err.Error(), "option(s) 2") {
+		t.Errorf("error = %v, want it to name the foreign selection", err)
+	}
+	if tail := form.keys[MCQResetKeysForTest:]; len(tail) != 0 {
+		t.Errorf("keys = %v, want none: the refusal must precede every keystroke", tail)
+	}
+	if form.submitted {
+		t.Error("the form must not have been submitted")
+	}
+}
+
+// Toggles that do not land must fail closed. Without this the advance would
+// move on and Submit would commit an EMPTY answer — delivered, audited, wrong.
+func TestClaudeTabsRefusesWhenTogglesDoNotLand(t *testing.T) {
+	form := newFakeForm(digitCommits, 1, 3)
+	form.multiTabs[0] = true
+	form.toggleDeaf = true
+
+	err := ClaudeTabs(context.Background(), form.config(),
+		[][]string{{"1"}, {"1"}}, []bool{true, false})
+	if err == nil {
+		t.Fatal("ClaudeTabs reported success though no checkbox changed")
+	}
+	if !strings.Contains(err.Error(), "did not land") {
+		t.Errorf("error = %v, want it to name the unlanded toggle", err)
+	}
+	if form.submitted {
+		t.Error("an unverified toggle must never reach Submit")
+	}
+}
+
+// Verification must fail CLOSED when an option stops being readable: skipping
+// the options the post-toggle re-render no longer shows would advance having
+// pressed a toggle nothing confirmed.
+func TestClaudeTabsRefusesWhenOptionsBecomeUnreadable(t *testing.T) {
+	form := newFakeForm(digitCommits, 1, 3)
+	form.multiTabs[0] = true
+	form.hideAfterToggle = 1 // only option 1 survives the re-render
+
+	err := ClaudeTabs(context.Background(), form.config(),
+		[][]string{{"1"}, {"1"}}, []bool{true, false})
+	if err == nil {
+		t.Fatal("ClaudeTabs accepted a selection it could not fully verify")
+	}
+	if !strings.Contains(err.Error(), "can not verify") {
+		t.Errorf("error = %v, want it to say the selection could not be verified", err)
+	}
+	if !strings.Contains(err.Error(), "option(s) 1 were pressed") {
+		t.Errorf("error = %v, want it to name the keys it already sent", err)
+	}
+	if form.submitted {
+		t.Error("an unverified selection must never reach Submit")
+	}
+}
+
+// The advance is verified too: a multi-select tab that does not move on would
+// otherwise have its next tab's answer typed into it.
+func TestClaudeTabsRefusesWhenMultiSelectTabDoesNotAdvance(t *testing.T) {
+	form := newFakeForm(digitCommits, 2, 3)
+	form.multiTabs[0] = true
+	form.stuckTab = true
+
+	err := ClaudeTabs(context.Background(), form.config(),
+		[][]string{{"1"}, {"1"}, {"1"}}, []bool{true, false, false})
+	if err == nil {
+		t.Fatal("ClaudeTabs reported success though the tab never advanced")
+	}
+	if !strings.Contains(err.Error(), "did not advance") {
+		t.Errorf("error = %v, want it to name the stuck advance", err)
+	}
+	if form.submitted {
+		t.Error("the form must not have been submitted")
+	}
+}
+
+// An answer naming an option the tab does not offer is refused before any
+// keystroke — a digit outside the option set would toggle nothing, or worse.
+func TestClaudeTabsRefusesUnofferedMultiSelectOption(t *testing.T) {
+	form := newFakeForm(digitCommits, 1, 2)
+	form.multiTabs[0] = true
+
+	err := ClaudeTabs(context.Background(), form.config(),
+		[][]string{{"3"}, {"1"}}, []bool{true, false})
+	if err == nil {
+		t.Fatal("ClaudeTabs accepted an option the tab does not offer")
+	}
+	if !strings.Contains(err.Error(), "does not offer option 3") {
+		t.Errorf("error = %v, want it to name the missing option", err)
+	}
+	if tail := form.keys[MCQResetKeysForTest:]; len(tail) != 0 {
+		t.Errorf("keys = %v, want none before the refusal", tail)
+	}
+}
+
+// A tab flagged multi-select whose options carry no checkboxes is not the
+// rendering this branch answers; toggling it blind would press digits into a
+// single-select menu.
+func TestClaudeTabsRefusesMultiSelectFlagOnPlainTab(t *testing.T) {
+	form := newFakeForm(digitCommits, 1, 3) // no multiTabs entry: plain options
+
+	err := ClaudeTabs(context.Background(), form.config(),
+		[][]string{{"1"}, {"1"}}, []bool{true, false})
+	if err == nil {
+		t.Fatal("ClaudeTabs toggled a tab that shows no checkboxes")
+	}
+	if !strings.Contains(err.Error(), "not multi-select") {
+		t.Errorf("error = %v, want it to report the missing checkboxes", err)
+	}
+	if tail := form.keys[MCQResetKeysForTest:]; len(tail) != 0 {
+		t.Errorf("keys = %v, want none before the refusal", tail)
 	}
 }
 

--- a/internal/mcqdeliver/mcqdeliver_test.go
+++ b/internal/mcqdeliver/mcqdeliver_test.go
@@ -169,8 +169,20 @@ func (f *fakeForm) Read(_ context.Context, _ string, _ int) (string, error) {
 		labels[i] = fmt.Sprintf("Option %d", i+1)
 	}
 	b.WriteString(f.renderOptions(labels))
-	b.WriteString("\nEnter to select · ↑/↓ to navigate · Tab to switch questions · Esc to cancel\n")
+	b.WriteString("\n" + f.footer())
 	return b.String(), nil
+}
+
+// footer mirrors the real render: the tab-switch hint appears only when there
+// is a sibling question to switch to. A ONE-question form (one tab plus the
+// generated Submit tab) shows the same plain footer as a single-question menu,
+// which is what made it read as a plain menu and get answered with a blind
+// digit that only toggled its checkbox.
+func (f *fakeForm) footer() string {
+	if f.questions > 1 {
+		return "Enter to select · ↑/↓ to navigate · Tab to switch questions · Esc to cancel\n"
+	}
+	return "Enter to select · ↑/↓ to navigate · Esc to cancel\n"
 }
 
 func (f *fakeForm) renderOptions(labels []string) string {

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -173,6 +173,10 @@ type DaemonStore interface {
 	RecordDecision(ctx context.Context, d domain.DecisionRecord) (int64, error)
 	AppendAudit(ctx context.Context, a domain.AuditRecord) (int64, error)
 	UpdateAuditStatus(ctx context.Context, auditID int64, status string) error
+	// EscalateAudit demotes a row to escalated WITH the reason and a
+	// confirmable suggestion (a bare status flip leaves the operator an
+	// unexplained, unconfirmable queue entry).
+	EscalateAudit(ctx context.Context, auditID int64, rationale, suggestion string) error
 	UpdateAgentRate(ctx context.Context, r domain.AgentRate) error
 	UpsertErrorRetry(ctx context.Context, e domain.ErrorRetry) error
 	ResetErrorRetry(ctx context.Context, errorSignature string) error

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -410,6 +410,20 @@ func (s *Store) UpdateAuditStatus(ctx context.Context, auditID int64, status str
 	})
 }
 
+// EscalateAudit flips an audit row to escalated and records WHY, plus the
+// suggestion the operator can confirm. A row demoted from "auto" still carries
+// the rule's own rationale and (because the autonomous path had nothing to
+// suggest) an empty suggestion, so flipping the status alone puts an entry in
+// the operator's queue that neither explains itself nor can be confirmed.
+func (s *Store) EscalateAudit(ctx context.Context, auditID int64, rationale, suggestion string) error {
+	return s.tx(ctx, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx,
+			`UPDATE audit_log SET status = 'escalated', rationale = ?, suggestion = ? WHERE id = ?`,
+			rationale, suggestion, auditID)
+		return err
+	})
+}
+
 // UpdateAgentRate stores the per-agent runaway counters (daemon-owned).
 func (s *Store) UpdateAgentRate(ctx context.Context, r domain.AgentRate) error {
 	return s.tx(ctx, func(tx *sql.Tx) error {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -495,6 +495,136 @@ func TestRealClaudeConsult(t *testing.T) {
 	t.Fatalf("claude did not proceed after confirm; the menu digit did not land.\npane:\n%s", pane1)
 }
 
+// formStanding reports whether an AskUserQuestion form is on screen and still
+// owes an answer: a tab header whose live row carries an unanswered ☐. It reads
+// the header through the PRODUCTION matcher (domain.MCQTabHeaderLine) so a
+// header-syntax drift can not silently disagree with the parser; the only thing
+// it deliberately bypasses is MultiTabForm's live-form corroboration, which is
+// the regression surface the test below must be able to fail on rather than
+// skip past. Answered/submitted forms mark every question ☒, so a header left
+// rendered in the transcript does not read as standing.
+func formStanding(content string) bool {
+	line, ok := domain.MCQTabHeaderLine(content)
+	return ok && strings.Contains(line, "☐")
+}
+
+// TestRealClaudeOneQuestionMultiSelectMCQDelivery drives a REAL Claude
+// AskUserQuestion form with exactly ONE multi-select question and asserts the
+// plugin toggles the choice, advances to Submit, and commits it.
+//
+// This is the shape that shipped broken: a one-question form has no sibling
+// question to switch to, so Claude renders the plain selection footer instead
+// of the tab-navigation one. MultiTabForm required that footer, so the form
+// read as a plain menu and the daemon sent a bare digit — which on a checkbox
+// question only TOGGLES the option. Nothing was committed, the Submit tab was
+// never reached, and the agent stayed blocked while the audit row said the
+// action was delivered (audit #41-#44, 2026-07-20; the retry toggled it back
+// off, so the screen looked untouched).
+//
+// The unit suite pins the parser and the deliverer against a fake form; only
+// this proves the real render still matches. Skips (never fails) when it cannot
+// elicit the form.
+func TestRealClaudeOneQuestionMultiSelectMCQDelivery(t *testing.T) {
+	if os.Getenv("HAP_ITEST_CLAUDE") != "1" {
+		t.Skip("set HAP_ITEST_CLAUDE=1 to run the real Claude one-question MCQ test")
+	}
+	requireHerdr(t)
+	if _, err := exec.LookPath("claude"); err != nil {
+		t.Skipf("claude CLI not found: %v", err)
+	}
+
+	cli := herdr.NewCLI()
+	pane := startClaudeAgent(t, cli, t.TempDir())
+
+	// ONE question (so the footer carries no tab hint) whose options are
+	// multi-select (so they render `[ ]` checkboxes a digit toggles).
+	prompt := "Use the AskUserQuestion tool right now and nothing else. Ask exactly ONE " +
+		"question, header 'Shape', question 'Which shapes do you like?', and allow MULTIPLE " +
+		"answers to be selected (multiSelect true) with options Circle, Square and Triangle. " +
+		"Do not give the options a preview."
+
+	var form string
+	ctx := t.Context()
+	for attempt := 0; attempt < 2 && form == ""; attempt++ {
+		if attempt > 0 {
+			// Never type a prompt into a standing menu: its characters would be
+			// consumed as selection keys and could commit a random answer.
+			if content, err := cli.ReadPaneVisible(ctx, pane, 60); err == nil && formStanding(content) {
+				t.Skip("claude rendered a form that is not one-question multi-select; nothing to assert")
+			}
+		}
+		if err := cli.Send(ctx, pane, prompt); err != nil {
+			t.Fatalf("send prompt to claude: %v", err)
+		}
+		tryHerdr("pane", "send-keys", pane, "enter")
+		deadline := time.Now().Add(60 * time.Second)
+		for time.Now().Before(deadline) {
+			content, err := cli.ReadPaneVisible(ctx, pane, 60)
+			if err == nil && formStanding(content) &&
+				domain.MultiSelectTab(domain.ExtractMCQForm(content)) {
+				form = content
+				break
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+	if form == "" {
+		t.Skip("claude did not render a one-question multi-select form; nothing to assert")
+	}
+
+	// The form IS on screen (header + checkbox options). From here a detection
+	// miss is a failure, not a skip: that is precisely the bug.
+	tabs, ok := domain.MultiTabForm(form)
+	if !ok {
+		t.Fatalf("a one-question form is standing but MultiTabForm did not detect it; "+
+			"it would be answered as a plain menu.\npane:\n%s", form)
+	}
+	if tabs != 2 {
+		t.Fatalf("tabs = %d, want 2 (one question + Submit).\npane:\n%s", tabs, form)
+	}
+	state, ok := domain.ClaudeTabForm(form)
+	if !ok || state.Unanswered != 1 {
+		t.Fatalf("ClaudeTabForm = %+v (ok=%v), want one unanswered tab.\npane:\n%s", state, ok, form)
+	}
+	t.Logf("one-question multi-select form is up: %d tabs, question %q", tabs, state.Question)
+
+	// Toggle option 1 on the question tab, then Submit — what the daemon
+	// delivers for the answer series "1 1" with tab 1 marked multi-select.
+	err := mcqdeliver.ClaudeTabs(ctx, mcqdeliver.Config{
+		Keys: cli, Read: cli.ReadPaneVisible, PaneID: pane,
+		ReadLines: 60, KeyDelay: 250 * time.Millisecond,
+	}, [][]string{{"1"}, {"1"}}, []bool{true, false})
+	if err != nil {
+		t.Fatalf("delivering the one-question multi-select form failed: %v", err)
+	}
+
+	// The form must be COMMITTED, not merely toggled: nothing still owes an
+	// answer, AND the chosen option shows up in claude's answer. The second
+	// half is what pins the toggle — the multi-select branch presses digits
+	// without verifying them, so a delivery that toggled nothing (or toggled
+	// on and back off, the audit #41-#44 behaviour) would still reach Submit,
+	// commit an empty answer, and clear the form.
+	var last string
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		content, err := cli.ReadPaneVisible(ctx, pane, 60)
+		if err != nil {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		last = content
+		if !formStanding(content) && strings.Contains(content, "Circle") {
+			return // committed — the toggled option is in the answer
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if formStanding(last) {
+		t.Fatalf("the one-question form is still standing; the answer did not commit.\npane:\n%s", last)
+	}
+	t.Fatalf("the form was submitted but the chosen option never appears in the answer; "+
+		"the digit did not toggle it.\npane:\n%s", last)
+}
+
 // TestRealClaudePreviewMCQDelivery drives a REAL Claude AskUserQuestion form
 // whose options carry PREVIEWS, and asserts the plugin actually answers it.
 //


### PR DESCRIPTION
## The bug

A Claude AskUserQuestion form with **one** question tab renders the tab header
but *not* the tab-navigation footer — with no sibling question to switch to it
shows the same plain footer as a single-question menu:

```
←  ☐ Scope  ✔ Submit  →

Which should I fix?

❯ 1. [ ] Hierarchical task IDs (Recommended)
  ...
Enter to select · ↑/↓ to navigate · Esc to cancel
```

`domain.MultiTabForm` required the tab footer (or the "Ready to submit your
answers?" body), so this read as a plain menu. The daemon delivered a blind
digit instead of routing to `internal/mcqdeliver`; on a checkbox question the
digit only *toggles* the option, so nothing was committed and the Submit tab
was never reached. Observed live (audit 41–44): two `auto` sends, both
`delivery_failed [still_blocked]`, the retry toggling the checkbox back off —
the screen looked untouched while the agent stayed blocked.

## The fix

Accept the plain selection footer as a third corroborating signal, so these
forms classify as `MCQClaudeTabs` and are answered by the deliverer that
verifies every keystroke landed.

Two guards keep the widened predicate from claiming panes that are not showing
a live form:

- the corroborating footer is searched **below the live header** only, so a
  footer left in scrollback above it cannot stand in;
- the plain-footer path additionally requires an **unanswered (☐) tab**, so a
  submitted form's header in scrollback cannot borrow the footer of an ordinary
  menu rendered underneath it and route that menu into the Right-arrow sweep.

## Tests

- The live capture as a classify transcript fixture + golden line (no existing
  classification drifted).
- Both one-question shapes at the domain layer: multi-choice (checkbox options)
  and single-choice (plain options) — same detection, different select kind.
- Two stale-render negatives (header above a live menu; footer above the header).
- `internal/mcqdeliver`'s fake form now renders the real one-question footer, so
  the fix is pinned where it actually failed: reverting it fails three delivery
  tests with `tab 1/2 is no longer showing a multi-tab form`.

Full suite green (`go test -tags "vectors cpu" ./... -count=1`); `internal/daemon`
run 3× consecutively to rule out its known startup-reconcile flake.