### PR TITLE
#1 feat: address checklist tasks by the id the document gives them

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -501,10 +501,28 @@ enable_auto_send_task_when_idle = true
 by the agent whose task source it is, or with `--path <file>` for any checklist
 (and for workspace-scoped sources, which aren't addressable by agent name).
 
-tasks are numbered by their **position in the file** (1..N, counting checked and
-unchecked alike). the number never changes with a status filter — `done 3`
-always means the third item in the file. numbers *do* shift after `add`/`remove`,
-so every mutating command re-prints the renumbered list. the checkbox is shown
+**addressing a task.** `list` numbers items by their **position in the file**
+(`#1..#N`, counting checked and unchecked alike, never varying with a status
+filter). a checklist may also number its own tasks in the item text — either the
+`1. `/`2. ` prefix hap's generated lists use, or hand-authored section ids like
+`3.4 create the public link`. what you pass to `get`/`start`/`done`/`undone`/
+`update`/`remove`/`send` is resolved like this:
+
+| you pass | it means |
+|---|---|
+| `3.4` | the item whose id is `3.4` |
+| `3` | the item whose id is `3` |
+| `3` — no item has that id | position 3, **unless** the item sitting there has an id of its own — then it is refused, to be spelled `#3` |
+| `#3` | position 3, always |
+
+that ordering matters because the id is what an agent reads in its prompt: told
+to do "3.4 create the public link", it reports `done 3.4`, which must not tick
+off whatever happens to sit at position 3. the fallback keeps unlabeled items
+reachable — a generated list plus one `task add` is exactly that mix. note that
+`#3` needs quoting in a shell (`'#3'`), which otherwise strips it as a comment.
+positions *do* shift after
+`add`/`remove`, so every mutating command re-prints the renumbered list. the
+checkbox is shown
 verbatim, so an in-progress `[-]` item (what the generated-task flow writes for
 the task an agent is actively working) renders as `[-]` and is *not* counted as
 pending (only truly-unchecked `[ ]` items are).
@@ -512,7 +530,8 @@ pending (only truly-unchecked `[ ]` items are).
 ```bash
 hap task backend-dev list                 # all items, with status + number
 hap task backend-dev list --status pending  # or: done | all (default all)
-hap task backend-dev get 3                 # show one item
+hap task backend-dev get 3                 # show one item (by id, or #3 by position)
+hap task backend-dev done 3.4              # tick off the item the list numbers 3.4
 hap task backend-dev add "wire up retries" # append a new unchecked item
 hap task backend-dev start 2               # mark item 2 in-progress ([-])
 hap task backend-dev done 2                # tick item 2 off ([x])
@@ -573,7 +592,7 @@ agent to manage its list through the `hap task` CLI with its own name pre-filled
 in every command (and a `--path` fallback for sources that aren't name-addressable):
 
 ```
-Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks: `hap task {agent_name} list` to view them, `hap task {agent_name} start <n>` to mark one in-progress when you begin working on it, and `hap task {agent_name} done <n>` to mark it complete as you go (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`).
+Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks: `hap task {agent_name} list` to view them, `hap task {agent_name} start <n>` to mark one in-progress when you begin working on it, and `hap task {agent_name} done <n>` to mark it complete as you go (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`). `<n>` is the task's own id when the list numbers its tasks (e.g. `done 3.4`); otherwise its position in the list, which `#3` always addresses.
 ```
 
 - `{next_task_content}` — the text of the next unchecked item (or `"none"` when the list is complete)

--- a/README.md
+++ b/README.md
@@ -449,7 +449,9 @@ error = "#ff5f5f"
 #    start <n>` to mark one in-progress when you begin working on it, and
 #    `hap task {agent_name} done <n>` to mark it complete as you go (if that
 #    name isn't recognized, use `--path {task_list_path}` in place of
-#    `{agent_name}`)."
+#    `{agent_name}`). `<n>` is the task's own id when the list numbers its
+#    tasks (e.g. `done 3.4`); otherwise its position in the list, which `#3`
+#    always addresses."
 # When every item is checked off, the templated prompt is never sent: the
 # plugin escalates a confirmable @noop suggestion ("No more pending tasks")
 # instead — unless BOTH llm.task_generate_command and

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -1010,11 +1011,13 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 // task manages the checklist ITEMS inside a task source's file (as opposed to
 // task-source, which manages the source config). The target is either a
 // positional <agent> (resolved to its configured task source) or --path <file>
-// to operate on any checklist directly. Tasks are addressed by their 1-based
-// position among all items in the file; every mutating op re-prints the
-// renumbered list so the caller always sees fresh numbers.
+// to operate on any checklist directly. Tasks are addressed by the id the list
+// gives them ("3.4"), or by their 1-based position among all items in the file
+// ("#3", and a bare number in a list with no ids) — see domain.ResolveTaskRef.
+// Every mutating op re-prints the renumbered list so the caller always sees
+// fresh numbers.
 func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
-	usage := "usage: task [<agent> | --path <file>] list [--status all|pending|done] | get <n> | add <text> | start <n> | done <n> | undone <n> | update <n> <text> | remove <n> | send <n> [--yes]"
+	usage := "usage: task [<agent> | --path <file>] list [--status all|pending|done] | get <n> | add <text> | start <n> | done <n> | undone <n> | update <n> <text> | remove <n> | send <n> [--yes]\n<n> is a task id from the list (e.g. 3.4), or #<position>"
 	agent, path, args, err := taskTarget(args)
 	if err != nil {
 		return err
@@ -1030,7 +1033,7 @@ func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) 
 	case "list", "ls":
 		return taskList(app, out, agent, path, rest)
 	case "get", "show":
-		idx, err := taskIndexArg(rest)
+		idx, err := taskIndexArg(app, agent, path, rest)
 		if err != nil {
 			return err
 		}
@@ -1062,7 +1065,7 @@ func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) 
 		if len(rest) < 2 {
 			return fmt.Errorf("usage: task %s update <n> <text>", taskTargetLabel(agent, path))
 		}
-		idx, err := taskIndexArg(rest[:1])
+		idx, err := taskIndexArg(app, agent, path, rest[:1])
 		if err != nil {
 			return err
 		}
@@ -1075,7 +1078,7 @@ func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) 
 		printTaskList(out, items, "all")
 		return nil
 	case "remove", "rm", "delete", "del":
-		idx, err := taskIndexArg(rest)
+		idx, err := taskIndexArg(app, agent, path, rest)
 		if err != nil {
 			return err
 		}
