### PR TITLE
#1 feat: parse markdown-escaped task ids, centralize id syntax, edit task-source settings

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -497,9 +497,18 @@ hap task-source add --agent backend-dev --auto-send-when-idle ./docs/tasks.md
 
 the TUI's *Config* tab `t` prompt takes the same word:
 `<path> [agent] [workspace] [--auto-send-when-idle]`. it is opt-in everywhere
-and never inferred; existing sources are switched on in config.toml. wherever
-sources are listed (`hap task-source list`, the *Config* tab) an enabled source
-shows `auto_send_when_idle=true`.
+and never inferred. an EXISTING source is switched on without editing
+config.toml:
+
+```bash
+hap task-source set <index> auto-send-when-idle true   # or false
+hap task-source set <index> max-tasks 40               # the refill/creation cap
+```
+
+the *Config* tab's `enter` on a task-source row is the same edit: it opens a
+picker of the two settings, then asks for the value. wherever sources are listed
+(`hap task-source list`, the *Config* tab) an enabled source shows
+`auto_send_when_idle=true`, and every source shows its `max_tasks`.
 
 - one task, one agent: agents matched by the same source get *different*
   pending items, and the delivered item is marked `[-]` as it is sent (a failed
@@ -638,7 +647,7 @@ without a declared task source, the plugin falls back to inferring the next task
 
 if inference finds nothing (no task source and nothing inferable from the pane) and `llm.task_generate_command` is configured, the plugin runs that CLI once to synthesize a next task for the idle agent (placeholders: `{self}`, `{agent_name}`, `{agent_type}`, `{pane_excerpt}`, `{cwd}`). the CLI's stdout is surfaced as an escalation the operator confirms (writing a per-agent `tasks.md`) or dismisses — the plugin never sends a synthesized task unattended. leave `task_generate_command` unset to keep the default: an idle agent with no task source escalates as `no_task_source` and nothing is synthesized. `task_generate_command_start` is the first-interaction variant (empty inherits `task_generate_command`); `task_generate_timeout_seconds` bounds one run (0 inherits `llm.timeout_seconds`).
 
-**`max_tasks` (per `[[task_sources]]`, default 20)** caps how large a source's checklist may grow. once the file holds MORE than `max_tasks` items — done, in-progress, and pending counted alike — and its pending items are exhausted, the daemon logs a warning (`maximum number of tasks reached … skipping task generation`, with the agent name) and skips LLM generation for that agent instead of appending to an already-long list. the **same cap gates manual creation**: adding tasks (the Tasks-tab `a`, or `hap task … add`) to a registered source is rejected once it would push the list past `max_tasks` (`maximum number of tasks reached …`), so a hand-added list can't grow past what the daemon would then refuse to refill. prune the checklist (or raise `max_tasks`) to resume. sending the pending items of an under-cap source is unaffected; the no-task-source bootstrap case (no `[[task_sources]]` entry) and an ad-hoc `--path` file that is not a registered source are never capped.
+**`max_tasks` (per `[[task_sources]]`, default 20)** caps how large a source's checklist may grow. once the file holds MORE than `max_tasks` items — done, in-progress, and pending counted alike — and its pending items are exhausted, the daemon logs a warning (`maximum number of tasks reached … skipping task generation`, with the agent name) and skips LLM generation for that agent instead of appending to an already-long list. the **same cap gates manual creation**: adding tasks (the Tasks-tab `a`, or `hap task … add`) to a registered source is rejected once it would push the list past `max_tasks` (`maximum number of tasks reached …`), so a hand-added list can't grow past what the daemon would then refuse to refill. prune the checklist (or raise `max_tasks` — `hap task-source set <index> max-tasks <n>`, or the *Config* tab's `enter` on the source row) to resume. a source added by hap writes its cap explicitly (`max_tasks = 20`), and a config loaded with the key unset is saved back with the effective default rather than a bare `0`. sending the pending items of an under-cap source is unaffected; the no-task-source bootstrap case (no `[[task_sources]]` entry) and an ad-hoc `--path` file that is not a registered source are never capped.
 
 ## reset data
 

--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -464,6 +464,13 @@ this makes hap send without a herdr attention event, so it is opt-in):
 hap task-source add --agent backend-dev --auto-send-when-idle ./docs/backend-tasks.md
 ```
 
+add a task source with a task cap other than the default 20 (see `max_tasks`
+below):
+
+```bash
+hap task-source add --agent backend-dev --max-tasks 40 ./docs/backend-tasks.md
+```
+
 remove a task source by index:
 
 ```bash
@@ -495,9 +502,9 @@ it can be turned on when the source is added, without editing config.toml:
 hap task-source add --agent backend-dev --auto-send-when-idle ./docs/tasks.md
 ```
 
-the TUI's *Config* tab `t` prompt takes the same word:
-`<path> [agent] [workspace] [--auto-send-when-idle]`. it is opt-in everywhere
-and never inferred. an EXISTING source is switched on without editing
+the TUI's *Config* tab `t` prompt takes the same words:
+`<path> [agent] [workspace] [--auto-send-when-idle] [--max-tasks N]`. it is
+opt-in everywhere and never inferred. an EXISTING source is switched on without editing
 config.toml:
 
 ```bash
@@ -506,7 +513,11 @@ hap task-source set <index> max-tasks 40               # the refill/creation cap
 ```
 
 the *Config* tab's `enter` on a task-source row is the same edit: it opens a
-picker of the two settings, then asks for the value. wherever sources are listed
+picker of the two settings, then asks for the value. both are also settable at
+creation time — `hap task-source add [--auto-send-when-idle] [--max-tasks N]`,
+and the *Config* tab's `t` prompt takes the same words:
+`<path> [agent] [workspace] [--auto-send-when-idle] [--max-tasks N]` (either
+`--max-tasks 40` or `--max-tasks=40`). wherever sources are listed
 (`hap task-source list`, the *Config* tab) an enabled source shows
 `auto_send_when_idle=true`, and every source shows its `max_tasks`.
 
@@ -647,7 +658,7 @@ without a declared task source, the plugin falls back to inferring the next task
 
 if inference finds nothing (no task source and nothing inferable from the pane) and `llm.task_generate_command` is configured, the plugin runs that CLI once to synthesize a next task for the idle agent (placeholders: `{self}`, `{agent_name}`, `{agent_type}`, `{pane_excerpt}`, `{cwd}`). the CLI's stdout is surfaced as an escalation the operator confirms (writing a per-agent `tasks.md`) or dismisses — the plugin never sends a synthesized task unattended. leave `task_generate_command` unset to keep the default: an idle agent with no task source escalates as `no_task_source` and nothing is synthesized. `task_generate_command_start` is the first-interaction variant (empty inherits `task_generate_command`); `task_generate_timeout_seconds` bounds one run (0 inherits `llm.timeout_seconds`).
 
-**`max_tasks` (per `[[task_sources]]`, default 20)** caps how large a source's checklist may grow. once the file holds MORE than `max_tasks` items — done, in-progress, and pending counted alike — and its pending items are exhausted, the daemon logs a warning (`maximum number of tasks reached … skipping task generation`, with the agent name) and skips LLM generation for that agent instead of appending to an already-long list. the **same cap gates manual creation**: adding tasks (the Tasks-tab `a`, or `hap task … add`) to a registered source is rejected once it would push the list past `max_tasks` (`maximum number of tasks reached …`), so a hand-added list can't grow past what the daemon would then refuse to refill. prune the checklist (or raise `max_tasks` — `hap task-source set <index> max-tasks <n>`, or the *Config* tab's `enter` on the source row) to resume. a source added by hap writes its cap explicitly (`max_tasks = 20`), and a config loaded with the key unset is saved back with the effective default rather than a bare `0`. sending the pending items of an under-cap source is unaffected; the no-task-source bootstrap case (no `[[task_sources]]` entry) and an ad-hoc `--path` file that is not a registered source are never capped.
+**`max_tasks` (per `[[task_sources]]`, default 20)** caps how large a source's checklist may grow. once the file holds MORE than `max_tasks` items — done, in-progress, and pending counted alike — and its pending items are exhausted, the daemon logs a warning (`maximum number of tasks reached … skipping task generation`, with the agent name) and skips LLM generation for that agent instead of appending to an already-long list. the **same cap gates manual creation**: adding tasks (the Tasks-tab `a`, or `hap task … add`) to a registered source is rejected once it would push the list past `max_tasks` (`maximum number of tasks reached …`), so a hand-added list can't grow past what the daemon would then refuse to refill. prune the checklist (or raise `max_tasks` — `hap task-source set <index> max-tasks <n>`, `hap task-source add --max-tasks <n>` at creation time, or the *Config* tab's `enter` on the source row) to resume. a source added by hap writes its cap explicitly (`max_tasks = 20`), and a config loaded with the key unset is saved back with the effective default rather than a bare `0`. sending the pending items of an under-cap source is unaffected; the no-task-source bootstrap case (no `[[task_sources]]` entry) and an ad-hoc `--path` file that is not a registered source are never capped.
 
 ## reset data
 

--- a/README.md
+++ b/README.md
@@ -523,8 +523,10 @@ each idle episode is driven exactly once — so an agent that finishes its work
 and sits there without a further event waits for you.
 
 Set `enable_auto_send_task_when_idle = true` on a source — or add the source
-with `hap task-source add --auto-send-when-idle <checklist.md>`, or type
-`--auto-send-when-idle` in the *Config* tab's `t` prompt — and the daemon also
+with `hap task-source add --auto-send-when-idle <checklist.md>`, type
+`--auto-send-when-idle` in the *Config* tab's `t` prompt, or flip it on an
+existing source with `hap task-source set <index> auto-send-when-idle true`
+(the *Config* tab's `enter` on a task-source row does the same) — and the daemon also
 polls once a minute: any agent that source matches which has been idle for
 more than a minute is handed its next pending `[ ]` item. Delivery goes
 through the normal pipeline, so the kill switch, never-auto patterns, rate
@@ -684,7 +686,8 @@ more onto an already-long list. The **same cap also gates manual creation** —
 adding tasks (the Tasks tab's `a`, or `hap task … add`) to a registered source
 is rejected once it would push the list past `max_tasks` — so a hand-added list
 can't grow past what the daemon would then refuse to refill. Prune the checklist
-(or raise `max_tasks` on the `[[task_sources]]` entry) to resume. Sending the
+(or raise `max_tasks` — `hap task-source set <index> max-tasks 40`, the *Config*
+tab's `enter` on the source row, or the `[[task_sources]]` entry) to resume. Sending the
 remaining pending items of a source under its cap is unaffected, and a `--path`
 file that isn't a registered `[[task_sources]]` entry is never capped.
 

--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ hap enable backend-dev          # allow automation again
 hap task-source --agent backend-dev ./docs/backend-tasks.md
 hap task-source --agent backend-dev --template 'Do this next: {next_task_content} (full list: {task_list_path})' ./docs/backend-tasks.md
 hap task-source --agent backend-dev --auto-send-when-idle ./docs/backend-tasks.md
+hap task-source --agent backend-dev --max-tasks 40 ./docs/backend-tasks.md
 ```
 
 `hap agents` output is tab-separated and gained a sixth column — the agent's
@@ -687,7 +688,10 @@ adding tasks (the Tasks tab's `a`, or `hap task … add`) to a registered source
 is rejected once it would push the list past `max_tasks` — so a hand-added list
 can't grow past what the daemon would then refuse to refill. Prune the checklist
 (or raise `max_tasks` — `hap task-source set <index> max-tasks 40`, the *Config*
-tab's `enter` on the source row, or the `[[task_sources]]` entry) to resume. Sending the
+tab's `enter` on the source row, or the `[[task_sources]]` entry) to resume. The
+cap can also be chosen when the source is created: `hap task-source add
+--max-tasks 40 <checklist.md>`, or `--max-tasks 40` in the *Config* tab's `t`
+prompt. Sending the
 remaining pending items of a source under its cap is unaffected, and a `--path`
 file that isn't a registered `[[task_sources]]` entry is never capped.
 

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -69,7 +69,8 @@ Operate:
 Configure:
   config [show|fields|path|set <field> <value>|set-threshold <situation> <value>]
   rules [list|add <regex>|remove <index>]      never-auto patterns
-  task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] <checklist.md> | list | remove <index>
+  task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] [--max-tasks N] <checklist.md>
+                        | list | set <index> <auto-send-when-idle|max-tasks> <value> | remove <index>
   task [<agent> | --path F] list [--status all|pending|done] | get <n> | add <text>
                         | start <n> | done <n> | undone <n> | update <n> <text>
                         | remove <n> | send <n> [--yes]

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -987,11 +987,11 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 		if idx < 0 || idx >= len(cfg.TaskSources) {
 			return fmt.Errorf("no task source #%d (see: task-source list)", idx)
 		}
-		expected := cfg.TaskSources[idx].Path
+		expected := cfg.TaskSources[idx]
 		if err := app.RemoveTaskSource(ctx, idx, expected); err != nil {
 			return err
 		}
-		fmt.Fprintf(out, "task source #%d removed: %s\n", idx, expected)
+		fmt.Fprintf(out, "task source #%d removed: %s\n", idx, expected.Path)
 		return nil
 	}
 	if len(args) > 0 && args[0] == "add" {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1002,6 +1002,7 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 	workspace := fs.String("workspace", "", "workspace name this source applies to (\"*\" wildcards, e.g. \"codex-*\")")
 	template := fs.String("template", "", "next-task prompt template ({next_task_content}, {task_list_path}, {task_list_path_quoted}, {agent_name} placeholders)")
 	autoSend := fs.Bool("auto-send-when-idle", false, "also hand out tasks on the periodic idle poll, not only on a herdr attention event")
+	maxTasks := fs.Int("max-tasks", config.DefaultMaxTasks, "cap on how many checklist items this source may hold before task generation stops refilling it")
 	fs.SetOutput(out)
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -1015,16 +1016,20 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 				return fmt.Errorf("flags must come before <checklist.md>: %s was read as an argument, not a flag", extra)
 			}
 		}
-		return fmt.Errorf("usage: task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] <checklist.md> | list | set <index> <key> <value> | remove <index>")
+		return fmt.Errorf("usage: task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] [--max-tasks N] <checklist.md> | list | set <index> <key> <value> | remove <index>")
 	}
 	var opts []frontend.TaskSourceOption
 	if *autoSend {
 		opts = append(opts, frontend.AutoSendWhenIdle())
 	}
+	// Passed unconditionally: guarding on "differs from the default" would
+	// couple this to AddTaskSource's own default and silently drop an explicit
+	// --max-tasks 20 the day either moves.
+	opts = append(opts, frontend.MaxTasks(*maxTasks))
 	if err := app.AddTaskSource(ctx, *agent, *workspace, fs.Arg(0), *template, opts...); err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "task source added: %s\n", fs.Arg(0))
+	fmt.Fprintf(out, "task source added: %s (max_tasks=%d)\n", fs.Arg(0), *maxTasks)
 	// Unprompted hand-out is the one setting that makes hap act without a herdr
 	// event, so say so plainly instead of leaving it to `task-source list`.
 	if *autoSend {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -957,20 +956,27 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 			}
 			// Only shown when on: it is the one source setting that makes hap
 			// hand out tasks unprompted, so it must be visible here. Set it
-			// with `task-source add --auto-send-when-idle`, or by editing
-			// config.toml for a source that already exists.
+			// with `task-source add --auto-send-when-idle`, or on an existing
+			// source with `task-source set <index> auto-send-when-idle <bool>`.
 			if src.EnableAutoSendTaskWhenIdle {
 				fmt.Fprint(out, " auto_send_when_idle=true")
 			}
+			// The cap is always shown, resolved through MaxTasksLimit so the
+			// number printed is the one the daemon enforces even for a config
+			// written before the cap was filled in on save.
+			fmt.Fprintf(out, " max_tasks=%d", src.MaxTasksLimit())
 			fmt.Fprintln(out)
 		}
 		return nil
