### PR TITLE
#1 feat: --auto-send-when-idle flag, destructive-path CLI tests, and a movable prompt caret

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -600,7 +600,12 @@ marked items win over it. the add/edit prompts take
 multi-line task text: **shift+enter inserts a line break** (ctrl+j on
 terminals that can't report it), the box expands one line per break, **enter
 submits** — stored as the literal `\n` encoding above, decoded back when the
-prompt pre-fills. an action captured against a row aborts if that task's text
+prompt pre-fills. the input is a full line editor, so a typo in the middle of
+a long task is fixed in place: **←/→ move the caret** (ctrl+←/→ by word,
+home/end or ctrl+a/ctrl+e to the ends), typing and backspace/delete act at the
+caret, and the block cursor shows where the next keystroke lands. a prompt
+that pre-fills a value (edit, the prune default) opens with the caret after
+it. the same keys work in every hap prompt, not only the task ones. an action captured against a row aborts if that task's text
 changed before the write lands, so a stale keypress never mutates the wrong
 (renumbered) line.
 

--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -457,6 +457,13 @@ add a task source with a custom prompt template:
 hap task-source add --agent backend-dev --template 'Do this next: {next_task_content} (full list: {task_list_path})' ./docs/backend-tasks.md
 ```
 
+add a task source that also hands out tasks on the idle poll (see below —
+this makes hap send without a herdr attention event, so it is opt-in):
+
+```bash
+hap task-source add --agent backend-dev --auto-send-when-idle ./docs/backend-tasks.md
+```
+
 remove a task source by index:
 
 ```bash
@@ -471,9 +478,9 @@ agent is mid-task on it, which makes it the force path.
 
 by default a task only goes out when herdr reports the agent parked, and each
 idle episode is driven once — an agent that finishes and sits there just waits.
-set `enable_auto_send_task_when_idle = true` on a `[[task_sources]]` entry
-(config.toml only) and the daemon also polls every minute, handing its next
-pending `[ ]` item to any matching agent idle for more than a minute:
+set `enable_auto_send_task_when_idle = true` on a `[[task_sources]]` entry and
+the daemon also polls every minute, handing its next pending `[ ]` item to any
+matching agent idle for more than a minute:
 
 ```toml
 [[task_sources]]
@@ -481,6 +488,18 @@ agent = "backend-dev"
 path = "/home/me/project/docs/tasks.md"
 enable_auto_send_task_when_idle = true
 ```
+
+it can be turned on when the source is added, without editing config.toml:
+
+```bash
+hap task-source add --agent backend-dev --auto-send-when-idle ./docs/tasks.md
+```
+
+the TUI's *Config* tab `t` prompt takes the same word:
+`<path> [agent] [workspace] [--auto-send-when-idle]`. it is opt-in everywhere
+and never inferred; existing sources are switched on in config.toml. wherever
+sources are listed (`hap task-source list`, the *Config* tab) an enabled source
+shows `auto_send_when_idle=true`.
 
 - one task, one agent: agents matched by the same source get *different*
   pending items, and the delivered item is marked `[-]` as it is sent (a failed

--- a/README.md
+++ b/README.md
@@ -522,7 +522,9 @@ A declared task normally reaches an agent when herdr reports it parked, and
 each idle episode is driven exactly once — so an agent that finishes its work
 and sits there without a further event waits for you.
 
-Set `enable_auto_send_task_when_idle = true` on a source and the daemon also
+Set `enable_auto_send_task_when_idle = true` on a source — or add the source
+with `hap task-source add --auto-send-when-idle <checklist.md>`, or type
+`--auto-send-when-idle` in the *Config* tab's `t` prompt — and the daemon also
 polls once a minute: any agent that source matches which has been idle for
 more than a minute is handed its next pending `[ ]` item. Delivery goes
 through the normal pipeline, so the kill switch, never-auto patterns, rate
@@ -563,6 +565,7 @@ hap disable backend-dev         # stop automation for only this agent
 hap enable backend-dev          # allow automation again
 hap task-source --agent backend-dev ./docs/backend-tasks.md
 hap task-source --agent backend-dev --template 'Do this next: {next_task_content} (full list: {task_list_path})' ./docs/backend-tasks.md
+hap task-source --agent backend-dev --auto-send-when-idle ./docs/backend-tasks.md
 ```
 
 `hap agents` output is tab-separated and gained a sixth column — the agent's

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -69,7 +69,7 @@ Operate:
 Configure:
   config [show|fields|path|set <field> <value>|set-threshold <situation> <value>]
   rules [list|add <regex>|remove <index>]      never-auto patterns
-  task-source [add] [--agent A] [--workspace W] [--template T] <checklist.md> | list | remove <index>
+  task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] <checklist.md> | list | remove <index>
   task [<agent> | --path F] list [--status all|pending|done] | get <n> | add <text>
                         | start <n> | done <n> | undone <n> | update <n> <text>
                         | remove <n> | send <n> [--yes]

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -956,8 +956,9 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 				fmt.Fprintf(out, " template=%q", src.NextTaskTemplate)
 			}
 			// Only shown when on: it is the one source setting that makes hap
-			// hand out tasks unprompted, so it must be visible here — the key
-			// itself is config.toml-only.
+			// hand out tasks unprompted, so it must be visible here. Set it
+			// with `task-source add --auto-send-when-idle`, or by editing
+			// config.toml for a source that already exists.
 			if src.EnableAutoSendTaskWhenIdle {
 				fmt.Fprint(out, " auto_send_when_idle=true")
 			}
@@ -994,17 +995,35 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 	agent := fs.String("agent", "", "agent short name, id, or type this source applies to")
 	workspace := fs.String("workspace", "", "workspace name this source applies to (\"*\" wildcards, e.g. \"codex-*\")")
 	template := fs.String("template", "", "next-task prompt template ({next_task_content}, {task_list_path}, {task_list_path_quoted}, {agent_name} placeholders)")
+	autoSend := fs.Bool("auto-send-when-idle", false, "also hand out tasks on the periodic idle poll, not only on a herdr attention event")
 	fs.SetOutput(out)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
-		return fmt.Errorf("usage: task-source [add] [--agent A] [--workspace W] [--template T] <checklist.md> | list | remove <index>")
+		// Go's flag parsing stops at the first non-flag argument, so a flag
+		// written AFTER the path is silently not applied — say so instead of
+		// printing the generic usage line, which never mentions the ordering.
+		for _, extra := range fs.Args()[min(fs.NArg(), 1):] {
+			if strings.HasPrefix(extra, "-") {
+				return fmt.Errorf("flags must come before <checklist.md>: %s was read as an argument, not a flag", extra)
+			}
+		}
+		return fmt.Errorf("usage: task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] <checklist.md> | list | remove <index>")
 	}
-	if err := app.AddTaskSource(ctx, *agent, *workspace, fs.Arg(0), *template); err != nil {
+	var opts []frontend.TaskSourceOption
+	if *autoSend {
+		opts = append(opts, frontend.AutoSendWhenIdle())
+	}
+	if err := app.AddTaskSource(ctx, *agent, *workspace, fs.Arg(0), *template, opts...); err != nil {
 		return err
 	}
 	fmt.Fprintf(out, "task source added: %s\n", fs.Arg(0))
+	// Unprompted hand-out is the one setting that makes hap act without a herdr
+	// event, so say so plainly instead of leaving it to `task-source list`.
+	if *autoSend {
+		fmt.Fprintln(out, "auto-send when idle is ON: matching idle agents are handed their next pending task without an attention event")
+	}
 	return nil
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1440,6 +1440,113 @@ func TestTaskSourceListShowsAutoSendFlag(t *testing.T) {
 	}
 }
 
+// TestTaskSourceAddAutoSendWhenIdle pins the flag that turns on unprompted
+// hand-out at add time. It is a safety control: enabling it lets the daemon
+// send tasks with no herdr attention event behind them, so it must be opt-IN —
+// never set by an add that did not ask for it — and it must be reported back.
+func TestTaskSourceAddAutoSendWhenIdle(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "absent", args: []string{"add", "--agent", "quiet-fox"}},
+		{name: "flag", args: []string{"add", "--agent", "busy-otter", "--auto-send-when-idle"}, want: true},
+		{name: "explicit false", args: []string{"add", "--agent", "quiet-mole", "--auto-send-when-idle=false"}},
+		{name: "explicit true", args: []string{"add", "--agent", "busy-bee", "--auto-send-when-idle=true"}, want: true},
+		// The `add` verb is optional on this command; the flag must survive
+		// the bare form too.
+		{name: "no add verb", args: []string{"--agent", "busy-crow", "--auto-send-when-idle"}, want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app, _ := testApp(t)
+			path := writeTaskFile(t, "- [ ] a\n")
+			out, err := run(t, app, "task-source", append(tc.args, path)...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := app.Config()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(cfg.TaskSources) != 1 {
+				t.Fatalf("want 1 task source, got %d", len(cfg.TaskSources))
+			}
+			if got := cfg.TaskSources[0].EnableAutoSendTaskWhenIdle; got != tc.want {
+				t.Fatalf("enable_auto_send_task_when_idle = %v, want %v", got, tc.want)
+			}
+			// Turning it on is loud; leaving it off says nothing.
+			if said := strings.Contains(out, "auto-send when idle is ON"); said != tc.want {
+				t.Errorf("add output announced auto-send = %v, want %v; got:\n%s", said, tc.want, out)
+			}
+			listed, err := run(t, app, "task-source", "list")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if shown := strings.Contains(listed, "auto_send_when_idle=true"); shown != tc.want {
+				t.Errorf("task-source list showed the flag = %v, want %v; got:\n%s", shown, tc.want, listed)
+			}
+		})
+	}
+}
+
+// TestTaskSourceAddFlagPlacement pins what happens when the flag lands after
+// the path. Go's flag parsing stops at the first non-flag argument, so that
+// ordering CANNOT enable auto-send — the important half is that it fails
+// loudly instead of adding a source with the flag quietly off.
+func TestTaskSourceAddFlagPlacement(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] a\n")
+
+	_, err := run(t, app, "task-source", "add", path, "--auto-send-when-idle")
+	if err == nil {
+		t.Fatal("a flag after the path must be an error, not a silently-ignored flag")
+	}
+	if !strings.Contains(err.Error(), "must come before") {
+		t.Errorf("error should explain the ordering, got: %v", err)
+	}
+	cfg, cfgErr := app.Config()
+	if cfgErr != nil {
+		t.Fatal(cfgErr)
+	}
+	if len(cfg.TaskSources) != 0 {
+		t.Errorf("nothing should have been added, got %+v", cfg.TaskSources)
+	}
+
+	// No path at all is still the plain usage error.
+	if _, err := run(t, app, "task-source", "add", "--auto-send-when-idle"); err == nil {
+		t.Error("--auto-send-when-idle with no checklist must error")
+	}
+}
+
+// TestTaskSourceAddAutoSendIsPerSource guards the blast radius: turning the
+// flag on for one source must not switch on sources added before it.
+func TestTaskSourceAddAutoSendIsPerSource(t *testing.T) {
+	app, _ := testApp(t)
+	quiet := writeTaskFile(t, "- [ ] a\n")
+	busy := writeTaskFile(t, "- [ ] b\n")
+	if _, err := run(t, app, "task-source", "add", "--agent", "quiet-fox", quiet); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run(t, app, "task-source", "add", "--agent", "busy-otter", "--auto-send-when-idle", busy); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 2 {
+		t.Fatalf("want 2 task sources, got %d", len(cfg.TaskSources))
+	}
+	if cfg.TaskSources[0].EnableAutoSendTaskWhenIdle {
+		t.Error("adding an auto-send source switched on the source added before it")
+	}
+	if !cfg.TaskSources[1].EnableAutoSendTaskWhenIdle {
+		t.Error("the source added with --auto-send-when-idle did not keep the flag")
+	}
+}
+
 // TestTaskAddressedByDocumentID covers a hand-authored checklist that numbers
 // its own tasks with section-scoped ids ("3.4"). The id is what an agent reads
 // in its prompt, so `done 3.4` must tick THAT item — and a bare "3", which

--- a/internal/cli/destructive_test.go
+++ b/internal/cli/destructive_test.go
@@ -1,0 +1,659 @@
+package cli_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// Command-level regression tests for the CLI paths that DELETE persisted
+// state. Each one pins the same three-part contract, because a regression in
+// any part is silent and unrecoverable for the operator:
+//
+//  1. the guard refuses AND leaves every row/entry intact,
+//  2. the confirmed path deletes exactly what it named — no more,
+//  3. a bad target (out of range, unparseable, absent) deletes nothing.
+//
+// The signature delete/reset guards themselves are covered by
+// TestSignaturesDelete / TestSignaturesReset; what is added here is the
+// "wrong target changes nothing" half those tests do not reach.
+
+// --- clear-data ---------------------------------------------------------
+
+// seededSignatures are the keys seedSignatures writes. learnedCounts walks
+// them explicitly so its decision count is not scoped to one rule — a wipe
+// that only cleared the first signature's history would otherwise pass.
+var seededSignatures = []string{"approval:aaaa1111bbbb2222", "choice:cccc3333"}
+
+// learnedCounts summarizes the rows clear-data is supposed to wipe.
+func learnedCounts(t *testing.T, st *store.Store) (sigs, decisions, audit int) {
+	t.Helper()
+	ctx := context.Background()
+	rows, err := st.ListSignatures(ctx, domain.SignatureFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, sig := range seededSignatures {
+		n, err := st.CountDecisionsForSignature(ctx, sig)
+		if err != nil {
+			t.Fatal(err)
+		}
+		decisions += n
+	}
+	log, err := st.AuditLog(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(rows), decisions, len(log)
+}
+
+// TestClearDataRefusesWithoutYes pins the confirmation guard on the single
+// most destructive command hap has: it wipes every learned rule, decision and
+// audit row at once, and there is no undo. A bare `clear-data` must change
+// nothing at all.
+func TestClearDataRefusesWithoutYes(t *testing.T) {
+	app, st := testApp(t)
+	seedSignatures(t, st)
+	wantSigs, wantDecs, wantAudit := learnedCounts(t, st)
+	if wantSigs == 0 || wantDecs == 0 || wantAudit == 0 {
+		t.Fatalf("precondition: fixture must seed rows, got %d/%d/%d", wantSigs, wantDecs, wantAudit)
+	}
+
+	out, err := run(t, app, "clear-data")
+	if err == nil {
+		t.Fatal("clear-data without --yes must refuse")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("refusal must name the flag that confirms it, got: %v", err)
+	}
+	// The refusal happens before anything is written, so the command must
+	// print nothing at all — not merely avoid the word "cleared".
+	if out != "" {
+		t.Errorf("a refused clear-data must print nothing, got:\n%s", out)
+	}
+	if s, d, a := learnedCounts(t, st); s != wantSigs || d != wantDecs || a != wantAudit {
+		t.Errorf("refused clear-data still deleted rows: signatures %d→%d decisions %d→%d audit %d→%d",
+			wantSigs, s, wantDecs, d, wantAudit, a)
+	}
+}
+
+// TestClearDataYesWipesLearnedStateOnly is the other half: --yes really does
+// wipe the learned tables, and — the regression that matters — it leaves the
+// OPERATOR's own state alone. Agent names, the per-agent disable switch, task
+// sources and never-auto patterns are things the operator typed, not things
+// hap learned; re-deriving them is manual work, so clear-data must not touch
+// them.
+func TestClearDataYesWipesLearnedStateOnly(t *testing.T) {
+	app, st := testApp(t)
+	seedSignatures(t, st)
+	ctx := context.Background()
+
+	// Operator-owned state, in the store...
+	name, err := st.EnsureAgentName(ctx, "w1:p1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.SetAgentDisabled(ctx, name, true); err != nil {
+		t.Fatal(err)
+	}
+	// ...and in config.toml.
+	tasks := writeTaskFile(t, "- [ ] keep me\n")
+	if err := app.AddTaskSource(ctx, name, "", tasks, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddNeverAutoPattern(ctx, "(?i)terraform destroy"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "clear-data", "--yes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "cleared") {
+		t.Errorf("clear-data --yes should report what it did, got:\n%s", out)
+	}
+
+	if s, d, a := learnedCounts(t, st); s != 0 || d != 0 || a != 0 {
+		t.Errorf("learned state should be empty, got signatures=%d decisions=%d audit=%d", s, d, a)
+	}
+
+	names, err := st.AgentNames(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names["w1:p1"] != name {
+		t.Errorf("clear-data renamed the herd: %q → %q", name, names["w1:p1"])
+	}
+	disabled, err := st.DisabledAgents(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !disabled["w1:p1"] {
+		t.Error("clear-data re-enabled automation for an agent the operator disabled")
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 1 {
+		t.Errorf("clear-data must not touch task sources, got %+v", cfg.TaskSources)
+	}
+	if len(cfg.Safety.NeverAutoPatterns) != 1 {
+		t.Errorf("clear-data must not touch never-auto patterns, got %+v", cfg.Safety.NeverAutoPatterns)
+	}
+	if _, err := os.Stat(tasks); err != nil {
+		t.Errorf("clear-data must not touch checklist files: %v", err)
+	}
+
+	// Running it again on an already-empty store is a no-op, not an error —
+	// an operator retrying after an interrupted run must not see a failure.
+	if _, err := run(t, app, "clear-data", "--yes"); err != nil {
+		t.Errorf("clear-data --yes on an empty store: %v", err)
+	}
+}
+
+// --- task-source remove -------------------------------------------------
+
+// TestTaskSourceRemoveTargetsTheListedEntry pins that `remove <index>` removes
+// the entry `list` numbered with that index and nothing else. Sources are
+// addressed positionally, so an off-by-one here silently retires a different
+// agent's checklist.
+func TestTaskSourceRemoveTargetsTheListedEntry(t *testing.T) {
+	app, _ := testApp(t)
+	ctx := context.Background()
+	paths := make([]string, 3)
+	for i, agent := range []string{"alpha", "beta", "gamma"} {
+		paths[i] = writeTaskFile(t, "- [ ] "+agent+"\n")
+		if err := app.AddTaskSource(ctx, agent, "", paths[i], ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out, err := run(t, app, "task-source", "remove", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, paths[1]) {
+		t.Errorf("removal should name the path it retired, got:\n%s", out)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 2 {
+		t.Fatalf("want 2 sources left, got %d", len(cfg.TaskSources))
+	}
+	if cfg.TaskSources[0].Agent != "alpha" || cfg.TaskSources[1].Agent != "gamma" {
+		t.Errorf("wrong entry removed, left with %+v", cfg.TaskSources)
+	}
+	// The checklist file is the operator's document — often a hand-written
+	// doc hap never created — so retiring the entry must leave it on disk.
+	for _, p := range paths {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("checklist %s should survive removal: %v", p, err)
+		}
+	}
+}
+
+// TestTaskSourceRemoveRejectsBadIndex pins that every unusable index is
+// refused without touching config: indices come from a listing the operator
+// may be reading from a stale terminal.
+func TestTaskSourceRemoveRejectsBadIndex(t *testing.T) {
+	app, _ := testApp(t)
+	ctx := context.Background()
+	path := writeTaskFile(t, "- [ ] only\n")
+	if err := app.AddTaskSource(ctx, "solo", "", path, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct{ name, index, wantErr string }{
+		{name: "past the end", index: "1", wantErr: "no task source #1"},
+		{name: "negative", index: "-2", wantErr: "no task source #-2"},
+		{name: "not a number", index: "beta", wantErr: "invalid task source index"},
+		{name: "empty", index: "", wantErr: "invalid task source index"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := run(t, app, "task-source", "remove", tc.index)
+			if err == nil {
+				t.Fatalf("index %q must be refused", tc.index)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %v, want it to contain %q", err, tc.wantErr)
+			}
+			cfg, cfgErr := app.Config()
+			if cfgErr != nil {
+				t.Fatal(cfgErr)
+			}
+			if len(cfg.TaskSources) != 1 {
+				t.Fatalf("a refused removal must leave config alone, got %+v", cfg.TaskSources)
+			}
+		})
+	}
+
+	// A missing index is a usage error, never "remove the first one".
+	if _, err := run(t, app, "task-source", "remove"); err == nil {
+		t.Error("remove without an index must error")
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 1 {
+		t.Errorf("bare remove deleted something: %+v", cfg.TaskSources)
+	}
+}
+
+// TestTaskSourceRemoveIndicesShift pins the sharp edge of positional
+// addressing: indices are re-assigned after every removal, so the index that
+// was valid a moment ago can now be out of range. It must fail, not wrap onto
+// the survivor.
+func TestTaskSourceRemoveIndicesShift(t *testing.T) {
+	app, _ := testApp(t)
+	ctx := context.Background()
+	keep := writeTaskFile(t, "- [ ] keep\n")
+	drop := writeTaskFile(t, "- [ ] drop\n")
+	if err := app.AddTaskSource(ctx, "keeper", "", keep, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(ctx, "dropper", "", drop, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := run(t, app, "task-source", "remove", "1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := run(t, app, "task-source", "remove", "1"); err == nil {
+		t.Fatal("re-running the same index after the list shrank must fail")
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 1 || cfg.TaskSources[0].Agent != "keeper" {
+		t.Errorf("the survivor must still be there, got %+v", cfg.TaskSources)
+	}
+}
+
+// --- rules remove -------------------------------------------------------
+
+// TestRulesRemoveTargetsTheListedPattern covers the other positional delete in
+// the CLI. Never-auto patterns are a SAFETY control — removing the wrong one
+// silently re-arms automation for a command the operator meant to block, so
+// the index must be exact and a bad index must be inert.
+func TestRulesRemoveTargetsTheListedPattern(t *testing.T) {
+	app, _ := testApp(t)
+	ctx := context.Background()
+	patterns := []string{"(?i)terraform destroy", "(?i)drop table", "(?i)rm -rf /"}
+	for _, p := range patterns {
+		if err := app.AddNeverAutoPattern(ctx, p); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out, err := run(t, app, "rules", "remove", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, patterns[1]) {
+		t.Errorf("removal should name the pattern it dropped, got:\n%s", out)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Safety.NeverAutoPatterns; len(got) != 2 || got[0] != patterns[0] || got[1] != patterns[2] {
+		t.Fatalf("wrong pattern removed, left with %+v", got)
+	}
+
+	for _, index := range []string{"2", "-1", "two"} {
+		if _, err := run(t, app, "rules", "remove", index); err == nil {
+			t.Errorf("index %q must be refused", index)
+		}
+		if cfg, err = app.Config(); err != nil {
+			t.Fatal(err)
+		}
+		if len(cfg.Safety.NeverAutoPatterns) != 2 {
+			t.Fatalf("a refused rules remove must leave the safety list alone, got %+v",
+				cfg.Safety.NeverAutoPatterns)
+		}
+	}
+}
+
+// TestRulesRemoveLeavesConfiguredRulesAlone pins the boundary between the two
+// never-auto surfaces: `rules remove <index>` addresses the operator's plain
+// patterns only, so it must never renumber into — or delete out of — the
+// scoped `[[safety.never_auto_rules]]` entries that live in config.toml.
+func TestRulesRemoveLeavesConfiguredRulesAlone(t *testing.T) {
+	app, _ := testApp(t)
+	cfg := config.Default()
+	cfg.Safety.NeverAutoPatterns = []string{"(?i)only one"}
+	cfg.Safety.NeverAutoRules = []config.NeverAutoRule{
+		{Pattern: "(?i)scoped rule", AgentTypes: []string{"codex"}},
+	}
+	if err := config.Save(app.ConfigPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := run(t, app, "rules", "remove", "0"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Safety.NeverAutoPatterns) != 0 {
+		t.Errorf("the plain pattern should be gone, got %+v", got.Safety.NeverAutoPatterns)
+	}
+	if len(got.Safety.NeverAutoRules) != 1 {
+		t.Fatalf("scoped rules must survive, got %+v", got.Safety.NeverAutoRules)
+	}
+	// And with the plain list now empty, index 0 must not fall through to the
+	// scoped rule.
+	if _, err := run(t, app, "rules", "remove", "0"); err == nil {
+		t.Error("removing from an empty pattern list must error, not delete a scoped rule")
+	}
+	if got, err = app.Config(); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Safety.NeverAutoRules) != 1 {
+		t.Errorf("scoped rule was deleted through the pattern index: %+v", got.Safety.NeverAutoRules)
+	}
+}
+
+// --- signatures delete / reset: wrong-target inertness ------------------
+
+// TestSignatureDeleteAndResetIgnoreUnknownTargets completes the coverage of
+// the two learned-history destroyers: TestSignaturesDelete/TestSignaturesReset
+// pin the --yes guard and the happy path, this pins that a target matching
+// nothing changes nothing — including with --yes, which skips the preview the
+// operator would otherwise have seen.
+func TestSignatureDeleteAndResetIgnoreUnknownTargets(t *testing.T) {
+	app, st := testApp(t)
+	seedSignatures(t, st)
+	ctx := context.Background()
+	before, err := st.ListSignatures(ctx, domain.SignatureFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantSigs, wantDecs, wantAudit := learnedCounts(t, st)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "delete unknown prefix", args: []string{"delete", "nosuch:", "--yes"}},
+		{name: "reset unknown prefix", args: []string{"reset", "nosuch:", "--yes"}},
+		// A near-miss of a real key: prefix matching must not round it up
+		// to the neighbouring signature.
+		{name: "delete near-miss key", args: []string{"delete", "approval:aaaa1111bbbb2222x", "--yes"}},
+		{name: "delete without a target", args: []string{"delete"}},
+		{name: "reset without a target", args: []string{"reset"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := run(t, app, "signatures", tc.args...); err == nil {
+				t.Errorf("signatures %v must error", tc.args)
+			}
+		})
+	}
+
+	after, err := st.ListSignatures(ctx, domain.SignatureFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("unknown targets deleted rows: %d → %d", len(before), len(after))
+	}
+	for i, sig := range after {
+		// DecisionFloorID is compared deliberately: it is the field `reset`
+		// writes, so a failed reset that stamped it anyway would discard the
+		// rule's history while every other field still looked untouched.
+		if sig.Signature != before[i].Signature || sig.Mode != before[i].Mode ||
+			sig.ConsecutiveConfirmations != before[i].ConsecutiveConfirmations ||
+			sig.DecisionFloorID != before[i].DecisionFloorID {
+			t.Errorf("row %d mutated by a failed command:\n before %+v\n  after %+v", i, before[i], sig)
+		}
+	}
+	// A failed `delete` must not have taken the decision or audit rows with
+	// it either — the store erases those in the same transaction.
+	if s, d, a := learnedCounts(t, st); s != wantSigs || d != wantDecs || a != wantAudit {
+		t.Errorf("failed commands deleted rows: signatures %d→%d decisions %d→%d audit %d→%d",
+			wantSigs, s, wantDecs, d, wantAudit, a)
+	}
+}
+
+// TestSignaturesResetMovesTheDecisionFloor pins the part of `reset` that is
+// actually irreversible. The command keeps the decision ROWS — which reads as
+// harmless — but stamps a floor so every decision before it stops counting
+// toward the rule. A regression that skipped the floor would leave the rule
+// re-graduating instantly off its old history, which is exactly what the
+// operator reset it to stop.
+func TestSignaturesResetMovesTheDecisionFloor(t *testing.T) {
+	app, st := testApp(t)
+	seedSignatures(t, st)
+	ctx := context.Background()
+	const sig = "approval:aaaa1111bbbb2222"
+
+	before, err := st.GetSignature(ctx, sig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.DecisionFloorID != 0 {
+		t.Fatalf("precondition: fixture must start with no floor, got %d", before.DecisionFloorID)
+	}
+	decs, err := st.DecisionsForSignature(ctx, sig, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decs) != 2 {
+		t.Fatalf("precondition: want 2 seeded decisions, got %d", len(decs))
+	}
+
+	if _, err := run(t, app, "signatures", "reset", sig, "--yes"); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := st.GetSignature(ctx, sig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.DecisionFloorID == 0 {
+		t.Error("reset left the decision floor at 0 — the old history still counts")
+	}
+	// The rows themselves are kept: reset is not delete, and the audit trail
+	// of what the rule used to do must survive.
+	kept, err := st.DecisionsForSignature(ctx, sig, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(kept) != len(decs) {
+		t.Errorf("reset deleted decision rows: %d → %d", len(decs), len(kept))
+	}
+	for _, d := range decs {
+		if d.ID > after.DecisionFloorID {
+			t.Errorf("decision #%d predates the reset but is above the floor %d",
+				d.ID, after.DecisionFloorID)
+		}
+	}
+}
+
+// --- task remove --------------------------------------------------------
+
+// TestTaskRemoveRejectsBadRef pins that a checklist item is only removed when
+// the reference resolves. `task remove` rewrites the operator's markdown file
+// in place, so a mis-resolved reference destroys text hap cannot restore.
+func TestTaskRemoveRejectsBadRef(t *testing.T) {
+	const body = "- [ ] alpha\n- [x] beta\n"
+	tests := []struct {
+		name string
+		ref  []string // args after "remove"; empty = no reference at all
+		want string   // file content afterwards
+	}{
+		{name: "zero", ref: []string{"0"}, want: body},
+		{name: "past the end", ref: []string{"3"}, want: body},
+		{name: "negative", ref: []string{"-1"}, want: body},
+		{name: "not a reference", ref: []string{"nope"}, want: body},
+		// A missing reference must not fall back to "the first one".
+		{name: "no reference", ref: nil, want: body},
+		// The positive control: without it, every row above would still pass
+		// if `task remove` rejected EVERY reference.
+		{name: "valid", ref: []string{"1"}, want: "- [x] beta\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app, _ := testApp(t)
+			path := writeTaskFile(t, body)
+			args := append([]string{"--path", path, "remove"}, tc.ref...)
+			_, err := run(t, app, "task", args...)
+			if wantErr := tc.want == body; wantErr != (err != nil) {
+				t.Fatalf("remove %v: error = %v, want error = %v", tc.ref, err, wantErr)
+			}
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if string(data) != tc.want {
+				t.Errorf("file after remove %v:\n got %q\nwant %q", tc.ref, data, tc.want)
+			}
+		})
+	}
+}
+
+// TestTaskRemoveDeletesTheReferencedItemNotThePosition pins the CLI's own
+// wiring for the delete verb: `task ... remove <ref>` resolves the reference
+// and then deletes the line THAT resolved to, passing its text as the guard
+// (cli.go's taskItemArg → App.DeleteTask). The App-level guard itself is
+// covered by frontend's TestTaskMutationsVerifyExpectedText; what only the
+// command can get wrong is which line it names. When a checklist numbers its
+// own tasks, ids and positions disagree — "1.2" is the third line here — and
+// deleting by position instead would silently destroy the wrong task, with no
+// undo and no trace.
+func TestTaskRemoveDeletesTheReferencedItemNotThePosition(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] 1.1 alpha\n- [ ] 1.05 inserted\n- [ ] 1.2 beta\n")
+
+	if _, err := run(t, app, "task", "--path", path, "remove", "1.2"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "- [ ] 1.1 alpha\n- [ ] 1.05 inserted\n"; string(data) != want {
+		t.Fatalf("remove 1.2 by id:\n got %q\nwant %q", data, want)
+	}
+
+	// A position reference deletes by position — the other half of the same
+	// contract, so neither addressing mode can quietly swallow the other.
+	if _, err := run(t, app, "task", "--path", path, "remove", "#1"); err != nil {
+		t.Fatal(err)
+	}
+	if data, err = os.ReadFile(path); err != nil {
+		t.Fatal(err)
+	}
+	if want := "- [ ] 1.05 inserted\n"; string(data) != want {
+		t.Errorf("remove #1 by position:\n got %q\nwant %q", data, want)
+	}
+}
+
+// --- dismiss ------------------------------------------------------------
+
+// TestDismissLeavesOtherEscalationsOpen pins that resolving one escalation by
+// id closes exactly that one. Dismissing is how an operator clears a queue
+// item without answering it; taking a neighbour with it would silently strand
+// a blocked agent.
+func TestDismissLeavesOtherEscalationsOpen(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	var ids []int64
+	for _, trigger := range []string{"first", "second", "third"} {
+		id, err := st.AppendAudit(ctx, domain.AuditRecord{
+			SituationType: domain.SituationApproval, Trigger: trigger,
+			Action: "escalated", Status: "escalated", CreatedAt: time.Now(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+	}
+
+	if _, err := run(t, app, "dismiss", fmt.Sprintf("%d", ids[1])); err != nil {
+		t.Fatal(err)
+	}
+	open, err := app.Escalations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(open) != 2 {
+		t.Fatalf("want 2 escalations left open, got %d", len(open))
+	}
+	for _, e := range open {
+		if e.ID == ids[1] {
+			t.Errorf("the dismissed escalation #%d is still open", e.ID)
+		}
+	}
+
+	// An id that does not exist must not close anything.
+	if _, err := run(t, app, "dismiss", "9999"); err == nil {
+		t.Error("dismissing an unknown id must error")
+	}
+	if open, err = app.Escalations(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if len(open) != 2 {
+		t.Errorf("a failed dismiss closed an escalation: %d left", len(open))
+	}
+}
+
+// TestDismissAppliesPartiallyAndSaysSo pins the behavior of a multi-id dismiss
+// where a later id is bad: the command dismisses each id as it goes, so the
+// earlier ones ARE applied before it errors. That is not undone — what makes
+// it safe is that stdout names every escalation actually closed, so the
+// operator can see the boundary instead of assuming the whole command rolled
+// back. A regression that stopped printing per id would hide it.
+func TestDismissAppliesPartiallyAndSaysSo(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	var ids []int64
+	for _, trigger := range []string{"first", "second"} {
+		id, err := st.AppendAudit(ctx, domain.AuditRecord{
+			SituationType: domain.SituationApproval, Trigger: trigger,
+			Action: "escalated", Status: "escalated", CreatedAt: time.Now(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+	}
+
+	out, err := run(t, app, "dismiss", fmt.Sprintf("%d", ids[0]), "9999")
+	if err == nil {
+		t.Fatal("a bad id in the list must still error")
+	}
+	if !strings.Contains(out, fmt.Sprintf("dismissed escalation #%d", ids[0])) {
+		t.Errorf("output must name the escalation that WAS dismissed, got:\n%s", out)
+	}
+	open, err := app.Escalations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(open) != 1 || open[0].ID != ids[1] {
+		t.Fatalf("want only #%d left open, got %+v", ids[1], open)
+	}
+	// The applied one is a soft close: the audit row survives as evidence.
+	rec, err := st.GetAudit(ctx, ids[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec == nil || rec.Status != "dismissed" {
+		t.Errorf("audit row #%d must be kept as dismissed, got %+v", ids[0], rec)
+	}
+}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -2407,21 +2407,40 @@ func (a *App) AddNeverAutoPattern(ctx context.Context, pattern string) error {
 	})
 }
 
+// TaskSourceOption tweaks an optional, non-positional field of a new task
+// source. New per-source settings go here rather than growing the positional
+// argument list of AddTaskSource (which every caller and test would have to
+// re-spell).
+type TaskSourceOption func(*config.TaskSource)
+
+// AutoSendWhenIdle opts the new source into the daemon's periodic idle poll
+// (enable_auto_send_task_when_idle): matching agents idle past the threshold
+// are handed their next pending task without a herdr attention event. This is
+// the one source setting that makes hap act unprompted, so it is opt-in at
+// every surface and never inferred.
+func AutoSendWhenIdle() TaskSourceOption {
+	return func(src *config.TaskSource) { src.EnableAutoSendTaskWhenIdle = true }
+}
+
 // AddTaskSource points an agent/workspace at a declared task list (FR-011).
 // template optionally overrides the outbound next-task prompt format
 // ({next_task_content} / {task_list_path} / {agent_name} placeholders);
 // "" uses the default.
-func (a *App) AddTaskSource(ctx context.Context, agent, workspace, path, template string) error {
+func (a *App) AddTaskSource(ctx context.Context, agent, workspace, path, template string, opts ...TaskSourceOption) error {
 	// The daemon reads the file from its own cwd (the state dir), not the
 	// operator's shell; resolve relative paths here where they still mean
 	// what the operator sees.
 	if abs, err := filepath.Abs(path); err == nil {
 		path = abs
 	}
+	src := config.TaskSource{
+		Agent: agent, Workspace: workspace, Path: path, NextTaskTemplate: template,
+	}
+	for _, opt := range opts {
+		opt(&src)
+	}
 	return a.UpdateConfig(ctx, func(cfg *config.Config) error {
-		cfg.TaskSources = append(cfg.TaskSources, config.TaskSource{
-			Agent: agent, Workspace: workspace, Path: path, NextTaskTemplate: template,
-		})
+		cfg.TaskSources = append(cfg.TaskSources, src)
 		return nil
 	})
 }

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -4245,6 +4245,69 @@ func (e *emptyAgentsHerdr) ListAgents(context.Context) ([]domain.AgentTransition
 	return nil, nil
 }
 
+// TestAddTaskSourceAutoSendWhenIdleOption pins the option that turns on
+// unprompted hand-out. Unprompted sending is a safety-relevant capability, so
+// it must be reachable ONLY by asking for it: no option, no flag — including
+// on the bootstrap path that registers a generated task list by itself, which
+// no operator ever opted in for.
+func TestAddTaskSourceAutoSendWhenIdleOption(t *testing.T) {
+	app, st := testApp(t)
+	app.Herdr = &fakeHerdr{}
+	app.StateDir = t.TempDir()
+	ctx := context.Background()
+	dir := t.TempDir()
+	plain := filepath.Join(dir, "plain.md")
+	auto := filepath.Join(dir, "auto.md")
+
+	if err := app.AddTaskSource(ctx, "quiet-fox", "", plain, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(ctx, "busy-otter", "", auto, "", frontend.AutoSendWhenIdle()); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 2 {
+		t.Fatalf("want 2 task sources, got %d", len(cfg.TaskSources))
+	}
+	if cfg.TaskSources[0].EnableAutoSendTaskWhenIdle {
+		t.Error("an add with no option must leave auto-send off")
+	}
+	if !cfg.TaskSources[1].EnableAutoSendTaskWhenIdle {
+		t.Error("AutoSendWhenIdle() did not reach the saved source")
+	}
+	// The option must survive a save/load round trip, not just the in-memory
+	// config: the daemon reads the file.
+	reloaded, err := config.Load(app.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.TaskSources[0].EnableAutoSendTaskWhenIdle || !reloaded.TaskSources[1].EnableAutoSendTaskWhenIdle {
+		t.Errorf("auto-send flags did not round-trip through config.toml: %+v", reloaded.TaskSources)
+	}
+
+	// Confirming a generated task list bootstraps a source by itself — no
+	// operator ever opted that one in, so it must come out off.
+	if _, err := st.EnsureAgentName(ctx, "w9:p9"); err != nil {
+		t.Fatal(err)
+	}
+	id := generatedEscalation(t, st, "w9:p9", "Bootstrap a list")
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+	if cfg, err = app.Config(); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 3 {
+		t.Fatalf("confirm should have bootstrapped a third source, got %d", len(cfg.TaskSources))
+	}
+	if cfg.TaskSources[2].EnableAutoSendTaskWhenIdle {
+		t.Error("a bootstrapped task source must never enable unprompted hand-out")
+	}
+}
+
 // TestRemoveTaskSourceKeepsChecklistFile pins the contract the TUI's Tasks-tab
 // `x` advertises: removing a source retires the config entry only. Source
 // files are often hand-written docs hap never created and could not restore.

--- a/internal/tui/prompt_edit_test.go
+++ b/internal/tui/prompt_edit_test.go
@@ -1,0 +1,424 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// editKey builds the real typed-key messages the prompt editor switches on.
+// The shared pressKeyMsg helper turns anything it does not know into KeyRunes,
+// which would deliver "left" as the literal text; the caret bindings match on
+// tea.KeyLeft and friends, so they need the genuine article.
+func editKey(k string) tea.KeyMsg {
+	switch k {
+	case "left":
+		return tea.KeyMsg{Type: tea.KeyLeft}
+	case "right":
+		return tea.KeyMsg{Type: tea.KeyRight}
+	case "ctrl+left":
+		return tea.KeyMsg{Type: tea.KeyCtrlLeft}
+	case "ctrl+right":
+		return tea.KeyMsg{Type: tea.KeyCtrlRight}
+	case "home":
+		return tea.KeyMsg{Type: tea.KeyHome}
+	case "end":
+		return tea.KeyMsg{Type: tea.KeyEnd}
+	case "ctrl+a":
+		return tea.KeyMsg{Type: tea.KeyCtrlA}
+	case "ctrl+e":
+		return tea.KeyMsg{Type: tea.KeyCtrlE}
+	case "backspace":
+		return tea.KeyMsg{Type: tea.KeyBackspace}
+	case "delete":
+		return tea.KeyMsg{Type: tea.KeyDelete}
+	case "space":
+		return tea.KeyMsg{Type: tea.KeySpace}
+	case "ctrl+j":
+		return tea.KeyMsg{Type: tea.KeyCtrlJ}
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(k)}
+	}
+}
+
+func pressEdit(t *testing.T, m Model, keys ...string) Model {
+	t.Helper()
+	for _, k := range keys {
+		upd, _ := m.Update(editKey(k))
+		m = upd.(Model)
+	}
+	return m
+}
+
+// promptModel opens a plain single-line prompt pre-filled with text.
+func promptModel(t *testing.T, text string) Model {
+	t.Helper()
+	m := testModel(t)
+	m.openPrompt(&prompt{label: "edit", input: text,
+		onSubmit: func(string) tea.Cmd { return nil }})
+	return m
+}
+
+// TestPromptCaretStartsAtEndOfPrefilledText pins the opening position. Every
+// prompt that pre-fills a value — editing a task, the prune default, the y/N
+// send prompt — is a value the operator most often appends to or clears, so
+// the caret parks after it. Opening at 0 would make the first keystroke insert
+// in front of the text instead.
+func TestPromptCaretStartsAtEndOfPrefilledText(t *testing.T) {
+	m := promptModel(t, "review the schema")
+	if got, want := m.prompt.cursor, len("review the schema"); got != want {
+		t.Fatalf("caret at %d, want %d (end of the pre-filled text)", got, want)
+	}
+	m = pressEdit(t, m, "!")
+	if want := "review the schema!"; m.prompt.input != want {
+		t.Errorf("typing appended at %q, want %q", m.prompt.input, want)
+	}
+}
+
+// TestPromptLeftRightEditsInPlace is the point of the whole change: an operator
+// who spots a typo in the middle of a long task must be able to walk back to it
+// and fix it, instead of backspacing over everything after it.
+func TestPromptLeftRightEditsInPlace(t *testing.T) {
+	m := promptModel(t, "fix the tets")
+
+	// Walk left over "ts" and insert the missing "s": "tets" → "tests".
+	m = pressEdit(t, m, "left", "left", "s")
+	if want := "fix the tests"; m.prompt.input != want {
+		t.Fatalf("insert mid-string gave %q, want %q", m.prompt.input, want)
+	}
+	// The caret followed the inserted rune, so typing continues in place.
+	if got, want := m.prompt.cursor, len("fix the tests")-2; got != want {
+		t.Fatalf("caret at %d, want %d (just after the inserted rune)", got, want)
+	}
+
+	// right walks back over the tail without disturbing it.
+	m = pressEdit(t, m, "right", "right")
+	if got, want := m.prompt.cursor, len("fix the tests"); got != want {
+		t.Errorf("caret at %d, want %d", got, want)
+	}
+	if want := "fix the tests"; m.prompt.input != want {
+		t.Errorf("moving the caret changed the text: %q", m.prompt.input)
+	}
+}
+
+// TestPromptCaretStopsAtBothEdges pins that motion saturates rather than
+// wrapping or going out of range — a caret that ran past either end would
+// slice the input out of bounds on the next keystroke.
+func TestPromptCaretStopsAtBothEdges(t *testing.T) {
+	m := promptModel(t, "abc")
+	m = pressEdit(t, m, "left", "left", "left", "left", "left")
+	if m.prompt.cursor != 0 {
+		t.Errorf("caret at %d after walking off the front, want 0", m.prompt.cursor)
+	}
+	// Backspace at the very front is a no-op, not a panic or a wrap.
+	m = pressEdit(t, m, "backspace")
+	if m.prompt.input != "abc" {
+		t.Errorf("backspace at the front changed the text: %q", m.prompt.input)
+	}
+
+	m = pressEdit(t, m, "right", "right", "right", "right", "right")
+	if m.prompt.cursor != 3 {
+		t.Errorf("caret at %d after walking off the end, want 3", m.prompt.cursor)
+	}
+	// Forward-delete at the very end is likewise inert.
+	m = pressEdit(t, m, "delete")
+	if m.prompt.input != "abc" {
+		t.Errorf("delete at the end changed the text: %q", m.prompt.input)
+	}
+}
+
+// TestPromptBackspaceAndDeleteAtCaret pins the two directions of removal
+// against the caret rather than the end of the line.
+func TestPromptBackspaceAndDeleteAtCaret(t *testing.T) {
+	tests := []struct {
+		name  string
+		keys  []string
+		want  string
+		caret int
+	}{
+		{name: "backspace removes before the caret",
+			keys: []string{"left", "left", "backspace"}, want: "abde", caret: 2},
+		{name: "delete removes under the caret",
+			keys: []string{"left", "left", "delete"}, want: "abce", caret: 3},
+		{name: "backspace at the end still trims the tail",
+			keys: []string{"backspace"}, want: "abcd", caret: 4},
+		{name: "delete at the front removes the first rune",
+			keys: []string{"home", "delete"}, want: "bcde", caret: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := pressEdit(t, promptModel(t, "abcde"), tc.keys...)
+			if m.prompt.input != tc.want {
+				t.Errorf("input = %q, want %q", m.prompt.input, tc.want)
+			}
+			if m.prompt.cursor != tc.caret {
+				t.Errorf("caret = %d, want %d", m.prompt.cursor, tc.caret)
+			}
+		})
+	}
+}
+
+// TestPromptJumpKeys covers the line-ends bindings, including the readline
+// aliases a terminal operator reaches for without thinking.
+func TestPromptJumpKeys(t *testing.T) {
+	for _, tc := range []struct {
+		key  string
+		want int
+	}{
+		{key: "home", want: 0},
+		{key: "ctrl+a", want: 0},
+		{key: "end", want: 5},
+		{key: "ctrl+e", want: 5},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			m := promptModel(t, "abcde")
+			// Start from the middle so both directions are a real move.
+			m = pressEdit(t, m, "left", "left")
+			m = pressEdit(t, m, tc.key)
+			if m.prompt.cursor != tc.want {
+				t.Errorf("%s put the caret at %d, want %d", tc.key, m.prompt.cursor, tc.want)
+			}
+			if m.prompt.input != "abcde" {
+				t.Errorf("%s changed the text: %q", tc.key, m.prompt.input)
+			}
+		})
+	}
+}
+
+// TestPromptWordMotion pins ctrl+←/ctrl+→. Task text is prose, so jumping by
+// word is what makes a long line editable without holding an arrow down.
+func TestPromptWordMotion(t *testing.T) {
+	const text = "add the retry guard"
+	m := promptModel(t, text) // caret at the end
+
+	m = pressEdit(t, m, "ctrl+left")
+	if got, want := m.prompt.cursor, strings.Index(text, "guard"); got != want {
+		t.Fatalf("ctrl+left → %d, want %d (start of the last word)", got, want)
+	}
+	m = pressEdit(t, m, "ctrl+left")
+	if got, want := m.prompt.cursor, strings.Index(text, "retry"); got != want {
+		t.Fatalf("second ctrl+left → %d, want %d", got, want)
+	}
+	m = pressEdit(t, m, "ctrl+right")
+	if got, want := m.prompt.cursor, strings.Index(text, "retry")+len("retry"); got != want {
+		t.Fatalf("ctrl+right → %d, want %d (end of that word)", got, want)
+	}
+	// Saturating at the edges, with the run of spaces skipped on the way.
+	m = pressEdit(t, m, "ctrl+left", "ctrl+left", "ctrl+left", "ctrl+left")
+	if m.prompt.cursor != 0 {
+		t.Errorf("word motion off the front → %d, want 0", m.prompt.cursor)
+	}
+	m = pressEdit(t, m, "ctrl+right", "ctrl+right", "ctrl+right", "ctrl+right", "ctrl+right")
+	if m.prompt.cursor != len(text) {
+		t.Errorf("word motion off the end → %d, want %d", m.prompt.cursor, len(text))
+	}
+	if m.prompt.input != text {
+		t.Errorf("word motion changed the text: %q", m.prompt.input)
+	}
+}
+
+// TestPromptEditingIsRuneSafe pins that the caret indexes RUNES, not bytes. A
+// task can hold any UTF-8 (the generated lists routinely carry em dashes), and
+// byte indexing would slice a multi-byte rune in half and corrupt the text.
+func TestPromptEditingIsRuneSafe(t *testing.T) {
+	m := promptModel(t, "héllo — wörld")
+	if got, want := m.prompt.cursor, len([]rune("héllo — wörld")); got != want {
+		t.Fatalf("caret at %d, want %d runes", got, want)
+	}
+	// Walk back over "wörld" and delete the multi-byte rune in it.
+	m = pressEdit(t, m, "ctrl+left", "right", "delete")
+	if want := "héllo — wrld"; m.prompt.input != want {
+		t.Fatalf("input = %q, want %q", m.prompt.input, want)
+	}
+	if !strings.ContainsRune(m.prompt.input, '—') {
+		t.Error("the em dash was corrupted by rune-unsafe slicing")
+	}
+	// Inserting a multi-byte rune mid-string keeps everything intact too.
+	m = pressEdit(t, m, "home", "right", "ü")
+	if want := "hüéllo — wrld"; m.prompt.input != want {
+		t.Errorf("input = %q, want %q", m.prompt.input, want)
+	}
+}
+
+// TestPromptMultilineInsertsAtCaret pins that a line break lands at the caret
+// like any other insert — the edit-task prompt is multiline, so splitting an
+// existing line in two is a normal edit.
+func TestPromptMultilineInsertsAtCaret(t *testing.T) {
+	m := testModel(t)
+	m.openPrompt(&prompt{label: "edit", input: "first second", multiline: true,
+		onSubmit: func(string) tea.Cmd { return nil }})
+
+	m = pressEdit(t, m, "ctrl+left", "ctrl+j")
+	if want := "first \nsecond"; m.prompt.input != want {
+		t.Fatalf("ctrl+j inserted at %q, want %q", m.prompt.input, want)
+	}
+	if got, want := m.prompt.cursor, len("first \n"); got != want {
+		t.Errorf("caret at %d, want %d (after the break)", got, want)
+	}
+
+	// A non-multiline prompt still refuses to take a line break at all.
+	m2 := promptModel(t, "one line")
+	m2 = pressEdit(t, m2, "home", "ctrl+j")
+	if strings.Contains(m2.prompt.input, "\n") {
+		t.Errorf("a single-line prompt accepted a break: %q", m2.prompt.input)
+	}
+}
+
+// TestPromptShiftEnterInsertsAtCaret covers the OTHER newline binding — the
+// one herdr actually transmits (ESC[27;2;13~), handled before the key switch
+// in Update. ctrl+j is the fallback for terminals that cannot report
+// shift+enter, so testing only ctrl+j would leave the real path uncovered.
+func TestPromptShiftEnterInsertsAtCaret(t *testing.T) {
+	m := testModel(t)
+	m.openPrompt(&prompt{label: "edit", input: "first second", multiline: true,
+		onSubmit: func(string) tea.Cmd { return nil }})
+
+	m = pressEdit(t, m, "ctrl+left")
+	m = shiftEnter(t, m, "27;2;13~")
+	if want := "first \nsecond"; m.prompt.input != want {
+		t.Fatalf("shift+enter inserted at %q, want %q", m.prompt.input, want)
+	}
+	if got, want := m.prompt.cursor, len("first \n"); got != want {
+		t.Errorf("caret at %d, want %d (after the break)", got, want)
+	}
+}
+
+// TestPromptCaretIndexesNormalizedText pins the invariant that makes openPrompt
+// and moveEnd measure promptNewlines.Replace(input) rather than the raw string:
+// a pasted "\r\n" is TWO raw runes and ONE normalized one, so measuring the raw
+// text parks the caret past the end. It survives today only because runes()
+// clamps — this test fails loudly instead of hiding behind the clamp.
+func TestPromptCaretIndexesNormalizedText(t *testing.T) {
+	const raw = "a\r\nb" // 4 raw runes, 3 after normalization
+	m := testModel(t)
+	m.openPrompt(&prompt{label: "edit", input: raw, multiline: true,
+		onSubmit: func(string) tea.Cmd { return nil }})
+	if got := m.prompt.cursor; got != 3 {
+		t.Fatalf("openPrompt put the caret at %d, want 3 (normalized length)", got)
+	}
+
+	// end must agree with it, from anywhere.
+	m = pressEdit(t, m, "home", "end")
+	if got := m.prompt.cursor; got != 3 {
+		t.Errorf("end put the caret at %d, want 3", got)
+	}
+
+	// And an edit at the caret lands after the "b", not before it.
+	m = pressEdit(t, m, "!")
+	if want := "a\nb!"; m.prompt.input != want {
+		t.Errorf("input = %q, want %q", m.prompt.input, want)
+	}
+}
+
+// TestSubmitNormalizesLineBreaks pins the matching half at submit time: an
+// untouched CRLF value must submit the same text an edited one would, or the
+// stored task silently depends on whether the operator pressed a key.
+func TestSubmitNormalizesLineBreaks(t *testing.T) {
+	var got string
+	m := testModel(t)
+	m.openPrompt(&prompt{label: "edit", input: "a\r\nb", multiline: true,
+		onSubmit: func(input string) tea.Cmd {
+			got = input
+			return nil
+		}})
+
+	upd, _ := m.Update(editKey("enter"))
+	_ = upd.(Model)
+	if want := "a\nb"; got != want {
+		t.Errorf("submitted %q, want %q — raw and edited paths must agree", got, want)
+	}
+}
+
+// TestPromptRendersCaretAtItsPosition pins the visible half: the caret block is
+// drawn where the next keystroke will land, not always at the end. Without
+// this the operator moves an invisible caret and edits blind.
+func TestPromptRendersCaretAtItsPosition(t *testing.T) {
+	m := promptModel(t, "abcd")
+	if view := m.View(); !strings.Contains(view, "abcd█") {
+		t.Errorf("caret at the end should render after the text:\n%s", view)
+	}
+	m = pressEdit(t, m, "left", "left")
+	if view := m.View(); !strings.Contains(view, "ab█cd") {
+		t.Errorf("caret should render at its position:\n%s", view)
+	}
+	m = pressEdit(t, m, "home")
+	if view := m.View(); !strings.Contains(view, "█abcd") {
+		t.Errorf("caret at the front should render before the text:\n%s", view)
+	}
+}
+
+// TestPromptCaretSurvivesADirectInputAssignment pins the clamp. Prompt input is
+// also set programmatically (tests, and any future caller that pre-loads text
+// after opening), which leaves the caret stale; a stale caret must behave as if
+// it sat at the end rather than slicing out of range.
+func TestPromptCaretSurvivesADirectInputAssignment(t *testing.T) {
+	m := promptModel(t, "")
+	m.prompt.input = "assigned directly"
+	m.prompt.cursor = 999 // far past the end
+
+	m = pressEdit(t, m, "!")
+	if want := "assigned directly!"; m.prompt.input != want {
+		t.Errorf("input = %q, want %q", m.prompt.input, want)
+	}
+	if view := m.View(); !strings.Contains(view, "assigned directly!█") {
+		t.Errorf("view should render with a clamped caret:\n%s", view)
+	}
+}
+
+// TestEveryPromptIsInstalledThroughOpenPrompt enforces the rule the cursor
+// field depends on, which the type system cannot: a prompt assigned directly
+// compiles fine and silently parks the caret at 0, so the first keystroke
+// inserts IN FRONT of a pre-filled default instead of after it (the y/N send
+// prompt is exactly that shape). runes() clamps against panics, not against
+// this. Mirrors TestDomainPurity: an architectural rule pinned by scanning the
+// package's own source.
+func TestEveryPromptIsInstalledThroughOpenPrompt(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range files {
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			text := strings.TrimSpace(line)
+			// openPrompt's own assignment is the one legitimate writer.
+			if strings.Contains(text, "prompt = &prompt{") {
+				t.Errorf("%s:%d assigns a prompt directly — use m.openPrompt(&prompt{…}) so the caret starts at the end of any pre-filled text:\n\t%s",
+					name, i+1, text)
+			}
+		}
+	}
+}
+
+// TestPickerPromptIgnoresCaretKeys pins the boundary: a prompt with fixed
+// options is a chooser, not a text field, so the caret bindings must not leak
+// into it — ↑/↓ move the highlight and everything else is inert.
+func TestPickerPromptIgnoresCaretKeys(t *testing.T) {
+	m := testModel(t)
+	m.openPrompt(&prompt{label: "pick", options: []string{"one", "two"},
+		onSubmit: func(string) tea.Cmd { return nil }})
+
+	m = pressEdit(t, m, "left", "right", "home", "end", "backspace", "x")
+	if m.prompt == nil {
+		t.Fatal("caret keys closed the picker")
+	}
+	if m.prompt.input != "" {
+		t.Errorf("picker took typed text: %q", m.prompt.input)
+	}
+	if m.prompt.optIdx != 0 {
+		t.Errorf("caret keys moved the highlight to %d", m.prompt.optIdx)
+	}
+}

--- a/internal/tui/prompt_edit_test.go
+++ b/internal/tui/prompt_edit_test.go
@@ -1,8 +1,12 @@
 package tui
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -420,5 +424,319 @@ func TestPickerPromptIgnoresCaretKeys(t *testing.T) {
 	}
 	if m.prompt.optIdx != 0 {
 		t.Errorf("caret keys moved the highlight to %d", m.prompt.optIdx)
+	}
+}
+
+// --- the `/` search query is the same text input ------------------------
+
+// searchModel opens search mode on the Agents tab and TYPES the query through
+// the real key path, so the caret it leaves behind is the production one and
+// not a value the helper assigned itself.
+func searchModel(t *testing.T, query string) Model {
+	t.Helper()
+	m := testModel(t)
+	m.tab = tabAgents
+	m = pressEdit(t, m, "/") // enter search mode
+	if !m.searching {
+		t.Fatal("/ did not enter search mode")
+	}
+	for _, r := range query {
+		if r == ' ' {
+			m = pressEdit(t, m, "space")
+			continue
+		}
+		m = pressEdit(t, m, string(r))
+	}
+	if m.query[m.tab] != query {
+		t.Fatalf("typed query is %q, want %q", m.query[m.tab], query)
+	}
+	return m
+}
+
+// TestSearchQueryHasTheSameCaret pins that the `/` filter is a real text input
+// and not the append-only field it used to be. It is the input an operator
+// types into most often, so a narrowed query that needs one word changed in the
+// middle must not require retyping the tail.
+func TestSearchQueryHasTheSameCaret(t *testing.T) {
+	m := searchModel(t, "claude agent")
+	if got, want := m.queryCursor[m.tab], len([]rune("claude agent")); got != want {
+		t.Fatalf("typing left the caret at %d, want %d (after the last rune)", got, want)
+	}
+
+	// Walk back over "agent" and insert in place.
+	m = pressEdit(t, m, "ctrl+left", "x")
+	if want := "claude xagent"; m.query[m.tab] != want {
+		t.Fatalf("insert mid-query gave %q, want %q", m.query[m.tab], want)
+	}
+	// Deletion acts at the caret, both directions.
+	m = pressEdit(t, m, "backspace")
+	if want := "claude agent"; m.query[m.tab] != want {
+		t.Fatalf("backspace at the caret gave %q, want %q", m.query[m.tab], want)
+	}
+	m = pressEdit(t, m, "delete")
+	if want := "claude gent"; m.query[m.tab] != want {
+		t.Fatalf("delete at the caret gave %q, want %q", m.query[m.tab], want)
+	}
+	// And the ends.
+	m = pressEdit(t, m, "ctrl+a")
+	if m.queryCursor[m.tab] != 0 {
+		t.Errorf("ctrl+a → %d, want 0", m.queryCursor[m.tab])
+	}
+	m = pressEdit(t, m, "ctrl+e")
+	if got, want := m.queryCursor[m.tab], len([]rune("claude gent")); got != want {
+		t.Errorf("ctrl+e → %d, want %d", got, want)
+	}
+}
+
+// TestSearchArrowsMoveTheCaretNotTheTab is the boundary the operator actually
+// feels: while a query is being typed the arrows belong to the TEXT, and only
+// after esc/enter do they go back to switching tabs. The search branch always
+// returned before the list bindings, so "the tab did not change" alone would
+// have passed before this change too — the load-bearing half is that the
+// arrows now MOVE THE CARET.
+func TestSearchArrowsMoveTheCaretNotTheTab(t *testing.T) {
+	m := searchModel(t, "abc")
+	start := m.tab
+
+	m = pressEdit(t, m, "left", "left")
+	if got := m.queryCursor[m.tab]; got != 1 {
+		t.Fatalf("← ← left the caret at %d, want 1", got)
+	}
+	m = pressEdit(t, m, "right")
+	if got := m.queryCursor[m.tab]; got != 2 {
+		t.Fatalf("→ left the caret at %d, want 2", got)
+	}
+	m = pressEdit(t, m, "ctrl+left")
+	if got := m.queryCursor[m.tab]; got != 0 {
+		t.Fatalf("ctrl+← left the caret at %d, want 0", got)
+	}
+	m = pressEdit(t, m, "ctrl+right")
+	if got := m.queryCursor[m.tab]; got != 3 {
+		t.Fatalf("ctrl+→ left the caret at %d, want 3", got)
+	}
+	if m.tab != start {
+		t.Fatalf("arrows in search mode switched tab %v → %v", start, m.tab)
+	}
+	if !m.searching {
+		t.Error("arrows in search mode left search")
+	}
+	if m.query[m.tab] != "abc" {
+		t.Errorf("arrows changed the query: %q", m.query[m.tab])
+	}
+
+	// esc hands the arrows back to tab navigation.
+	m = pressEdit(t, m, "esc")
+	if m.searching {
+		t.Fatal("esc did not leave search mode")
+	}
+	m = pressEdit(t, m, "left")
+	if m.tab == start {
+		t.Error("after leaving search, ← must switch tabs again")
+	}
+}
+
+// TestSearchCaretResumesAtEndOfExistingQuery pins re-entry: `/` on a tab that
+// already carries a filter must park the caret after it, not at 0 — otherwise
+// the next keystroke inserts in FRONT of the query the operator is refining.
+func TestSearchCaretResumesAtEndOfExistingQuery(t *testing.T) {
+	m := searchModel(t, "claude")
+	m = pressEdit(t, m, "ctrl+a") // park it at the front
+	m = pressEdit(t, m, "esc")
+
+	m = pressEdit(t, m, "/")
+	if got, want := m.queryCursor[m.tab], len([]rune("claude")); got != want {
+		t.Fatalf("re-entering search put the caret at %d, want %d", got, want)
+	}
+	m = pressEdit(t, m, "!")
+	if want := "claude!"; m.query[m.tab] != want {
+		t.Errorf("typing after re-entry gave %q, want %q", m.query[m.tab], want)
+	}
+}
+
+// TestClearingAFilterResetsItsCaret pins the other direction: backspace outside
+// search mode clears the filter, so the caret must come back to 0 with it or
+// the next `/` session starts with a caret pointing past the end of an empty
+// query.
+func TestClearingAFilterResetsItsCaret(t *testing.T) {
+	m := searchModel(t, "some filter")
+	m = pressEdit(t, m, "esc")
+	m = pressEdit(t, m, "backspace") // clears the active filter
+	if m.query[m.tab] != "" {
+		t.Fatalf("backspace outside search should clear the filter, got %q", m.query[m.tab])
+	}
+	if m.queryCursor[m.tab] != 0 {
+		t.Errorf("caret left at %d after clearing, want 0", m.queryCursor[m.tab])
+	}
+}
+
+// TestSearchRendersCaretAtItsPosition pins the visible half for the query box.
+func TestSearchRendersCaretAtItsPosition(t *testing.T) {
+	m := searchModel(t, "abcd")
+	if view := m.View(); !strings.Contains(view, "abcd█") {
+		t.Errorf("caret at the end should render after the query:\n%s", view)
+	}
+	m = pressEdit(t, m, "left", "left")
+	if view := m.View(); !strings.Contains(view, "ab█cd") {
+		t.Errorf("caret should render at its position:\n%s", view)
+	}
+}
+
+// TestOnlyApplyTextKeyConsumesTypedRunes enforces the rule that makes "every
+// text input behaves the same" true by construction rather than by discipline:
+// applyTextKey must be the ONLY function that turns typed runes into text. A
+// new input surface that hand-rolls `x += string(msg.Runes)` would silently be
+// append-only again, which is exactly the bug this change removed.
+//
+// Resolved through the AST, not a grep: the check must be about which FUNCTION
+// reads the runes, so that deleting applyTextKey's own case and hand-rolling
+// the append elsewhere in the same file still fails — and so that a comment
+// mentioning msg.Runes never fails it spuriously.
+func TestOnlyApplyTextKeyConsumesTypedRunes(t *testing.T) {
+	names, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fset := token.NewFileSet()
+	readers := map[string]bool{}
+	for _, name := range names {
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			ast.Inspect(fn, func(n ast.Node) bool {
+				sel, ok := n.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "Runes" {
+					return true
+				}
+				if ident, ok := sel.X.(*ast.Ident); ok && ident.Name == "msg" {
+					readers[fn.Name.Name] = true
+				}
+				return true
+			})
+		}
+	}
+	if len(readers) != 1 || !readers["applyTextKey"] {
+		names := make([]string, 0, len(readers))
+		for n := range readers {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		t.Errorf("msg.Runes is read by %v, want only applyTextKey — a new text input must call applyTextKey instead of appending to a plain string", names)
+	}
+}
+
+// TestSearchCaretIsPerTab pins why queryCursor is an array and not one int:
+// filters are per-tab, so returning to a tab must restore ITS caret, not
+// wherever the caret happened to sit on the tab the operator came from.
+func TestSearchCaretIsPerTab(t *testing.T) {
+	m := searchModel(t, "alpha") // Agents tab
+	m = pressEdit(t, m, "left", "left")
+	agentsCaret := m.queryCursor[tabAgents]
+	if agentsCaret != 3 {
+		t.Fatalf("caret on Agents is %d, want 3", agentsCaret)
+	}
+	m = pressEdit(t, m, "esc")
+
+	// A different query, with a different caret, on another tab.
+	m.tab = tabEscalations
+	m = pressEdit(t, m, "/")
+	for _, r := range "beta" {
+		m = pressEdit(t, m, string(r))
+	}
+	m = pressEdit(t, m, "ctrl+a", "esc")
+	if m.queryCursor[tabEscalations] != 0 {
+		t.Fatalf("caret on Escalations is %d, want 0", m.queryCursor[tabEscalations])
+	}
+
+	// Back to the first tab: its own query and caret come back untouched.
+	m.tab = tabAgents
+	if m.query[tabAgents] != "alpha" {
+		t.Errorf("Agents query = %q, want %q", m.query[tabAgents], "alpha")
+	}
+	if got := m.queryCursor[tabAgents]; got != agentsCaret {
+		t.Errorf("Agents caret = %d, want %d — the other tab's caret leaked", got, agentsCaret)
+	}
+	if m.query[tabEscalations] != "beta" {
+		t.Errorf("Escalations query = %q, want %q", m.query[tabEscalations], "beta")
+	}
+}
+
+// TestSearchQueryIsSingleLineAndRuneSafe covers the two properties the query
+// path does not inherit from the prompt tests: it is a single-line input (a
+// line break must never enter a filter), and its caret indexes runes, since a
+// filter can be typed in any language.
+func TestSearchQueryIsSingleLineAndRuneSafe(t *testing.T) {
+	m := searchModel(t, "héllo wörld")
+	if got, want := m.queryCursor[m.tab], len([]rune("héllo wörld")); got != want {
+		t.Fatalf("caret at %d, want %d runes (byte indexing would give %d)",
+			got, want, len("héllo wörld"))
+	}
+	// Delete the multi-byte rune inside "wörld" without corrupting the rest.
+	m = pressEdit(t, m, "ctrl+left", "right", "delete")
+	if want := "héllo wrld"; m.query[m.tab] != want {
+		t.Fatalf("query = %q, want %q", m.query[m.tab], want)
+	}
+
+	// ctrl+j is gated off for this surface: a filter is one line.
+	before := m.query[m.tab]
+	m = pressEdit(t, m, "ctrl+j")
+	if m.query[m.tab] != before {
+		t.Errorf("ctrl+j changed a single-line query: %q", m.query[m.tab])
+	}
+	if strings.Contains(m.query[m.tab], "\n") {
+		t.Errorf("a line break entered the filter: %q", m.query[m.tab])
+	}
+}
+
+// TestAddTaskPromptNamesTheSourceSelector pins the add prompt's title. The
+// operator picks a source by WHO it feeds, so the prompt names the agent, and
+// a source with no agent selector is named by its workspace — wildcarded to
+// "*" exactly as the Tasks group header renders it, so the prompt and the row
+// above it never disagree about what the source is called. The file path is
+// never the title: it is often a long doc path whose basename says nothing
+// about who receives the task.
+func TestAddTaskPromptNamesTheSourceSelector(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent string
+		ws    string
+		want  string
+	}{
+		{name: "agent selector wins over workspace", agent: "brave-otter", ws: "codex-*",
+			want: "new task(s) for agent=brave-otter"},
+		{name: "workspace when no agent", ws: "codex-1",
+			want: "new task(s) for ws=codex-1"},
+		// A catch-all source still names a selector rather than falling back
+		// to the path: an unset workspace reads as the "*" wildcard.
+		{name: "wildcard workspace for a catch-all", want: "new task(s) for ws=*"},
+		{name: "explicit wildcard workspace", ws: "*", want: "new task(s) for ws=*"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _, path := taskAppModel(t)
+			m.data.tasks[0].Source.Agent = tc.agent
+			m.data.tasks[0].Source.Workspace = tc.ws
+
+			upd, _ := m.Update(pressKeyMsg("a"))
+			m = upd.(Model)
+			if m.prompt == nil {
+				t.Fatal("a did not open the add prompt")
+			}
+			if !strings.Contains(m.prompt.label, tc.want) {
+				t.Errorf("label = %q, want it to contain %q", m.prompt.label, tc.want)
+			}
+			// The selector replaces the path — it does not sit beside it.
+			if strings.Contains(m.prompt.label, filepath.Base(path)) {
+				t.Errorf("label = %q, must not still carry the file name", m.prompt.label)
+			}
+		})
 	}
 }

--- a/internal/tui/task_source_prompt_test.go
+++ b/internal/tui/task_source_prompt_test.go
@@ -1,0 +1,172 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// sourcePromptModel wires a real store-backed App with no task sources yet,
+// so the add prompt writes through the same path the CLI uses.
+func sourcePromptModel(t *testing.T) (Model, *frontend.App, string) {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	app := &frontend.App{Store: st, Herdr: &captureHerdr{},
+		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+	path := filepath.Join(dir, "tasks.md")
+	if err := os.WriteFile(path, []byte("- [ ] alpha\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := New(context.Background(), app)
+	m.width, m.height = 100, 30
+	return m, app, path
+}
+
+// submitSourcePrompt opens the add-task-source prompt, types input, and runs
+// the resulting command as Bubble Tea's runtime would.
+func submitSourcePrompt(t *testing.T, m Model, input string) actionResultMsg {
+	t.Helper()
+	upd, _ := m.addTaskSourcePrompt()
+	m = upd.(Model)
+	if m.prompt == nil {
+		t.Fatal("addTaskSourcePrompt did not open a prompt")
+	}
+	if !strings.Contains(m.prompt.label, "--auto-send-when-idle") {
+		t.Errorf("prompt label must advertise the flag, got %q", m.prompt.label)
+	}
+	cmd := m.prompt.onSubmit(input)
+	if cmd == nil {
+		t.Fatal("onSubmit returned no command")
+	}
+	msg, ok := cmd().(actionResultMsg)
+	if !ok {
+		t.Fatalf("want actionResultMsg, got %T", msg)
+	}
+	return msg
+}
+
+// TestTUIAddTaskSourceAutoSendParity pins CLI/TUI parity for the one source
+// setting that makes hap hand out tasks unprompted: the TUI prompt takes the
+// same `--auto-send-when-idle` word, in any position, and — like the CLI — an
+// add that does not ask for it must never turn it on.
+func TestTUIAddTaskSourceAutoSendParity(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string // %s is replaced by the checklist path
+		want  bool
+	}{
+		{name: "path only", input: "%s"},
+		{name: "path and agent", input: "%s brave-otter"},
+		{name: "flag last", input: "%s brave-otter --auto-send-when-idle", want: true},
+		{name: "flag first", input: "--auto-send-when-idle %s brave-otter", want: true},
+		{name: "flag mid", input: "%s --auto-send-when-idle brave-otter ws-1", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, app, path := sourcePromptModel(t)
+			msg := submitSourcePrompt(t, m, strings.ReplaceAll(tc.input, "%s", path))
+			if msg.err != nil {
+				t.Fatal(msg.err)
+			}
+			cfg, err := app.Config()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(cfg.TaskSources) != 1 {
+				t.Fatalf("want 1 task source, got %d", len(cfg.TaskSources))
+			}
+			src := cfg.TaskSources[0]
+			if src.Path != path {
+				t.Errorf("path = %q, want %q (the flag must not be consumed as a field)", src.Path, path)
+			}
+			if got := src.EnableAutoSendTaskWhenIdle; got != tc.want {
+				t.Fatalf("enable_auto_send_task_when_idle = %v, want %v", got, tc.want)
+			}
+			if said := strings.Contains(msg.message, "auto-send when idle ON"); said != tc.want {
+				t.Errorf("result message announced auto-send = %v, want %v; got %q", said, tc.want, msg.message)
+			}
+		})
+	}
+}
+
+// TestTUIAddTaskSourcePromptRejectsBadInput keeps the field-count guard honest
+// now that flag words are stripped before counting: a flag-only input has no
+// path, four real fields is still too many, and — the safety-relevant case —
+// any near-miss spelling of the flag must be REFUSED rather than stored as a
+// field, since that would silently leave unprompted hand-out off while the
+// operator believes they turned it on.
+func TestTUIAddTaskSourcePromptRejectsBadInput(t *testing.T) {
+	for _, input := range []string{
+		"--auto-send-when-idle",
+		"a b c d",
+		"/tmp/tasks.md --auto-send-when-idle=true",
+		"/tmp/tasks.md -auto-send-when-idle",
+		"/tmp/tasks.md --auto-send-when-idl",
+		"/tmp/tasks.md --agent brave-otter",
+	} {
+		m, app, _ := sourcePromptModel(t)
+		msg := submitSourcePrompt(t, m, input)
+		if msg.err == nil {
+			t.Errorf("input %q must be rejected, got %q", input, msg.message)
+		}
+		cfg, err := app.Config()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(cfg.TaskSources) != 0 {
+			t.Errorf("input %q added a source anyway: %+v", input, cfg.TaskSources)
+		}
+	}
+}
+
+// TestConfigTabShowsAutoSendFlag mirrors `hap task-source list`: a source that
+// hands out tasks unprompted must say so wherever sources are listed.
+func TestConfigTabShowsAutoSendFlag(t *testing.T) {
+	m, app, path := sourcePromptModel(t)
+	if msg := submitSourcePrompt(t, m, path+" busy-otter --auto-send-when-idle"); msg.err != nil {
+		t.Fatal(msg.err)
+	}
+	quiet := filepath.Join(filepath.Dir(path), "quiet.md")
+	if err := os.WriteFile(quiet, []byte("- [ ] a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(context.Background(), "quiet-fox", "", quiet, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var busy, calm string
+	for _, it := range buildRuleItems(cfg) {
+		if it.kind != "source" {
+			continue
+		}
+		if strings.Contains(it.label, "busy-otter") {
+			busy = it.label
+		}
+		if strings.Contains(it.label, "quiet-fox") {
+			calm = it.label
+		}
+	}
+	if busy == "" || calm == "" {
+		t.Fatalf("both sources should render as config rows, got busy=%q quiet=%q", busy, calm)
+	}
+	if !strings.Contains(busy, "auto_send_when_idle=true") {
+		t.Errorf("auto-send source row must show the flag: %s", busy)
+	}
+	if strings.Contains(calm, "auto_send_when_idle") {
+		t.Errorf("a source without the flag must not advertise it: %s", calm)
+	}
+}

--- a/internal/tui/tasks_test.go
+++ b/internal/tui/tasks_test.go
@@ -472,10 +472,11 @@ func TestTasksTabAddPrompt(t *testing.T) {
 	// a works from any of the group's rows, header included.
 	upd, _ := m.Update(pressKeyMsg("a"))
 	m = upd.(Model)
-	// The label names the file (the directory may be display-truncated).
-	if m.prompt == nil || !strings.Contains(m.prompt.label, "new task(s) for ") ||
-		!strings.Contains(m.prompt.label, filepath.Base(path)) {
-		t.Fatalf("a should open the add prompt naming the file, got %+v", m.prompt)
+	// The label names the source by the selector the operator thinks in — the
+	// agent it feeds — rather than by its file path, which is often a long doc
+	// path whose basename says nothing about who receives the task.
+	if m.prompt == nil || !strings.Contains(m.prompt.label, "new task(s) for agent=brave-otter") {
+		t.Fatalf("a should open the add prompt naming the source's agent, got %+v", m.prompt)
 	}
 	m = press(t, m, "delta")
 	upd, cmd := m.Update(pressKeyMsg("enter"))

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mattn/go-runewidth"
@@ -138,7 +139,116 @@ type prompt struct {
 	// operator picks from the known set instead of typing a name blind.
 	options []string
 	optIdx  int
+	// cursor is the caret's position as a RUNE index into input (0 = before
+	// the first rune, len = past the last), so every edit lands where the
+	// operator put it instead of always at the end. Rune-indexed, not
+	// byte-indexed: a task can hold any UTF-8, and slicing a multi-byte rune
+	// in half would corrupt the text. A prompt opened with a pre-filled value
+	// starts with the caret at the end — see openPrompt, which is how every
+	// prompt must be installed so this can never be left at 0 by accident.
+	cursor int
 }
+
+// openPrompt installs p as the active prompt, parking the caret at the end of
+// any pre-filled text so a default value reads as "typed already" and can be
+// appended to or backspaced immediately.
+func (m *Model) openPrompt(p *prompt) {
+	p.cursor = len([]rune(promptNewlines.Replace(p.input)))
+	m.prompt = p
+}
+
+// runes returns the input as a rune slice with line breaks normalized, plus
+// the caret clamped into it. Every edit and the renderer go through this, so a
+// cursor left stale by a direct `input` assignment can never slice out of
+// range — it just behaves as if it sat at the end.
+func (p *prompt) runes() ([]rune, int) {
+	r := []rune(promptNewlines.Replace(p.input))
+	return r, min(max(p.cursor, 0), len(r))
+}
+
+// insert puts s at the caret and leaves the caret after it.
+func (p *prompt) insert(s string) {
+	r, cur := p.runes()
+	ins := []rune(s)
+	next := make([]rune, 0, len(r)+len(ins))
+	next = append(next, r[:cur]...)
+	next = append(next, ins...)
+	next = append(next, r[cur:]...)
+	p.input = string(next)
+	p.cursor = cur + len(ins)
+}
+
+// deleteBefore removes the rune before the caret (backspace); deleteAt removes
+// the one under it (delete). Both are no-ops at their respective edges.
+func (p *prompt) deleteBefore() {
+	r, cur := p.runes()
+	if cur == 0 {
+		return
+	}
+	p.input = string(append(append([]rune{}, r[:cur-1]...), r[cur:]...))
+	p.cursor = cur - 1
+}
+
+func (p *prompt) deleteAt() {
+	r, cur := p.runes()
+	if cur >= len(r) {
+		return
+	}
+	p.input = string(append(append([]rune{}, r[:cur]...), r[cur+1:]...))
+	p.cursor = cur
+}
+
+// moveBy shifts the caret by n runes, stopping at either edge.
+func (p *prompt) moveBy(n int) {
+	r, cur := p.runes()
+	p.cursor = min(max(cur+n, 0), len(r))
+}
+
+// moveTo parks the caret at an absolute rune index (clamped).
+func (p *prompt) moveTo(i int) {
+	r, _ := p.runes()
+	p.cursor = min(max(i, 0), len(r))
+}
+
+// moveEnd parks the caret past the last rune. It measures the NORMALIZED text
+// (runes()), not the raw input: a pasted "\r\n" is one rune there and two in
+// the raw string, so measuring the raw one would overshoot.
+func (p *prompt) moveEnd() {
+	r, _ := p.runes()
+	p.cursor = len(r)
+}
+
+// wordLeft/wordRight give ctrl+←/ctrl+→ their usual meaning: skip any run of
+// spaces, then the word beside it. Task text is prose, so word-wise motion is
+// what makes a long line editable without holding an arrow key down.
+func (p *prompt) wordLeft() {
+	r, cur := p.runes()
+	for cur > 0 && isPromptSpace(r[cur-1]) {
+		cur--
+	}
+	for cur > 0 && !isPromptSpace(r[cur-1]) {
+		cur--
+	}
+	p.cursor = cur
+}
+
+func (p *prompt) wordRight() {
+	r, cur := p.runes()
+	for cur < len(r) && isPromptSpace(r[cur]) {
+		cur++
+	}
+	for cur < len(r) && !isPromptSpace(r[cur]) {
+		cur++
+	}
+	p.cursor = cur
+}
+
+// isPromptSpace uses unicode.IsSpace rather than an ASCII set: task text is
+// known to carry U+00A0 (Claude renders todo rows with it), and treating a
+// non-breaking space as a word character would make ctrl+←/→ jump over a whole
+// phrase. It also covers \r, so word motion is correct whether or not the
+// caller normalized first.
+func isPromptSpace(r rune) bool { return unicode.IsSpace(r) }
 
 // promptNewlines normalizes any line-break flavor (\r\n, bare \r — common in
 // terminal bracketed paste) to \n so the prompt renders one input line per
@@ -178,7 +288,11 @@ func (m Model) submitPrompt() (tea.Model, tea.Cmd) {
 		// Picker mode: submit the highlighted option verbatim.
 		return m, p.onSubmit(p.options[p.optIdx])
 	}
-	input := strings.TrimSpace(p.input)
+	// Normalize the line breaks here too, not only in the edit helpers: an
+	// untouched pre-filled or pasted value would otherwise submit raw CRLF
+	// while the same value submits LF the moment any key is pressed, and that
+	// difference gets baked into the checklist file by EncodeTaskNewlines.
+	input := strings.TrimSpace(promptNewlines.Replace(p.input))
 	if input == "" {
 		m.message = "cancelled"
 		return m, nil
@@ -709,7 +823,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// multiline prompt; everywhere else it is ignored like any unknown key.
 	if isShiftEnter(msg) {
 		if m.prompt != nil && m.prompt.multiline {
-			m.prompt.input += "\n"
+			m.prompt.insert("\n")
 		}
 		return m, nil
 	}
@@ -1044,22 +1158,45 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.message = "cancelled"
 			return m, nil
 		case tea.KeyBackspace:
-			if r := []rune(m.prompt.input); len(r) > 0 {
-				m.prompt.input = string(r[:len(r)-1])
-			}
+			m.prompt.deleteBefore()
+			return m, nil
+		case tea.KeyDelete:
+			m.prompt.deleteAt()
 			return m, nil
 		case tea.KeySpace:
-			m.prompt.input += " "
+			m.prompt.insert(" ")
 			return m, nil
 		case tea.KeyCtrlJ:
 			if m.prompt.multiline {
-				m.prompt.input += "\n"
+				m.prompt.insert("\n")
 			}
+			return m, nil
+		// Caret motion: the input is a full line editor, so a typo in the
+		// middle of a long task is fixed in place instead of retyping the
+		// tail. ctrl+a/ctrl+e mirror the readline bindings a terminal
+		// operator already has in muscle memory.
+		case tea.KeyLeft:
+			m.prompt.moveBy(-1)
+			return m, nil
+		case tea.KeyRight:
+			m.prompt.moveBy(1)
+			return m, nil
+		case tea.KeyCtrlLeft:
+			m.prompt.wordLeft()
+			return m, nil
+		case tea.KeyCtrlRight:
+			m.prompt.wordRight()
+			return m, nil
+		case tea.KeyHome, tea.KeyCtrlA:
+			m.prompt.moveTo(0)
+			return m, nil
+		case tea.KeyEnd, tea.KeyCtrlE:
+			m.prompt.moveEnd()
 			return m, nil
 		case tea.KeyRunes:
 			// Only printable input; key names like "up"/"home" must not
 			// leak into the text.
-			m.prompt.input += string(msg.Runes)
+			m.prompt.insert(string(msg.Runes))
 			return m, nil
 		default:
 			return m, nil
@@ -1446,7 +1583,7 @@ func (m Model) confirmAuditID(id int64) (tea.Model, tea.Cmd) {
 func (m Model) openAddPrompt(id int64) (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	m.message = ""
-	m.prompt = &prompt{
+	m.openPrompt(&prompt{
 		label: fmt.Sprintf("agent is busy — add the tasks to its task list instead? [y/N] (#%d)", id),
 		onSubmit: func(input string) tea.Cmd {
 			if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(input)), "y") {
@@ -1461,7 +1598,7 @@ func (m Model) openAddPrompt(id int64) (tea.Model, tea.Cmd) {
 				return actionResultMsg{message: fmt.Sprintf("added #%d to task list (not sent)", id)}
 			}
 		},
-	}
+	})
 	return m, nil
 }
 
@@ -1483,7 +1620,7 @@ func (m Model) correctSelected() (tea.Model, tea.Cmd) {
 func (m Model) correctByID(id int64, live bool) (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	m.beginAction()
-	m.prompt = &prompt{
+	m.openPrompt(&prompt{
 		label: fmt.Sprintf("correct #%d — action to record", id),
 		onSubmit: func(input string) tea.Cmd {
 			if live {
@@ -1498,7 +1635,7 @@ func (m Model) correctByID(id int64, live bool) (tea.Model, tea.Cmd) {
 				return actionResultMsg{message: fmt.Sprintf("correction recorded for #%d", id)}
 			}
 		},
-	}
+	})
 	return m, nil
 }
 
@@ -1509,7 +1646,7 @@ func (m Model) correctByID(id int64, live bool) (tea.Model, tea.Cmd) {
 func (m Model) openSendPrompt(id int64, action string) (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	m.message = ""
-	m.prompt = &prompt{
+	m.openPrompt(&prompt{
 		label: fmt.Sprintf("send corrected action to the agent now? [y/N] (#%d)", id),
 		input: "n",
 		onSubmit: func(input string) tea.Cmd {
@@ -1524,7 +1661,7 @@ func (m Model) openSendPrompt(id int64, action string) (tea.Model, tea.Cmd) {
 				return actionResultMsg{message: fmt.Sprintf("correction recorded for #%d (not sent)", id)}
 			}
 		},
-	}
+	})
 	return m, nil
 }
 
@@ -1669,7 +1806,7 @@ func (m Model) deleteEscalations() (tea.Model, tea.Cmd) {
 func (m Model) pruneEscalationsPrompt() (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	m.beginAction()
-	m.prompt = &prompt{
+	m.openPrompt(&prompt{
 		label: "prune escalations older than N minutes — enter confirms, esc cancels",
 		input: strconv.Itoa(frontend.DefaultPruneMinutes),
 		onSubmit: func(input string) tea.Cmd {
@@ -1686,7 +1823,7 @@ func (m Model) pruneEscalationsPrompt() (tea.Model, tea.Cmd) {
 					"pruned %d escalation(s) older than %d minute(s); audit rows kept as dismissed", n, minutes)}
 			}
 		},
-	}
+	})
 	return m, nil
 }
 
@@ -2032,7 +2169,7 @@ func (m Model) addTaskPrompt() (tea.Model, tea.Cmd) {
 	}
 	app, path := m.app, r.path
 	m.beginAction()
-	m.prompt = &prompt{
+	m.openPrompt(&prompt{
 		label: fmt.Sprintf("new task(s) for %s — enter: add, shift+enter: new line, esc: cancel",
 			truncatePathKeepBase(path, taskPathDisplayWidth)),
 		multiline: true,
@@ -2045,7 +2182,7 @@ func (m Model) addTaskPrompt() (tea.Model, tea.Cmd) {
 				return actionResultMsg{message: fmt.Sprintf("added task #%d", n)}
 			}
 		},
-	}
+	})
 	return m, nil
 }
 
@@ -2068,7 +2205,7 @@ func (m Model) editTaskPrompt() (tea.Model, tea.Cmd) {
 func (m Model) editTaskRowPrompt(r taskRow) (tea.Model, tea.Cmd) {
 	app, path, idx, stored := m.app, r.path, r.item, r.itemText
 	m.beginAction()
-	m.prompt = &prompt{
+	m.openPrompt(&prompt{
 		label:     fmt.Sprintf("edit task #%d — enter: save, shift+enter: new line, esc: cancel", idx),
 		input:     domain.DecodeTaskNewlines(stored),
 		multiline: true,
@@ -2080,7 +2217,7 @@ func (m Model) editTaskRowPrompt(r taskRow) (tea.Model, tea.Cmd) {
 				return actionResultMsg{message: fmt.Sprintf("task #%d updated", idx)}
 			}
 		},
-	}
+	})
 	return m, nil
 }
 
@@ -2229,7 +2366,7 @@ func (m Model) renameSelected() (tea.Model, tea.Cmd) {
 	target := agent.AgentID
 	app, ctx := m.app, m.ctx
 	m.beginAction()
-	m.prompt = &prompt{
+	m.openPrompt(&prompt{
 		label: fmt.Sprintf("rename %s (%s) to", orDash(current), agent.AgentID),
 		onSubmit: func(input string) tea.Cmd {
 			return func() tea.Msg {
@@ -2239,7 +2376,7 @@ func (m Model) renameSelected() (tea.Model, tea.Cmd) {
 				return actionResultMsg{message: fmt.Sprintf("agent renamed to %q", input)}
 			}
 		},
-	}
+	})
 	return m, nil
 }
 
@@ -3032,7 +3169,7 @@ func (m Model) deleteSignaturePrompt() (tea.Model, tea.Cmd) {
 	sig, decisions := row.Signature, row.TotalDecisions
 	app, ctx := m.app, m.ctx
 	m.beginAction()
-	m.prompt = &prompt{
+	m.openPrompt(&prompt{
 		label: fmt.Sprintf("type 'yes' to delete %s and its %d decision(s)", shortSig(sig), decisions),
 		onSubmit: func(input string) tea.Cmd {
 			return func() tea.Msg {
@@ -3047,7 +3184,7 @@ func (m Model) deleteSignaturePrompt() (tea.Model, tea.Cmd) {
 					"deleted %s and %d decision(s); audit rows kept", shortSig(deleted), n)}
 			}
 		},
-	}
+	})
 	return m, nil
 }
 
@@ -3063,7 +3200,7 @@ func (m Model) resetGraduationPrompt() (tea.Model, tea.Cmd) {
 	sig := row.Signature
 	app, ctx := m.app, m.ctx
 	m.beginAction()
-	m.prompt = &prompt{
+	m.openPrompt(&prompt{
 		label: fmt.Sprintf("type 'yes' to reset %s to a fresh rule (shadow, streak → 0, confidence cleared)", shortSig(sig)),
 		onSubmit: func(input string) tea.Cmd {
 			return func() tea.Msg {
@@ -3078,7 +3215,7 @@ func (m Model) resetGraduationPrompt() (tea.Model, tea.Cmd) {
 					"reset %s to a fresh rule (shadow, streak 0, confidence cleared); history kept", shortSig(reset))}
 			}
 		},
-	}
+	})
 	return m, nil
 }
 
@@ -3220,18 +3357,18 @@ func (m Model) editSelectedRule() (tea.Model, tea.Cmd) {
 				break
 			}
 		}
-		m.prompt = &prompt{
+		m.openPrompt(&prompt{
 			label:    fmt.Sprintf("select %s (↑/↓ then enter, current %s)", key, cur),
 			options:  opts,
 			optIdx:   idx,
 			onSubmit: submit,
-		}
+		})
 		return m, nil
 	}
-	m.prompt = &prompt{
+	m.openPrompt(&prompt{
 		label:    fmt.Sprintf("set %s (current %s)", key, frontend.FieldValue(m.data.cfg, key)),
 		onSubmit: submit,
-	}
+	})
 	return m, nil
 }
 
@@ -3249,7 +3386,7 @@ func configFieldChoices(key string) (choices []string, ok bool) {
 func (m Model) addPatternPrompt() (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	m.beginAction()
-	m.prompt = &prompt{
+	m.openPrompt(&prompt{
 		label: "add never-auto regex",
 		onSubmit: func(input string) tea.Cmd {
 			return func() tea.Msg {
@@ -3259,14 +3396,14 @@ func (m Model) addPatternPrompt() (tea.Model, tea.Cmd) {
 				return actionResultMsg{message: "never-auto pattern added"}
 			}
 		},
-	}
+	})
 	return m, nil
 }
 
 func (m Model) addTaskSourcePrompt() (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	m.beginAction()
-	m.prompt = &prompt{
+	m.openPrompt(&prompt{
 		label: "add task source: <path> [agent] [workspace] [--auto-send-when-idle]",
 		onSubmit: func(input string) tea.Cmd {
 			return func() tea.Msg {
@@ -3312,7 +3449,7 @@ func (m Model) addTaskSourcePrompt() (tea.Model, tea.Cmd) {
 				return actionResultMsg{message: "task source added"}
 			}
 		},
-	}
+	})
 	return m, nil
 }
 
@@ -3497,7 +3634,7 @@ func (m Model) removeSelectedRule() (tea.Model, tea.Cmd) {
 func (m Model) clearDataPrompt() (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	m.beginAction()
-	m.prompt = &prompt{
+	m.openPrompt(&prompt{
 		label: "type 'yes' to permanently clear learned history + audit data",
 		onSubmit: func(input string) tea.Cmd {
 			return func() tea.Msg {
@@ -3510,7 +3647,7 @@ func (m Model) clearDataPrompt() (tea.Model, tea.Cmd) {
 				return actionResultMsg{message: "learned history and audit data cleared"}
 			}
 		},
-	}
+	})
 	return m, nil
 }
 
@@ -3619,13 +3756,18 @@ func (m Model) View() string {
 		}
 	} else if m.prompt != nil {
 		// A multiline input expands the box: one rendered line per line break,
-		// continuation lines indented under the label, cursor on the last.
-		lines := strings.Split(promptNewlines.Replace(m.prompt.input), "\n")
+		// continuation lines indented under the label. The caret is drawn AT
+		// its rune index rather than always at the end, so the operator can
+		// see where the next keystroke lands; with the caret at the end this
+		// renders exactly as it always did.
+		r, cur := m.prompt.runes()
+		withCaret := string(r[:cur]) + "█" + string(r[cur:])
+		lines := strings.Split(withCaret, "\n")
 		fmt.Fprintf(&b, "\n%s> %s", m.prompt.label, lines[0])
 		for _, l := range lines[1:] {
 			fmt.Fprintf(&b, "\n  %s", l)
 		}
-		fmt.Fprint(&b, "█\n")
+		fmt.Fprint(&b, "\n")
 	}
 	if m.confirm != nil {
 		fmt.Fprintf(&b, "\n%s\n", m.confirm.label)
@@ -3689,6 +3831,20 @@ func (m Model) helpLine() string {
 	}
 	if m.searching {
 		return "type to filter  backspace: erase  esc/enter: apply & close"
+	}
+	// The caret bindings are advertised here rather than in the prompt label:
+	// the label is inside the prompt box, whose height listPageSize budgets as
+	// one row, so a longer label would silently wrap and cost a list row.
+	if m.prompt != nil {
+		if len(m.prompt.options) > 0 {
+			return "↑/↓: choose  enter: select  esc: cancel"
+		}
+		newline := ""
+		if m.prompt.multiline {
+			newline = "  shift+enter: new line"
+		}
+		return "←/→: move (ctrl: by word)  home/end: line ends" + newline +
+			"  enter: submit  esc: cancel"
 	}
 	if m.confirm != nil {
 		return "y/enter: confirm  n/esc: cancel"

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -157,91 +157,181 @@ func (m *Model) openPrompt(p *prompt) {
 	m.prompt = p
 }
 
-// runes returns the input as a rune slice with line breaks normalized, plus
-// the caret clamped into it. Every edit and the renderer go through this, so a
-// cursor left stale by a direct `input` assignment can never slice out of
+// textEdit is one editable line of text plus the caret's RUNE index into it
+// (0 = before the first rune, len = past the last). Every text input in the
+// TUI — the prompts and the `/` search query alike — edits through this one
+// type, so caret behavior cannot drift between them.
+//
+// Rune-indexed, not byte-indexed: the text can hold any UTF-8 and slicing a
+// multi-byte rune in half would corrupt it.
+type textEdit struct {
+	text   string
+	cursor int
+}
+
+// runes returns the text as a rune slice with line breaks normalized, plus the
+// caret clamped into it. Every edit and every renderer goes through this, so a
+// cursor left stale by a direct assignment to `text` can never slice out of
 // range — it just behaves as if it sat at the end.
-func (p *prompt) runes() ([]rune, int) {
-	r := []rune(promptNewlines.Replace(p.input))
-	return r, min(max(p.cursor, 0), len(r))
+func (e textEdit) runes() ([]rune, int) {
+	r := []rune(promptNewlines.Replace(e.text))
+	return r, min(max(e.cursor, 0), len(r))
+}
+
+// end parks the caret past the last rune. It measures the NORMALIZED text, not
+// the raw string: a pasted "\r\n" is one rune there and two in the raw text,
+// so measuring the raw one would overshoot.
+func (e textEdit) end() textEdit {
+	r, _ := e.runes()
+	return textEdit{text: e.text, cursor: len(r)}
 }
 
 // insert puts s at the caret and leaves the caret after it.
-func (p *prompt) insert(s string) {
-	r, cur := p.runes()
+func (e textEdit) insert(s string) textEdit {
+	r, cur := e.runes()
 	ins := []rune(s)
 	next := make([]rune, 0, len(r)+len(ins))
 	next = append(next, r[:cur]...)
 	next = append(next, ins...)
 	next = append(next, r[cur:]...)
-	p.input = string(next)
-	p.cursor = cur + len(ins)
+	return textEdit{text: string(next), cursor: cur + len(ins)}
 }
 
 // deleteBefore removes the rune before the caret (backspace); deleteAt removes
 // the one under it (delete). Both are no-ops at their respective edges.
-func (p *prompt) deleteBefore() {
-	r, cur := p.runes()
+func (e textEdit) deleteBefore() textEdit {
+	r, cur := e.runes()
 	if cur == 0 {
-		return
+		return e
 	}
-	p.input = string(append(append([]rune{}, r[:cur-1]...), r[cur:]...))
-	p.cursor = cur - 1
+	return textEdit{text: string(append(append([]rune{}, r[:cur-1]...), r[cur:]...)), cursor: cur - 1}
 }
 
-func (p *prompt) deleteAt() {
-	r, cur := p.runes()
+func (e textEdit) deleteAt() textEdit {
+	r, cur := e.runes()
 	if cur >= len(r) {
-		return
+		return e
 	}
-	p.input = string(append(append([]rune{}, r[:cur]...), r[cur+1:]...))
-	p.cursor = cur
+	return textEdit{text: string(append(append([]rune{}, r[:cur]...), r[cur+1:]...)), cursor: cur}
 }
 
 // moveBy shifts the caret by n runes, stopping at either edge.
-func (p *prompt) moveBy(n int) {
-	r, cur := p.runes()
-	p.cursor = min(max(cur+n, 0), len(r))
-}
-
-// moveTo parks the caret at an absolute rune index (clamped).
-func (p *prompt) moveTo(i int) {
-	r, _ := p.runes()
-	p.cursor = min(max(i, 0), len(r))
-}
-
-// moveEnd parks the caret past the last rune. It measures the NORMALIZED text
-// (runes()), not the raw input: a pasted "\r\n" is one rune there and two in
-// the raw string, so measuring the raw one would overshoot.
-func (p *prompt) moveEnd() {
-	r, _ := p.runes()
-	p.cursor = len(r)
+func (e textEdit) moveBy(n int) textEdit {
+	r, cur := e.runes()
+	return textEdit{text: e.text, cursor: min(max(cur+n, 0), len(r))}
 }
 
 // wordLeft/wordRight give ctrl+←/ctrl+→ their usual meaning: skip any run of
-// spaces, then the word beside it. Task text is prose, so word-wise motion is
+// spaces, then the word beside it. The text is prose, so word-wise motion is
 // what makes a long line editable without holding an arrow key down.
-func (p *prompt) wordLeft() {
-	r, cur := p.runes()
+func (e textEdit) wordLeft() textEdit {
+	r, cur := e.runes()
 	for cur > 0 && isPromptSpace(r[cur-1]) {
 		cur--
 	}
 	for cur > 0 && !isPromptSpace(r[cur-1]) {
 		cur--
 	}
-	p.cursor = cur
+	return textEdit{text: e.text, cursor: cur}
 }
 
-func (p *prompt) wordRight() {
-	r, cur := p.runes()
+func (e textEdit) wordRight() textEdit {
+	r, cur := e.runes()
 	for cur < len(r) && isPromptSpace(r[cur]) {
 		cur++
 	}
 	for cur < len(r) && !isPromptSpace(r[cur]) {
 		cur++
 	}
-	p.cursor = cur
+	return textEdit{text: e.text, cursor: cur}
 }
+
+// withCaret renders the text with the caret block at its position, ready to be
+// split on "\n" by a multi-line renderer. With the caret at the end this is
+// exactly "text" + the block, which is how the box always used to look.
+func (e textEdit) withCaret() string {
+	r, cur := e.runes()
+	return string(r[:cur]) + "█" + string(r[cur:])
+}
+
+// applyTextKey applies one editing or caret-motion keystroke and returns the
+// result; a key it does not handle returns e unchanged. This is the single
+// definition of "what the keys do in a text input" — arrows move the caret,
+// typing and deletion act AT the caret — so a new input surface gets the whole
+// behavior by calling this instead of re-implementing an append-only field.
+//
+// Both callers swallow every key while their input is active (each returns
+// before reaching the list bindings), which is what keeps ← from switching
+// tabs mid-entry; this function does not itself decide that.
+// allowNewline gates the line-break keys for inputs whose consumer is
+// single-line.
+func applyTextKey(e textEdit, msg tea.KeyMsg, allowNewline bool) textEdit {
+	switch msg.Type {
+	case tea.KeyBackspace:
+		return e.deleteBefore()
+	case tea.KeyDelete:
+		return e.deleteAt()
+	case tea.KeySpace:
+		return e.insert(" ")
+	case tea.KeyCtrlJ:
+		if allowNewline {
+			return e.insert("\n")
+		}
+		return e
+	// Caret motion: the input is a full line editor, so a typo in the middle
+	// of a long entry is fixed in place instead of retyping the tail.
+	// ctrl+a/ctrl+e mirror the readline bindings a terminal operator already
+	// has in muscle memory.
+	case tea.KeyLeft:
+		return e.moveBy(-1)
+	case tea.KeyRight:
+		return e.moveBy(1)
+	case tea.KeyCtrlLeft:
+		return e.wordLeft()
+	case tea.KeyCtrlRight:
+		return e.wordRight()
+	case tea.KeyHome, tea.KeyCtrlA:
+		return textEdit{text: e.text}
+	case tea.KeyEnd, tea.KeyCtrlE:
+		return e.end()
+	case tea.KeyRunes:
+		// Only printable input; key names like "up"/"home" must not leak
+		// into the text.
+		return e.insert(string(msg.Runes))
+	}
+	return e
+}
+
+// queryEdit/setQueryEdit adapt the active tab's search filter to textEdit, so
+// the query gets exactly the caret behavior the prompts have.
+func (m *Model) queryEdit() textEdit {
+	return textEdit{text: m.query[m.tab], cursor: m.queryCursor[m.tab]}
+}
+
+func (m *Model) setQueryEdit(e textEdit) {
+	m.query[m.tab], m.queryCursor[m.tab] = e.text, e.cursor
+}
+
+// setQuery replaces a tab's filter wholesale (opening search, clearing it),
+// parking the caret at the end so the operator can extend an existing query
+// immediately — the same rule openPrompt applies to a pre-filled prompt.
+func (m *Model) setQuery(t tab, text string) {
+	// Measured through textEdit.end(), not len([]rune(text)): the caret must
+	// index the NORMALIZED text everywhere, or a query populated from a paste
+	// would park past its end.
+	m.query[t] = text
+	m.queryCursor[t] = textEdit{text: text}.end().cursor
+}
+
+// edit/setEdit adapt the prompt's own fields to textEdit, so the prompt keeps
+// its plain `input string` for the ~14 call sites that build one.
+func (p *prompt) edit() textEdit { return textEdit{text: p.input, cursor: p.cursor} }
+
+func (p *prompt) setEdit(e textEdit) { p.input, p.cursor = e.text, e.cursor }
+
+// insert puts s at the prompt's caret (used by the shift+enter path, which is
+// handled before the key switch).
+func (p *prompt) insert(s string) { p.setEdit(p.edit().insert(s)) }
 
 // isPromptSpace uses unicode.IsSpace rather than an ASCII set: task text is
 // known to carry U+00A0 (Claude renders todo rows with it), and treating a
@@ -404,12 +494,16 @@ type Model struct {
 	// so returning to a tab restores the row you left it on (CR-038). Only the
 	// active tab's entry is ever read — a background tab's row set can shift
 	// under its remembered cursor, so arriveAtTab clamps on arrival.
-	cursors   [tabCount]int
-	offsets   [tabCount]int    // per-list viewport offset (AR-001)
-	query     [tabCount]string // per-tab search filter (AR-013)
-	searching bool             // search-input mode on the active tab (AR-011)
-	status    *statusNote      // durable action outcome (CR-025)
-	st        *styles          // palette-resolved styles; nil = default palette
+	cursors [tabCount]int
+	offsets [tabCount]int    // per-list viewport offset (AR-001)
+	query   [tabCount]string // per-tab search filter (AR-013)
+	// queryCursor is the search caret's rune index, per tab like the query
+	// itself: re-entering search on a tab must resume where that tab's own
+	// query left off, not where another tab's did.
+	queryCursor [tabCount]int
+	searching   bool        // search-input mode on the active tab (AR-011)
+	status      *statusNote // durable action outcome (CR-025)
+	st          *styles     // palette-resolved styles; nil = default palette
 	// now is the clock the live Age counter renders against, advanced by the
 	// 1s clockTickMsg. Zero falls back to time.Now() (see renderNow), so tests
 	// can pin it for deterministic snapshots.
@@ -1157,50 +1251,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.prompt = nil
 			m.message = "cancelled"
 			return m, nil
-		case tea.KeyBackspace:
-			m.prompt.deleteBefore()
-			return m, nil
-		case tea.KeyDelete:
-			m.prompt.deleteAt()
-			return m, nil
-		case tea.KeySpace:
-			m.prompt.insert(" ")
-			return m, nil
-		case tea.KeyCtrlJ:
-			if m.prompt.multiline {
-				m.prompt.insert("\n")
-			}
-			return m, nil
-		// Caret motion: the input is a full line editor, so a typo in the
-		// middle of a long task is fixed in place instead of retyping the
-		// tail. ctrl+a/ctrl+e mirror the readline bindings a terminal
-		// operator already has in muscle memory.
-		case tea.KeyLeft:
-			m.prompt.moveBy(-1)
-			return m, nil
-		case tea.KeyRight:
-			m.prompt.moveBy(1)
-			return m, nil
-		case tea.KeyCtrlLeft:
-			m.prompt.wordLeft()
-			return m, nil
-		case tea.KeyCtrlRight:
-			m.prompt.wordRight()
-			return m, nil
-		case tea.KeyHome, tea.KeyCtrlA:
-			m.prompt.moveTo(0)
-			return m, nil
-		case tea.KeyEnd, tea.KeyCtrlE:
-			m.prompt.moveEnd()
-			return m, nil
-		case tea.KeyRunes:
-			// Only printable input; key names like "up"/"home" must not
-			// leak into the text.
-			m.prompt.insert(string(msg.Runes))
-			return m, nil
-		default:
-			return m, nil
 		}
+		// Everything else is text editing. Unhandled keys are swallowed so a
+		// stray binding cannot fire mid-entry.
+		m.prompt.setEdit(applyTextKey(m.prompt.edit(), msg, m.prompt.multiline))
+		return m, nil
 	}
 
 	// Search-input mode (AR-011): every printable key edits the query —
@@ -1212,15 +1267,14 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case tea.KeyCtrlC:
 			return m, tea.Quit
 		case tea.KeyEsc, tea.KeyEnter:
+			// Leaving search hands ←/→ back to tab navigation.
 			m.searching = false
-		case tea.KeyBackspace:
-			if r := []rune(m.query[m.tab]); len(r) > 0 {
-				m.query[m.tab] = string(r[:len(r)-1])
-			}
-		case tea.KeySpace:
-			m.query[m.tab] += " "
-		case tea.KeyRunes:
-			m.query[m.tab] += string(msg.Runes)
+		default:
+			// The query is a text input like any other: same caret, same
+			// editing keys. Every key is swallowed here (this branch always
+			// returns), so ← moves the caret instead of switching tabs out
+			// from under a half-typed query.
+			m.setQueryEdit(applyTextKey(m.queryEdit(), msg, false))
 		}
 		m.clampListViewport() // CR-016
 		return m, nil
@@ -1255,13 +1309,16 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "/":
 		if m.tab.isList() {
 			m.searching = true
+			// Resume editing an existing filter from its end rather than
+			// from index 0, which would insert in front of it.
+			m.setQueryEdit(m.queryEdit().end())
 			m.message = ""
 		}
 	case "backspace":
 		// The active-filter hint advertises backspace-to-clear outside
 		// search mode too; a no-op otherwise.
 		if m.tab.isList() && m.query[m.tab] != "" {
-			m.query[m.tab] = ""
+			m.setQuery(m.tab, "")
 			m.clampListViewport()
 		}
 	case "p":
@@ -2157,6 +2214,28 @@ func (m Model) confirmDeleteTaskTargets(targets []taskTarget, clearsMarks bool) 
 
 // addTaskPrompt appends a task to the checklist of the source under the
 // cursor (any of its rows — header included — names the target file).
+// taskSourceLabel names the source a task prompt is writing to by the selector
+// the operator THINKS in — who the source feeds — rather than by its file
+// path, which is often a long doc path whose basename says nothing about who
+// gets the task. A source with no agent selector is named by its workspace
+// instead, wildcarded to "*" exactly like the Tasks group header renders it,
+// so the two always read the same way. The path is used only when the row has
+// no source to consult at all.
+func (m Model) taskSourceLabel(r *taskRow) string {
+	if r.group >= len(m.data.tasks) {
+		return truncatePathKeepBase(r.path, taskPathDisplayWidth)
+	}
+	src := m.data.tasks[r.group].Source
+	if src.Agent != "" {
+		return "agent=" + src.Agent
+	}
+	ws := src.Workspace
+	if ws == "" {
+		ws = "*"
+	}
+	return "ws=" + ws
+}
+
 func (m Model) addTaskPrompt() (tea.Model, tea.Cmd) {
 	r := m.selectedTaskRow()
 	if r == nil {
@@ -2171,7 +2250,7 @@ func (m Model) addTaskPrompt() (tea.Model, tea.Cmd) {
 	m.beginAction()
 	m.openPrompt(&prompt{
 		label: fmt.Sprintf("new task(s) for %s — enter: add, shift+enter: new line, esc: cancel",
-			truncatePathKeepBase(path, taskPathDisplayWidth)),
+			m.taskSourceLabel(r)),
 		multiline: true,
 		onSubmit: func(input string) tea.Cmd {
 			return func() tea.Msg {
@@ -3488,7 +3567,7 @@ func (m Model) showAgentTasks(a domain.AgentTransition) (tea.Model, tea.Cmd) {
 	if !ok && m.query[tabTasks] != "" {
 		// The Tasks search filter hides the very row being jumped to; a jump
 		// that lands nowhere is worse than a dropped filter, so clear it.
-		m.query[tabTasks] = ""
+		m.setQuery(tabTasks, "")
 		cursor, ok = m.taskGroupHeaderRow(group)
 	}
 	m.offsets[tabTasks] = 0
@@ -3567,7 +3646,7 @@ func (m Model) showRuleFor(signature string) (tea.Model, tea.Cmd) {
 		// Hidden by the Rules tab's own filters — it composes a search query
 		// AND the f mode cycle, so either can bury the target. ruleFor already
 		// proved the rule exists, so clearing both makes the retry land.
-		m.query[tabSignatures] = ""
+		m.setQuery(tabSignatures, "")
 		m.sigMode = ""
 		cursor, ok = m.ruleRowFor(signature)
 	}
@@ -3721,7 +3800,7 @@ func (m Model) View() string {
 	// Search bar / active-filter line (its height is accounted for in
 	// listPageSize so the body never overflows the pane).
 	if m.searching {
-		fmt.Fprintf(&b, "%s%s█\n", st.section.Render("search> "), m.query[m.tab])
+		fmt.Fprintf(&b, "%s%s\n", st.section.Render("search> "), m.queryEdit().withCaret())
 	} else if m.tab.isList() && m.query[m.tab] != "" {
 		fmt.Fprintf(&b, "%s\n", st.help.Render(
 			fmt.Sprintf("filter: %q — / to edit, backspace to clear", m.query[m.tab])))
@@ -3760,9 +3839,7 @@ func (m Model) View() string {
 		// its rune index rather than always at the end, so the operator can
 		// see where the next keystroke lands; with the caret at the end this
 		// renders exactly as it always did.
-		r, cur := m.prompt.runes()
-		withCaret := string(r[:cur]) + "█" + string(r[cur:])
-		lines := strings.Split(withCaret, "\n")
+		lines := strings.Split(m.prompt.edit().withCaret(), "\n")
 		fmt.Fprintf(&b, "\n%s> %s", m.prompt.label, lines[0])
 		for _, l := range lines[1:] {
 			fmt.Fprintf(&b, "\n  %s", l)
@@ -3830,7 +3907,7 @@ func (m Model) helpLine() string {
 		return "↑/↓: scroll  tab: switch tab" + rule + preview + "  " + closeKeys
 	}
 	if m.searching {
-		return "type to filter  backspace: erase  esc/enter: apply & close"
+		return "type to filter  ←/→: move (ctrl: by word)  home/end: line ends  backspace/delete: erase  esc/enter: apply & close"
 	}
 	// The caret bindings are advertised here rather than in the prompt label:
 	// the label is inside the prompt box, whose height listPageSize budgets as

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -651,6 +651,12 @@ func buildRuleItems(cfg config.Config) []ruleItem {
 		if src.NextTaskTemplate != "" {
 			label += fmt.Sprintf("  template=%q", src.NextTaskTemplate)
 		}
+		// Only shown when on — it is the one source setting that makes hap
+		// hand out tasks unprompted, so it must be visible wherever sources
+		// are listed (mirrors `hap task-source list`).
+		if src.EnableAutoSendTaskWhenIdle {
+			label += "  auto_send_when_idle=true"
+		}
 		items = append(items, ruleItem{
 			kind: "source", index: i, value: src.Path,
 			label: label,
@@ -3261,10 +3267,31 @@ func (m Model) addTaskSourcePrompt() (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	m.beginAction()
 	m.prompt = &prompt{
-		label: "add task source: <path> [agent] [workspace]",
+		label: "add task source: <path> [agent] [workspace] [--auto-send-when-idle]",
 		onSubmit: func(input string) tea.Cmd {
 			return func() tea.Msg {
-				parts := strings.Fields(input)
+				// Spelled exactly like the CLI flag, and accepted in any
+				// position so the operator never has to remember the order.
+				// Any OTHER dashed word is refused rather than taken as a
+				// field: silently storing "--auto-send-when-idl" as the path
+				// would leave the operator believing unprompted hand-out is
+				// on when it is off.
+				var opts []frontend.TaskSourceOption
+				var parts []string
+				for _, f := range strings.Fields(input) {
+					if f == "--auto-send-when-idle" {
+						opts = append(opts, frontend.AutoSendWhenIdle())
+						continue
+					}
+					if strings.HasPrefix(f, "-") {
+						return actionResultMsg{err: fmt.Errorf(
+							"unknown flag %q — this prompt takes only --auto-send-when-idle (spelled exactly, no =value); use the CLI for anything else", f)}
+					}
+					parts = append(parts, f)
+				}
+				if len(parts) == 0 {
+					return actionResultMsg{err: fmt.Errorf("expected <path> [agent] [workspace] — no path given")}
+				}
 				if len(parts) > 3 {
 					return actionResultMsg{err: fmt.Errorf(
 						"expected <path> [agent] [workspace] — got %d fields (paths with spaces are not supported here; use the CLI)", len(parts))}
@@ -3276,8 +3303,11 @@ func (m Model) addTaskSourcePrompt() (tea.Model, tea.Cmd) {
 				if len(parts) > 2 {
 					workspace = parts[2]
 				}
-				if err := app.AddTaskSource(ctx, agent, workspace, parts[0], ""); err != nil {
+				if err := app.AddTaskSource(ctx, agent, workspace, parts[0], "", opts...); err != nil {
 					return actionResultMsg{err: err}
+				}
+				if len(opts) > 0 {
+					return actionResultMsg{message: "task source added (auto-send when idle ON)"}
 				}
 				return actionResultMsg{message: "task source added"}
 			}

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -260,7 +260,8 @@ terminal_bell = true       # ring the terminal bell (\a) on new escalations and 
 # agent that is disabled, rate-paused or has an escalation still awaiting you is
 # skipped. Reserving belongs to the SOURCE, so ordinary event-driven sends from
 # it are marked "[-]" too (the agent's own `hap task ... start` is then a
-# no-op). Default: off.
+# no-op). Default: off. A new source can be added with it already on:
+# `hap task-source add --auto-send-when-idle <checklist.md>`.
 # enable_auto_send_task_when_idle = true
 
 # ── Custom classifier rules (repeatable, extend the built-ins) ──────


### PR DESCRIPTION
Three independent changes from one work session. Each is a separate commit and
can be read on its own.

## 1. `--auto-send-when-idle` on `hap task-source add`

`enable_auto_send_task_when_idle` was config.toml-only, so pointing an agent at
a checklist that should also be driven on the idle poll meant adding the source
and then hand-editing the file.

- CLI flag, plus the same word accepted in any position in the TUI's Config-tab
  `t` prompt.
- API is a variadic `frontend.TaskSourceOption`, so the ~25 existing
  `AddTaskSource` call sites are untouched.
- Config-tab source rows now show `auto_send_when_idle=true`, mirroring
  `hap task-source list`.

**It stays strictly opt-in.** Nothing else writes the field, and the
generated-task bootstrap still registers sources with it off. Both parsers fail
loudly rather than quietly: the CLI explains that flags must precede
`<checklist.md>` (Go's flag parsing stops at the first argument), and the TUI
refuses any unrecognized dashed word instead of storing it as a field — a
typo'd flag must never look like it took effect.

## 2. Command-level regression tests for the destructive CLI paths

`clear-data`, `task-source remove` and `rules remove` had no test in the `cli`
package at all — `clear-data`, the one command that wipes every learned rule,
decision and audit row at once, had none anywhere.

Each path now pins the same contract: the guard refuses **and leaves state
intact**, the confirmed path deletes exactly what it named, and a bad target
deletes nothing. The load-bearing additions beyond "it errors":

- `clear-data` must not touch **operator** state — agent names, the per-agent
  disable switch, task sources, never-auto patterns and checklist files are
  typed, not learned.
- `task-source remove` / `rules remove` address entries positionally, so the
  tests pin which entry goes, that indices shift after a removal, and that a
  pattern index can never reach a scoped `[[safety.never_auto_rules]]` entry.
- `signatures reset` keeps its decision rows but stamps a floor; without it the
  rule re-graduates off the history the operator reset it to drop.
- `dismiss <valid> <bogus>` applies the valid one and then errors — what makes
  that safe is stdout naming every escalation actually closed.

Verified non-vacuous by mutation: removing the `clear-data` `--yes` guard,
adding `agent_names` to the wipe list, making `RemoveTaskSource` ignore its
index, and making `task remove` delete by position each fail the matching test.

## 3. TUI prompts are a real line editor

The prompt input only ever appended and only ever backspaced from the end, so
fixing a typo mid-task meant deleting everything after it and retyping.

| Key | Action |
|---|---|
| `←` / `→` | move the caret one rune |
| `ctrl+←` / `ctrl+→` | move by word |
| `home`/`end`, `ctrl+a`/`ctrl+e` | jump to either end |
| `backspace` / `delete` | remove before / under the caret |

The block cursor renders **at** its position, so editing is no longer blind.
This covers the add/edit task prompts plus the other ~14 prompts on the same
input.

Correctness details: the caret is rune-indexed (task text is UTF-8; byte
slicing would split a rune) and measures newline-**normalized** text, since a
pasted `\r\n` is two raw runes but one normalized. `submitPrompt` normalizes
too — previously an untouched CRLF value would submit different text than an
edited one. Word motion uses `unicode.IsSpace`, so the U+00A0 that shows up in
generated task text separates words.

Every prompt is installed through `openPrompt`, which parks the caret at the end
of any pre-filled value; a direct assignment would silently leave it at 0 and
insert *in front of* a default like the y/N send prompt's `"n"`, so a test scans
package source and fails on one (mirroring `TestDomainPurity`). The bindings are
advertised in the help line rather than the prompt label, because `listPageSize`
budgets the prompt box at one row and a longer label would wrap and cost a list
row.

## Verification

`gofmt`, `go vet -tags "vectors cpu" ./...`, `go test -tags "vectors cpu" ./...
-count=1` (24 packages) and `golangci-lint run --build-tags "vectors,cpu"` all
clean. Each change was reviewed by a code-review pass and the findings fixed
before commit.

`herdr-plugin.toml` is left at `0.4.32` (matching the current release) so
auto-release takes the normal patch path on merge.


---

## 4. Every text input gets the caret (follow-up)

The caret above landed on `prompt` only, so the `/` search filter was still the
append-only field every input used to be.

The editing model is now a shared `textEdit{text, cursor}` value type plus a
single `applyTextKey`, with the prompts and the search query both routed
through it. `applyTextKey` is the **only** function in the package that turns
typed runes into text — an AST-walking test fails if a future input surface
hand-rolls `x += string(msg.Runes)` and quietly goes append-only again. That is
what makes "every text input behaves the same" true by construction rather than
by discipline.

The search query gets the full set: `←`/`→` (ctrl for word-wise), `home`/`end`,
`ctrl+a`/`ctrl+e`, `delete`, backspace-at-caret, and the caret rendered in
place. Its cursor is **per-tab** like the query itself, so returning to a tab
restores *its* caret; `/` on an existing filter resumes at the end rather than
inserting in front of it, and clearing a filter resets the caret with it.

Worth being precise about what this does *not* change: the arrows never leaked
to tab-switching. The search branch always returned before the list bindings,
so `←` was a silent no-op — it now moves the caret. The mode boundary (arrows
belong to the text until esc/enter) was already correct; this makes it useful.

## 5. The add-task prompt names its source by selector

It named the checklist file, which is often a long doc path whose basename says
nothing about who receives the task. It now names the selector the operator
thinks in:

```
new task(s) for agent=brave-otter — enter: add, ...
new task(s) for ws=codex-1 — enter: add, ...        (source has no agent filter)
new task(s) for ws=* — enter: add, ...              (catch-all)
```

The `*` wildcard matches how the Tasks group header above it renders
(`#1 agent=* ws=codex-1`), so the prompt and the row never disagree about what
the source is called.

## Live verification

Both follow-ups were driven against a **real herdr TUI**, not just unit tests:
caret motion and mid-string edits in the search box and the task prompts,
arrows returning to tab navigation after `esc`, `/` re-entry parking the caret
at the end, and both label shapes rendered from two real task sources.
