### PR TITLE
#1 refactor: print task-management instructions in `hap task <agent> list`

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -592,7 +592,7 @@ agent at its own list with its name pre-filled (and a `--path` fallback for
 sources that aren't name-addressable):
 
 ```
-Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks (start/done), run bash `hap task {agent_name} list` to view them (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`).
+Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks (start/done), run bash `hap task {agent_name} list` to view them (if that name isn't recognized, use `--path {task_list_path_quoted}` in place of `{agent_name}`).
 ```
 
 the lifecycle instructions themselves (`start <n>`, `done <n>`, how `<n>` is
@@ -602,6 +602,7 @@ being re-sent with every prompt.
 
 - `{next_task_content}` — the text of the next unchecked item (or `"none"` when the list is complete)
 - `{task_list_path}` — absolute path to the checklist file
+- `{task_list_path_quoted}` — that path as one shell word (quoted only when it needs it); use this, not `{task_list_path}`, inside a command the agent is meant to run
 - `{agent_name}` — the agent's hap-owned short name
 - `{cwd}` — the agent's working directory (the project it is in)
 

--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -587,13 +587,18 @@ changed before the write lands, so a stale keypress never mutates the wrong
 
 ### template placeholders
 
-the prompt sent to the agent is rendered from a template. the default steers the
-agent to manage its list through the `hap task` CLI with its own name pre-filled
-in every command (and a `--path` fallback for sources that aren't name-addressable):
+the prompt sent to the agent is rendered from a template. the default points the
+agent at its own list with its name pre-filled (and a `--path` fallback for
+sources that aren't name-addressable):
 
 ```
-Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks: `hap task {agent_name} list` to view them, `hap task {agent_name} start <n>` to mark one in-progress when you begin working on it, and `hap task {agent_name} done <n>` to mark it complete as you go (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`). `<n>` is the task's own id when the list numbers its tasks (e.g. `done 3.4`); otherwise its position in the list, which `#3` always addresses.
+Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks (start/done), run bash `hap task {agent_name} list` to view them (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`).
 ```
+
+the lifecycle instructions themselves (`start <n>`, `done <n>`, how `<n>` is
+addressed, and the `--path` fallback) are printed by `hap task <agent> list` at
+the bottom of its output — stated once beside the real task numbers instead of
+being re-sent with every prompt.
 
 - `{next_task_content}` — the text of the next unchecked item (or `"none"` when the list is complete)
 - `{task_list_path}` — absolute path to the checklist file

--- a/README.md
+++ b/README.md
@@ -484,7 +484,8 @@ error = "#ff5f5f"
 # sources that aren't name-addressable):
 #   "Your next task is {next_task_content}. Prefer the hap CLI to manage your
 #    tasks (start/done), run bash `hap task {agent_name} list` to view them
-#    (if that name isn't recognized, use `--path {task_list_path}` in place of
+#    (if that name isn't recognized, use `--path {task_list_path_quoted}` in
+#    place of
 #    `{agent_name}`)."
 # The full instructions — `start <n>`, `done <n>`, how `<n>` is addressed, and
 # the --path fallback — are printed by `hap task <agent> list` itself, so they
@@ -502,7 +503,9 @@ agent = "brave-otter" # agent short name, pane id, or type ("" = any)
 workspace = ""        # workspace name; "" or "*" = any, "*" wildcards work
                       # ("codex-*" = starts with, "*-vscode3" = ends with)
 path = "/home/me/project/docs/tasks.md"
-# Optional per-source prompt format ({next_task_content}, {task_list_path}, {agent_name}, {cwd}):
+# Optional per-source prompt format ({next_task_content}, {task_list_path},
+# {task_list_path_quoted} — the path as one shell word, for commands the agent
+# runs — {agent_name}, {cwd}):
 next_task_template = "Your next task is {next_task_content}. Read the full tasks list at {task_list_path}. Verify task dependencies before starting. When there is no task available, focus on improving the test coverage of this project."
 # When an [llm].command is configured, each determined task is first reviewed by
 # the LLM before it is sent (see "Reviewing tasks before they are sent" below).

--- a/README.md
+++ b/README.md
@@ -108,6 +108,44 @@ Notes:
   like `key = "ctrl+alt+a"` also work — ctrl+letter, function keys, and
   explicit modified chords are the most reliable.
 
+### Hotkeys for pause / resume / status (optional)
+
+The same `[[keys.command]]` mechanism can drive the CLI directly, so the
+kill switch is one chord away without opening the pane:
+
+```toml
+[[keys.command]]
+key = "prefix+p"
+type = "shell"
+command = "hap pause"
+description = "Pause Auto Prompter (kill switch)"
+
+[[keys.command]]
+key = "prefix+o"
+type = "shell"
+command = "hap resume"
+description = "Resume Auto Prompter"
+
+[[keys.command]]
+key = "prefix+h"
+type = "shell"
+command = "hap status"
+description = "Show Auto Prompter status"
+```
+
+Reload with `herdr server reload-config`, then `ctrl+b p` pauses, `ctrl+b o`
+resumes, and `ctrl+b h` prints the status.
+
+Notes:
+
+- These use the bare `hap` command, which needs the
+  `/usr/local/bin/hap` symlink from the next section. Without it, use the
+  full path to the installed binary instead (under
+  `~/.config/herdr/plugins/<source>/herd-auto-prompter-*/bin/hap`).
+- `hap pause` and `hap resume` are silent state changes; `hap status` prints
+  output, so bind it to a key only if your Herdr build surfaces shell-command
+  output (otherwise read status in the pane).
+
 ### Make the CLI available from any shell
 
 Open the **Auto Prompter** pane with the hotkey above, switch to the **Config**
@@ -441,17 +479,17 @@ error = "#ff5f5f"
 # else the first
 # pending one). Other agent types skip inference entirely and escalate.
 #
-# The prompt sent to the agent is rendered from a template. The default steers
-# the agent to manage its list through the hap CLI with its own name pre-filled
-# (and a --path fallback for sources that aren't name-addressable):
+# The prompt sent to the agent is rendered from a template. The default points
+# the agent at its own list with its name pre-filled (and a --path fallback for
+# sources that aren't name-addressable):
 #   "Your next task is {next_task_content}. Prefer the hap CLI to manage your
-#    tasks: `hap task {agent_name} list` to view them, `hap task {agent_name}
-#    start <n>` to mark one in-progress when you begin working on it, and
-#    `hap task {agent_name} done <n>` to mark it complete as you go (if that
-#    name isn't recognized, use `--path {task_list_path}` in place of
-#    `{agent_name}`). `<n>` is the task's own id when the list numbers its
-#    tasks (e.g. `done 3.4`); otherwise its position in the list, which `#3`
-#    always addresses."
+#    tasks (start/done), run bash `hap task {agent_name} list` to view them
+#    (if that name isn't recognized, use `--path {task_list_path}` in place of
+#    `{agent_name}`)."
+# The full instructions — `start <n>`, `done <n>`, how `<n>` is addressed, and
+# the --path fallback — are printed by `hap task <agent> list` itself, so they
+# are stated once beside the real task numbers rather than re-sent with every
+# prompt.
 # When every item is checked off, the templated prompt is never sent: the
 # plugin escalates a confirmable @noop suggestion ("No more pending tasks")
 # instead — unless BOTH llm.task_generate_command and

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -993,7 +993,7 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 	fs := flag.NewFlagSet("task-source", flag.ContinueOnError)
 	agent := fs.String("agent", "", "agent short name, id, or type this source applies to")
 	workspace := fs.String("workspace", "", "workspace name this source applies to (\"*\" wildcards, e.g. \"codex-*\")")
-	template := fs.String("template", "", "next-task prompt template ({next_task_content}, {task_list_path}, {agent_name} placeholders)")
+	template := fs.String("template", "", "next-task prompt template ({next_task_content}, {task_list_path}, {task_list_path_quoted}, {agent_name} placeholders)")
 	fs.SetOutput(out)
 	if err := fs.Parse(args); err != nil {
 		return err

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1309,11 +1309,22 @@ func taskList(app *frontend.App, out io.Writer, agent, path string, args []strin
 	default:
 		return fmt.Errorf("invalid --status %q (all|pending|done)", *status)
 	}
-	items, err := app.ListTasks(agent, path)
+	// Resolve the file once and list from it, so the path printed in the hints
+	// is exactly the file the items above came from.
+	resolved, err := app.TaskFilePath(agent, path)
+	if err != nil {
+		return err
+	}
+	items, err := app.ListTasks("", resolved)
 	if err != nil {
 		return err
 	}
 	printTaskList(out, items, *status)
+	// The task-management instructions are stated here and nowhere else: the
+	// next-task prompt only points the agent at `hap task <agent> list`, so it
+	// reads them beside the actual task numbers. Only `list` prints them —
+	// the mutating ops reprint the list without repeating the instructions.
+	fmt.Fprint(out, "\n"+domain.TaskManagementHints(agent, resolved))
 	return nil
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1088,7 +1088,10 @@ func TestTaskListStatusFilterPreservesNumbers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, "#1") || !strings.Contains(out, "#3") {
+	// Assert on whole rows: the hints block printed under every listing
+	// mentions '#3' too, so a bare Contains("#3") would pass even on a
+	// renumbered list.
+	if !strings.Contains(out, "#1\t[ ]\tone") || !strings.Contains(out, "#3\t[ ]\tthree") {
 		t.Errorf("pending filter must keep absolute numbers #1 and #3, got:\n%s", out)
 	}
 	if strings.Contains(out, "two") || strings.Contains(out, "#2") {
@@ -1105,13 +1108,15 @@ func TestTaskListStatusFilterPreservesNumbers(t *testing.T) {
 // "[-]", not "[x]", and is treated as not-pending by the filters.
 func TestTaskInProgressMarkerFaithful(t *testing.T) {
 	app, _ := testApp(t)
-	path := writeTaskFile(t, "- [-] working on it\n- [ ] queued\n")
+	// The item texts must not appear in the task-management hints printed
+	// under every listing, or "not shown" assertions match the hints instead.
+	path := writeTaskFile(t, "- [-] active-item\n- [ ] queued\n")
 
 	out, err := run(t, app, "task", "--path", path, "list")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, "[-]\tworking on it") {
+	if !strings.Contains(out, "[-]\tactive-item") {
 		t.Errorf("in-progress marker must render as [-], got:\n%s", out)
 	}
 
@@ -1119,7 +1124,7 @@ func TestTaskInProgressMarkerFaithful(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(out, "working on it") {
+	if strings.Contains(out, "active-item") {
 		t.Errorf("in-progress item must not count as pending, got:\n%s", out)
 	}
 	if !strings.Contains(out, "queued") {
@@ -1274,6 +1279,87 @@ func TestTaskByAgentResolvesSource(t *testing.T) {
 	data, _ := os.ReadFile(cfg.TaskSources[0].Path)
 	if want := "- [ ] alpha\n- [x] beta\n"; string(data) != want {
 		t.Errorf("done via agent name:\n got %q\nwant %q", string(data), want)
+	}
+}
+
+// TestTaskListPrintsManagementHints pins the move of the task-management
+// instructions out of the next-task prompt and into `task … list` itself: the
+// prompt only points the agent here, so a listing that omits them leaves the
+// agent with no way to learn `start`/`done`.
+func TestTaskListPrintsManagementHints(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] alpha\n")
+	if err := app.AddTaskSource(context.Background(), "backend", "", path, ""); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 1 {
+		t.Fatalf("want 1 task source, got %d", len(cfg.TaskSources))
+	}
+	abs := cfg.TaskSources[0].Path
+
+	out, err := run(t, app, "task", "backend", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"`hap task backend start <n>`",
+		"`hap task backend done <n>`",
+		"`'#3'` always addresses",
+		"use `--path " + abs + "` in place of `backend`",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("agent-addressed list must print %q, got:\n%s", want, out)
+		}
+	}
+
+	// A --path list has no name to fall back FROM: every command is spelled
+	// with the path and the "name no longer recognized" note is dropped.
+	out, err = run(t, app, "task", "--path", abs, "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "`hap task --path "+abs+" start <n>`") {
+		t.Errorf("--path list must spell commands with the path, got:\n%s", out)
+	}
+	if strings.Contains(out, "no longer recognized") {
+		t.Errorf("--path list must not print the name-fallback note, got:\n%s", out)
+	}
+
+	// Only `list` teaches: the mutating ops reprint the list, and repeating
+	// the whole instruction block on every done/start would drown it.
+	out, err = run(t, app, "task", "backend", "done", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "start <n>") {
+		t.Errorf("mutating ops must not repeat the hints, got:\n%s", out)
+	}
+}
+
+// TestTaskListHintsQuotePathWithSpace pins that the commands the hints hand an
+// agent survive a shell: a checklist under a directory with a space must be
+// one argument, not two.
+func TestTaskListHintsQuotePathWithSpace(t *testing.T) {
+	app, _ := testApp(t)
+	dir := filepath.Join(t.TempDir(), "my docs")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "tasks.md")
+	if err := os.WriteFile(path, []byte("- [ ] alpha\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "task", "--path", path, "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "--path '"+path+"' done <n>") {
+		t.Errorf("a path with a space must be shell-quoted in the hints, got:\n%s", out)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -263,8 +263,10 @@ type TaskSource struct {
 	Path      string `toml:"path"` // markdown checklist file
 	// NextTaskTemplate overrides the outbound prompt format. Placeholders:
 	// {next_task_content} (next unchecked item, or "none" when the list is
-	// complete), {task_list_path}, {agent_name} (the agent's short name), and
-	// {cwd} (the agent's working directory). Empty uses the built-in default.
+	// complete), {task_list_path}, {task_list_path_quoted} (that path as one
+	// shell word — use it inside any command the template hands the agent to
+	// run), {agent_name} (the agent's short name), and {cwd} (the agent's
+	// working directory). Empty uses the built-in default.
 	NextTaskTemplate string `toml:"next_task_template,omitempty"`
 	// EnableLLMReview gates the pre-send LLM review of this source's
 	// determined tasks. When an [llm].command is configured, a determined

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -27,18 +27,58 @@ var inProgressItemRE = regexp.MustCompile(`^\s*(?:[-*+]\s+)?\[-\]\s*(.+)$`)
 // is the agent's working directory (the project it is in).
 //
 // The default steers the agent to manage its list through the `hap task` CLI
-// with the agent's own name pre-filled in every command (so `hap task
-// {agent_name} done <n>` resolves this exact source), covering the full task
-// lifecycle: `start <n>` marks a task [-] in-progress the moment the agent
-// begins it (an ordinary source's send leaves the item [ ], so without this
-// nothing records that the task is being worked; a source with
-// enable_auto_send_task_when_idle pre-marks it at delivery, which makes `start`
-// a harmless no-op there), and `done <n>` ticks it off. It also spells out the
-// `--path {task_list_path}` form so a source that
-// isn't name-addressable (one scoped by agent type, pane id, workspace, or
-// "any") is still manageable — `hap task {agent_name}` errors on those, and
-// the path form always works.
-const DefaultNextTaskTemplate = "Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks: `hap task {agent_name} list` to view them, `hap task {agent_name} start <n>` to mark one in-progress when you begin working on it, and `hap task {agent_name} done <n>` to mark it complete as you go (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`). `<n>` is the task's own id when the list numbers its tasks (e.g. `done 3.4`); otherwise its position in the list, which `#3` always addresses."
+// with the agent's own name pre-filled (so `hap task {agent_name} list`
+// resolves this exact source). It deliberately carries only the pointer to
+// `list`: the full lifecycle instructions (`start <n>`, `done <n>`, how `<n>`
+// is addressed, and the `--path` fallback) are printed by that command itself
+// (TaskManagementHints), so they are stated once, next to the real task
+// numbers, instead of being re-sent with every prompt.
+const DefaultNextTaskTemplate = "Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks (start/done), run bash `hap task {agent_name} list` to view them (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`)."
+
+// TaskManagementHints renders the task-management instructions printed under a
+// `hap task … list`. They live here — beside the template that points the agent
+// at `list` — so the prompt and the listing can never drift apart.
+//
+// agent is the name the caller addressed the list by, and path the resolved
+// checklist file. When the caller used --path (agent == ""), every command is
+// spelled with that path and the "name no longer recognized" note is dropped:
+// there is no name to fall back from. That note is what keeps a source that
+// isn't name-addressable (scoped by agent type, pane id, workspace, or "any")
+// manageable — `hap task {agent}` errors on those, and the path form always
+// works.
+func TaskManagementHints(agent, path string) string {
+	quoted := ShellQuote(path)
+	target := agent
+	if target == "" {
+		target = "--path " + quoted
+	}
+	var b strings.Builder
+	b.WriteString("Prefer using the hap CLI to manage your tasks:\n")
+	fmt.Fprintf(&b, "- `hap task %s start <n>` to mark one in-progress when you begin working on it.\n", target)
+	fmt.Fprintf(&b, "- `hap task %s done <n>` to mark it complete as you go.\n", target)
+	b.WriteString("Note:\n")
+	// '#3' is quoted because these commands are run in a shell, where a bare
+	// #3 is stripped as a comment and the ref reaches hap as nothing at all.
+	b.WriteString("- `<n>` is the task's own id when the list numbers its tasks (e.g. `done 3.1`); otherwise its position in the list, which `'#3'` always addresses (quote it — a bare #3 is a shell comment).\n")
+	if agent != "" {
+		fmt.Fprintf(&b, "- when the agent name `%s` is no longer recognized, use `--path %s` in place of `%s`\n", agent, quoted, agent)
+	}
+	return b.String()
+}
+
+// shellSafeRE matches a string that needs no quoting to survive a shell word
+// split — the common case, so an ordinary path stays copy-pasteable and plain.
+var shellSafeRE = regexp.MustCompile(`^[A-Za-z0-9_@%+=:,./-]+$`)
+
+// ShellQuote renders s as a single shell word. The hints and the next-task
+// prompt hand agents commands they run in bash, so a checklist path holding a
+// space (or any metacharacter) must arrive as one argument, not two.
+func ShellQuote(s string) string {
+	if s != "" && shellSafeRE.MatchString(s) {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
 
 // NoTaskContent is the {next_task_content} value when a declared list has
 // no unchecked item left: the templated prompt is still delivered so the

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -23,8 +23,11 @@ var inProgressItemRE = regexp.MustCompile(`^\s*(?:[-*+]\s+)?\[-\]\s*(.+)$`)
 // DefaultNextTaskTemplate is the prompt template used when a task source
 // declares none. Placeholders: {next_task_content} is the next unchecked
 // item (or NoTaskContent when the list is complete), {task_list_path} is
-// the task-source file path, {agent_name} is the agent's short name, {cwd}
-// is the agent's working directory (the project it is in).
+// the task-source file path, {task_list_path_quoted} is that path as a single
+// shell word (use it whenever the template hands the agent a command to RUN —
+// a path with a space would otherwise split into two arguments),
+// {agent_name} is the agent's short name, {cwd} is the agent's working
+// directory (the project it is in).
 //
 // The default steers the agent to manage its list through the `hap task` CLI
 // with the agent's own name pre-filled (so `hap task {agent_name} list`
@@ -33,7 +36,7 @@ var inProgressItemRE = regexp.MustCompile(`^\s*(?:[-*+]\s+)?\[-\]\s*(.+)$`)
 // is addressed, and the `--path` fallback) are printed by that command itself
 // (TaskManagementHints), so they are stated once, next to the real task
 // numbers, instead of being re-sent with every prompt.
-const DefaultNextTaskTemplate = "Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks (start/done), run bash `hap task {agent_name} list` to view them (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`)."
+const DefaultNextTaskTemplate = "Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks (start/done), run bash `hap task {agent_name} list` to view them (if that name isn't recognized, use `--path {task_list_path_quoted}` in place of `{agent_name}`)."
 
 // TaskManagementHints renders the task-management instructions printed under a
 // `hap task … list`. They live here — beside the template that points the agent
@@ -134,6 +137,10 @@ func TemplateOrDefault(template string) string {
 func (t DeclaredTask) Prompt() string {
 	tpl := TemplateOrDefault(t.Template)
 	return strings.NewReplacer(
+		// The quoted form comes first: NewReplacer matches in argument order,
+		// so the shorter {task_list_path} would otherwise consume its prefix
+		// and leave a stray "_quoted" in the prompt.
+		"{task_list_path_quoted}", ShellQuote(t.Path),
 		"{next_task_content}", DecodeTaskNewlines(t.Task),
 		"{task_list_path}", t.Path,
 		"{agent_name}", t.AgentName,

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -88,14 +88,14 @@ func TestDeclaredTaskPrompt(t *testing.T) {
 		want string
 	}{
 		{
-			name: "default template crafts CLI commands with the agent name and a --path fallback",
+			name: "default template points at the list command with the agent name and a --path fallback",
 			task: DeclaredTask{Task: "add validation", Path: "/docs/tasks.md", AgentName: "brave-otter"},
-			want: "Your next task is add validation. Prefer the hap CLI to manage your tasks: `hap task brave-otter list` to view them, `hap task brave-otter start <n>` to mark one in-progress when you begin working on it, and `hap task brave-otter done <n>` to mark it complete as you go (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`). `<n>` is the task's own id when the list numbers its tasks (e.g. `done 3.4`); otherwise its position in the list, which `#3` always addresses.",
+			want: "Your next task is add validation. Prefer the hap CLI to manage your tasks (start/done), run bash `hap task brave-otter list` to view them (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`).",
 		},
 		{
 			name: "completed list uses none",
 			task: DeclaredTask{Task: NoTaskContent, Path: "/docs/tasks.md", AgentName: "brave-otter"},
-			want: "Your next task is none. Prefer the hap CLI to manage your tasks: `hap task brave-otter list` to view them, `hap task brave-otter start <n>` to mark one in-progress when you begin working on it, and `hap task brave-otter done <n>` to mark it complete as you go (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`). `<n>` is the task's own id when the list numbers its tasks (e.g. `done 3.4`); otherwise its position in the list, which `#3` always addresses.",
+			want: "Your next task is none. Prefer the hap CLI to manage your tasks (start/done), run bash `hap task brave-otter list` to view them (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`).",
 		},
 		{
 			name: "custom template",
@@ -857,5 +857,49 @@ func TestHierarchicalTaskFileIsUsable(t *testing.T) {
 	}
 	if got := ParseChecklist(out)[idx-1]; got.Mark != "x" || !strings.HasPrefix(got.Text, "3.4 ") {
 		t.Errorf("after done, item #%d = [%s] %q", idx, got.Mark, got.Text)
+	}
+}
+
+// TestTaskManagementHints pins the instructions `hap task … list` prints: the
+// default prompt no longer carries them, so this text is the only place an
+// agent learns start/done and how <n> is addressed.
+func TestTaskManagementHints(t *testing.T) {
+	got := TaskManagementHints("happy-pelican", "/state/tasks/happy-pelican.md")
+	want := "Prefer using the hap CLI to manage your tasks:\n" +
+		"- `hap task happy-pelican start <n>` to mark one in-progress when you begin working on it.\n" +
+		"- `hap task happy-pelican done <n>` to mark it complete as you go.\n" +
+		"Note:\n" +
+		"- `<n>` is the task's own id when the list numbers its tasks (e.g. `done 3.1`); otherwise its position in the list, which `'#3'` always addresses (quote it — a bare #3 is a shell comment).\n" +
+		"- when the agent name `happy-pelican` is no longer recognized, use `--path /state/tasks/happy-pelican.md` in place of `happy-pelican`\n"
+	if got != want {
+		t.Errorf("hints:\n got %q\nwant %q", got, want)
+	}
+}
+
+// A path-addressed list has no agent name, so the commands carry the path and
+// the name-fallback note — which would say "use --path X in place of ”" — is
+// dropped entirely.
+func TestTaskManagementHintsPathOnly(t *testing.T) {
+	got := TaskManagementHints("", "/docs/tasks.md")
+	if !strings.Contains(got, "`hap task --path /docs/tasks.md done <n>`") {
+		t.Errorf("path-only hints must spell commands with the path, got:\n%s", got)
+	}
+	if strings.Contains(got, "no longer recognized") {
+		t.Errorf("path-only hints must not print the name-fallback note, got:\n%s", got)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/docs/tasks.md", "/docs/tasks.md"},
+		{"/my docs/tasks.md", "'/my docs/tasks.md'"},
+		{"/it's/tasks.md", `'/it'\''s/tasks.md'`},
+		{"", "''"},
+		{"/a;rm -rf b/tasks.md", "'/a;rm -rf b/tasks.md'"},
+	}
+	for _, c := range cases {
+		if got := ShellQuote(c.in); got != c.want {
+			t.Errorf("ShellQuote(%q) = %s, want %s", c.in, got, c.want)
+		}
 	}
 }

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -98,6 +98,20 @@ func TestDeclaredTaskPrompt(t *testing.T) {
 			want: "Your next task is none. Prefer the hap CLI to manage your tasks (start/done), run bash `hap task brave-otter list` to view them (if that name isn't recognized, use `--path /docs/tasks.md` in place of `brave-otter`).",
 		},
 		{
+			name: "default template shell-quotes a path with a space",
+			task: DeclaredTask{Task: "add validation", Path: "/my docs/tasks.md", AgentName: "brave-otter"},
+			want: "Your next task is add validation. Prefer the hap CLI to manage your tasks (start/done), run bash `hap task brave-otter list` to view them (if that name isn't recognized, use `--path '/my docs/tasks.md'` in place of `brave-otter`).",
+		},
+		{
+			name: "explicit quoted placeholder in a custom template",
+			task: DeclaredTask{
+				Task:     "x",
+				Path:     "/my docs/t.md",
+				Template: "run `hap task --path {task_list_path_quoted} list`; the file is {task_list_path}",
+			},
+			want: "run `hap task --path '/my docs/t.md' list`; the file is /my docs/t.md",
+		},
+		{
 			name: "custom template",
 			task: DeclaredTask{
 				Task:     "wire logging",

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -2784,6 +2784,14 @@ func (a *App) ListTasks(agent, path string) ([]domain.ChecklistItem, error) {
 	return readChecklist(p)
 }
 
+// TaskFilePath resolves the checklist file a task target names, without
+// reading it: an explicit --path (made absolute) wins, otherwise the agent's
+// configured source. Exported for the CLI, which prints the resolved path in
+// the task-management hints under `hap task … list`.
+func (a *App) TaskFilePath(agent, path string) (string, error) {
+	return a.taskFilePath(agent, path)
+}
+
 // ResolveTaskRef maps a task reference — the list's own task id ("3.4"), a
 // bare number, or an explicit position ("#3") — to the item it names. See
 // domain.ResolveTaskRef for the rules.

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -228,7 +228,9 @@ terminal_bell = true       # ring the terminal bell (\a) on new escalations and 
 # A list may number its own tasks ("- [ ] 3.4 create the public link") — those
 # ids are what `hap task <agent> done 3.4` addresses, while `#3` always means
 # the third item in the file.
-# next_task_template placeholders: {next_task_content}, {task_list_path}, {agent_name}, {cwd}
+# next_task_template placeholders: {next_task_content}, {task_list_path},
+# {task_list_path_quoted} (that path as ONE shell word — use it whenever the
+# template hands the agent a command to run), {agent_name}, {cwd}
 # next_task_template = "Your next task is {next_task_content}.\nRead the full tasks list at {task_list_path}. Verify task dependencies before starting. Once you have completed your task, mark it as done (`[x]`) in the tasks list.\nIf you are unsure what to do, ask for clarification. When there is no task available, focus on improving the test coverage of this project."
 # When an [llm].command is configured, each determined task is first REVIEWED by
 # the LLM (via the get_context/submit_decision MCP tools): it sees the live pane


### PR DESCRIPTION
## What

The next-task prompt carried the full task lifecycle in every send (`start <n>`, `done <n>`, how `<n>` is addressed, the `--path` fallback). This moves that text into the output of `hap task <agent> list`, which the prompt now simply points at — stated once, beside the real task numbers.

Listing output:

```
#1	[ ]	3.1 wire the logger
#2	[-]	3.2 add metrics
2 task(s): 1 pending, 1 in-progress, 0 done

Prefer using the hap CLI to manage your tasks:
- `hap task happy-pelican start <n>` to mark one in-progress when you begin working on it.
- `hap task happy-pelican done <n>` to mark it complete as you go.
Note:
- `<n>` is the task's own id when the list numbers its tasks (e.g. `done 3.1`); otherwise its position in the list, which `'#3'` always addresses (quote it — a bare #3 is a shell comment).
- when the agent name `happy-pelican` is no longer recognized, use `--path /…/happy-pelican.md` in place of `happy-pelican`
```

A `--path`-addressed list spells every command with the path and drops the last note (there is no name to fall back from).

New default prompt template:

> Your next task is {next_task_content}. Prefer the hap CLI to manage your tasks (start/done), run bash `hap task {agent_name} list` to view them (if that name isn't recognized, use `--path {task_list_path}` in place of `{agent_name}`).

## Changes

- `domain.TaskManagementHints` renders the block; `internal/cli` prints it under `list` **only** — mutating ops reprint the list without repeating it.
- `frontend.App.TaskFilePath` exports the existing resolver, so the listing and the printed path resolve exactly once, together.
- Two shell-correctness fixes surfaced in review: `'#3'` is quoted (bash strips a bare `#3` as a comment, so `done #3` reached hap with no ref), and paths go through a new `domain.ShellQuote` so a checklist under a directory with a space stays one argument.
- Fixes two pre-existing CLI assertions the new output would have silently defanged — `Contains(out, "#3")` now matches whole rows.
- Docs: `README.md`, `.claude/skills/hap/SKILL.md`. The README also gains an optional "Hotkeys for pause / resume / status" section (docs-only, bundled from the same session).

## Tests

- `TestTaskManagementHints` / `…PathOnly` golden tests, `TestShellQuote` table test.
- `TestTaskListPrintsManagementHints` (agent-addressed vs `--path`, plus mutating ops must not repeat the block), `TestTaskListHintsQuotePathWithSpace`.
- Full suite `go test -tags "vectors cpu" ./... -count=1` passes; the only failure seen was the known flaky `TestEmbedTextRealModel` 2s embed stall guard under load, which passes in isolation and is unrelated.