+	}
+	if len(args) > 0 && args[0] == "set" {
+		return taskSourceSet(ctx, app, out, args[1:])
 	}
 	if len(args) > 0 && args[0] == "remove" {
 		if len(args) != 2 {
 			return fmt.Errorf("usage: task-source remove <index> (see: task-source list)")
 		}
-		idx, err := strconv.Atoi(args[1])
+		idx, err := strconv.Atoi(strings.TrimPrefix(args[1], "#"))
 		if err != nil {
 			return fmt.Errorf("invalid task source index %q", args[1])
 		}
@@ -1009,7 +1015,7 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 				return fmt.Errorf("flags must come before <checklist.md>: %s was read as an argument, not a flag", extra)
 			}
 		}
-		return fmt.Errorf("usage: task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] <checklist.md> | list | remove <index>")
+		return fmt.Errorf("usage: task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] <checklist.md> | list | set <index> <key> <value> | remove <index>")
 	}
 	var opts []frontend.TaskSourceOption
 	if *autoSend {
@@ -1025,6 +1031,58 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 		fmt.Fprintln(out, "auto-send when idle is ON: matching idle agents are handed their next pending task without an attention event")
 	}
 	return nil
+}
+
+// taskSourceSet edits one setting of an existing task source — the CLI twin of
+// the TUI Config tab's enter on a task-source row. Only the two settings that
+// are meaningful to flip after the fact are exposed; path/agent/workspace are
+// remove-and-re-add, since changing them silently re-points an agent's work.
+func taskSourceSet(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
+	const usage = "usage: task-source set <index> <auto-send-when-idle|max-tasks> <value> (see: task-source list)"
+	if len(args) != 3 {
+		return fmt.Errorf("%s", usage)
+	}
+	// `task-source list` prints indexes as "#0", so the copied-and-pasted form
+	// must work (the `hap task` refs accept it too).
+	idx, err := strconv.Atoi(strings.TrimPrefix(args[0], "#"))
+	if err != nil {
+		return fmt.Errorf("invalid task source index %q", args[0])
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		return err
+	}
+	if idx < 0 || idx >= len(cfg.TaskSources) {
+		return fmt.Errorf("no task source #%d (see: task-source list)", idx)
+	}
+	expected := cfg.TaskSources[idx]
+	key, value := args[1], args[2]
+	switch key {
+	case "auto-send-when-idle", "enable_auto_send_task_when_idle":
+		on, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid %s value %q (true|false)", key, value)
+		}
+		if err := app.SetTaskSourceAutoSend(ctx, idx, expected, on); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "task source #%d: auto_send_when_idle=%v\n", idx, on)
+		if on {
+			fmt.Fprintln(out, "auto-send when idle is ON: matching idle agents are handed their next pending task without an attention event")
+		}
+		return nil
+	case "max-tasks", "max_tasks":
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("invalid %s value %q (a whole number of tasks)", key, value)
+		}
+		if err := app.SetTaskSourceMaxTasks(ctx, idx, expected, n); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "task source #%d: max_tasks=%d\n", idx, n)
+		return nil
+	}
+	return fmt.Errorf("unknown task-source key %q\n%s", key, usage)
 }
 
 // task manages the checklist ITEMS inside a task source's file (as opposed to