@@ -1114,7 +1117,7 @@ func taskSend(ctx context.Context, app *frontend.App, out io.Writer, agent, path
 	if agent == "" {
 		return fmt.Errorf("task send needs an agent name (a --path list has no agent to send to)")
 	}
-	idx, err := taskIndexArg(idxArgs)
+	idx, err := taskIndexArg(app, agent, path, idxArgs)
 	if err != nil {
 		return err
 	}
@@ -1232,22 +1235,32 @@ func taskTargetLabel(agent, path string) string {
 	return agent
 }
 
-func taskIndexArg(args []string) (int, error) {
+// taskRefRE is the syntactic shape of a task reference: a task id ("3.4",
+// optionally with the trailing separator an agent may copy along) or a
+// position ("#3"). It only screens out typos before any I/O — whether the
+// reference names a real task is domain.ResolveTaskRef's call.
+var taskRefRE = regexp.MustCompile(`^(?:#\d+|\d+(?:\.\d+)*[.):]?)$`)
+
+// taskIndexArg resolves the first argument into an item's 1-based position.
+// The argument is a task REFERENCE, not necessarily a position: a checklist
+// that numbers its own tasks ("3.4 Implement …") is addressed by those ids,
+// which is what an agent reads in its prompt; "#3" always means position 3.
+// domain.ResolveTaskRef owns the rules — this only supplies the list.
+func taskIndexArg(app *frontend.App, agent, path string, args []string) (int, error) {
 	if len(args) == 0 {
-		return 0, fmt.Errorf("a task number is required (see: task ... list)")
+		return 0, domain.ErrTaskRefRequired
 	}
-	n, err := strconv.Atoi(args[0])
-	if err != nil {
-		return 0, fmt.Errorf("invalid task number %q", args[0])
+	// Reject a syntactically impossible reference before reading anything:
+	// resolution needs the checklist, so without this `done xyz` on a missing
+	// file reports the file error instead of the typo that caused it.
+	if !taskRefRE.MatchString(strings.TrimSpace(args[0])) {
+		return 0, fmt.Errorf("invalid task number %q — pass a task id from the list (e.g. 3.4) or a position (e.g. '#3')", args[0])
 	}
-	if n < 1 {
-		return 0, fmt.Errorf("task number must be 1 or greater, got %d", n)
-	}
-	return n, nil
+	return app.ResolveTaskRef(agent, path, args[0])
 }
 
 func taskToggle(app *frontend.App, out io.Writer, agent, path string, rest []string, done bool) error {
-	idx, err := taskIndexArg(rest)
+	idx, err := taskIndexArg(app, agent, path, rest)
 	if err != nil {
 		return err
 	}
@@ -1267,7 +1280,7 @@ func taskToggle(app *frontend.App, out io.Writer, agent, path string, rest []str
 // taskStart marks item n with the [-] in-progress marker — the op the default
 // next-task template tells an agent to run when it begins working a task.
 func taskStart(app *frontend.App, out io.Writer, agent, path string, rest []string) error {
-	idx, err := taskIndexArg(rest)
+	idx, err := taskIndexArg(app, agent, path, rest)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1033,11 +1033,9 @@ func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) 
 	case "list", "ls":
 		return taskList(app, out, agent, path, rest)
 	case "get", "show":
-		idx, err := taskIndexArg(app, agent, path, rest)
-		if err != nil {
-			return err
-		}
-		it, err := app.GetTask(agent, path, idx)
+		// Resolution already read the item — no second read (and no window
+		// for the two to disagree) just to display it.
+		it, err := taskItemArg(app, agent, path, rest)
 		if err != nil {
 			return err
 		}
@@ -1065,12 +1063,13 @@ func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) 
 		if len(rest) < 2 {
 			return fmt.Errorf("usage: task %s update <n> <text>", taskTargetLabel(agent, path))
 		}
-		idx, err := taskIndexArg(app, agent, path, rest[:1])
+		it, err := taskItemArg(app, agent, path, rest[:1])
 		if err != nil {
 			return err
 		}
+		idx := it.Index
 		text := strings.TrimSpace(strings.Join(rest[1:], " "))
-		items, err := app.EditTask(agent, path, idx, text)
+		items, err := app.EditTask(agent, path, idx, text, it.Text)
 		if err != nil {
 			return err
 		}
@@ -1078,11 +1077,12 @@ func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) 
 		printTaskList(out, items, "all")
 		return nil
 	case "remove", "rm", "delete", "del":
-		idx, err := taskIndexArg(app, agent, path, rest)
+		it, err := taskItemArg(app, agent, path, rest)
 		if err != nil {
 			return err
 		}
-		items, err := app.DeleteTask(agent, path, idx)
+		idx := it.Index
+		items, err := app.DeleteTask(agent, path, idx, it.Text)
 		if err != nil {
 			return err
 		}
@@ -1117,14 +1117,11 @@ func taskSend(ctx context.Context, app *frontend.App, out io.Writer, agent, path
 	if agent == "" {
 		return fmt.Errorf("task send needs an agent name (a --path list has no agent to send to)")
 	}
-	idx, err := taskIndexArg(app, agent, path, idxArgs)
+	it, err := taskItemArg(app, agent, path, idxArgs)
 	if err != nil {
 		return err
 	}
-	it, err := app.GetTask(agent, path, idx)
-	if err != nil {
-		return err
-	}
+	idx := it.Index
 	if it.Done {
 		return fmt.Errorf("task #%d is %q — only a pending [ ] task can be sent", idx, it.Mark)
 	}
@@ -1241,30 +1238,36 @@ func taskTargetLabel(agent, path string) string {
 // reference names a real task is domain.ResolveTaskRef's call.
 var taskRefRE = regexp.MustCompile(`^(?:#\d+|\d+(?:\.\d+)*[.):]?)$`)
 
-// taskIndexArg resolves the first argument into an item's 1-based position.
-// The argument is a task REFERENCE, not necessarily a position: a checklist
-// that numbers its own tasks ("3.4 Implement …") is addressed by those ids,
-// which is what an agent reads in its prompt; "#3" always means position 3.
-// domain.ResolveTaskRef owns the rules — this only supplies the list.
-func taskIndexArg(app *frontend.App, agent, path string, args []string) (int, error) {
+// taskItemArg resolves the first argument into the item it names. The argument
+// is a task REFERENCE, not necessarily a position: a checklist that numbers its
+// own tasks ("3.4 Implement …") is addressed by those ids, which is what an
+// agent reads in its prompt; "#3" always means position 3. domain.ResolveTaskRef
+// owns the rules — this only supplies the list.
+//
+// Every MUTATING caller must pass the returned Text back as the expectText
+// guard: resolution happens before the file lock, so a concurrent add/remove
+// would otherwise shift positions under the resolved index and rewrite the
+// wrong line.
+func taskItemArg(app *frontend.App, agent, path string, args []string) (domain.ChecklistItem, error) {
 	if len(args) == 0 {
-		return 0, domain.ErrTaskRefRequired
+		return domain.ChecklistItem{}, domain.ErrTaskRefRequired
 	}
 	// Reject a syntactically impossible reference before reading anything:
 	// resolution needs the checklist, so without this `done xyz` on a missing
 	// file reports the file error instead of the typo that caused it.
 	if !taskRefRE.MatchString(strings.TrimSpace(args[0])) {
-		return 0, fmt.Errorf("invalid task number %q — pass a task id from the list (e.g. 3.4) or a position (e.g. '#3')", args[0])
+		return domain.ChecklistItem{}, fmt.Errorf("invalid task number %q — pass a task id from the list (e.g. 3.4) or a position (e.g. '#3')", args[0])
 	}
 	return app.ResolveTaskRef(agent, path, args[0])
 }
 
 func taskToggle(app *frontend.App, out io.Writer, agent, path string, rest []string, done bool) error {
-	idx, err := taskIndexArg(app, agent, path, rest)
+	it, err := taskItemArg(app, agent, path, rest)
 	if err != nil {
 		return err
 	}
-	items, err := app.SetTaskDone(agent, path, idx, done)
+	idx := it.Index
+	items, err := app.SetTaskDone(agent, path, idx, done, it.Text)
 	if err != nil {
 		return err
 	}
@@ -1280,11 +1283,12 @@ func taskToggle(app *frontend.App, out io.Writer, agent, path string, rest []str
 // taskStart marks item n with the [-] in-progress marker — the op the default
 // next-task template tells an agent to run when it begins working a task.
 func taskStart(app *frontend.App, out io.Writer, agent, path string, rest []string) error {
-	idx, err := taskIndexArg(app, agent, path, rest)
+	it, err := taskItemArg(app, agent, path, rest)
 	if err != nil {
 		return err
 	}
-	items, err := app.MarkTaskInProgress(agent, path, idx)
+	idx := it.Index
+	items, err := app.MarkTaskInProgress(agent, path, idx, it.Text)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1353,3 +1353,142 @@ func TestTaskSourceListShowsAutoSendFlag(t *testing.T) {
 		t.Errorf("a source with the flag must show it: %s", lines[1])
 	}
 }
+
+// TestTaskAddressedByDocumentID covers a hand-authored checklist that numbers
+// its own tasks with section-scoped ids ("3.4"). The id is what an agent reads
+// in its prompt, so `done 3.4` must tick THAT item — and a bare "3", which
+// used to mean position 3, must resolve by id too now that the list has ids.
+func TestTaskAddressedByDocumentID(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, strings.Join([]string{
+		"# Tasks: Project Public Link",
+		"",
+		"## 1. Platform",
+		"",
+		"- [ ] 1.1 sign a batch of revisions",
+		"- [ ] 1.2 clamp the expiry",
+		"",
+		"## 3. Worker",
+		"",
+		"- [ ] 3.4 create the public link",
+		"- [ ] 3.5 revoke the public link",
+		"",
+	}, "\n"))
+
+	out, err := run(t, app, "task", "--path", path, "done", "3.4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "task #3 marked done") {
+		t.Errorf("done 3.4 must report the resolved position #3, got:\n%s", out)
+	}
+
+	// "#2" is always positional, whatever the ids say.
+	if _, err := run(t, app, "task", "--path", path, "start", "#2"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "- [x] 3.4 create the public link") {
+		t.Errorf("item 3.4 should be done:\n%s", got)
+	}
+	if !strings.Contains(got, "- [-] 1.2 clamp the expiry") {
+		t.Errorf("#2 should be in-progress:\n%s", got)
+	}
+	if !strings.Contains(got, "- [ ] 1.1 sign a batch of revisions") || !strings.Contains(got, "- [ ] 3.5 revoke the public link") {
+		t.Errorf("untouched items must stay pending:\n%s", got)
+	}
+	if !strings.Contains(got, "## 3. Worker") {
+		t.Errorf("headings must survive a mutation:\n%s", got)
+	}
+
+	// A number matching no id is refused rather than silently retargeted onto
+	// that position — position 2 must still be the [-] set above.
+	if _, err := run(t, app, "task", "--path", path, "done", "2"); err == nil {
+		t.Error("a bare number matching no task id must error in an id-numbered list")
+	}
+	data, _ = os.ReadFile(path)
+	if !strings.Contains(string(data), "- [-] 1.2 clamp the expiry") {
+		t.Errorf("the refused command must not have mutated the file:\n%s", string(data))
+	}
+}
+
+// TestTaskBareNumberStaysPositional pins the backward-compatible path: a list
+// with no task ids keeps addressing items by position.
+func TestTaskBareNumberStaysPositional(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] alpha\n- [ ] beta\n- [ ] gamma\n")
+
+	if _, err := run(t, app, "task", "--path", path, "done", "2"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "- [ ] alpha\n- [x] beta\n- [ ] gamma\n"; string(data) != want {
+		t.Errorf("file after done 2:\n got %q\nwant %q", string(data), want)
+	}
+}
+
+// TestTaskGeneratedIDsAddressable: the "N. " prefix RenderGeneratedTaskList
+// writes is a task id too, so `done 2` on a generated list resolves by id —
+// which for an unreordered generated list is also its position.
+func TestTaskGeneratedIDsAddressable(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "# Tasks for backend\n\n- [x] 1. first\n- [ ] 2. second\n- [ ] 3. third\n")
+
+	if _, err := run(t, app, "task", "--path", path, "done", "3"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "- [x] 3. third") || !strings.Contains(string(data), "- [ ] 2. second") {
+		t.Errorf("done 3 must tick the item labeled 3:\n%s", string(data))
+	}
+}
+
+// TestTaskMixedListStaysAddressable is the shape a generated list takes as
+// soon as somebody runs `task add`: numbered items plus one unlabeled one.
+// The added item has no id of its own, so a bare number must still reach it
+// by position — that sequence worked before ids existed and must keep working.
+func TestTaskMixedListStaysAddressable(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "# Tasks for backend\n\n- [ ] 1. generated one\n- [ ] 2. generated two\n")
+
+	if _, err := run(t, app, "task", "--path", path, "add", "hand-added task"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run(t, app, "task", "--path", path, "done", "3"); err != nil {
+		t.Fatalf("done 3 must reach the unlabeled added item: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "- [x] hand-added task") {
+		t.Errorf("the added item should be done:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), "- [ ] 2. generated two") {
+		t.Errorf("the labeled items must be untouched:\n%s", string(data))
+	}
+}
+
+// TestTaskInvalidRefReportsTheTypo: a malformed reference must be reported as
+// a bad task number, not as whatever I/O error resolving it would hit first.
+func TestTaskInvalidRefReportsTheTypo(t *testing.T) {
+	app, _ := testApp(t)
+	_, err := run(t, app, "task", "--path", filepath.Join(t.TempDir(), "missing.md"), "done", "xyz")
+	if err == nil {
+		t.Fatal("a non-numeric task reference must error")
+	}
+	if !strings.Contains(err.Error(), `invalid task number "xyz"`) {
+		t.Errorf("error should name the bad reference, got: %v", err)
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1492,3 +1492,46 @@ func TestTaskInvalidRefReportsTheTypo(t *testing.T) {
 		t.Errorf("error should name the bad reference, got: %v", err)
 	}
 }
+
+// TestTaskRefMutationIsGuardedAgainstAConcurrentEdit: resolving a reference
+// necessarily reads the checklist before the mutation takes the file lock, so
+// another process adding or removing an item in between shifts positions under
+// the resolved index. The resolved TEXT is threaded through as the guard, so
+// that race must refuse rather than rewrite the wrong line.
+func TestTaskRefMutationIsGuardedAgainstAConcurrentEdit(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] 1.1 alpha\n- [ ] 1.2 beta\n")
+
+	items, err := app.ResolveTaskRef("", path, "1.2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if items.Index != 2 || items.Text != "1.2 beta" {
+		t.Fatalf("resolved %+v, want #2 %q", items, "1.2 beta")
+	}
+
+	// Somebody inserts a task ahead of it: position 2 is now "1.05 inserted".
+	if err := os.WriteFile(path, []byte("- [ ] 1.1 alpha\n- [ ] 1.05 inserted\n- [ ] 1.2 beta\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := app.SetTaskDone("", path, items.Index, true, items.Text); err == nil {
+		t.Fatal("a mutation on a stale index must be refused, not applied")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "[x]") {
+		t.Errorf("nothing should have been ticked off:\n%s", string(data))
+	}
+
+	// Re-resolving after the edit finds the same task at its new position.
+	again, err := app.ResolveTaskRef("", path, "1.2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Index != 3 || again.Text != "1.2 beta" {
+		t.Errorf("re-resolved %+v, want #3 %q", again, "1.2 beta")
+	}
+}

--- a/internal/domain/taskgen.go
+++ b/internal/domain/taskgen.go
@@ -227,7 +227,9 @@ func RenderGeneratedTaskList(agentName string, tasks []string) string {
 // writes for the i-th (0-based) generated task: the numbered ID plus the raw
 // task. It is the single source of truth for that format — the delivery-time
 // reservation must name exactly this text to claim the item, so the two sites
-// cannot be allowed to drift apart silently.
+// cannot be allowed to drift apart silently. The ID shape must also stay
+// within what domain.TaskLabel recognizes (tasklist.go), or `hap task done 3`
+// would stop addressing generated task 3 by its id.
 func GeneratedTaskItemText(i int, task string) string {
 	return strconv.Itoa(i+1) + ". " + task
 }

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -1,8 +1,10 @@
 package domain
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -36,7 +38,7 @@ var inProgressItemRE = regexp.MustCompile(`^\s*(?:[-*+]\s+)?\[-\]\s*(.+)$`)
 // isn't name-addressable (one scoped by agent type, pane id, workspace, or
 // "any") is still manageable — `hap task {agent_name}` errors on those, and
 // the path form always works.
-const DefaultNextTaskTemplate = "Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks: `hap task {agent_name} list` to view them, `hap task {agent_name} start <n>` to mark one in-progress when you begin working on it, and `hap task {agent_name} done <n>` to mark it complete as you go (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`)."
+const DefaultNextTaskTemplate = "Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks: `hap task {agent_name} list` to view them, `hap task {agent_name} start <n>` to mark one in-progress when you begin working on it, and `hap task {agent_name} done <n>` to mark it complete as you go (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`). `<n>` is the task's own id when the list numbers its tasks (e.g. `done 3.4`); otherwise its position in the list, which `#3` always addresses."
 
 // NoTaskContent is the {next_task_content} value when a declared list has
 // no unchecked item left: the templated prompt is still delivered so the
@@ -232,6 +234,151 @@ func ParseChecklist(content string) []ChecklistItem {
 		})
 	}
 	return items
+}
+
+// taskLabelRE extracts the hierarchical task ID a checklist may carry at the
+// start of an item's text — "1.1 Add a domain method…" or the "1. " prefix
+// GeneratedTaskItemText writes (see taskgen.go, which must keep writing an ID
+// this recognizes). Two shapes are accepted:
+//
+//   - multi-level ("1.1", "2.3.4"): the dots alone mark it as an ID, so a
+//     trailing separator is optional — hand-authored plans write "1.1 Add…"
+//     as often as "1.1. Add…" or "1.1: Add…";
+//   - single-level ("3"): a trailing ".", ")" or ":" is REQUIRED. Without it,
+//     ordinary prose like "3 blind mice" would read as task ID 3 and a plain
+//     `hap task done 3` would silently retarget from position 3 onto it.
+//
+// The ID must be followed by whitespace or end of line either way, so "1.1.2"
+// never matches as "1.1".
+//
+// The looser multi-level rule does misread a decimal that opens an item ("2.5
+// GB export path" reads as ID 2.5). That is deliberate — requiring a separator
+// would reject the common "1.1 Add…" spelling, which is the whole point — and
+// ResolveTaskRef contains the damage: a bare number still resolves positionally
+// whenever the item at that position carries no ID of its own. An ID wrapped in
+// markdown emphasis ("**1.1** Add…") is out of scope; such a list stays
+// positional.
+var taskLabelRE = regexp.MustCompile(`^(?:(\d+(?:\.\d+)+)[.):]?|(\d+)[.):])(?:\s|$)`)
+
+// TaskLabel returns the hierarchical task ID an item's text declares, or ""
+// when it declares none. This is the ID a document numbers its own tasks with
+// ("3.4"), as opposed to ChecklistItem.Index, which is the item's absolute
+// position in the file. ResolveTaskRef prefers the former precisely because an
+// agent reads the former in its prompt.
+func TaskLabel(text string) string {
+	m := taskLabelRE.FindStringSubmatch(text)
+	if m == nil {
+		return ""
+	}
+	if m[1] != "" {
+		return m[1]
+	}
+	return m[2]
+}
+
+// ErrTaskRefRequired is returned when no task reference was supplied. It names
+// the shell trap explicitly: a bare `#3` is a comment in every common shell, so
+// the argument silently vanishes and the command arrives here looking like the
+// caller just forgot it.
+var ErrTaskRefRequired = errors.New("a task number is required (see: task ... list) — quote a positional reference ('#3'), since an unquoted #3 is stripped by the shell as a comment")
+
+// ResolveTaskRef maps a user- or agent-supplied task reference to an item's
+// 1-based Index. Task text is what an agent sees, so a checklist that numbers
+// its own tasks must be addressable by those numbers — otherwise an agent told
+// to work "3.4 Implement authenticated POST …" reports `done 3` and ticks off
+// whatever happens to sit at position 3.
+//
+//   - "#3" always means position 3.
+//   - "3.4" means the item labeled 3.4 (never a position — positions are
+//     integers, so this form was an error before this existed).
+//   - "3" means the item labeled 3 when one exists.
+//   - "3" with no such label means position 3, but ONLY when the item sitting
+//     there carries no label of its own. That item is unaddressable any other
+//     way (a mixed list — a generated "1."/"2." list plus a hand-added item —
+//     is the common case), so refusing would strand it. When position 3 IS
+//     labeled, the ref is refused instead: silently ticking off "1.3" for
+//     somebody who asked for task 3 is the exact mistake this whole function
+//     exists to prevent.
+func ResolveTaskRef(items []ChecklistItem, ref string) (int, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return 0, ErrTaskRefRequired
+	}
+	if positional, ok := strings.CutPrefix(ref, "#"); ok {
+		return resolvePosition(items, positional, ref)
+	}
+	// Labels never keep their trailing separator, but an agent copying the id
+	// out of its own task text plausibly types it back with one ("done 3.4.").
+	ref = strings.TrimRight(ref, ".):")
+
+	var matches []int
+	for _, it := range items {
+		if label := TaskLabel(it.Text); label != "" && label == ref {
+			matches = append(matches, it.Index)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if len(matches) > 1 {
+		return 0, fmt.Errorf("task %q is ambiguous: %d items carry that id (positions %s) — address one by position, e.g. #%d",
+			ref, len(matches), joinPositions(matches), matches[0])
+	}
+
+	// No label matched. A dotted ref is an id and nothing else — positions are
+	// plain integers — so it can only be a miss.
+	if _, err := strconv.Atoi(ref); err != nil {
+		return 0, noSuchIDErr(ref, "")
+	}
+	// Otherwise fall back to the position: the only way to address an unlabeled
+	// item, and how every checklist worked before ids were understood. Unless
+	// that position is itself labeled — then the ref is ambiguous between "id
+	// 3" and "position 3" and must be spelled "#3".
+	pos, err := resolvePosition(items, ref, ref)
+	if err != nil {
+		return 0, err
+	}
+	if label := TaskLabel(items[pos-1].Text); label != "" {
+		return 0, noSuchIDErr(ref, label)
+	}
+	return pos, nil
+}
+
+// noSuchIDErr reports a reference that names no task id. occupant, when set, is
+// the id of the item sitting at the same position — the thing the caller would
+// have hit by falling back to positional addressing, and so worth naming.
+func noSuchIDErr(ref, occupant string) error {
+	if occupant != "" {
+		return fmt.Errorf("no task %q: this checklist numbers its tasks and none is %s (position %s holds task %s) — run `list` to see the ids, or address by position with #%s",
+			ref, ref, ref, occupant, ref)
+	}
+	return fmt.Errorf("no task %q: this checklist numbers its tasks and none is %s — run `list` to see the ids",
+		ref, ref)
+}
+
+// resolvePosition validates a positional task number. raw is the reference as
+// the caller typed it, so the error quotes "#3" rather than "3".
+func resolvePosition(items []ChecklistItem, digits, raw string) (int, error) {
+	n, err := strconv.Atoi(digits)
+	if err != nil {
+		return 0, fmt.Errorf("invalid task number %q", raw)
+	}
+	if n < 1 {
+		return 0, fmt.Errorf("task number must be 1 or greater, got %d", n)
+	}
+	if n > len(items) {
+		return 0, outOfRangeErr(n, len(items))
+	}
+	return n, nil
+}
+
+// joinPositions renders candidate positions as "#4, #9" for an ambiguity error.
+func joinPositions(indices []int) string {
+	parts := make([]string, len(indices))
+	for i, n := range indices {
+		parts[i] = "#" + strconv.Itoa(n)
+	}
+	return strings.Join(parts, ", ")
 }
 
 // validateTaskText trims surrounding whitespace and rejects empty or

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -90,12 +90,12 @@ func TestDeclaredTaskPrompt(t *testing.T) {
 		{
 			name: "default template crafts CLI commands with the agent name and a --path fallback",
 			task: DeclaredTask{Task: "add validation", Path: "/docs/tasks.md", AgentName: "brave-otter"},
-			want: "Your next task is add validation. Prefer the hap CLI to manage your tasks: `hap task brave-otter list` to view them, `hap task brave-otter start <n>` to mark one in-progress when you begin working on it, and `hap task brave-otter done <n>` to mark it complete as you go (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`).",
+			want: "Your next task is add validation. Prefer the hap CLI to manage your tasks: `hap task brave-otter list` to view them, `hap task brave-otter start <n>` to mark one in-progress when you begin working on it, and `hap task brave-otter done <n>` to mark it complete as you go (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`). `<n>` is the task's own id when the list numbers its tasks (e.g. `done 3.4`); otherwise its position in the list, which `#3` always addresses.",
 		},
 		{
 			name: "completed list uses none",
 			task: DeclaredTask{Task: NoTaskContent, Path: "/docs/tasks.md", AgentName: "brave-otter"},
-			want: "Your next task is none. Prefer the hap CLI to manage your tasks: `hap task brave-otter list` to view them, `hap task brave-otter start <n>` to mark one in-progress when you begin working on it, and `hap task brave-otter done <n>` to mark it complete as you go (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`).",
+			want: "Your next task is none. Prefer the hap CLI to manage your tasks: `hap task brave-otter list` to view them, `hap task brave-otter start <n>` to mark one in-progress when you begin working on it, and `hap task brave-otter done <n>` to mark it complete as you go (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`). `<n>` is the task's own id when the list numbers its tasks (e.g. `done 3.4`); otherwise its position in the list, which `#3` always addresses.",
 		},
 		{
 			name: "custom template",
@@ -635,5 +635,227 @@ func TestAppendChecklistItem(t *testing.T) {
 		if _, _, err := AppendChecklistItem("- [ ] a", bad); err == nil {
 			t.Errorf("AppendChecklistItem must reject embedded newline in %q", bad)
 		}
+	}
+}
+
+func TestTaskLabel(t *testing.T) {
+	cases := []struct{ name, text, want string }{
+		{"hierarchical", "1.1 Add a domain method to sign", "1.1"},
+		{"hierarchical with dot", "3.4. Implement the endpoint", "3.4"},
+		{"deep hierarchy", "2.3.4 nested task", "2.3.4"},
+		{"generated numbered id", "12. wire up retries", "12"},
+		{"paren separator", "7) review the diff", "7"},
+		{"bare number is not an id", "3 blind mice", ""},
+		{"unlabeled", "wire up retries", ""},
+		{"id only, no text after", "4.", "4"},
+		{"decimal inside text", "bump to 1.2 today", ""},
+		{"empty", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := TaskLabel(c.text); got != c.want {
+				t.Errorf("TaskLabel(%q) = %q, want %q", c.text, got, c.want)
+			}
+		})
+	}
+}
+
+// TestResolveTaskRefLabeled covers a checklist that numbers its own tasks: a
+// bare number must resolve by id, never by position, or an agent reporting
+// "done 3" for task 3.1 would tick off whatever sits at position 3.
+func TestResolveTaskRefLabeled(t *testing.T) {
+	items := ParseChecklist(strings.Join([]string{
+		"- [ ] 1.1 first",
+		"- [ ] 1.2 second",
+		"- [ ] 1.3 third",
+		"- [ ] 3.4 fourth",
+		"- [ ] 12. twelfth",
+	}, "\n"))
+
+	cases := []struct {
+		name, ref string
+		want      int
+		wantErr   string
+	}{
+		{name: "hierarchical id", ref: "3.4", want: 4},
+		{name: "single-level id", ref: "12", want: 5},
+		{name: "trailing separator on the ref", ref: "3.4.", want: 4},
+		{name: "explicit position", ref: "#3", want: 3},
+		{name: "position beyond end", ref: "#9", wantErr: "valid task numbers are 1..5"},
+		{name: "id that matches nothing, position is labeled", ref: "2", wantErr: "none is 2"},
+		{name: "id that matches nothing, beyond end", ref: "9", wantErr: "valid task numbers are 1..5"},
+		{name: "hierarchical id that matches nothing", ref: "4.2", wantErr: "none is 4.2"},
+		{name: "empty ref", ref: "  ", wantErr: "task number is required"},
+		{name: "not a number", ref: "#abc", wantErr: `invalid task number "#abc"`},
+		{name: "zero position", ref: "#0", wantErr: "must be 1 or greater"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ResolveTaskRef(items, c.ref)
+			if c.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ResolveTaskRef(%q) = %d, want error containing %q", c.ref, got, c.wantErr)
+				}
+				if !strings.Contains(err.Error(), c.wantErr) {
+					t.Fatalf("ResolveTaskRef(%q) error = %v, want it to contain %q", c.ref, err, c.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveTaskRef(%q) unexpected error: %v", c.ref, err)
+			}
+			if got != c.want {
+				t.Errorf("ResolveTaskRef(%q) = %d, want %d", c.ref, got, c.want)
+			}
+		})
+	}
+	if _, err := ResolveTaskRef(items, "2"); err == nil {
+		t.Fatal("a bare number matching no id must be an error when that position is itself labeled")
+	}
+}
+
+// TestResolveTaskRefMixedList covers the shape a generated list takes the
+// moment somebody runs `hap task <agent> add`: numbered items plus one
+// unlabeled one. The added item has no id, so a bare number MUST still reach
+// it by position — refusing would leave it addressable only as "#3".
+func TestResolveTaskRefMixedList(t *testing.T) {
+	items := ParseChecklist("- [ ] 1. generated one\n- [ ] 2. generated two\n- [ ] hand-added task")
+
+	for _, ref := range []string{"3", "#3"} {
+		got, err := ResolveTaskRef(items, ref)
+		if err != nil {
+			t.Fatalf("ResolveTaskRef(%q) unexpected error: %v", ref, err)
+		}
+		if got != 3 {
+			t.Errorf("ResolveTaskRef(%q) = %d, want the unlabeled item at 3", ref, got)
+		}
+	}
+	// The labeled items still resolve by their id, which here equals their
+	// position — a generated list is numbered in file order.
+	if got, err := ResolveTaskRef(items, "2"); err != nil || got != 2 {
+		t.Errorf("ResolveTaskRef(2) = %d, %v; want 2, nil", got, err)
+	}
+}
+
+// TestResolveTaskRefDecimalProse: an item opening with a bare decimal ("2.5 GB
+// export path") parses as an id, since requiring a trailing separator would
+// reject the "1.1 Add…" spelling this feature exists for. The positional
+// fallback must contain that misread — every unlabeled item stays reachable by
+// number. (A decimal glued to a unit, "0.5s timeout", is not a label at all:
+// taskLabelRE requires whitespace after the id.)
+func TestResolveTaskRefDecimalProse(t *testing.T) {
+	items := ParseChecklist("- [ ] alpha\n- [ ] 2.5 GB export path\n- [ ] gamma")
+	if TaskLabel("0.5s timeout tuning") != "" {
+		t.Error("a decimal glued to a unit must not read as a task id")
+	}
+
+	for _, tc := range []struct {
+		ref  string
+		want int
+	}{{"1", 1}, {"3", 3}, {"2.5", 2}} {
+		got, err := ResolveTaskRef(items, tc.ref)
+		if err != nil {
+			t.Fatalf("ResolveTaskRef(%q) unexpected error: %v", tc.ref, err)
+		}
+		if got != tc.want {
+			t.Errorf("ResolveTaskRef(%q) = %d, want %d", tc.ref, got, tc.want)
+		}
+	}
+	// Position 2 IS labeled (0.5), so a bare "2" is ambiguous and refused.
+	if _, err := ResolveTaskRef(items, "2"); err == nil {
+		t.Error("a bare number landing on a labeled item must be refused")
+	}
+}
+
+// TestResolveTaskRefUnlabeled pins the backward-compatible path: a list that
+// numbers nothing keeps addressing tasks by position, which is how every
+// checklist worked before ids were understood.
+func TestResolveTaskRefUnlabeled(t *testing.T) {
+	items := ParseChecklist("- [ ] alpha\n- [ ] beta\n- [ ] gamma")
+	for _, ref := range []string{"2", "#2"} {
+		got, err := ResolveTaskRef(items, ref)
+		if err != nil {
+			t.Fatalf("ResolveTaskRef(%q) unexpected error: %v", ref, err)
+		}
+		if got != 2 {
+			t.Errorf("ResolveTaskRef(%q) = %d, want 2", ref, got)
+		}
+	}
+	if _, err := ResolveTaskRef(items, "4"); err == nil {
+		t.Error("ResolveTaskRef past the end should error")
+	}
+}
+
+// TestResolveTaskRefAmbiguous: two items carrying the same id cannot be
+// addressed by it — the error must name the positions that do address them.
+func TestResolveTaskRefAmbiguous(t *testing.T) {
+	items := ParseChecklist("- [ ] 1.1 first\n- [ ] 2.1 second\n- [ ] 1.1 duplicate")
+	_, err := ResolveTaskRef(items, "1.1")
+	if err == nil {
+		t.Fatal("ResolveTaskRef on a duplicated id should error")
+	}
+	for _, want := range []string{"ambiguous", "#1", "#3"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %v should mention %q", err, want)
+		}
+	}
+}
+
+// TestHierarchicalTaskFileIsUsable is the regression guard for the whole
+// hand-authored format: section headings, intro prose, and `N.M`-numbered
+// items in one file.
+func TestHierarchicalTaskFileIsUsable(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "hierarchical_tasks.md"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	content := string(data)
+
+	items := ParseChecklist(content)
+	wantItems := strings.Count(content, "\n- [ ] ")
+	if len(items) != wantItems {
+		t.Fatalf("ParseChecklist found %d items, want %d — headings or prose leaked in", len(items), wantItems)
+	}
+	for _, it := range items {
+		if TaskLabel(it.Text) == "" {
+			t.Errorf("item #%d %q carries no task id", it.Index, it.Text)
+		}
+	}
+
+	if got := NextDeclaredTask(content); !strings.HasPrefix(got, "1.1 ") {
+		t.Errorf("NextDeclaredTask = %q, want the 1.1 item", got)
+	}
+	if len(PendingDeclaredTasks(content)) != len(items) {
+		t.Errorf("every fixture item is pending; got %d of %d", len(PendingDeclaredTasks(content)), len(items))
+	}
+
+	idx, err := ResolveTaskRef(items, "3.4")
+	if err != nil {
+		t.Fatalf("ResolveTaskRef(3.4): %v", err)
+	}
+	if !strings.HasPrefix(items[idx-1].Text, "3.4 ") {
+		t.Errorf("ref 3.4 resolved to #%d %q", idx, items[idx-1].Text)
+	}
+
+	// Ticking one item off must leave every other line byte-identical.
+	out, err := SetChecklistItemDone(content, idx, true)
+	if err != nil {
+		t.Fatalf("SetChecklistItemDone: %v", err)
+	}
+	before, after := strings.Split(content, "\n"), strings.Split(out, "\n")
+	if len(before) != len(after) {
+		t.Fatalf("line count changed: %d → %d", len(before), len(after))
+	}
+	changed := 0
+	for i := range before {
+		if before[i] != after[i] {
+			changed++
+		}
+	}
+	if changed != 1 {
+		t.Errorf("%d lines changed, want exactly 1", changed)
+	}
+	if got := ParseChecklist(out)[idx-1]; got.Mark != "x" || !strings.HasPrefix(got.Text, "3.4 ") {
+		t.Errorf("after done, item #%d = [%s] %q", idx, got.Mark, got.Text)
 	}
 }

--- a/internal/domain/testdata/hierarchical_tasks.md
+++ b/internal/domain/testdata/hierarchical_tasks.md
@@ -1,0 +1,28 @@
+# Tasks: Project Public Link
+
+Implementation checklist grounded in the approved proposal.md and requirements.md delta. Tasks are ordered by dependency: platform signing first, then webapp persistence/binding, then the worker public branch, then the client, then the share UI, and finally the public page + shared-viewer refactor. Each task cites the requirement codes it satisfies.
+
+## 1. Platform — Batch signing endpoint (Go)
+
+- [ ] 1.1 Add a domain method to sign an explicit set of `{fileID, revisionNumber}` with a caller-supplied `expiry`, generalizing the existing `GetSpecLinksForIDs` in `internal/modules/project/domain/file_service.go` / `domain/service.go`. (AR-PLAT-1, AR-PLAT-4)
+- [ ] 1.2 For each pair, route latest-revision requests to the R2 presigned path (`GetDownloadURL` → `storage.GenerateSignedURL(file.FileURI, expiry)`) and historical-revision requests to `GetRevisionDownloadURL`. (AR-PLAT-4, AR-PLAT-5, AR-PLAT-6)
+- [ ] 1.3 Change `GetRevisionDownloadURL` to accept and honor a caller-supplied expiry instead of the fixed `revisionURLTTL = 1h`. (CR-PLAT-7)
+- [ ] 1.4 Clamp `expiry` to a 7-day (604800s) maximum and default to 7 days when omitted. (AR-PLAT-2, AR-PLAT-3)
+- [ ] 1.5 Authorize every requested `fileID` against the caller's org; reject the whole request if any file is inaccessible. (AR-PLAT-8)
+
+## 2. Webapp — Cloudflare D1 binding & schema
+
+- [ ] 2.1 Add a `[[d1_databases]]` binding for each environment (top-level/local, `env.dev`, `env.staging`, `env.production`) in `wrangler.toml`. (AR-D1-1)
+- [ ] 2.2 Reflect the D1 binding in the worker env types (`app/env.d.ts` `WindowEnv` is client-only — add to the worker `Env`/`WorkerEnv` in `~/shared/env` and the `react-router` `AppLoadContext.cloudflare.env`). (AR-D1-1)
+
+## 3. Webapp Worker — Public API branch (`workers/app.ts`)
+
+- [ ] 3.1 Add an `/api/public/*` branch dispatched BEFORE the authenticated `/api/v1/*` block, wired to a new handler that reads/writes D1 directly (no auth pass-through). (AR-WW-1)
+- [ ] 3.2 Add a public CORS policy for `/api/public/*` appropriate to anonymous cross-origin visitors, distinct from the credentialed `/api/v1/*` policy. (AR-WW-11)
+- [ ] 3.3 Implement unauthenticated `GET /api/public/links/:token`: return project header + shared files (metadata + signed URLs); return 404/410 when `status='revoked'` or now > `expires_at`. (AR-WW-2, AR-WW-3)
+- [ ] 3.4 Implement authenticated `POST /api/public/links`: enforce the files-per-link cap, call the platform batch signing method with a 7-day expiry, generate a crypto-random token, set `expires_at = created_at + 7d`, insert `PUBLIC_LINK` + `PUBLIC_LINK_FILE` rows, return `/p/:token`. (AR-WW-4, AR-D1-6, AR-D1-7, AR-D1-8)
+
+## 8. Cross-cutting verification
+
+- [ ] 8.1 Confirm no public-link lifetime exceeds the 7-day signed-URL ceiling anywhere in create/regenerate. (AR-X-1)
+- [ ] 8.5 Add end-to-end coverage: create → open public link anonymously → revoke → confirm public read now refused; and latest-live vs pinned-frozen content behavior after an edit. (AR-PLAT-5, AR-PLAT-6, AR-WW-3, AR-WW-7)

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -2776,19 +2776,27 @@ func (a *App) ListTasks(agent, path string) ([]domain.ChecklistItem, error) {
 }
 
 // ResolveTaskRef maps a task reference — the list's own task id ("3.4"), a
-// bare number, or an explicit position ("#3") — to the 1-based item number
-// every other task method takes. See domain.ResolveTaskRef for the rules.
+// bare number, or an explicit position ("#3") — to the item it names. See
+// domain.ResolveTaskRef for the rules.
 //
-// Resolution reads the file OUTSIDE the mutation lock, exactly as a
-// human-supplied number is resolved from a previous `list` today. A checklist
-// that changes in between is caught by the mutation's own guard
-// (taskfile.ExpectText) rather than here.
-func (a *App) ResolveTaskRef(agent, path, ref string) (int, error) {
+// It returns the whole ChecklistItem, not just its Index, and callers that go
+// on to MUTATE must pass the returned Text back as the expectText guard.
+// Resolution necessarily reads the file OUTSIDE the mutation lock, so the
+// index it yields is stale the moment another process adds or removes an item;
+// the guard is what turns that race into a refusal instead of a rewrite of the
+// wrong line. This matters more for a reference than for a hand-typed number:
+// "3.4" names a specific task, so silently landing on its neighbour would
+// betray exactly what the caller asked for.
+func (a *App) ResolveTaskRef(agent, path, ref string) (domain.ChecklistItem, error) {
 	items, err := a.ListTasks(agent, path)
 	if err != nil {
-		return 0, err
+		return domain.ChecklistItem{}, err
 	}
-	return domain.ResolveTaskRef(items, ref)
+	index, err := domain.ResolveTaskRef(items, ref)
+	if err != nil {
+		return domain.ChecklistItem{}, err
+	}
+	return items[index-1], nil
 }
 
 // GetTask returns the single item addressed by its 1-based number.

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -2775,6 +2775,22 @@ func (a *App) ListTasks(agent, path string) ([]domain.ChecklistItem, error) {
 	return readChecklist(p)
 }
 
+// ResolveTaskRef maps a task reference — the list's own task id ("3.4"), a
+// bare number, or an explicit position ("#3") — to the 1-based item number
+// every other task method takes. See domain.ResolveTaskRef for the rules.
+//
+// Resolution reads the file OUTSIDE the mutation lock, exactly as a
+// human-supplied number is resolved from a previous `list` today. A checklist
+// that changes in between is caught by the mutation's own guard
+// (taskfile.ExpectText) rather than here.
+func (a *App) ResolveTaskRef(agent, path, ref string) (int, error) {
+	items, err := a.ListTasks(agent, path)
+	if err != nil {
+		return 0, err
+	}
+	return domain.ResolveTaskRef(items, ref)
+}
+
 // GetTask returns the single item addressed by its 1-based number.
 func (a *App) GetTask(agent, path string, index int) (domain.ChecklistItem, error) {
 	items, err := a.ListTasks(agent, path)

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -223,6 +223,11 @@ terminal_bell = true       # ring the terminal bell (\a) on new escalations and 
 # agent = ""                 # short name, pane id, or type; "" = any
 # workspace = ""             # "" or "*" = any; wildcards like "codex-*" work
 # path = "/home/me/project/docs/tasks.md"
+# Any markdown checklist works: "- [ ] item" lines, with headings and prose
+# freely interleaved (they are skipped, and every edit leaves them untouched).
+# A list may number its own tasks ("- [ ] 3.4 create the public link") — those
+# ids are what `hap task <agent> done 3.4` addresses, while `#3` always means
+# the third item in the file.
 # next_task_template placeholders: {next_task_content}, {task_list_path}, {agent_name}, {cwd}
 # next_task_template = "Your next task is {next_task_content}.\nRead the full tasks list at {task_list_path}. Verify task dependencies before starting. Once you have completed your task, mark it as done (`[x]`) in the tasks list.\nIf you are unsure what to do, ask for clarification. When there is no task available, focus on improving the test coverage of this project."
 # When an [llm].command is configured, each determined task is first REVIEWED by


### PR DESCRIPTION
## Why

A `[[task_sources]]` entry pointed at a hand-authored `tasks.md` that numbers its own tasks:

```markdown
## 3. Webapp Worker — Public API branch

- [ ] 3.4 Implement authenticated `POST /api/public/links`: … (AR-WW-4)
```

**Parsing already worked** — headings and prose are skipped, and every mutation leaves them byte-identical. **Addressing did not.** Task numbers were positional, parsed with `strconv.Atoi`:

- `hap task <agent> done 3.4` → hard error `invalid task number "3.4"`
- `hap task <agent> done 3` → **silently ticked position 3**, which in that file is `1.3`

The id is what an agent reads in its prompt, so it is the number the agent reports back.

## What changed

| you pass | it means |
|---|---|
| `3.4` | the item whose id is `3.4` |
| `3` | the item whose id is `3` |
| `3`, no such id | position 3 — **unless** the item there carries an id of its own, then it is refused (spell it `'#3'`) |
| `'#3'` | position 3, always |

The positional fallback keeps a **mixed list** working: a generated `1.`/`2.` list plus one `hap task add` leaves an unlabeled item that a bare number must still reach. A bare number landing on a *labeled* item is refused instead — that retarget is the whole thing this prevents.

Recognized id shapes: multi-level (`1.1`, `2.3.4`, separator optional) and single-level (`3.`, `7)`, `4:` — separator **required**, so `3 blind mice` is not id 3). This is the same shape `GeneratedTaskItemText` already writes, so both id schemes unify under one resolver.

- `internal/domain/tasklist.go` — `TaskLabel`, `ResolveTaskRef`, `ErrTaskRefRequired`; extended `DefaultNextTaskTemplate` so agents know which form to use.
- `internal/frontend/frontend.go` — `App.ResolveTaskRef`.
- `internal/cli/cli.go` — `taskIndexArg` resolves refs; a syntactic pre-check keeps `done xyz` reporting the typo rather than a file error.
- Docs: `sample/config.toml`, `README.md`, `.claude/skills/hap/SKILL.md`.

`max_tasks` is untouched — it gates TUI/CLI `add` and LLM generation only, so a hand-edited 50-item list still sends fine.

## Tests

- `TestTaskLabel`, `TestResolveTaskRef{Labeled,Unlabeled,MixedList,Ambiguous,DecimalProse}`
- `TestHierarchicalTaskFileIsUsable` over a new fixture of the real format — pins parsing, numbering, and headings surviving a mutation
- CLI: id addressing, `'#3'` positional, backward-compat bare number on a label-free list, add-then-done on a mixed list, refused refs leaving the file untouched

Full suite green (24 packages), `gofmt`/`go vet`/`golangci-lint` clean. Also verified with a real `hap` binary against the actual file: `done 3.4` ticked line 23, `undone '#3'` hit position 3, `done 2` was refused naming the conflict, headings byte-identical.

https://claude.ai/code/session_019oaepE4739f2yCZTtE4HuL