@@ -1190,7 +1248,7 @@ func taskSend(ctx context.Context, app *frontend.App, out io.Writer, agent, path
 		if stdin == os.Stdin && !stdinIsTTY() {
 			return fmt.Errorf("confirmation needs a terminal; rerun as: task %s send %d --yes", agent, idx)
 		}
-		fmt.Fprintf(out, "send task #%d (%s) to %s? [y/N] ", idx, oneLineText(it.Text, 60), agent)
+		fmt.Fprintf(out, "send task #%d (%s) to %s? [y/N] ", idx, oneLineText(domain.DisplayTaskText(it.Text), 60), agent)
 		answer := ""
 		if _, err := fmt.Fscanln(stdin, &answer); err != nil {
 			answer = "" // EOF or a bare newline both read as the default No
@@ -1251,12 +1309,6 @@ func taskTargetLabel(agent, path string) string {
 	return agent
 }
 
-// taskRefRE is the syntactic shape of a task reference: a task id ("3.4",
-// optionally with the trailing separator an agent may copy along) or a
-// position ("#3"). It only screens out typos before any I/O — whether the
-// reference names a real task is domain.ResolveTaskRef's call.
-var taskRefRE = regexp.MustCompile(`^(?:#\d+|\d+(?:\.\d+)*[.):]?)$`)
-
 // taskItemArg resolves the first argument into the item it names. The argument
 // is a task REFERENCE, not necessarily a position: a checklist that numbers its
 // own tasks ("3.4 Implement …") is addressed by those ids, which is what an
@@ -1274,7 +1326,7 @@ func taskItemArg(app *frontend.App, agent, path string, args []string) (domain.C
 	// Reject a syntactically impossible reference before reading anything:
 	// resolution needs the checklist, so without this `done xyz` on a missing
 	// file reports the file error instead of the typo that caused it.
-	if !taskRefRE.MatchString(strings.TrimSpace(args[0])) {
+	if !domain.TaskRefSyntaxOK(args[0]) {
 		return domain.ChecklistItem{}, fmt.Errorf("invalid task number %q — pass a task id from the list (e.g. 3.4) or a position (e.g. '#3')", args[0])
 	}
 	return app.ResolveTaskRef(agent, path, args[0])
@@ -1349,9 +1401,11 @@ func taskList(app *frontend.App, out io.Writer, agent, path string, args []strin
 
 // formatTask renders one item, preserving its raw checkbox rune so an
 // in-progress "[-]" (or any non-standard marker) is shown as-is rather than
-// collapsed to "[x]".
+// collapsed to "[x]". The task id is shown unescaped (domain.DisplayTaskText):
+// a listing that printed "8\.1" would read as if the backslash were part of
+// the id somebody has to type back.
 func formatTask(it domain.ChecklistItem) string {
-	return fmt.Sprintf("#%d\t[%s]\t%s", it.Index, it.Mark, it.Text)
+	return fmt.Sprintf("#%d\t[%s]\t%s", it.Index, it.Mark, domain.DisplayTaskText(it.Text))
 }
 
 // printTaskList prints items matching the status filter, numbered by absolute

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1728,3 +1728,142 @@ func TestTaskRefMutationIsGuardedAgainstAConcurrentEdit(t *testing.T) {
 		t.Errorf("re-resolved %+v, want #3 %q", again, "1.2 beta")
 	}
 }
+
+// TestTaskEscapedIDsListAndAddress covers a checklist whose ids carry the
+// backslash escapes some markdown editors insert ("1\.", "8\.1") to stop the
+// line rendering as an ordered list. The listing must show the plain id, and
+// the plain id must be what addresses the task — the operator never types the
+// backslash.
+func TestTaskEscapedIDsListAndAddress(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] 1\\. alpha-item\n- [ ] 8\\.1 beta-item\n- [ ] 8\\.2 gamma-item\n")
+
+	out, err := run(t, app, "task", "--path", path, "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"#1\t[ ]\t1. alpha-item", "#2\t[ ]\t8.1 beta-item", "#3\t[ ]\t8.2 gamma-item"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list must show unescaped ids, missing %q, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, `8\.1`) {
+		t.Errorf("list must not print the markdown escape, got:\n%s", out)
+	}
+
+	if _, err := run(t, app, "task", "--path", path, "done", "8.1"); err != nil {
+		t.Fatalf("done 8.1 must address the escaped id: %v", err)
+	}
+	// The escaped spelling must survive the syntactic ref screen too: the
+	// next-task prompt hands the item text over verbatim, so an agent reads
+	// "8\.2 …" and plausibly types the id back exactly that way.
+	if _, err := run(t, app, "task", "--path", path, "done", `8\.2`); err != nil {
+		t.Fatalf(`done 8\.2 must be accepted as a task ref: %v`, err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The file keeps the operator's escape — hap ticks the box, nothing else.
+	if !strings.Contains(string(content), "[x] 8\\.1 beta-item") {
+		t.Errorf("done must tick the escaped item and preserve its text, got:\n%s", content)
+	}
+	if !strings.Contains(string(content), "[ ] 1\\. alpha-item") {
+		t.Errorf("no other item may change, got:\n%s", content)
+	}
+}
+
+// TestTaskRefScreenMatchesDomain: the CLI's pre-flight reference screen is
+// domain.TaskRefSyntaxOK — one rule, one place. A reference the domain would
+// resolve must reach it, and a malformed one must be refused as a typo rather
+// than as a file error.
+func TestTaskRefScreenMatchesDomain(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] 1. alpha\n- [ ] 8\\.1 beta\n")
+
+	for _, ref := range []string{"1", "1.", `8\.1`, "8.1", "#2"} {
+		if !domain.TaskRefSyntaxOK(ref) {
+			t.Errorf("domain screen rejects %q, which the CLI must accept", ref)
+		}
+	}
+	for _, bad := range []string{"xyz", "1))", "+2", `3\4`} {
+		out, err := run(t, app, "task", "--path", path, "get", bad)
+		if err == nil {
+			t.Errorf("get %q should be refused, got:\n%s", bad, out)
+			continue
+		}
+		if !strings.Contains(err.Error(), "invalid task number") && !strings.Contains(err.Error(), "no task") {
+			t.Errorf("get %q should report a bad reference, got: %v", bad, err)
+		}
+	}
+}
+
+// TestTaskSourceSet covers editing an existing source from the CLI — the twin
+// of the TUI Config tab's enter on a task-source row. The values must land in
+// config.toml, and a bad key/value/index must be refused rather than silently
+// doing nothing.
+func TestTaskSourceSet(t *testing.T) {
+	app, _ := testApp(t)
+	cfg := config.Default()
+	cfg.TaskSources = []config.TaskSource{
+		{Agent: "quiet-fox", Path: "/tmp/quiet.md"},
+		{Agent: "busy-otter", Path: "/tmp/busy.md"},
+	}
+	if err := config.Save(app.ConfigPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "task-source", "set", "1", "auto-send-when-idle", "true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "auto_send_when_idle=true") || !strings.Contains(out, "without an attention event") {
+		t.Errorf("turning unprompted hand-out ON must say so plainly, got:\n%s", out)
+	}
+	if _, err = run(t, app, "task-source", "set", "1", "max-tasks", "7"); err != nil {
+		t.Fatal(err)
+	}
+	saved, err := config.Load(app.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !saved.TaskSources[1].EnableAutoSendTaskWhenIdle || saved.TaskSources[1].MaxTasks != 7 {
+		t.Errorf("settings did not reach config.toml: %+v", saved.TaskSources[1])
+	}
+	// Source #0 is untouched and still carries the filled default cap.
+	if saved.TaskSources[0].EnableAutoSendTaskWhenIdle || saved.TaskSources[0].MaxTasks != config.DefaultMaxTasks {
+		t.Errorf("source #0 must be untouched, got %+v", saved.TaskSources[0])
+	}
+
+	// The listing reports both settings back.
+	if out, err = run(t, app, "task-source", "list"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "max_tasks=7") || !strings.Contains(out, fmt.Sprintf("max_tasks=%d", config.DefaultMaxTasks)) {
+		t.Errorf("list should report each source's cap, got:\n%s", out)
+	}
+
+	// The listing prints "#1", so that copied form must address the same entry.
+	if _, err = run(t, app, "task-source", "set", "#1", "max-tasks", "8"); err != nil {
+		t.Fatalf("a pasted #index must be accepted: %v", err)
+	}
+	if saved, err = config.Load(app.ConfigPath); err != nil {
+		t.Fatal(err)
+	}
+	if saved.TaskSources[1].MaxTasks != 8 {
+		t.Errorf("#1 should address source #1, got %+v", saved.TaskSources)
+	}
+
+	for _, bad := range [][]string{
+		{"set", "1", "bogus-key", "1"},
+		{"set", "1", "max-tasks", "zero"},
+		{"set", "1", "max-tasks", "0"},
+		{"set", "1", "auto-send-when-idle", "maybe"},
+		{"set", "9", "max-tasks", "5"},
+		{"set", "1", "max-tasks"},
+	} {
+		if _, err := run(t, app, "task-source", bad...); err == nil {
+			t.Errorf("task-source %v must be refused", bad)
+		}
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1910,3 +1910,48 @@ func TestTaskSourceRemoveDuplicatePath(t *testing.T) {
 		t.Error("an out-of-range index must be refused")
 	}
 }
+
+// TestTaskSourceAddMaxTasks: the cap can be set when the source is created,
+// persists to config.toml, and is validated — the CLI half of the parity the
+// TUI add prompt mirrors.
+func TestTaskSourceAddMaxTasks(t *testing.T) {
+	app, _ := testApp(t)
+	dir := t.TempDir()
+	capped := filepath.Join(dir, "capped.md")
+	plain := filepath.Join(dir, "plain.md")
+
+	out, err := run(t, app, "task-source", "add", "--agent", "a1", "--max-tasks", "40", capped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "max_tasks=40") {
+		t.Errorf("add should report the cap it stored, got:\n%s", out)
+	}
+	// An add that does not ask for a cap gets the default, named explicitly.
+	if _, err = run(t, app, "task-source", "add", "--agent", "a2", plain); err != nil {
+		t.Fatal(err)
+	}
+	saved, err := config.Load(app.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved.TaskSources[0].MaxTasks != 40 {
+		t.Errorf("--max-tasks did not persist: %+v", saved.TaskSources[0])
+	}
+	if saved.TaskSources[1].MaxTasks != config.DefaultMaxTasks {
+		t.Errorf("an add without the flag should carry the default cap, got %+v", saved.TaskSources[1])
+	}
+
+	for _, bad := range []string{"0", "-1", "abc"} {
+		if _, err := run(t, app, "task-source", "add", "--max-tasks", bad, plain); err == nil {
+			t.Errorf("--max-tasks %s must be refused", bad)
+		}
+	}
+	// The refused adds must not have created anything.
+	if saved, err = config.Load(app.ConfigPath); err != nil {
+		t.Fatal(err)
+	}
+	if len(saved.TaskSources) != 2 {
+		t.Errorf("a refused add must not register a source, got %+v", saved.TaskSources)
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1867,3 +1867,46 @@ func TestTaskSourceSet(t *testing.T) {
 		}
 	}
 }
+
+// TestTaskSourceRemoveDuplicatePath: two sources may point at the SAME
+// checklist under different agent selectors, so a path-only guard could not
+// tell them apart. Removing #0 must retire exactly that entry and leave the
+// other agent's source pointing at the shared file.
+func TestTaskSourceRemoveDuplicatePath(t *testing.T) {
+	app, _ := testApp(t)
+	cfg := config.Default()
+	cfg.TaskSources = []config.TaskSource{
+		{Agent: "alpha", Path: "/tmp/shared.md"},
+		{Agent: "beta", Path: "/tmp/shared.md"},
+		{Agent: "gamma", Workspace: "ws-1", Path: "/tmp/shared.md"},
+	}
+	if err := config.Save(app.ConfigPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := run(t, app, "task-source", "remove", "0"); err != nil {
+		t.Fatal(err)
+	}
+	saved, err := config.Load(app.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(saved.TaskSources) != 2 || saved.TaskSources[0].Agent != "beta" || saved.TaskSources[1].Agent != "gamma" {
+		t.Fatalf("remove 0 must retire exactly the first entry, got %+v", saved.TaskSources)
+	}
+
+	// Indexes shift down after a removal — "#1" now names gamma, and the
+	// listing the operator would re-read says so.
+	if _, err = run(t, app, "task-source", "remove", "#1"); err != nil {
+		t.Fatal(err)
+	}
+	if saved, err = config.Load(app.ConfigPath); err != nil {
+		t.Fatal(err)
+	}
+	if len(saved.TaskSources) != 1 || saved.TaskSources[0].Agent != "beta" {
+		t.Errorf("wrong source removed: %+v", saved.TaskSources)
+	}
+	if _, err = run(t, app, "task-source", "remove", "5"); err == nil {
+		t.Error("an out-of-range index must be refused")
+	}
+}

--- a/internal/cli/task_escaped_id_test.go
+++ b/internal/cli/task_escaped_id_test.go
@@ -1,0 +1,208 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// escapedFixture is a checklist as several markdown editors write one: the dot
+// after a leading number is backslash-escaped so the line is not re-rendered as
+// an ordered list. The ids deliberately do NOT line up with the positions —
+// id "2.1" sits at position 2 and id "3." at position 4 — so any helper that
+// quietly falls back to positional addressing hits the wrong item and the
+// assertions below catch it.
+const escapedFixture = "# Tasks\n\n" +
+	"- [ ] 1\\. alpha\n" +
+	"- [ ] 2\\.1 beta\n" +
+	"- [ ] 2\\.2 gamma\n" +
+	"- [x] 3\\. delta\n"
+
+// escapedApp wires a store-backed App to a checklist written with escaped ids,
+// plus one idle live agent so `task send` is exercisable.
+func escapedApp(t *testing.T) (*frontend.App, *sendRecorderHerdr, string) {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	h := &sendRecorderHerdr{agents: []domain.AgentTransition{
+		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"},
+	}}
+	app := &frontend.App{Store: st, Herdr: h,
+		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+	path := filepath.Join(dir, "tasks.md")
+	if err := os.WriteFile(path, []byte(escapedFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(context.Background(), "w1:p1", "", path, ""); err != nil {
+		t.Fatal(err)
+	}
+	return app, h, path
+}
+
+// readFixture returns the checklist file's current content.
+func readFixture(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+// assertNeighborsIntact pins that every item except the one under test still
+// carries its ORIGINAL raw markdown, escapes and all. Each op below rewrites
+// the whole file, so this is what proves an op touched exactly one line and
+// never normalized the operator's escaping away.
+func assertNeighborsIntact(t *testing.T, content, step string) {
+	t.Helper()
+	for _, want := range []string{
+		"- [ ] 1\\. alpha",
+		"- [ ] 2\\.2 gamma",
+		"- [x] 3\\. delta",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("after %s: line %q must be untouched, got:\n%s", step, want, content)
+		}
+	}
+}
+
+// TestEscapedIDLifecycle drives one task through every `hap task` op by its
+// escaped id and pins the two properties that make escaped ids safe: the FILE
+// keeps the operator's raw markdown (hap ticks boxes, it does not reformat),
+// and each op targets exactly the named item — never the item that happens to
+// sit at the same position.
+func TestEscapedIDLifecycle(t *testing.T) {
+	app, h, path := escapedApp(t)
+	// Every op below is addressed by the plain id: an operator reads "2.1" in
+	// the listing and types "2.1", never the backslash.
+	const ref = "2.1"
+
+	// list — the escape is a rendering artifact, so it never reaches the screen.
+	out, err := runSend(t, app, "--path", path, "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"#1\t[ ]\t1. alpha",
+		"#2\t[ ]\t2.1 beta",
+		"#3\t[ ]\t2.2 gamma",
+		"#4\t[x]\t3. delta",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list missing %q, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, `\.`) {
+		t.Errorf("list must not print the markdown escape, got:\n%s", out)
+	}
+
+	// get — resolves the id to its own position (2), not to position 1 (id "1")
+	// and not to the "3." item sitting at position 4.
+	if out, err = runSend(t, app, "--path", path, "get", ref); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "#2\t[ ]\t2.1 beta") {
+		t.Errorf("get %s should print item #2, got:\n%s", ref, out)
+	}
+	if out, err = runSend(t, app, "--path", path, "get", "3"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "#4\t[x]\t3. delta") {
+		t.Errorf("get 3 should reach the item LABELED 3 (position 4), got:\n%s", out)
+	}
+	// A bare "2" names no id, and position 2 carries one — refusing is the
+	// whole point: ticking "2.1" for somebody who asked for task 2 is the
+	// mistake the ref rules exist to prevent.
+	if _, err = runSend(t, app, "--path", path, "get", "2"); err == nil {
+		t.Error("a bare 2 must be refused: no item is labeled 2 and position 2 is labeled")
+	}
+
+	// start — marks [-] on the named item only.
+	if _, err = runSend(t, app, "--path", path, "start", ref); err != nil {
+		t.Fatal(err)
+	}
+	content := readFixture(t, path)
+	if !strings.Contains(content, "- [-] 2\\.1 beta") {
+		t.Errorf("start should mark the escaped item [-] and keep its text raw, got:\n%s", content)
+	}
+	assertNeighborsIntact(t, content, "start")
+
+	// undone — back to pending, so the item is sendable again.
+	if _, err = runSend(t, app, "--path", path, "undone", ref); err != nil {
+		t.Fatal(err)
+	}
+	content = readFixture(t, path)
+	if !strings.Contains(content, "- [ ] 2\\.1 beta") {
+		t.Errorf("undone should return the item to [ ], got:\n%s", content)
+	}
+	assertNeighborsIntact(t, content, "undone")
+
+	// update — new text, written exactly as typed (the operator may keep the
+	// escape, and hap must not "helpfully" strip or add one).
+	if _, err = runSend(t, app, "--path", path, "update", ref, `2\.1 beta reworded`); err != nil {
+		t.Fatal(err)
+	}
+	content = readFixture(t, path)
+	if !strings.Contains(content, "- [ ] 2\\.1 beta reworded") {
+		t.Errorf("update should rewrite only the named item, verbatim, got:\n%s", content)
+	}
+	assertNeighborsIntact(t, content, "update")
+
+	// send — addressed by AGENT (a --path list has nobody to send to), which
+	// also proves the two ways of naming the same source resolve the same item.
+	// The agent is the one party that should never see the escape: it reads the
+	// id in its prompt and types it back at `hap task done`.
+	if _, err = runSend(t, app, "w1:p1", "send", ref, "--yes"); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.sent) != 1 {
+		t.Fatalf("expected exactly one delivery, got %v", h.sent)
+	}
+	if !strings.Contains(h.sent[0], "2.1 beta reworded") || strings.Contains(h.sent[0], `2\.1`) {
+		t.Errorf("prompt should carry the unescaped id, got %q", h.sent[0])
+	}
+	content = readFixture(t, path)
+	if !strings.Contains(content, "- [-] 2\\.1 beta reworded") {
+		t.Errorf("send should reserve the item as [-] and keep its text raw, got:\n%s", content)
+	}
+	assertNeighborsIntact(t, content, "send")
+
+	// done — the escaped id still addresses the item now that it is [-].
+	if _, err = runSend(t, app, "--path", path, "done", `2\.1`); err != nil {
+		t.Fatalf("the escaped spelling must address the same task: %v", err)
+	}
+	content = readFixture(t, path)
+	if !strings.Contains(content, "- [x] 2\\.1 beta reworded") {
+		t.Errorf("done should tick the named item, got:\n%s", content)
+	}
+	assertNeighborsIntact(t, content, "done")
+
+	// remove — deletes that line and nothing else; the remaining items keep
+	// their raw text and their own ids.
+	if _, err = runSend(t, app, "--path", path, "remove", ref); err != nil {
+		t.Fatal(err)
+	}
+	content = readFixture(t, path)
+	if strings.Contains(content, "beta") {
+		t.Errorf("remove should delete the named item, got:\n%s", content)
+	}
+	assertNeighborsIntact(t, content, "remove")
+	if want, got := 3, len(domain.ParseChecklist(content)); got != want {
+		t.Errorf("checklist should hold %d items after remove, got %d:\n%s", want, got, content)
+	}
+	// The header and blank line the operator wrote are still there: hap edits
+	// checklist lines, never the document around them.
+	if !strings.HasPrefix(content, "# Tasks\n\n") {
+		t.Errorf("surrounding markdown must survive the lifecycle, got:\n%s", content)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -286,7 +286,10 @@ type TaskSource struct {
 	// it: once the file has more than MaxTasks items and its pending items are
 	// exhausted, the daemon logs a warning and skips generation instead of
 	// piling more onto an already-long list — the operator prunes it to make
-	// room. 0 (unset) uses DefaultMaxTasks; see MaxTasksLimit.
+	// room. Load fills an unset value with DefaultMaxTasks (fillZeroes), so a
+	// saved config always names the cap it is actually running under rather
+	// than a bare 0 that reads like "no limit"; MaxTasksLimit still substitutes
+	// the default for a config built in memory.
 	MaxTasks int `toml:"max_tasks,omitempty"`
 	// EnableAutoSendTaskWhenIdle opts this source into the daemon's periodic
 	// idle poll: on every sweep the daemon re-drives any matching agent that
@@ -314,7 +317,25 @@ func (s TaskSource) MatchesAgent(agentID, agentType, agentName string) bool {
 }
 
 // DefaultMaxTasks is the fallback for TaskSource.MaxTasks when unset (0).
+//
+// Because Load and Save materialize it (normalizeTaskSources), an existing
+// config pins this number on disk after its first save and is then
+// indistinguishable from an operator who chose 20 deliberately. Raising this
+// constant therefore only affects sources created afterwards — changing the
+// cap for existing installs needs a migration, not just a new default.
 const DefaultMaxTasks = 20
+
+// normalizeTaskSources fills each source's cap with DefaultMaxTasks when it is
+// unset or nonsensical. It runs on both Load and Save: "max_tasks = 0" (or a
+// missing key) reads like "unlimited" to an operator opening config.toml, when
+// the daemon has been enforcing DefaultMaxTasks all along.
+func (c *Config) normalizeTaskSources() {
+	for i := range c.TaskSources {
+		if c.TaskSources[i].MaxTasks <= 0 {
+			c.TaskSources[i].MaxTasks = DefaultMaxTasks
+		}
+	}
+}
 
 // MaxTasksLimit returns the source's task cap, substituting DefaultMaxTasks
 // when unset. Resolved dynamically (like GenerateTaskTimeout) rather than via
@@ -792,6 +813,7 @@ func (c *Config) fillZeroes() {
 	if w := c.Learning.ConfirmationWeight; w < 1 || math.IsNaN(w) || math.IsInf(w, 0) {
 		c.Learning.ConfirmationWeight = d.Learning.ConfirmationWeight
 	}
+	c.normalizeTaskSources()
 	if c.Limits.MaxConsecutiveAutoPrompts <= 0 {
 		c.Limits.MaxConsecutiveAutoPrompts = d.Limits.MaxConsecutiveAutoPrompts
 	}
@@ -880,8 +902,13 @@ func (c Config) CaptureDelay(agentType string, start bool) time.Duration {
 	return defaultCaptureEventDelay
 }
 
-// Save writes the config to path in TOML form (used by `config set`).
+// Save writes the config to path in TOML form (used by `config set`). Task
+// sources are normalized first, so a source appended by ANY write path (an
+// operator add, or the generated-task bootstrap) lands on disk naming the cap
+// it runs under — fillZeroes at load time only covers sources that were
+// already in the file.
 func Save(path string, cfg Config) error {
+	cfg.normalizeTaskSources()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -500,9 +501,11 @@ max_tasks = 5
 	if len(cfg.TaskSources) != 2 {
 		t.Fatalf("want 2 task sources, got %d", len(cfg.TaskSources))
 	}
-	// Unset max_tasks stays 0 on the struct but resolves to the default.
-	if cfg.TaskSources[0].MaxTasks != 0 {
-		t.Errorf("unset max_tasks should stay 0, got %d", cfg.TaskSources[0].MaxTasks)
+	// Unset max_tasks is FILLED with the default at load, so the next Save
+	// writes the cap the daemon actually enforces instead of a bare 0 — which
+	// reads like "no limit" to anyone opening config.toml.
+	if cfg.TaskSources[0].MaxTasks != DefaultMaxTasks {
+		t.Errorf("unset max_tasks should be filled with DefaultMaxTasks (%d), got %d", DefaultMaxTasks, cfg.TaskSources[0].MaxTasks)
 	}
 	if got := cfg.TaskSources[0].MaxTasksLimit(); got != DefaultMaxTasks {
 		t.Errorf("unset max_tasks should resolve to DefaultMaxTasks (%d), got %d", DefaultMaxTasks, got)
@@ -512,9 +515,25 @@ max_tasks = 5
 		t.Errorf("explicit max_tasks=5 should parse and resolve to 5, got %d / %d",
 			cfg.TaskSources[1].MaxTasks, cfg.TaskSources[1].MaxTasksLimit())
 	}
-	// A non-positive value falls back to the default (guards a hand-edited 0/-1).
+	// A non-positive value falls back to the default (guards a hand-edited 0/-1,
+	// and a config built in memory that never went through Load).
 	if got := (TaskSource{MaxTasks: -1}).MaxTasksLimit(); got != DefaultMaxTasks {
 		t.Errorf("non-positive max_tasks should resolve to DefaultMaxTasks (%d), got %d", DefaultMaxTasks, got)
+	}
+	// Saving the loaded config writes the filled cap, and the explicit one is
+	// left alone.
+	if err := Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), fmt.Sprintf("max_tasks = %d", DefaultMaxTasks)) {
+		t.Errorf("saved config should name the default cap explicitly, got:\n%s", data)
+	}
+	if !strings.Contains(string(data), "max_tasks = 5") {
+		t.Errorf("saved config should keep the explicit cap, got:\n%s", data)
 	}
 }
 

--- a/internal/domain/taskgen.go
+++ b/internal/domain/taskgen.go
@@ -57,7 +57,11 @@ func AgentBusy(status string) bool {
 // matching at all. A spaced rule ("- - -") does match here but has no
 // alphanumeric body, so the mode-detection check in NormalizeGeneratedTasks
 // still refuses to treat it as a list marker.
-var listItemRE = regexp.MustCompile(`^\s*(?:(?:[-*+]|\d+[.)])\s+(?:\[\s*[xX+\-*]?\s*\]\s*)?|\[\s*[xX+\-*]?\s*\]\s*)(.*)$`)
+// The ordered marker is built from the shared taskIDSepPat (tasklist.go), so an
+// escaped "1\." is stripped like a plain "1." — an LLM echoing a checklist it
+// read from an escaped file would otherwise leave the marker inside the task
+// text, and the renumbering would render "1. 1\. foo".
+var listItemRE = regexp.MustCompile(`^\s*(?:(?:[-*+]|\d+` + taskIDSepPat + `)\s+(?:\[\s*[xX+\-*]?\s*\]\s*)?|\[\s*[xX+\-*]?\s*\]\s*)(.*)$`)
 
 // isFenceLine reports whether a line is a Markdown code-fence delimiter
 // ("```", "~~~"), which is never a task.
@@ -236,8 +240,11 @@ func GeneratedTaskItemText(i int, task string) string {
 
 // generatedItemIDRE matches the numbered-ID prefix GeneratedTaskItemText
 // writes ("1. ", "23. ", …), and nothing looser: the ID is always digits, a
-// dot, and a single space, at the very start of the item text.
-var generatedItemIDRE = regexp.MustCompile(`^\d+\. `)
+// dot, and a single space, at the very start of the item text. The dot comes
+// from the shared taskIDDotPat (tasklist.go), so it may be backslash-escaped
+// ("1\. ") exactly as everywhere else — some markdown editors write that to
+// stop the line rendering as an ordered list.
+var generatedItemIDRE = regexp.MustCompile(`^\d+` + taskIDDotPat + ` `)
 
 // GeneratedTaskIdentity strips the numbered-ID prefix GeneratedTaskItemText
 // adds, recovering the raw task as a position-independent identity. A

--- a/internal/domain/taskgen_test.go
+++ b/internal/domain/taskgen_test.go
@@ -265,3 +265,22 @@ func TestRenderGeneratedTaskList(t *testing.T) {
 		t.Errorf("pending declared tasks = %v, want all three with ID markers intact", pending)
 	}
 }
+
+// TestGeneratedTaskIdentityEscapedID: a markdown editor may escape the dot in
+// the numbered ID hap writes ("1. " → "1\. ") so the line is not re-rendered
+// as an ordered list. Identity must still strip that prefix, or a regeneration
+// would fail to recognize the same logical task and lose its marker.
+func TestGeneratedTaskIdentityEscapedID(t *testing.T) {
+	cases := map[string]string{
+		"1. wire up retries":   "wire up retries",
+		`1\. wire up retries`:  "wire up retries",
+		`23\. wire up retries`: "wire up retries",
+		"hand-added task":      "hand-added task",
+		`1\.1 sub task`:        `1\.1 sub task`, // only the flat "<n>. " prefix is an ID
+	}
+	for text, want := range cases {
+		if got := GeneratedTaskIdentity(text); got != want {
+			t.Errorf("GeneratedTaskIdentity(%q) = %q, want %q", text, got, want)
+		}
+	}
+}

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -141,7 +141,11 @@ func (t DeclaredTask) Prompt() string {
 		// so the shorter {task_list_path} would otherwise consume its prefix
 		// and leave a stray "_quoted" in the prompt.
 		"{task_list_path_quoted}", ShellQuote(t.Path),
-		"{next_task_content}", DecodeTaskNewlines(t.Task),
+		// The task reaches the agent with its id unescaped: the agent reads the
+		// id here and types it back at `hap task done`, so showing it "8\.1"
+		// invites a reference nobody typed intentionally. The FILE keeps the
+		// operator's escape — only the outbound copy is normalized.
+		"{next_task_content}", DecodeTaskNewlines(DisplayTaskText(t.Task)),
 		"{task_list_path}", t.Path,
 		"{agent_name}", t.AgentName,
 		"{cwd}", t.Cwd,
@@ -298,6 +302,11 @@ func ParseChecklist(content string) []ChecklistItem {
 // The ID must be followed by whitespace or end of line either way, so "1.1.2"
 // never matches as "1.1".
 //
+// Every dot may arrive BACKSLASH-ESCAPED ("1\. Add…", "2\.3 Add…"): several
+// markdown editors escape a leading "<digits>." automatically so the line is
+// not re-rendered as an ordered list. The escape is a rendering artifact, not
+// part of the id — TaskLabel strips it, so "2\.3" and "2.3" are the same task.
+//
 // The looser multi-level rule does misread a decimal that opens an item ("2.5
 // GB export path" reads as ID 2.5). That is deliberate — requiring a separator
 // would reject the common "1.1 Add…" spelling, which is the whole point — and
@@ -305,7 +314,76 @@ func ParseChecklist(content string) []ChecklistItem {
 // whenever the item at that position carries no ID of its own. An ID wrapped in
 // markdown emphasis ("**1.1** Add…") is out of scope; such a list stays
 // positional.
-var taskLabelRE = regexp.MustCompile(`^(?:(\d+(?:\.\d+)+)[.):]?|(\d+)[.):])(?:\s|$)`)
+var taskLabelRE = regexp.MustCompile(`^(?:(` + taskIDMultiPat + `)` + taskIDSepPat + `?|(\d+)` + taskIDSepPat + `)(?:\s|$)`)
+
+// The task-id syntax lives in these four fragments. Every place that
+// RECOGNIZES an id is built from them — the label parser above, the syntactic
+// screen the CLI runs before touching the file (TaskRefSyntaxOK), the
+// generated "1. " prefix reader and the ordered-list marker stripper in
+// taskgen.go — so widening the syntax once widens it everywhere. Splitting
+// them apart is how the escaped spelling used to parse in the domain but get
+// rejected by the CLI's own copy of the rule. The one deliberate exception is
+// the WRITER, GeneratedTaskItemText, which spells its ". " literally: hap
+// always writes the plain form, and only ever reads back the escaped one.
+const (
+	// taskIDDotPat is one dot inside an id, optionally backslash-escaped:
+	// several markdown editors escape a leading "<digits>." automatically so
+	// the line is not re-rendered as an ordered list.
+	taskIDDotPat = `\\?\.`
+	// taskIDSepPat is the trailing separator an id may carry ("3.", "3)",
+	// "3:"). Only the DOT has an escaped form: a markdown editor escapes a
+	// leading "<digits>." because that renders as an ordered list, and nothing
+	// escapes ")" or ":". Accepting "3\)" here would let the syntax screen pass
+	// a reference the resolver then fails on with a stray backslash — the same
+	// layer disagreement this file exists to prevent, in the other direction.
+	taskIDSepPat = `(?:` + taskIDDotPat + `|[):])`
+	// taskIDMultiPat is a multi-level id ("1.1", "2.3.4") — at least one dot.
+	taskIDMultiPat = `\d+(?:` + taskIDDotPat + `\d+)+`
+	// taskIDPat is any id, single- or multi-level.
+	taskIDPat = `\d+(?:` + taskIDDotPat + `\d+)*`
+)
+
+// taskRefSyntaxRE is the syntactic shape of a task reference: an id (with the
+// trailing separator an agent may copy along) or a position ("#3"). It screens
+// out typos before any I/O; whether a reference names a real task is
+// ResolveTaskRef's call. Built from the same fragments as taskLabelRE, so it
+// can never reject a spelling the label parser accepts — TestTaskRefSyntaxOK
+// and FuzzResolveTaskRef pin that.
+var taskRefSyntaxRE = regexp.MustCompile(`^(?:#\d+|` + taskIDPat + taskIDSepPat + `?)$`)
+
+// positionRE is a bare position, the "#3" form's payload: digits and nothing
+// else. It is the same `\d+` taskRefSyntaxRE screens with.
+var positionRE = regexp.MustCompile(`^\d+$`)
+
+// TaskRefSyntaxOK reports whether ref is even shaped like a task reference.
+// The CLI calls it to reject a typo before reading the checklist file: without
+// it, `done xyz` on a missing file reports the file error instead of the typo
+// that caused it. It is deliberately permissive — ResolveTaskRef owns the real
+// rules.
+func TaskRefSyntaxOK(ref string) bool {
+	return taskRefSyntaxRE.MatchString(strings.TrimSpace(ref))
+}
+
+// NormalizeTaskID removes the backslashes a markdown editor may have inserted
+// before an id's dots ("8\.1" → "8.1"), so an escaped id compares equal to the
+// plain one everywhere ids are matched. ONLY a backslash-dot pair is
+// unescaped: stripping every backslash would turn a ref like `3\4` into "34"
+// and resolve it to a different task, the exact mis-targeting these helpers
+// exist to stop. This is the single normalization every id comparison uses —
+// parsing a label, resolving a reference, and rendering one for display.
+func NormalizeTaskID(s string) string {
+	return strings.ReplaceAll(s, `\.`, ".")
+}
+
+// trimTaskIDSeparator drops the single trailing separator an id may be typed
+// with ("3.4." → "3.4"). It runs on an already-normalized id, so an escaped
+// separator is a plain one by the time it gets here.
+func trimTaskIDSeparator(s string) string {
+	if len(s) > 0 && strings.ContainsAny(s[len(s)-1:], ".):") {
+		return s[:len(s)-1]
+	}
+	return s
+}
 
 // TaskLabel returns the hierarchical task ID an item's text declares, or ""
 // when it declares none. This is the ID a document numbers its own tasks with
@@ -318,9 +396,23 @@ func TaskLabel(text string) string {
 		return ""
 	}
 	if m[1] != "" {
-		return m[1]
+		return NormalizeTaskID(m[1])
 	}
 	return m[2]
+}
+
+// DisplayTaskText renders an item's text for a human (a TUI row, a CLI
+// listing): the backslashes a markdown editor may have inserted into the
+// leading task id ("8\.1 commit…") are dropped, so the id on screen is exactly
+// the id `hap task done 8.1` takes. Only the id prefix is unescaped — the rest
+// of the text is passed through verbatim, and the FILE is never rewritten: the
+// escape is the editor's, and hap has no business normalizing it away.
+func DisplayTaskText(text string) string {
+	prefix := taskLabelRE.FindString(text)
+	if prefix == "" {
+		return text
+	}
+	return NormalizeTaskID(prefix) + text[len(prefix):]
 }
 
 // ErrTaskRefRequired is returned when no task reference was supplied. It names
@@ -355,8 +447,12 @@ func ResolveTaskRef(items []ChecklistItem, ref string) (int, error) {
 		return resolvePosition(items, positional, ref)
 	}
 	// Labels never keep their trailing separator, but an agent copying the id
-	// out of its own task text plausibly types it back with one ("done 3.4.").
-	ref = strings.TrimRight(ref, ".):")
+	// out of its own task text plausibly types it back with one ("done 3.4.") —
+	// or with the markdown escapes the file carries ("done 8\.1"). Exactly ONE
+	// separator is dropped, matching TaskRefSyntaxOK: trimming a run of them
+	// would resolve "1))" here while the CLI screen refuses it, and a reference
+	// the two layers disagree about is a reference nobody can reason about.
+	ref = trimTaskIDSeparator(NormalizeTaskID(ref))
 
 	var matches []int
 	for _, it := range items {
@@ -406,6 +502,12 @@ func noSuchIDErr(ref, occupant string) error {
 // resolvePosition validates a positional task number. raw is the reference as
 // the caller typed it, so the error quotes "#3" rather than "3".
 func resolvePosition(items []ChecklistItem, digits, raw string) (int, error) {
+	// Digits only: strconv.Atoi also accepts a sign, so "+4" would otherwise
+	// resolve here while the CLI's syntactic screen refuses it — the two layers
+	// must agree on what a position even looks like.
+	if !positionRE.MatchString(digits) {
+		return 0, fmt.Errorf("invalid task number %q", raw)
+	}
 	n, err := strconv.Atoi(digits)
 	if err != nil {
 		return 0, fmt.Errorf("invalid task number %q", raw)

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -664,6 +665,12 @@ func TestTaskLabel(t *testing.T) {
 		{"id only, no text after", "4.", "4"},
 		{"decimal inside text", "bump to 1.2 today", ""},
 		{"empty", "", ""},
+		{"escaped single-level id", `1\. Fix MultiTabForm detection`, "1"},
+		{"escaped hierarchical id", `8\.1 commit to a new branch`, "8.1"},
+		{"escaped hierarchical id with trailing dot", `8\.1\. commit to a new branch`, "8.1"},
+		{"escaped deep hierarchy", `2\.3\.4 nested task`, "2.3.4"},
+		{"escaped id only, no text after", `4\.`, "4"},
+		{"escaped decimal inside text", `bump to 1\.2 today`, ""},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -725,6 +732,40 @@ func TestResolveTaskRefLabeled(t *testing.T) {
 	}
 	if _, err := ResolveTaskRef(items, "2"); err == nil {
 		t.Fatal("a bare number matching no id must be an error when that position is itself labeled")
+	}
+}
+
+// TestResolveTaskRefEscapedDots covers the file shape some markdown editors
+// write: they escape the dot after a leading number ("1\.", "8\.1") so the
+// line is not re-rendered as an ordered list. The escape is a rendering
+// artifact, so those items must stay addressable by their plain ids — and by
+// the escaped spelling an agent may copy back out of its prompt.
+func TestResolveTaskRefEscapedDots(t *testing.T) {
+	items := ParseChecklist(strings.Join([]string{
+		`- [x] 1\. first`,
+		`- [x] 2\. second`,
+		`- [ ] 8\.1 commit to a new branch`,
+		`- [ ] 8\.2 submit a github PR`,
+	}, "\n"))
+
+	for _, c := range []struct {
+		ref  string
+		want int
+	}{
+		{"1", 1},
+		{`1\.`, 1},
+		{"8.1", 3},
+		{`8\.1`, 3},
+		{`8\.2`, 4},
+		{"#4", 4},
+	} {
+		got, err := ResolveTaskRef(items, c.ref)
+		if err != nil {
+			t.Fatalf("ResolveTaskRef(%q) unexpected error: %v", c.ref, err)
+		}
+		if got != c.want {
+			t.Errorf("ResolveTaskRef(%q) = %d, want %d", c.ref, got, c.want)
+		}
 	}
 }
 
@@ -915,5 +956,250 @@ func TestShellQuote(t *testing.T) {
 		if got := ShellQuote(c.in); got != c.want {
 			t.Errorf("ShellQuote(%q) = %s, want %s", c.in, got, c.want)
 		}
+	}
+}
+
+// TestDisplayTaskText: the id's markdown escapes are dropped for display, so
+// the id on screen is the id the CLI accepts; everything after the id — and a
+// text carrying no id at all — is untouched.
+func TestDisplayTaskText(t *testing.T) {
+	cases := map[string]string{
+		`1\. alpha`:            "1. alpha",
+		`8\.1 beta`:            "8.1 beta",
+		`2\.3\.4 nested`:       "2.3.4 nested",
+		"3.4 plain":            "3.4 plain",
+		"no id here":           "no id here",
+		`escape 1\.2 mid-text`: `escape 1\.2 mid-text`,
+		`4\.`:                  "4.",
+		"":                     "",
+	}
+	for text, want := range cases {
+		if got := DisplayTaskText(text); got != want {
+			t.Errorf("DisplayTaskText(%q) = %q, want %q", text, got, want)
+		}
+	}
+}
+
+// TestResolveTaskRefEscapedAmbiguity: because "1\." and "1." are the same id,
+// a list carrying both is genuinely ambiguous and must be refused rather than
+// silently ticking the first — the fail-safe every id rule here defends.
+func TestResolveTaskRefEscapedAmbiguity(t *testing.T) {
+	items := ParseChecklist("- [ ] 1. plain\n- [ ] 1\\. escaped")
+	if _, err := ResolveTaskRef(items, "1"); err == nil {
+		t.Fatal("two items labeled 1 must be ambiguous, not resolved")
+	} else if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("error = %v, want an ambiguity error", err)
+	}
+	// Position addressing is the documented way out.
+	if got, err := ResolveTaskRef(items, "#2"); err != nil || got != 2 {
+		t.Errorf("ResolveTaskRef(#2) = %d, %v; want 2, nil", got, err)
+	}
+}
+
+// TestResolveTaskRefNonDotBackslash: only a backslash-DOT pair is an escape.
+// A stray backslash elsewhere must not be swallowed — "3\4" collapsing to "34"
+// would resolve a ref to a task nobody named.
+func TestResolveTaskRefNonDotBackslash(t *testing.T) {
+	items := ParseChecklist("- [ ] a\n- [ ] b\n- [ ] c")
+	if _, err := ResolveTaskRef(items, `3\4`); err == nil {
+		t.Error(`ResolveTaskRef("3\\4") must not resolve — the backslash escapes nothing`)
+	}
+}
+
+// TestTaskRefSyntaxOK pins the syntactic screen the CLI runs before it reads
+// any file. It is deliberately permissive (ResolveTaskRef owns the real
+// rules), but it must never reject a spelling that resolves — see
+// TestTaskRefSyntaxAcceptsEverythingResolvable.
+func TestTaskRefSyntaxOK(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want bool
+	}{
+		{"3", true},
+		{"3.4", true},
+		{"3.4.5", true},
+		{"3.", true},
+		{"3)", true},
+		{"3:", true},
+		{"#3", true},
+		{" 3.4 ", true}, // surrounding whitespace is trimmed
+		{`8\.1`, true},
+		{`8\.1\.`, true},
+		{`1\.`, true},
+		{"", false},
+		{"xyz", false},
+		{"#", false},
+		{"#3.4", false}, // a position is a plain integer
+		{`3\4`, false},  // a backslash escapes nothing here
+		// Only the DOT is ever escaped by a markdown editor; accepting "12\:"
+		// here would hand the resolver a ref carrying a stray backslash.
+		{`12\:`, false},
+		{`8\.1\)`, false},
+		{`3\`, false},
+		{"3..4", false},
+		{"3.4.", true},
+		{"-3", false},
+		{"3 4", false},
+	}
+	for _, c := range cases {
+		if got := TaskRefSyntaxOK(c.ref); got != c.want {
+			t.Errorf("TaskRefSyntaxOK(%q) = %v, want %v", c.ref, got, c.want)
+		}
+	}
+}
+
+// TestTaskRefSyntaxAcceptsEverythingResolvable is the invariant that keeps the
+// CLI's pre-flight screen and the resolver from drifting apart: the screen runs
+// FIRST, so any reference it rejects can never reach ResolveTaskRef — which is
+// exactly how the escaped spelling once parsed in the domain but was refused at
+// the command line.
+func TestTaskRefSyntaxAcceptsEverythingResolvable(t *testing.T) {
+	items := ParseChecklist(strings.Join([]string{
+		`- [ ] 1\. alpha`,
+		"- [ ] 2.3 beta",
+		`- [ ] 4\.5 gamma`,
+		"- [ ] unlabeled",
+	}, "\n"))
+	refs := []string{"1", `1\.`, "1.", "2.3", "2.3.", "4.5", `4\.5`, `4\.5\.`, "#4", "#1", "4"}
+	resolved := 0
+	for _, ref := range refs {
+		if _, err := ResolveTaskRef(items, ref); err != nil {
+			continue // unresolvable refs say nothing about the screen
+		}
+		resolved++
+		if !TaskRefSyntaxOK(ref) {
+			t.Errorf("ref %q resolves but the CLI screen rejects it", ref)
+		}
+	}
+	// Without this the test passes vacuously the day every ref stops resolving.
+	if resolved < len(refs)-1 {
+		t.Fatalf("only %d of %d references resolved — the fixture, not the screen, is what is being tested", resolved, len(refs))
+	}
+}
+
+// taskIDRE is what a NORMALIZED id must look like: digits and plain dots, no
+// escapes, no separator. Every TaskLabel result is checked against it.
+var normalizedIDRE = regexp.MustCompile(`^\d+(?:\.\d+)*$`)
+
+// FuzzTaskLabel pins the label parser's invariants on arbitrary item text: the
+// id it reports is always a normalized id, display only ever removes escapes
+// from that id, and neither operation changes which task the text names.
+func FuzzTaskLabel(f *testing.F) {
+	for _, seed := range []string{
+		"1. alpha", `1\. alpha`, `8\.1 beta`, "2.3.4 nested", "3 blind mice",
+		`4\.`, "", `\`, `\.`, `1\`, `1\\.2 x`, "0.5s timeout", `1\.2\.3\. deep`,
+		"12) review", "1:1 sync", strings.Repeat(`1\.`, 20) + " deep",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, text string) {
+		label := TaskLabel(text)
+		if label != "" && !normalizedIDRE.MatchString(label) {
+			t.Fatalf("TaskLabel(%q) = %q, which is not a normalized id", text, label)
+		}
+
+		shown := DisplayTaskText(text)
+		// Display only ever drops backslashes — never adds or reorders anything.
+		if len(shown) > len(text) {
+			t.Fatalf("DisplayTaskText(%q) = %q grew the text", text, shown)
+		}
+		if strings.ReplaceAll(text, `\`, "") != strings.ReplaceAll(shown, `\`, "") {
+			t.Fatalf("DisplayTaskText(%q) = %q changed more than the escapes", text, shown)
+		}
+		// Unescaping for display must not change which task the text names,
+		// and doing it twice must change nothing further.
+		if got := TaskLabel(shown); got != label {
+			t.Fatalf("TaskLabel(DisplayTaskText(%q)) = %q, want %q", text, got, label)
+		}
+		if again := DisplayTaskText(shown); again != shown {
+			t.Fatalf("DisplayTaskText not idempotent on %q: %q then %q", text, shown, again)
+		}
+	})
+}
+
+// FuzzResolveTaskRef pins the resolver's safety invariants on arbitrary refs:
+// it never panics, never returns an out-of-range index, only resolves refs the
+// CLI screen would let through, and treats an escaped id exactly like the plain
+// one. Mis-targeting a task is the failure this whole ref layer exists to
+// prevent, so these are checked rather than assumed.
+func FuzzResolveTaskRef(f *testing.F) {
+	for _, seed := range []string{
+		"1", "#1", "2.3", `4\.5`, `4\.5\.`, "3.", "", "  ", "xyz", `3\4`,
+		"#0", "#99", "0", "99", `\.`, "1.1.1", "#-1",
+	} {
+		f.Add(seed)
+	}
+	items := ParseChecklist(strings.Join([]string{
+		`- [ ] 1\. alpha`,
+		"- [ ] 2.3 beta",
+		`- [ ] 4\.5 gamma`,
+		"- [ ] unlabeled",
+	}, "\n"))
+	f.Fuzz(func(t *testing.T, ref string) {
+		idx, err := ResolveTaskRef(items, ref)
+		if err != nil {
+			if idx != 0 {
+				t.Fatalf("ResolveTaskRef(%q) returned index %d alongside an error", ref, idx)
+			}
+			return
+		}
+		if idx < 1 || idx > len(items) {
+			t.Fatalf("ResolveTaskRef(%q) = %d, out of range 1..%d", ref, idx, len(items))
+		}
+		if !TaskRefSyntaxOK(ref) {
+			t.Fatalf("ResolveTaskRef(%q) resolved a ref the CLI screen rejects", ref)
+		}
+		// The invariant the whole ref layer exists for: a resolved id names the
+		// item carrying THAT id. Falling back to the position is allowed only
+		// when the item sitting there declares no id of its own.
+		if !strings.HasPrefix(strings.TrimSpace(ref), "#") {
+			want := trimTaskIDSeparator(NormalizeTaskID(strings.TrimSpace(ref)))
+			if label := TaskLabel(items[idx-1].Text); label != want && label != "" {
+				t.Fatalf("ResolveTaskRef(%q) = %d, whose item is labeled %q", ref, idx, label)
+			}
+		}
+		// The markdown escape is a rendering artifact: it must never change
+		// which item a reference names.
+		plainIdx, plainErr := ResolveTaskRef(items, NormalizeTaskID(ref))
+		if plainErr != nil || plainIdx != idx {
+			t.Fatalf("ResolveTaskRef(%q) = %d but the unescaped %q = %d, %v",
+				ref, idx, NormalizeTaskID(ref), plainIdx, plainErr)
+		}
+	})
+}
+
+// TestResolveTaskRefMalformedSeparators pins the two shapes FuzzResolveTaskRef
+// caught: a run of trailing separators ("1))") and a signed position ("+4").
+// Both used to resolve here while the CLI's syntactic screen refused them, so
+// the same reference meant different things at different layers.
+func TestResolveTaskRefMalformedSeparators(t *testing.T) {
+	items := ParseChecklist("- [ ] 1. alpha\n- [ ] 2. beta\n- [ ] 3. gamma\n- [ ] 4. delta")
+	for _, ref := range []string{"1))", "1..", "+4", "#+4", "-1", "#-1", `1\`, `1\\.`, `1\:`, `2\.1\)`} {
+		if idx, err := ResolveTaskRef(items, ref); err == nil {
+			t.Errorf("ResolveTaskRef(%q) = %d, want an error (the CLI screen rejects it)", ref, idx)
+		}
+	}
+	// The single trailing separator an agent may copy along still works.
+	for _, ref := range []string{"1", "1.", "1)", "1:"} {
+		if idx, err := ResolveTaskRef(items, ref); err != nil || idx != 1 {
+			t.Errorf("ResolveTaskRef(%q) = %d, %v; want 1, nil", ref, idx, err)
+		}
+	}
+}
+
+// TestDeclaredTaskPromptUnescapesID: the outbound prompt carries the id the
+// CLI accepts. The agent reads its task here and types the id back at
+// `hap task done`, so a prompt saying "8\.1" invites a reference nobody meant
+// to type — while the FILE keeps the operator's escape untouched.
+func TestDeclaredTaskPromptUnescapesID(t *testing.T) {
+	task := DeclaredTask{Task: `8\.1 commit to a new branch`, Path: "/p/t.md", AgentName: "a",
+		Template: "Next: {next_task_content}"}
+	if got, want := task.Prompt(), "Next: 8.1 commit to a new branch"; got != want {
+		t.Errorf("Prompt() = %q, want %q", got, want)
+	}
+	// The stored `\n` encoding still decodes, and only the id is unescaped.
+	multi := DeclaredTask{Task: `2\.3 first line\nsecond line`, Path: "/p", Template: "{next_task_content}"}
+	if got, want := multi.Prompt(), "2.3 first line\nsecond line"; got != want {
+		t.Errorf("Prompt() = %q, want %q", got, want)
 	}
 }

--- a/internal/domain/testdata/fuzz/FuzzResolveTaskRef/81c78495bd53063d
+++ b/internal/domain/testdata/fuzz/FuzzResolveTaskRef/81c78495bd53063d
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("1))")

--- a/internal/domain/testdata/fuzz/FuzzResolveTaskRef/8beaa77e69763a42
+++ b/internal/domain/testdata/fuzz/FuzzResolveTaskRef/8beaa77e69763a42
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("+4")

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -2358,36 +2358,46 @@ func (a *App) RemoveNeverAutoPattern(ctx context.Context, index int, expected st
 	})
 }
 
-// RemoveTaskSource deletes a task source by index; expectedPath guards
-// against removing a different entry after a stale listing.
-func (a *App) RemoveTaskSource(ctx context.Context, index int, expectedPath string) error {
+// RemoveTaskSource deletes a task source by index. expected is the entry the
+// caller listed; it guards against removing a DIFFERENT source after the
+// config shifted underneath — the destructive twin of updateTaskSource's
+// guard, and it compares the same three fields for the same reason (two
+// sources may share one checklist under different selectors).
+func (a *App) RemoveTaskSource(ctx context.Context, index int, expected config.TaskSource) error {
 	return a.UpdateConfig(ctx, func(cfg *config.Config) error {
-		if index < 0 || index >= len(cfg.TaskSources) {
-			return fmt.Errorf("no task source #%d", index)
-		}
-		if got := cfg.TaskSources[index].Path; got != expectedPath {
-			return fmt.Errorf("task source #%d changed since it was listed (now %s); re-list and retry", index, got)
+		if err := checkTaskSourceUnchanged(*cfg, index, expected); err != nil {
+			return err
 		}
 		cfg.TaskSources = append(cfg.TaskSources[:index], cfg.TaskSources[index+1:]...)
 		return nil
 	})
 }
 
+// checkTaskSourceUnchanged verifies that task source #index is still the entry
+// the caller listed. The index is a position in a slice the operator (or
+// another surface) may have changed since it was shown, so every write keyed
+// by index goes through this. Path alone is NOT enough: two sources may point
+// at the same checklist with different agent/workspace scopes, and a path-only
+// check would happily hit the wrong one of that pair.
+func checkTaskSourceUnchanged(cfg config.Config, index int, expected config.TaskSource) error {
+	if index < 0 || index >= len(cfg.TaskSources) {
+		return fmt.Errorf("no task source #%d", index)
+	}
+	got := cfg.TaskSources[index]
+	if got.Path != expected.Path || got.Agent != expected.Agent || got.Workspace != expected.Workspace {
+		return fmt.Errorf("task source #%d changed since it was listed (now agent=%q workspace=%q %s); re-list and retry",
+			index, got.Agent, got.Workspace, got.Path)
+	}
+	return nil
+}
+
 // updateTaskSource applies mutate to task source #index, guarding on the
-// source the caller believes sits there so a stale listing can never retarget
-// the edit — the index is a position in a slice the operator may have changed
-// since it was shown. The guard compares the selectors too, not just the path:
-// two sources may point at the SAME checklist with different agent/workspace
-// scopes, and a path-only check would happily edit the wrong one of the pair.
+// source the caller believes sits there (checkTaskSourceUnchanged) so a stale
+// listing can never retarget the edit.
 func (a *App) updateTaskSource(ctx context.Context, index int, expected config.TaskSource, mutate func(*config.TaskSource)) error {
 	return a.UpdateConfig(ctx, func(cfg *config.Config) error {
-		if index < 0 || index >= len(cfg.TaskSources) {
-			return fmt.Errorf("no task source #%d", index)
-		}
-		got := cfg.TaskSources[index]
-		if got.Path != expected.Path || got.Agent != expected.Agent || got.Workspace != expected.Workspace {
-			return fmt.Errorf("task source #%d changed since it was listed (now agent=%q workspace=%q %s); re-list and retry",
-				index, got.Agent, got.Workspace, got.Path)
+		if err := checkTaskSourceUnchanged(*cfg, index, expected); err != nil {
+			return err
 		}
 		mutate(&cfg.TaskSources[index])
 		return nil

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -2477,6 +2477,14 @@ func AutoSendWhenIdle() TaskSourceOption {
 	return func(src *config.TaskSource) { src.EnableAutoSendTaskWhenIdle = true }
 }
 
+// MaxTasks overrides the new source's task cap (max_tasks). Omitted, a source
+// is created with config.DefaultMaxTasks. AddTaskSource rejects a value below
+// 1 — 0 is what "unset" looks like on disk, so storing it would silently mean
+// the default rather than the "no cap" somebody typing 0 expects.
+func MaxTasks(n int) TaskSourceOption {
+	return func(src *config.TaskSource) { src.MaxTasks = n }
+}
+
 // AddTaskSource points an agent/workspace at a declared task list (FR-011).
 // template optionally overrides the outbound next-task prompt format
 // ({next_task_content} / {task_list_path} / {agent_name} placeholders);
@@ -2497,6 +2505,11 @@ func (a *App) AddTaskSource(ctx context.Context, agent, workspace, path, templat
 	}
 	for _, opt := range opts {
 		opt(&src)
+	}
+	// Validated after the options run, so every surface that can set a cap
+	// inherits the same rule from one place.
+	if src.MaxTasks < 1 {
+		return fmt.Errorf("max_tasks must be 1 or greater, got %d", src.MaxTasks)
 	}
 	return a.UpdateConfig(ctx, func(cfg *config.Config) error {
 		cfg.TaskSources = append(cfg.TaskSources, src)

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -1627,7 +1627,8 @@ func (a *App) addTaskSourceIfAbsent(ctx context.Context, agentID, agentType, nam
 				return fmt.Errorf("agent %q already has a task source (%s); refusing to register a second — append the generated tasks to it instead", name, ts.Path)
 			}
 		}
-		cfg.TaskSources = append(cfg.TaskSources, config.TaskSource{Agent: name, Path: path})
+		cfg.TaskSources = append(cfg.TaskSources, config.TaskSource{
+			Agent: name, Path: path, MaxTasks: config.DefaultMaxTasks})
 		return nil
 	})
 }
@@ -2372,6 +2373,50 @@ func (a *App) RemoveTaskSource(ctx context.Context, index int, expectedPath stri
 	})
 }
 
+// updateTaskSource applies mutate to task source #index, guarding on the
+// source the caller believes sits there so a stale listing can never retarget
+// the edit — the index is a position in a slice the operator may have changed
+// since it was shown. The guard compares the selectors too, not just the path:
+// two sources may point at the SAME checklist with different agent/workspace
+// scopes, and a path-only check would happily edit the wrong one of the pair.
+func (a *App) updateTaskSource(ctx context.Context, index int, expected config.TaskSource, mutate func(*config.TaskSource)) error {
+	return a.UpdateConfig(ctx, func(cfg *config.Config) error {
+		if index < 0 || index >= len(cfg.TaskSources) {
+			return fmt.Errorf("no task source #%d", index)
+		}
+		got := cfg.TaskSources[index]
+		if got.Path != expected.Path || got.Agent != expected.Agent || got.Workspace != expected.Workspace {
+			return fmt.Errorf("task source #%d changed since it was listed (now agent=%q workspace=%q %s); re-list and retry",
+				index, got.Agent, got.Workspace, got.Path)
+		}
+		mutate(&cfg.TaskSources[index])
+		return nil
+	})
+}
+
+// SetTaskSourceAutoSend turns enable_auto_send_task_when_idle on or off for an
+// existing source. This is the one source setting that makes hap hand out work
+// unprompted, so turning it ON is always an explicit operator act — never a
+// side effect of editing something else.
+func (a *App) SetTaskSourceAutoSend(ctx context.Context, index int, expected config.TaskSource, on bool) error {
+	return a.updateTaskSource(ctx, index, expected, func(src *config.TaskSource) {
+		src.EnableAutoSendTaskWhenIdle = on
+	})
+}
+
+// SetTaskSourceMaxTasks sets a source's max_tasks cap. The value must be at
+// least 1: 0 is what "unset" looks like on disk, so accepting it here would
+// silently mean DefaultMaxTasks rather than the "no cap" an operator typing 0
+// would expect.
+func (a *App) SetTaskSourceMaxTasks(ctx context.Context, index int, expected config.TaskSource, max int) error {
+	if max < 1 {
+		return fmt.Errorf("max_tasks must be 1 or greater, got %d", max)
+	}
+	return a.updateTaskSource(ctx, index, expected, func(src *config.TaskSource) {
+		src.MaxTasks = max
+	})
+}
+
 // SetThreshold updates one confidence threshold (FR-009) and reloads.
 func (a *App) SetThreshold(ctx context.Context, situation string, value float64) error {
 	if value <= 0 || value >= 1 {
@@ -2435,6 +2480,10 @@ func (a *App) AddTaskSource(ctx context.Context, agent, workspace, path, templat
 	}
 	src := config.TaskSource{
 		Agent: agent, Workspace: workspace, Path: path, NextTaskTemplate: template,
+		// Written explicitly rather than left at 0: a saved source names the cap
+		// it actually runs under, so config.toml never reads "max_tasks = 0"
+		// (which looks like "no limit") for a source capped at 20.
+		MaxTasks: config.DefaultMaxTasks,
 	}
 	for _, opt := range opts {
 		opt(&src)

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -2465,13 +2465,17 @@ func TestRemoveByIndexIsValueVerified(t *testing.T) {
 		t.Error("out-of-range pattern index must error")
 	}
 
-	if err := app.RemoveTaskSource(ctx, 0, "/wrong/path.md"); err == nil {
+	listed := config.TaskSource{Agent: "builder", Path: "/tmp/tasks.md", MaxTasks: config.DefaultMaxTasks}
+	if err := app.RemoveTaskSource(ctx, 0, config.TaskSource{Agent: "builder", Path: "/wrong/path.md"}); err == nil {
 		t.Error("mismatched expected path must refuse removal")
 	}
-	if err := app.RemoveTaskSource(ctx, 0, "/tmp/tasks.md"); err != nil {
+	if err := app.RemoveTaskSource(ctx, 0, config.TaskSource{Agent: "someone-else", Path: "/tmp/tasks.md"}); err == nil {
+		t.Error("mismatched agent selector must refuse removal")
+	}
+	if err := app.RemoveTaskSource(ctx, 0, listed); err != nil {
 		t.Fatal(err)
 	}
-	if err := app.RemoveTaskSource(ctx, 0, "/tmp/tasks.md"); err == nil {
+	if err := app.RemoveTaskSource(ctx, 0, listed); err == nil {
 		t.Error("removing from empty task sources must error")
 	}
 }
@@ -4333,7 +4337,7 @@ func TestRemoveTaskSourceKeepsChecklistFile(t *testing.T) {
 	if len(cfg.TaskSources) != 1 {
 		t.Fatalf("want 1 task source, got %d", len(cfg.TaskSources))
 	}
-	if err := app.RemoveTaskSource(ctx, 0, cfg.TaskSources[0].Path); err != nil {
+	if err := app.RemoveTaskSource(ctx, 0, cfg.TaskSources[0]); err != nil {
 		t.Fatal(err)
 	}
 	if cfg, err = app.Config(); err != nil {
@@ -4611,5 +4615,61 @@ func TestSetTaskSourceSettings(t *testing.T) {
 	sameFile.Agent = "someone-else"
 	if err := app.SetTaskSourceMaxTasks(ctx, 0, sameFile, 5); err == nil {
 		t.Error("a source whose selectors no longer match must be refused")
+	}
+}
+
+// TestRemoveTaskSourceDuplicatePathReordered is the regression the path-only
+// guard could not catch: two sources may point at the SAME checklist under
+// different agent selectors, so after a reorder the index the operator listed
+// holds a different entry whose path still matches. Removal must refuse rather
+// than retire the wrong agent's source — and the entry the operator DID name
+// is still removable by its new index.
+func TestRemoveTaskSourceDuplicatePathReordered(t *testing.T) {
+	app, _ := testApp(t)
+	ctx := context.Background()
+	shared := filepath.Join(t.TempDir(), "shared.md")
+	if err := os.WriteFile(shared, []byte("- [ ] a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(ctx, "alpha", "", shared, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(ctx, "beta", "", shared, ""); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	listed := cfg.TaskSources[0] // agent "alpha", at index 0 when listed
+	if listed.Agent != "alpha" {
+		t.Fatalf("fixture: expected alpha first, got %+v", cfg.TaskSources)
+	}
+
+	// Somebody reorders the file underneath (both entries still share a path).
+	cfg.TaskSources[0], cfg.TaskSources[1] = cfg.TaskSources[1], cfg.TaskSources[0]
+	if err := config.Save(app.ConfigPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.RemoveTaskSource(ctx, 0, listed); err == nil {
+		t.Fatal("a reordered duplicate-path entry must refuse removal")
+	}
+	if cfg, err = app.Config(); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 2 {
+		t.Fatalf("a refused removal must change nothing, got %+v", cfg.TaskSources)
+	}
+
+	// Re-listed, the same source removes cleanly from its new index — the
+	// guard refuses a stale reference, it does not strand the entry.
+	if err := app.RemoveTaskSource(ctx, 1, cfg.TaskSources[1]); err != nil {
+		t.Fatal(err)
+	}
+	if cfg, err = app.Config(); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 1 || cfg.TaskSources[0].Agent != "beta" {
+		t.Errorf("wrong source removed: %+v", cfg.TaskSources)
 	}
 }

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -4568,6 +4568,21 @@ func TestSetTaskSourceSettings(t *testing.T) {
 	if cfg.TaskSources[0].MaxTasks != config.DefaultMaxTasks {
 		t.Errorf("a new source should carry max_tasks=%d, got %d", config.DefaultMaxTasks, cfg.TaskSources[0].MaxTasks)
 	}
+	// The cap can also be chosen at creation time, and is validated there —
+	// every surface that offers it inherits this one rule.
+	third := filepath.Join(dir, "third.md")
+	if err := app.AddTaskSource(ctx, "a3", "", third, "", frontend.MaxTasks(40)); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(ctx, "a4", "", filepath.Join(dir, "bad.md"), "", frontend.MaxTasks(0)); err == nil {
+		t.Error("MaxTasks(0) must be refused — on disk 0 means unset")
+	}
+	if cfg, err = app.Config(); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 3 || cfg.TaskSources[2].MaxTasks != 40 {
+		t.Fatalf("MaxTasks option did not persist (and a refused add must register nothing): %+v", cfg.TaskSources)
+	}
 
 	if err := app.SetTaskSourceAutoSend(ctx, 0, cfg.TaskSources[0], true); err != nil {
 		t.Fatal(err)

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -4306,6 +4306,11 @@ func TestAddTaskSourceAutoSendWhenIdleOption(t *testing.T) {
 	if cfg.TaskSources[2].EnableAutoSendTaskWhenIdle {
 		t.Error("a bootstrapped task source must never enable unprompted hand-out")
 	}
+	// It still names its cap: a source hap creates itself must not land on disk
+	// with "max_tasks" missing, which reads as "no limit".
+	if cfg.TaskSources[2].MaxTasks != config.DefaultMaxTasks {
+		t.Errorf("bootstrapped source should carry max_tasks=%d, got %d", config.DefaultMaxTasks, cfg.TaskSources[2].MaxTasks)
+	}
 }
 
 // TestRemoveTaskSourceKeepsChecklistFile pins the contract the TUI's Tasks-tab
@@ -4531,5 +4536,80 @@ func TestConfirmRemoteEnvGonePickerFailsClosed(t *testing.T) {
 	}
 	if len(fake.inputs) != 0 || len(fake.keys) != 0 {
 		t.Errorf("nothing may be sent when the picker is gone: inputs=%v keys=%v", fake.inputs, fake.keys)
+	}
+}
+
+// TestSetTaskSourceSettings covers editing an EXISTING source's two mutable
+// settings: the values must reach config.toml (the daemon reads the file), the
+// stale-listing guard must refuse an index whose path has moved, and max_tasks
+// must refuse 0 — on disk 0 means "unset", so accepting it would silently mean
+// the default rather than the "no cap" an operator typing 0 expects.
+func TestSetTaskSourceSettings(t *testing.T) {
+	app, _ := testApp(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.md")
+	second := filepath.Join(dir, "second.md")
+	if err := app.AddTaskSource(ctx, "a1", "", first, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(ctx, "a2", "", second, ""); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A new source names its cap explicitly rather than leaving a bare 0.
+	if cfg.TaskSources[0].MaxTasks != config.DefaultMaxTasks {
+		t.Errorf("a new source should carry max_tasks=%d, got %d", config.DefaultMaxTasks, cfg.TaskSources[0].MaxTasks)
+	}
+
+	if err := app.SetTaskSourceAutoSend(ctx, 0, cfg.TaskSources[0], true); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.SetTaskSourceMaxTasks(ctx, 0, cfg.TaskSources[0], 7); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := config.Load(app.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reloaded.TaskSources[0].EnableAutoSendTaskWhenIdle || reloaded.TaskSources[0].MaxTasks != 7 {
+		t.Errorf("settings did not round-trip through config.toml: %+v", reloaded.TaskSources[0])
+	}
+	// The other source is untouched — an edit targets exactly one entry.
+	if reloaded.TaskSources[1].EnableAutoSendTaskWhenIdle || reloaded.TaskSources[1].MaxTasks != config.DefaultMaxTasks {
+		t.Errorf("source #1 must be untouched, got %+v", reloaded.TaskSources[1])
+	}
+
+	// Turning it back off must be readable as off after a reload (the key is
+	// omitempty, so "off" is an absent key — that is what false means on disk).
+	if err := app.SetTaskSourceAutoSend(ctx, 0, cfg.TaskSources[0], false); err != nil {
+		t.Fatal(err)
+	}
+	if reloaded, err = config.Load(app.ConfigPath); err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.TaskSources[0].EnableAutoSendTaskWhenIdle {
+		t.Error("auto-send should be off again")
+	}
+
+	// Guards.
+	if err := app.SetTaskSourceMaxTasks(ctx, 0, cfg.TaskSources[0], 0); err == nil {
+		t.Error("max_tasks 0 must be refused — on disk it means unset")
+	}
+	if err := app.SetTaskSourceMaxTasks(ctx, 0, config.TaskSource{Agent: "a1", Path: "/some/other.md"}, 5); err == nil {
+		t.Error("a stale expected path must be refused")
+	}
+	if err := app.SetTaskSourceAutoSend(ctx, 9, cfg.TaskSources[0], true); err == nil {
+		t.Error("an out-of-range index must be refused")
+	}
+	// Two sources may share a checklist with different scopes, so the guard
+	// compares the selectors too — a path-only check would edit the wrong one.
+	sameFile := cfg.TaskSources[0]
+	sameFile.Agent = "someone-else"
+	if err := app.SetTaskSourceMaxTasks(ctx, 0, sameFile, 5); err == nil {
+		t.Error("a source whose selectors no longer match must be refused")
 	}
 }

--- a/internal/tui/task_source_prompt_test.go
+++ b/internal/tui/task_source_prompt_test.go
@@ -2,11 +2,13 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store"
 )
@@ -168,5 +170,152 @@ func TestConfigTabShowsAutoSendFlag(t *testing.T) {
 	}
 	if strings.Contains(calm, "auto_send_when_idle") {
 		t.Errorf("a source without the flag must not advertise it: %s", calm)
+	}
+}
+
+// editSourceSetting drives the two-step Config-tab edit of task source #index:
+// the settings picker, then the value prompt the picked setting opens. It
+// returns the final action result, exactly as the Bubble Tea runtime would
+// produce it.
+func editSourceSetting(t *testing.T, m Model, index int, path, pick, value string) actionResultMsg {
+	t.Helper()
+	upd, _ := m.editTaskSourcePrompt(index, path)
+	m = upd.(Model)
+	if m.prompt == nil || len(m.prompt.options) != 2 {
+		t.Fatalf("expected a two-option settings picker, got %+v", m.prompt)
+	}
+	var chosen string
+	for _, o := range m.prompt.options {
+		if strings.HasPrefix(o, pick) {
+			chosen = o
+		}
+	}
+	if chosen == "" {
+		t.Fatalf("picker has no %q option: %v", pick, m.prompt.options)
+	}
+	cmd := m.prompt.onSubmit(chosen)
+	if cmd == nil {
+		t.Fatal("settings picker returned no command")
+	}
+	fieldMsg, ok := cmd().(openTaskSourceFieldMsg)
+	if !ok {
+		t.Fatalf("picker should chain to a value prompt, got %T", cmd())
+	}
+	upd, _ = m.Update(fieldMsg)
+	m = upd.(Model)
+	if m.prompt == nil {
+		t.Fatal("value prompt did not open")
+	}
+	cmd = m.prompt.onSubmit(value)
+	if cmd == nil {
+		t.Fatal("value prompt returned no command")
+	}
+	msg, ok := cmd().(actionResultMsg)
+	if !ok {
+		t.Fatalf("want actionResultMsg, got %T", cmd())
+	}
+	return msg
+}
+
+// TestConfigTabEditsTaskSourceSettings pins the Config tab's enter on a
+// task-source row: both mutable settings are editable there, and the values
+// reach config.toml (the daemon reads the file, not the model).
+func TestConfigTabEditsTaskSourceSettings(t *testing.T) {
+	m, app, path := sourcePromptModel(t)
+	if msg := submitSourcePrompt(t, m, path+" busy-otter"); msg.err != nil {
+		t.Fatal(msg.err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.data.cfg = cfg
+	m.items = buildRuleItems(cfg)
+
+	// A source starts with unprompted hand-out off and the default cap named
+	// explicitly — never a bare 0, which reads as "no limit".
+	if cfg.TaskSources[0].EnableAutoSendTaskWhenIdle || cfg.TaskSources[0].MaxTasks != config.DefaultMaxTasks {
+		t.Fatalf("unexpected starting state: %+v", cfg.TaskSources[0])
+	}
+
+	if msg := editSourceSetting(t, m, 0, path, "auto_send_when_idle", "true"); msg.err != nil {
+		t.Fatal(msg.err)
+	}
+	if cfg, err = app.Config(); err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.TaskSources[0].EnableAutoSendTaskWhenIdle {
+		t.Error("picking true must turn unprompted hand-out on")
+	}
+	m.data.cfg = cfg
+
+	if msg := editSourceSetting(t, m, 0, path, "max_tasks", "9"); msg.err != nil {
+		t.Fatal(msg.err)
+	}
+	saved, err := config.Load(app.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved.TaskSources[0].MaxTasks != 9 || !saved.TaskSources[0].EnableAutoSendTaskWhenIdle {
+		t.Errorf("settings did not reach config.toml: %+v", saved.TaskSources[0])
+	}
+	m.data.cfg = saved
+
+	// Turning it back off writes false rather than leaving the old value.
+	if msg := editSourceSetting(t, m, 0, path, "auto_send_when_idle", "false"); msg.err != nil {
+		t.Fatal(msg.err)
+	}
+	if saved, err = config.Load(app.ConfigPath); err != nil {
+		t.Fatal(err)
+	}
+	if saved.TaskSources[0].EnableAutoSendTaskWhenIdle {
+		t.Error("picking false must turn unprompted hand-out off")
+	}
+
+	// Bad values are refused, and a stale path guard refuses the write outright.
+	if msg := editSourceSetting(t, m, 0, path, "max_tasks", "none"); msg.err == nil {
+		t.Error("a non-numeric max_tasks must be refused")
+	}
+	if msg := editSourceSetting(t, m, 0, path, "max_tasks", "0"); msg.err == nil {
+		t.Error("max_tasks 0 must be refused — on disk it means unset")
+	}
+	// A row whose path no longer matches is refused BEFORE the picker opens —
+	// prompting with another source's values is how the wrong entry gets edited.
+	upd, _ := m.editTaskSourcePrompt(0, "/gone.md")
+	stale := upd.(Model)
+	if stale.prompt != nil || !strings.Contains(stale.message, "no longer listed") {
+		t.Errorf("a stale row must refuse before prompting, got prompt=%v message=%q", stale.prompt != nil, stale.message)
+	}
+	if saved, err = config.Load(app.ConfigPath); err != nil {
+		t.Fatal(err)
+	}
+	if saved.TaskSources[0].MaxTasks != 9 {
+		t.Errorf("a refused edit must leave the value alone, got %d", saved.TaskSources[0].MaxTasks)
+	}
+}
+
+// TestConfigTabSourceRowShowsMaxTasks: the row names the cap enter is about to
+// edit, resolved through MaxTasksLimit so a config written before the cap was
+// filled in still shows the number the daemon enforces.
+func TestConfigTabSourceRowShowsMaxTasks(t *testing.T) {
+	cfg := config.Default()
+	cfg.TaskSources = []config.TaskSource{
+		{Agent: "a1", Path: "/tmp/one.md"},              // unset → default
+		{Agent: "a2", Path: "/tmp/two.md", MaxTasks: 3}, // explicit
+	}
+	var rows []string
+	for _, it := range buildRuleItems(cfg) {
+		if it.kind == "source" {
+			rows = append(rows, it.label)
+		}
+	}
+	if len(rows) != 2 {
+		t.Fatalf("want 2 source rows, got %d", len(rows))
+	}
+	if !strings.Contains(rows[0], fmt.Sprintf("max_tasks=%d", config.DefaultMaxTasks)) {
+		t.Errorf("an unset cap must render as the effective default: %s", rows[0])
+	}
+	if !strings.Contains(rows[1], "max_tasks=3") {
+		t.Errorf("an explicit cap must render verbatim: %s", rows[1])
 	}
 }

--- a/internal/tui/task_source_prompt_test.go
+++ b/internal/tui/task_source_prompt_test.go
@@ -319,3 +319,185 @@ func TestConfigTabSourceRowShowsMaxTasks(t *testing.T) {
 		t.Errorf("an explicit cap must render verbatim: %s", rows[1])
 	}
 }
+
+// dupSourceModel builds a Config-tab model over two sources that share ONE
+// checklist under different agent selectors — the shape a path-only stale
+// guard cannot tell apart.
+func dupSourceModel(t *testing.T) (Model, *frontend.App, string) {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	app := &frontend.App{Store: st, Herdr: &captureHerdr{},
+		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+	shared := filepath.Join(dir, "shared.md")
+	if err := os.WriteFile(shared, []byte("- [ ] a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if err := app.AddTaskSource(ctx, "alpha", "", shared, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(ctx, "beta", "", shared, ""); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := New(ctx, app)
+	m.width, m.height = 100, 40
+	m.data.cfg = cfg
+	m.items = buildRuleItems(cfg)
+	m.tab = tabConfig
+	return m, app, shared
+}
+
+// sourceRow returns the Config row index of task source #index.
+func sourceRow(t *testing.T, m Model, index int) int {
+	t.Helper()
+	for i, it := range m.items {
+		if it.kind == "source" && it.index == index {
+			return i
+		}
+	}
+	t.Fatalf("no config row for task source #%d", index)
+	return -1
+}
+
+// TestConfigRemoveTaskSourceDuplicatePath: removing the Config row for source
+// #0 must retire exactly that entry, even though source #1 points at the same
+// checklist file.
+func TestConfigRemoveTaskSourceDuplicatePath(t *testing.T) {
+	m, app, _ := dupSourceModel(t)
+	m.cursors[tabConfig] = sourceRow(t, m, 0)
+
+	upd, cmd := m.removeSelectedRule()
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatalf("removal should run, got message %q", m.message)
+	}
+	if res, ok := cmd().(actionResultMsg); !ok || res.err != nil {
+		t.Fatalf("removal failed: %+v", res)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 1 || cfg.TaskSources[0].Agent != "beta" {
+		t.Errorf("wrong source removed: %+v", cfg.TaskSources)
+	}
+}
+
+// TestConfigRemoveTaskSourceRefusesAfterReorder is the regression the widened
+// guard exists for: the config is reordered underneath the listing, so the row
+// the operator is pointing at now holds a DIFFERENT source whose path still
+// matches. The removal must abort rather than retire the wrong agent's source.
+func TestConfigRemoveTaskSourceRefusesAfterReorder(t *testing.T) {
+	m, app, _ := dupSourceModel(t)
+	m.cursors[tabConfig] = sourceRow(t, m, 0) // "alpha", as listed
+
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.TaskSources[0], cfg.TaskSources[1] = cfg.TaskSources[1], cfg.TaskSources[0]
+	if err := config.Save(app.ConfigPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+	// The model still shows the pre-reorder listing (no refresh yet).
+
+	upd, cmd := m.removeSelectedRule()
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatalf("the stale row was refused before dispatch, message %q", m.message)
+	}
+	res, ok := cmd().(actionResultMsg)
+	if !ok || res.err == nil {
+		t.Fatalf("a reordered duplicate-path row must refuse removal, got %+v", res)
+	}
+	if !strings.Contains(res.err.Error(), "re-list and retry") {
+		t.Errorf("the error should tell the operator to re-list, got %v", res.err)
+	}
+	if cfg, err = app.Config(); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 2 {
+		t.Errorf("a refused removal must change nothing, got %+v", cfg.TaskSources)
+	}
+}
+
+// TestConfigRemoveTaskSourceRefusesVanishedRow: a row whose index no longer
+// exists (the config shrank underneath) is refused in the model, before any
+// write is dispatched.
+func TestConfigRemoveTaskSourceRefusesVanishedRow(t *testing.T) {
+	m, app, _ := dupSourceModel(t)
+	m.cursors[tabConfig] = sourceRow(t, m, 1)
+	// The model keeps the two-source listing; its own config view loses one.
+	m.data.cfg.TaskSources = m.data.cfg.TaskSources[:1]
+
+	upd, cmd := m.removeSelectedRule()
+	m = upd.(Model)
+	if cmd != nil {
+		t.Fatal("a vanished row must not dispatch a removal")
+	}
+	if !strings.Contains(m.message, "no longer listed") {
+		t.Errorf("the operator should be told to refresh, got %q", m.message)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 2 {
+		t.Errorf("nothing should have been removed, got %+v", cfg.TaskSources)
+	}
+}
+
+// TestTasksTabRemoveSourceRefusesAfterReorder covers the OTHER removal path —
+// the Tasks tab's `x` on a group header, which passes the group's whole config
+// entry. Two groups share one checklist; after a reorder underneath, accepting
+// the confirmation must abort instead of retiring the wrong agent's source.
+func TestTasksTabRemoveSourceRefusesAfterReorder(t *testing.T) {
+	m, app, _ := dupSourceModel(t)
+	m.tab = tabTasks
+	upd, _ := m.Update(refreshData(context.Background(), app))
+	m = upd.(Model)
+	if len(m.data.tasks) != 2 {
+		t.Fatalf("expected two task groups, got %d", len(m.data.tasks))
+	}
+	if m.data.tasks[0].Source.Agent != "alpha" {
+		t.Fatalf("fixture: expected alpha first, got %+v", m.data.tasks[0].Source)
+	}
+
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.TaskSources[0], cfg.TaskSources[1] = cfg.TaskSources[1], cfg.TaskSources[0]
+	if err := config.Save(app.ConfigPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	m = press(t, m, "x") // cursor starts on group #0's header row
+	if m.confirm == nil {
+		t.Fatalf("an unmatched source should be removable, got message %q", m.message)
+	}
+	upd, cmd := m.Update(pressKeyMsg("y"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("accepting the confirmation should dispatch the guarded removal")
+	}
+	res, ok := cmd().(actionResultMsg)
+	if !ok || res.err == nil {
+		t.Fatalf("a reordered duplicate-path group must refuse removal, got %+v", res)
+	}
+	if cfg, err = app.Config(); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 2 {
+		t.Errorf("a refused removal must change nothing, got %+v", cfg.TaskSources)
+	}
+}

--- a/internal/tui/task_source_prompt_test.go
+++ b/internal/tui/task_source_prompt_test.go
@@ -501,3 +501,97 @@ func TestTasksTabRemoveSourceRefusesAfterReorder(t *testing.T) {
 		t.Errorf("a refused removal must change nothing, got %+v", cfg.TaskSources)
 	}
 }
+
+// TestTUIAddTaskSourceMaxTasksParity pins CLI/TUI parity for the cap: the add
+// prompt takes the same `--max-tasks` flag, in either spelling and any
+// position, alongside the auto-send word.
+func TestTUIAddTaskSourceMaxTasksParity(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string // %s is replaced by the checklist path
+		want  int
+		auto  bool
+	}{
+		{name: "no flag keeps the default", input: "%s", want: config.DefaultMaxTasks},
+		{name: "separate value", input: "%s --max-tasks 40", want: 40},
+		{name: "equals value", input: "%s --max-tasks=7", want: 7},
+		{name: "flag first", input: "--max-tasks 5 %s brave-otter", want: 5},
+		{name: "with auto-send", input: "%s --auto-send-when-idle --max-tasks 12", want: 12, auto: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, app, path := sourcePromptModel(t)
+			msg := submitSourcePrompt(t, m, strings.ReplaceAll(tc.input, "%s", path))
+			if msg.err != nil {
+				t.Fatal(msg.err)
+			}
+			cfg, err := app.Config()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(cfg.TaskSources) != 1 {
+				t.Fatalf("want 1 task source, got %d", len(cfg.TaskSources))
+			}
+			src := cfg.TaskSources[0]
+			if src.Path != path {
+				t.Errorf("path = %q, want %q (a flag value must not be taken as a field)", src.Path, path)
+			}
+			if src.MaxTasks != tc.want {
+				t.Errorf("max_tasks = %d, want %d", src.MaxTasks, tc.want)
+			}
+			if src.EnableAutoSendTaskWhenIdle != tc.auto {
+				t.Errorf("auto-send = %v, want %v", src.EnableAutoSendTaskWhenIdle, tc.auto)
+			}
+			if said := strings.Contains(msg.message, "auto-send when idle ON"); said != tc.auto {
+				t.Errorf("result message announced auto-send = %v, want %v; got %q", said, tc.auto, msg.message)
+			}
+			// The message names the cap that was stored: an operator who typed
+			// the flag must see it was parsed, not read as a positional field.
+			if want := fmt.Sprintf("max_tasks=%d", tc.want); !strings.Contains(msg.message, want) {
+				t.Errorf("result message should report %s, got %q", want, msg.message)
+			}
+		})
+	}
+}
+
+// TestTUIAddTaskSourceMaxTasksErrorWording: a flag with no value at all says
+// so, instead of complaining about an empty string the operator never typed.
+func TestTUIAddTaskSourceMaxTasksErrorWording(t *testing.T) {
+	m, _, path := sourcePromptModel(t)
+	msg := submitSourcePrompt(t, m, path+" --max-tasks")
+	if msg.err == nil || !strings.Contains(msg.err.Error(), "needs a value") {
+		t.Errorf("a valueless --max-tasks should say it needs one, got %v", msg.err)
+	}
+	m, _, path = sourcePromptModel(t)
+	msg = submitSourcePrompt(t, m, path+" --max-task 5")
+	if msg.err == nil || !strings.Contains(msg.err.Error(), "--max-tasks=N") {
+		t.Errorf("the unknown-flag message should spell both accepted forms, got %v", msg.err)
+	}
+}
+
+// TestTUIAddTaskSourceMaxTasksRejectsBadValues: a cap that is not a whole
+// number of tasks — or a flag with no value at all — must be REFUSED, never
+// silently dropped, or the source is created under a cap nobody chose.
+func TestTUIAddTaskSourceMaxTasksRejectsBadValues(t *testing.T) {
+	for _, input := range []string{
+		"/tmp/tasks.md --max-tasks",
+		"/tmp/tasks.md --max-tasks abc",
+		"/tmp/tasks.md --max-tasks=",
+		"/tmp/tasks.md --max-tasks 0",
+		"/tmp/tasks.md --max-tasks -3",
+		"/tmp/tasks.md --max-task 5",
+	} {
+		m, app, _ := sourcePromptModel(t)
+		msg := submitSourcePrompt(t, m, input)
+		if msg.err == nil {
+			t.Errorf("input %q must be rejected, got %q", input, msg.message)
+		}
+		cfg, err := app.Config()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(cfg.TaskSources) != 0 {
+			t.Errorf("input %q added a source anyway: %+v", input, cfg.TaskSources)
+		}
+	}
+}

--- a/internal/tui/tasks_test.go
+++ b/internal/tui/tasks_test.go
@@ -1292,3 +1292,34 @@ func TestTasksMarkedItemsWinOverSourceRemoval(t *testing.T) {
 		t.Errorf("source must survive an item delete, got %+v", cfg.TaskSources)
 	}
 }
+
+// TestTasksTabUnescapesDisplayedIDs: a checklist whose ids carry the markdown
+// escape some editors write ("8\.1") must show the plain id — both in the list
+// row and in the detail — so what is on screen is the id `hap task done`
+// takes. The underlying item text stays raw (it identifies the file line).
+func TestTasksTabUnescapesDisplayedIDs(t *testing.T) {
+	m := taskModel(t)
+	m.data.tasks[0].Items = []domain.ChecklistItem{
+		{Index: 1, Mark: " ", Text: `8\.1 commit to a new branch`},
+	}
+	view := m.View()
+	if !strings.Contains(view, "#1 [ ] 8.1 commit to a new branch") {
+		t.Errorf("task row should show the unescaped id:\n%s", view)
+	}
+	if strings.Contains(view, `8\.1`) {
+		t.Errorf("task row must not show the markdown escape:\n%s", view)
+	}
+
+	m = press(t, m, "down", "v")
+	if m.detail == nil {
+		t.Fatal("v on an item row should open the task detail")
+	}
+	detail := m.View()
+	if !strings.Contains(detail, "8.1 commit to a new branch") || strings.Contains(detail, `8\.1`) {
+		t.Errorf("task detail should show the unescaped id:\n%s", detail)
+	}
+	// The row keeps the raw text: it is what matches the line in the file.
+	if got := m.taskRows()[1].itemText; got != `8\.1 commit to a new branch` {
+		t.Errorf("itemText = %q, want the raw file text", got)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -105,6 +105,16 @@ type openAddPromptMsg struct {
 	id int64
 }
 
+// openTaskSourceFieldMsg re-opens a prompt for the VALUE of the task-source
+// setting the operator just picked (enter on a Config task-source row opens a
+// picker of settings first). Chained through a message for the same reason as
+// the two above: a picker's onSubmit returns a tea.Cmd, not a model.
+type openTaskSourceFieldMsg struct {
+	index    int
+	expected config.TaskSource // the row as it was listed, the stale-listing guard
+	field    string            // tsFieldAutoSend | tsFieldMaxTasks
+}
+
 // statusNote is a durable action outcome shown in the status area until the
 // next mutating action starts (or a later outcome replaces it) — unlike the
 // transient m.message hint line, navigation and read-only actions never clear
@@ -665,9 +675,14 @@ func (m Model) taskRows() []taskRow {
 				if m.taskMarks[taskMarkKey(g.Index, it.Index)] {
 					markCh = "✓ "
 				}
+				// Displayed and searched with the id's markdown escapes removed
+				// ("8\.1" → "8.1"), so what is on screen is what `hap task done`
+				// takes. itemText below stays RAW — it identifies the line in the
+				// file for edit/send, and must match it byte for byte.
+				shown := domain.DisplayTaskText(it.Text)
 				rows = append(rows, taskRow{
-					text:       fmt.Sprintf("%s#%d [%s] %s", markCh, it.Index, it.Mark, oneLine(it.Text, max(20, m.contentWidth()-12))),
-					fields:     append([]string{fmt.Sprintf("#%d", it.Index), it.Text, it.Mark}, hfields...),
+					text:       fmt.Sprintf("%s#%d [%s] %s", markCh, it.Index, it.Mark, oneLine(shown, max(20, m.contentWidth()-12))),
+					fields:     append([]string{fmt.Sprintf("#%d", it.Index), shown, it.Mark}, hfields...),
 					done:       it.Done,
 					inProgress: it.Mark == domain.MarkInProgress,
 					group:      g.Index,
@@ -865,6 +880,10 @@ func buildRuleItems(cfg config.Config) []ruleItem {
 		if src.EnableAutoSendTaskWhenIdle {
 			label += "  auto_send_when_idle=true"
 		}
+		// Always shown, resolved through MaxTasksLimit so the row names the cap
+		// the daemon actually enforces — and so the operator can see what enter
+		// is about to edit.
+		label += fmt.Sprintf("  max_tasks=%d", src.MaxTasksLimit())
 		items = append(items, ruleItem{
 			kind: "source", index: i, value: src.Path,
 			label: label,
@@ -1013,6 +1032,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.openSendPrompt(msg.id, msg.action)
 	case openAddPromptMsg:
 		return m.openAddPrompt(msg.id)
+	case openTaskSourceFieldMsg:
+		return m.openTaskSourceFieldPrompt(msg)
 	case tickMsg:
 		return m, tea.Batch(m.refresh(), tick())
 	case clockTickMsg:
@@ -2409,8 +2430,9 @@ func (m Model) taskDetailLines(r taskRow, width int) []string {
 	lines = m.detailField(lines, w, "Task", fmt.Sprintf("#%d", r.item))
 	lines = m.detailField(lines, w, "Status", status)
 	// Stored literal `\n` sequences render as real line breaks here — the
-	// detail shows the task as the agent will receive it.
-	lines = m.detailField(lines, w, "Text", domain.DecodeTaskNewlines(r.itemText))
+	// detail shows the task as the agent will receive it. The id is unescaped
+	// like the list row, so both show the id `hap task done` takes.
+	lines = m.detailField(lines, w, "Text", domain.DecodeTaskNewlines(domain.DisplayTaskText(r.itemText)))
 	lines = m.detailField(lines, w, "Source file", r.path)
 	if r.group < len(m.data.tasks) {
 		src := m.data.tasks[r.group].Source
@@ -3402,6 +3424,8 @@ func (m Model) editSelectedRule() (tea.Model, tea.Cmd) {
 	case "shortcut":
 		m.message = "press enter to run this quick shortcut"
 		return m, nil
+	case "source":
+		return m.editTaskSourcePrompt(item.index, item.value)
 	case "field":
 	default:
 		return m, nil
@@ -3447,6 +3471,130 @@ func (m Model) editSelectedRule() (tea.Model, tea.Cmd) {
 	m.openPrompt(&prompt{
 		label:    fmt.Sprintf("set %s (current %s)", key, frontend.FieldValue(m.data.cfg, key)),
 		onSubmit: submit,
+	})
+	return m, nil
+}
+
+// Task-source setting labels, shared by the picker and the message that
+// carries the choice to the value prompt.
+const (
+	tsFieldAutoSend = "auto_send_when_idle"
+	tsFieldMaxTasks = "max_tasks"
+)
+
+// editTaskSourcePrompt opens the settings picker for task source #index
+// (enter on a Config task-source row). Only the two settings worth flipping
+// after the fact are offered: path/agent/workspace are remove-and-re-add,
+// because changing them silently re-points an agent's work. The chosen setting
+// then gets its own value prompt (openTaskSourceFieldMsg) — a picker cannot
+// open a second prompt itself.
+func (m Model) editTaskSourcePrompt(index int, path string) (tea.Model, tea.Cmd) {
+	src, ok := m.taskSourceAt(index, path)
+	if !ok {
+		m.message = "task source is no longer listed — refresh and retry"
+		return m, nil
+	}
+	// Each option carries the field key it selects, so adding a third setting
+	// can never fall through to editing max_tasks by default.
+	fields := []struct{ key, label string }{
+		{tsFieldAutoSend, fmt.Sprintf("%s (currently %v)", tsFieldAutoSend, src.EnableAutoSendTaskWhenIdle)},
+		{tsFieldMaxTasks, fmt.Sprintf("%s (currently %d)", tsFieldMaxTasks, src.MaxTasksLimit())},
+	}
+	opts := make([]string, len(fields))
+	for i, f := range fields {
+		opts[i] = f.label
+	}
+	m.message = ""
+	m.openPrompt(&prompt{
+		label:   fmt.Sprintf("edit task source #%d — pick a setting (↑/↓ then enter)", index),
+		options: opts,
+		onSubmit: func(input string) tea.Cmd {
+			for _, f := range fields {
+				if input == f.label {
+					return func() tea.Msg {
+						return openTaskSourceFieldMsg{index: index, expected: src, field: f.key}
+					}
+				}
+			}
+			return func() tea.Msg {
+				return actionResultMsg{err: fmt.Errorf("unknown task source setting %q", input)}
+			}
+		},
+	})
+	return m, nil
+}
+
+// taskSourceAt returns task source #index when it is still the row the caller
+// listed (same path), so an edit opened against a refreshed config is refused
+// before it can prompt with somebody else's values.
+func (m Model) taskSourceAt(index int, path string) (config.TaskSource, bool) {
+	if index < 0 || index >= len(m.data.cfg.TaskSources) {
+		return config.TaskSource{}, false
+	}
+	src := m.data.cfg.TaskSources[index]
+	if src.Path != path {
+		return config.TaskSource{}, false
+	}
+	return src, true
+}
+
+// openTaskSourceFieldPrompt asks for the picked setting's new value and
+// applies it. Both writes carry the expected path so a config that changed
+// since the row was listed is refused rather than silently re-targeted.
+func (m Model) openTaskSourceFieldPrompt(msg openTaskSourceFieldMsg) (tea.Model, tea.Cmd) {
+	app, ctx := m.app, m.ctx
+	index, expected := msg.index, msg.expected
+	// A refresh can land between the picker and this prompt: re-check the row
+	// rather than prompting with the zero value's misleading defaults.
+	current, ok := m.taskSourceAt(index, expected.Path)
+	if !ok {
+		m.message = "task source is no longer listed — refresh and retry"
+		return m, nil
+	}
+	m.beginAction()
+	if msg.field == tsFieldAutoSend {
+		// A picker, not free text: this is the one source setting that makes
+		// hap hand out work unprompted, so "true" is chosen from a list rather
+		// than typed (and mistyped) into a yes/no box.
+		opts := []string{"false", "true"}
+		idx := 0
+		if current.EnableAutoSendTaskWhenIdle {
+			idx = 1
+		}
+		m.openPrompt(&prompt{
+			label:   fmt.Sprintf("task source #%d %s (↑/↓ then enter, currently %v)", index, tsFieldAutoSend, current.EnableAutoSendTaskWhenIdle),
+			options: opts,
+			optIdx:  idx,
+			onSubmit: func(input string) tea.Cmd {
+				on := input == "true"
+				return func() tea.Msg {
+					if err := app.SetTaskSourceAutoSend(ctx, index, expected, on); err != nil {
+						return actionResultMsg{err: err}
+					}
+					if on {
+						return actionResultMsg{message: fmt.Sprintf("task source #%d: auto-send when idle ON", index)}
+					}
+					return actionResultMsg{message: fmt.Sprintf("task source #%d: auto-send when idle off", index)}
+				}
+			},
+		})
+		return m, nil
+	}
+	m.openPrompt(&prompt{
+		label: fmt.Sprintf("task source #%d %s (whole number, 1 or more)", index, tsFieldMaxTasks),
+		input: strconv.Itoa(current.MaxTasksLimit()),
+		onSubmit: func(input string) tea.Cmd {
+			return func() tea.Msg {
+				n, err := strconv.Atoi(strings.TrimSpace(input))
+				if err != nil {
+					return actionResultMsg{err: fmt.Errorf("invalid max_tasks %q — a whole number of tasks", input)}
+				}
+				if err := app.SetTaskSourceMaxTasks(ctx, index, expected, n); err != nil {
+					return actionResultMsg{err: err}
+				}
+				return actionResultMsg{message: fmt.Sprintf("task source #%d: max_tasks=%d", index, n)}
+			}
+		},
 	})
 	return m, nil
 }
@@ -3942,7 +4090,7 @@ func (m Model) helpLine() string {
 	case tabSignatures:
 		return "enter/v: details  x: delete  0: reset  f: filter mode  /: search  " + common
 	case tabConfig:
-		return "enter: edit/run shortcut  e: edit field  a: add pattern  t: add task source  x: remove  X: clear data  " + common
+		return "enter: edit/run shortcut  e: edit field/source  a: add pattern  t: add task source  x: remove  X: clear data  " + common
 	}
 	return common
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -3631,25 +3631,44 @@ func (m Model) addTaskSourcePrompt() (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	m.beginAction()
 	m.openPrompt(&prompt{
-		label: "add task source: <path> [agent] [workspace] [--auto-send-when-idle]",
+		label: "add task source: <path> [agent] [workspace] [--auto-send-when-idle] [--max-tasks N]",
 		onSubmit: func(input string) tea.Cmd {
 			return func() tea.Msg {
-				// Spelled exactly like the CLI flag, and accepted in any
-				// position so the operator never has to remember the order.
+				// Flags are spelled exactly like the CLI's and accepted in any
+				// position, so the operator never has to remember the order.
 				// Any OTHER dashed word is refused rather than taken as a
 				// field: silently storing "--auto-send-when-idl" as the path
 				// would leave the operator believing unprompted hand-out is
 				// on when it is off.
 				var opts []frontend.TaskSourceOption
 				var parts []string
-				for _, f := range strings.Fields(input) {
+				fields := strings.Fields(input)
+				maxTasks := config.DefaultMaxTasks
+				for i := 0; i < len(fields); i++ {
+					f := fields[i]
 					if f == "--auto-send-when-idle" {
 						opts = append(opts, frontend.AutoSendWhenIdle())
 						continue
 					}
+					// --max-tasks takes a value, written either way round:
+					// "--max-tasks 40" or "--max-tasks=40".
+					if value, ok := maxTasksFlagValue(fields, &i); ok {
+						if value == "" {
+							return actionResultMsg{err: fmt.Errorf(
+								"--max-tasks needs a value (e.g. --max-tasks 40)")}
+						}
+						n, err := strconv.Atoi(value)
+						if err != nil {
+							return actionResultMsg{err: fmt.Errorf(
+								"invalid --max-tasks %q — a whole number of tasks", value)}
+						}
+						opts = append(opts, frontend.MaxTasks(n))
+						maxTasks = n
+						continue
+					}
 					if strings.HasPrefix(f, "-") {
 						return actionResultMsg{err: fmt.Errorf(
-							"unknown flag %q — this prompt takes only --auto-send-when-idle (spelled exactly, no =value); use the CLI for anything else", f)}
+							"unknown flag %q — this prompt takes --auto-send-when-idle (spelled exactly, no =value) and --max-tasks N (or --max-tasks=N); use the CLI for anything else", f)}
 					}
 					parts = append(parts, f)
 				}
@@ -3670,14 +3689,49 @@ func (m Model) addTaskSourcePrompt() (tea.Model, tea.Cmd) {
 				if err := app.AddTaskSource(ctx, agent, workspace, parts[0], "", opts...); err != nil {
 					return actionResultMsg{err: err}
 				}
-				if len(opts) > 0 {
-					return actionResultMsg{message: "task source added (auto-send when idle ON)"}
+				// Both settings are echoed back: an operator who typed a flag
+				// needs to see it was parsed, not mis-read as a positional
+				// field. Matches the CLI's success line.
+				msg := fmt.Sprintf("task source added (max_tasks=%d)", maxTasks)
+				if autoSendRequested(fields) {
+					msg += " (auto-send when idle ON)"
 				}
-				return actionResultMsg{message: "task source added"}
+				return actionResultMsg{message: msg}
 			}
 		},
 	})
 	return m, nil
+}
+
+// maxTasksFlagValue recognizes the --max-tasks flag at fields[*i] in either
+// spelling ("--max-tasks 40" or "--max-tasks=40"), advancing *i past a
+// separate value word. A trailing "--max-tasks" with nothing after it returns
+// an empty value, which the caller reports as invalid rather than ignoring —
+// silently dropping it would create the source under the default cap.
+func maxTasksFlagValue(fields []string, i *int) (string, bool) {
+	f := fields[*i]
+	if value, ok := strings.CutPrefix(f, "--max-tasks="); ok {
+		return value, true
+	}
+	if f != "--max-tasks" {
+		return "", false
+	}
+	if *i+1 < len(fields) {
+		*i++
+		return fields[*i], true
+	}
+	return "", true
+}
+
+// autoSendRequested reports whether the add prompt's input asked for
+// unprompted hand-out, so the result message can say so.
+func autoSendRequested(fields []string) bool {
+	for _, f := range fields {
+		if f == "--auto-send-when-idle" {
+			return true
+		}
+	}
+	return false
 }
 
 // showSelectedAgentTasks jumps to the Tasks tab for the agent under the

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2155,13 +2155,13 @@ func (m Model) removeTaskSourcePrompt(group int) (tea.Model, tea.Cmd) {
 		m.message = reason
 		return m, nil
 	}
-	// g.Index is the config index and g.Source.Path the raw (untruncated)
-	// path the header only displays abbreviated — RemoveTaskSource re-checks
-	// both, so a config that shifted underneath aborts instead of removing a
-	// neighbour.
+	// g.Index is the config index and g.Source the entry as it was listed
+	// (its raw, untruncated path plus both selectors) — RemoveTaskSource
+	// re-checks all of them, so a config that shifted underneath aborts
+	// instead of removing a neighbour.
 	remove := m.do(fmt.Sprintf("task source #%d removed (checklist file kept)", g.Index),
 		func(c context.Context) error {
-			return app.RemoveTaskSource(c, g.Index, g.Source.Path)
+			return app.RemoveTaskSource(c, g.Index, g.Source)
 		})
 	// A source with no path configured has no file name to name it by.
 	name := filepath.Base(g.Source.Path)
@@ -3841,8 +3841,16 @@ func (m Model) removeSelectedRule() (tea.Model, tea.Cmd) {
 			return app.RemoveNeverAutoPattern(c, idx, expected)
 		})
 	case "source":
+		// The row carries only the path; the guard needs the whole entry, so
+		// look it up by (index, path) — a row that no longer matches is
+		// refused here rather than removing whatever moved into its slot.
+		expected, ok := m.taskSourceAt(item.index, item.value)
+		if !ok {
+			m.message = "task source is no longer listed — refresh and retry"
+			return m, nil
+		}
 		m.beginAction()
-		idx, expected := item.index, item.value
+		idx := item.index
 		return m, m.do(fmt.Sprintf("task source #%d removed", idx), func(c context.Context) error {
 			return app.RemoveTaskSource(c, idx, expected)
 		})


### PR DESCRIPTION
## Why

Several markdown editors escape the dot after a leading number (`1\.`, `8\.1`) so the line is not re-rendered as an ordered list. hap read those items as **unlabeled**, so `hap task done 8.1` could not address them, and the escape leaked into listings and agent prompts.

## What changed

**Escaped ids parse everywhere.** `internal/domain/tasklist.go` is now the single source of task-id syntax — four fragments (`taskIDDotPat`, `taskIDSepPat`, `taskIDMultiPat`, `taskIDPat`) feed the label parser, the new `TaskRefSyntaxOK` screen, the generated-id reader, and taskgen's ordered-list marker. `NormalizeTaskID` is the one normalization used by parsing, resolution, and display, so `8\.1` and `8.1` are the same task.

**Display vs. file.** CLI listings, the TUI rows/detail, and the outbound prompt show the plain id (`DisplayTaskText`); the checklist file keeps the operator's raw markdown untouched. The agent reads its id in the prompt and types it back at `hap task done`, so it must see the spelling the CLI accepts.

**Two layer disagreements found by fuzzing and fixed:**
- `1))` resolved in the domain while the CLI's screen refused it — exactly one trailing separator is trimmed now.
- `+4` resolved as position 4 through `strconv.Atoi`'s sign handling — positions are digits-only now.

**Task-source settings are editable.** `hap task-source set <index> <auto-send-when-idle|max-tasks> <value>`, and the Config tab's `enter` on a task-source row (settings picker → value prompt). Both are guarded against a stale listing (index + path + selectors). `max_tasks` is materialized on load **and** save, so `config.toml` names the cap it actually runs under instead of a bare `0` that reads as "no limit".

## Tests

- Table-driven: `TestTaskRefSyntaxOK`, `TestResolveTaskRefMalformedSeparators`, `TestResolveTaskRefEscapedDots`, escaped-id ambiguity, non-dot backslash.
- Layer agreement: `TestTaskRefSyntaxAcceptsEverythingResolvable` (with a non-vacuity guard) and the CLI-side `TestTaskRefScreenMatchesDomain`.
- Fuzz: `FuzzTaskLabel` (normalized output, display only removes escapes, idempotent, label-preserving) and `FuzzResolveTaskRef` (in range, only resolves what the screen accepts, escaped ≡ plain, resolved item actually carries the named id). The two minimized failing inputs are checked in as corpus seeds.
- End-to-end: `TestEscapedIDLifecycle` drives one task through list/get/start/undone/update/send/done/remove on a fixture whose ids deliberately do not line up with positions, asserting the neighbours' raw markdown is untouched at every step.
- Config editing: frontend, CLI, and TUI tests for both settings plus the guards.

Full suite, `go vet`, `golangci-lint`, and `gofmt` all pass.