### PR TITLE
#1 feat: AI-agent-friendly CLI — command registry, per-command --help, next-step footers

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -22,6 +22,31 @@ HAP="$PLUGIN_ROOT/bin/hap"
 
 if `hap` is already on `PATH`, use it directly.
 
+## discovering commands from the CLI itself
+
+the CLI documents itself, so you rarely need to guess:
+
+```bash
+hap help                 # every command, grouped, plus common workflows
+hap help task            # full guide for one command: usage, every flag, details, examples
+hap escalations --help   # same page; --help (or -h) works anywhere in the arguments
+```
+
+most commands end with a **"Next steps"** footer listing what to run next, with real
+ids filled in (`hap confirm 42 --send`). when parsing output in a script, suppress it:
+
+```bash
+hap agents --no-hints                                  # per invocation
+HAP_NO_HINTS=1 hap agents                              # per environment
+hap config set cli.ai_agent_friendly_output false      # persistent (default true)
+```
+
+none of these affect `hap help` or `<command> --help` — those footers are part of
+the guide.
+
+listings are tab-separated; `hap state-dir` and `hap config path` print a bare value
+(never a footer) so `$(hap state-dir)` stays usable.
+
 ## concepts
 
 **situation types** — the plugin classifies agent states into four types:
@@ -368,6 +393,7 @@ edits made through `hap config set` / `set-threshold` apply live — the command
 | `embedding.pane_salient_chars` | 800 | fallback signature window for idle/unclassified situations (trailing N chars) |
 | `tui.max_content_width` | 0 (full width) | cap variable-width list columns; 0 = full width |
 | `tui.theme` | default | TUI color theme: default, dark, light, high-contrast (in the TUI Config tab, `e` on this row opens a ↑/↓ picker of the available themes) |
+| `cli.ai_agent_friendly_output` | true | append the "Next steps" footer to command output (for AI agents driving the CLI); never affects `hap help` / `--help`, which always show theirs |
 | `tui.terminal_bell` | true | ring the terminal bell (\a) on new escalations and on pauses caused by a different process |
 
 TUI palette colors (`tui.palette.*`) are config.toml-only — roles: `title`, `section`, `error`, `ok`, `paused`, `running`, `warn`, `help`. values are 256-color codes (`"205"`) or hex (`"#ff5faf"`).

--- a/README.md
+++ b/README.md
@@ -168,6 +168,22 @@ hap escalations
 hap pause          # global kill switch
 ```
 
+The CLI documents itself — useful for humans and for the coding agents that
+drive it:
+
+```sh
+hap help                 # every command, grouped, plus common workflows
+hap help task            # one command in full: usage, every flag, details, examples
+hap escalations --help   # the same page; --help works anywhere in the arguments
+```
+
+Most commands end with a **"Next steps"** footer naming what to run next, with
+real ids filled in. Turn it off per invocation with `--no-hints`, per shell with
+`HAP_NO_HINTS=1`, or permanently with
+`hap config set cli.ai_agent_friendly_output false` (default `true`). None of
+these affect the help pages, and `hap state-dir` / `hap config path` always print
+a bare value.
+
 Run from any shell, `hap` operates on the same instance the daemon uses:
 it honors the `HERDR_PLUGIN_CONFIG_DIR`/`HERDR_PLUGIN_STATE_DIR` env vars
 Herdr injects, and without them auto-detects Herdr's plugin directories

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -34,66 +34,39 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/tui"
 )
 
-const usage = `hap (Herd Auto Prompter) — keep your Herdr agents unblocked, hands-free
-
-Core:
-  daemon [--ensure]     run the monitoring daemon (--ensure: start if not
-                        running; replace a daemon left by an older binary)
-  tui                   run the TUI control pane
-  mcp                   run the stdio MCP server (used by the LLM fallback)
-
-Operate:
-  status                automation state, pending escalations, agents
-  agents                list agents (short name, id, type, status, automation)
-  capture <agent>       re-run the normal capture pipeline for a live
-                        blocked/idle/done agent (name or pane id)
-  rename <agent> <name> give an agent a short name (used by task sources)
-  disable <agent>       disable autonomous actions for one agent
-  enable <agent>        re-enable autonomous actions for one agent
-  escalations [prune [minutes]]  list pending escalations; prune dismisses
-                        those older than N minutes (default 360)
-  confirm <id> [--send]         confirm an escalation's suggested action
-  resolve <id> --action TEXT [--send]   record the correct action (post-hoc correction)
-  dismiss <id>...       drop pending escalation(s) without responding
-                        (audit rows kept; nothing sent or learned)
-  audit [--limit N]     show the audit log
-  signatures [list|show <sig>|delete <sig> [--yes]]   learned signatures (alias: sigs)
-                        list filters: --type T --mode M --agent-type A --min-conf C
-  signatures reembed [--force]   re-compute stored embeddings after an
-                        embedding model change (via the daemon when running)
-  pause | resume        global pause/kill switch
-  kill-history          pause/kill event history
-  state-dir             print the state directory (DB, logs, socket, index)
-  paths                 print resolved config + state paths (labeled)
-
-Configure:
-  config [show|fields|path|set <field> <value>|set-threshold <situation> <value>]
-  rules [list|add <regex>|remove <index>]      never-auto patterns
-  task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] [--max-tasks N] <checklist.md>
-                        | list | set <index> <auto-send-when-idle|max-tasks> <value> | remove <index>
-  task [<agent> | --path F] list [--status all|pending|done] | get <n> | add <text>
-                        | start <n> | done <n> | undone <n> | update <n> <text>
-                        | remove <n> | send <n> [--yes]
-                        CRUD the checklist items in an agent's task list
-  clear-data --yes      reset learned history + audit data
-
-  version               print version
-`
-
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Print(usage)
+		// Same path as `hap help`, so the overview's own footer is never
+		// subject to the switches that gate command output.
+		_ = cli.Run(context.Background(), nil, os.Stdout, "help", nil)
 		os.Exit(2)
 	}
 	verb := os.Args[1]
 	args := os.Args[2:]
 
-	if verb == "version" || verb == "--version" || verb == "-V" {
-		fmt.Println("hap (herd-auto-prompter)", buildinfo.Version)
+	// Help is served from the command registry (internal/cli), so the overview,
+	// the per-command guides, and the dispatch table can never drift apart.
+	// `hap help <command>` and `hap <command> --help` both land in cli.Run.
+	if verb == "help" || verb == "--help" || verb == "-h" {
+		if err := cli.Run(context.Background(), nil, os.Stdout, "help", args); err != nil {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
 		return
 	}
-	if verb == "help" || verb == "--help" || verb == "-h" {
-		fmt.Print(usage)
+	// The commands main dispatches itself still document themselves through the
+	// registry, so `hap daemon --help` works before any store is opened. This
+	// runs BEFORE the version branch so `hap version --help` is a help request,
+	// as the guides promise; it returns false for unknown verbs.
+	if cli.WantsCommandHelp(verb, args) {
+		if err := cli.Run(context.Background(), nil, os.Stdout, "help", []string{verb}); err != nil {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
+		return
+	}
+	if verb == "version" || verb == "--version" || verb == "-V" {
+		fmt.Println("hap (herd-auto-prompter)", buildinfo.Version)
 		return
 	}
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -29,69 +29,111 @@ import (
 // "error:" prefix, so scripted health checks can detect it.
 var ErrUnhealthy = errors.New("daemon unhealthy")
 
-// Run dispatches one CLI verb against the shared front-end layer.
+// Run dispatches one CLI verb against the shared front-end layer, through the
+// command registry (help.go) so that every verb carries its own help text and
+// "Next steps" footer.
+//
+// Two arguments are handled here rather than by any verb: `--help`/`-h`
+// anywhere in the arguments prints the verb's guide, and `--no-hints` (like
+// HAP_NO_HINTS=1) suppresses the footers for scripts parsing the listings.
+// The footers are also gated by config `cli.ai_agent_friendly_output`.
 func Run(ctx context.Context, app *frontend.App, out io.Writer, verb string, args []string) error {
-	switch verb {
-	case "status":
-		return status(ctx, app, out)
-	case "agents":
-		return agents(ctx, app, out)
-	case "capture":
-		return capture(ctx, app, out, args)
-	case "escalations":
-		return escalations(ctx, app, out, args)
-	case "audit":
-		return audit(ctx, app, out, args)
-	case "confirm":
-		return confirm(ctx, app, out, args)
-	case "resolve", "correct":
-		return resolve(ctx, app, out, args)
-	case "dismiss":
-		return dismiss(ctx, app, out, args)
-	case "pause":
-		if err := app.Pause(ctx); err != nil {
-			return err
-		}
-		fmt.Fprintln(out, "automation paused (kill switch active)")
-		return nil
-	case "resume":
-		if err := app.Resume(ctx); err != nil {
-			return err
-		}
-		fmt.Fprintln(out, "automation resumed")
-		return nil
-	case "kill-history":
-		return killHistory(ctx, app, out)
-	case "config":
-		return configCmd(ctx, app, out, args)
-	case "state-dir":
-		fmt.Fprintln(out, app.StateDir)
-		return nil
-	case "paths":
-		return paths(out, app)
-	case "rules":
-		return rules(ctx, app, out, args)
-	case "task-source":
-		return taskSource(ctx, app, out, args)
-	case "task":
-		return task(ctx, app, out, args)
-	case "rename":
-		return rename(ctx, app, out, args)
-	case "disable":
-		return setAgentDisabled(ctx, app, out, args, true)
-	case "enable":
-		return setAgentDisabled(ctx, app, out, args, false)
-	case "signatures", "sigs":
-		return signatures(ctx, app, out, args)
-	case "clear-data":
-		return clearData(ctx, app, out, args)
+	args, wantHints := stripHintFlag(args)
+
+	// Help is documentation, not command output: its footer is part of the
+	// guide, so neither the config flag nor the suppression switches apply.
+	if verb == "help" || verb == "--help" || verb == "-h" {
+		return help(&hintWriter{Writer: out, on: true}, args)
 	}
-	return fmt.Errorf("unknown command %q", verb)
+	cmd, ok := Lookup(verb)
+	if !ok {
+		return UnknownCommandError(verb)
+	}
+	if wantsHelp(args) {
+		PrintHelp(&hintWriter{Writer: out, on: true}, cmd)
+		return nil
+	}
+
+	// app is carried, not read: the config gate is evaluated when a footer is
+	// actually printed, so a `config set` of the switch obeys its own result.
+	hinted := &hintWriter{Writer: out, on: wantHints && envHintsEnabled(), app: app}
+	if cmd.Handler == nil {
+		// A `Core` entry documented here but dispatched by main (daemon, tui,
+		// mcp, version): reaching Run means main's own switch missed it.
+		return fmt.Errorf("command %q is not available here — run: hap %s", verb, verb)
+	}
+	if err := cmd.Handler(ctx, app, hinted, args); err != nil {
+		return err
+	}
+	// SelfHints verbs print a footer built from live ids; adding the static one
+	// would double it. Bare verbs print a single value for `$(…)` capture.
+	if !cmd.SelfHints && !cmd.Bare {
+		PrintNextSteps(hinted, cmd.Next)
+	}
+	return nil
+}
+
+// help implements `hap help [command]`.
+func help(out io.Writer, args []string) error {
+	if wantsHelp(args) {
+		// `hap help --help`: the guide for help itself, not the overview.
+		if cmd, ok := Lookup("help"); ok {
+			PrintHelp(out, cmd)
+			return nil
+		}
+	}
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		Overview(out)
+		return nil
+	}
+	cmd, ok := Lookup(args[0])
+	if !ok {
+		return UnknownCommandError(args[0])
+	}
+	PrintHelp(out, cmd)
+	return nil
+}
+
+// wantsHelp reports whether the arguments ask for the verb's guide.
+func wantsHelp(args []string) bool {
+	for i, a := range args {
+		if a != "--help" && a != "-h" && a != "-help" {
+			continue
+		}
+		if i > 0 && valueFlagSet()[args[i-1]] {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// stripHintFlag removes a `--no-hints` argument wherever it appears and
+// reports whether footers are still wanted.
+func stripHintFlag(args []string) ([]string, bool) {
+	on := true
+	kept := make([]string, 0, len(args))
+	for i, a := range args {
+		// Same rule as wantsHelp: a `--no-hints` sitting in a value-taking
+		// flag's slot is that flag's VALUE, not our flag.
+		isValue := i > 0 && valueFlagSet()[args[i-1]]
+		isFlag := (a == "--no-hints" || a == "-no-hints") && !isValue
+		if isFlag {
+			on = false
+			continue
+		}
+		kept = append(kept, a)
+	}
+	if on {
+		// Untouched: hand back the caller's slice so nothing depends on a copy.
+		return args, true
+	}
+	return kept, false
 }
 
 func capture(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
 	if len(args) != 1 || strings.TrimSpace(args[0]) == "" {
-		return fmt.Errorf("usage: capture <agent-name-or-pane-id>")
+		return fmt.Errorf("usage: capture <agent-name-or-pane-id> (see: hap help capture)")
 	}
 	if app.DaemonInfo != nil {
 		running, _, ver := app.DaemonInfo()
@@ -134,7 +176,7 @@ func signatures(ctx context.Context, app *frontend.App, out io.Writer, args []st
 	if strings.HasPrefix(sub, "-") {
 		return signaturesList(ctx, app, out, append([]string{sub}, args...))
 	}
-	return fmt.Errorf("usage: signatures [list|show <sig-or-prefix>|delete <sig-or-prefix> [--yes]|reset <sig-or-prefix> [--yes]|reembed [--force]]")
+	return fmt.Errorf("usage: signatures [list|show <sig-or-prefix>|delete <sig-or-prefix> [--yes]|reset <sig-or-prefix> [--yes]|reembed [--force]] (see: hap help signatures)")
 }
 
 // signaturesReembed re-computes stored signature embeddings for the
@@ -179,7 +221,10 @@ func signaturesReembed(ctx context.Context, app *frontend.App, out io.Writer, ar
 			if err := app.RequestReembed(ctx); err != nil {
 				return err
 			}
-			fmt.Fprintln(out, "daemon nudged — re-embedding runs in the background; check: hap status")
+			fmt.Fprintln(out, "daemon nudged — re-embedding runs in the background")
+			PrintNextSteps(out, []Hint{
+				{Cmd: "hap status", Why: "the drift line clears when it finishes"},
+			})
 			return nil
 		}
 	}
@@ -200,6 +245,10 @@ func signaturesReembed(ctx context.Context, app *frontend.App, out io.Writer, ar
 		fmt.Fprintf(out, "WARNING: %d re-embedded row(s) failed to persist and stay stale — re-run: hap signatures reembed\n",
 			res.PersistFailed)
 	}
+	PrintNextSteps(out, []Hint{
+		{Cmd: "hap status", Why: "confirm the drift line is gone"},
+		{Cmd: "hap signatures list", Why: "the rules that were re-embedded"},
+	})
 	return nil
 }
 
@@ -236,8 +285,14 @@ func signaturesList(ctx context.Context, app *frontend.App, out io.Writer, args 
 	if len(rows) == 0 {
 		if filtered {
 			fmt.Fprintln(out, "no signatures match the filter")
+			PrintNextSteps(out, []Hint{
+				{Cmd: "hap signatures list", Why: "every learned rule, unfiltered"},
+			})
 		} else {
 			fmt.Fprintln(out, "no learned signatures yet — confirm suggestions to teach hap")
+			PrintNextSteps(out, []Hint{
+				{Cmd: "hap escalations", Why: "confirming a suggestion here is what creates a rule"},
+			})
 		}
 		return nil
 	}
@@ -248,13 +303,22 @@ func signaturesList(ctx context.Context, app *frontend.App, out io.Writer, args 
 			r.ConsecutiveConfirmations, graduationN, frontend.ConfidenceLabel(r.Confidence),
 			r.TopAction, r.UpdatedAt.Format("01-02 15:04:05"))
 	}
-	fmt.Fprintf(out, "\n%d signature(s); inspect with: signatures show <prefix>\n", len(rows))
+	fmt.Fprintf(out, "\n%d signature(s)\n", len(rows))
+	// A real prefix from the first row, so the follow-ups are copy-pasteable.
+	prefix := shortSignature(rows[0].Signature)
+	prefix = strings.TrimSuffix(prefix, "…")
+	PrintNextSteps(out, []Hint{
+		{Cmd: "hap signatures show " + prefix, Why: "the original situation, plus recent decisions"},
+		{Cmd: "hap signatures reset " + prefix + " --yes", Why: "back to shadow: it must re-earn graduation before acting alone"},
+		{Cmd: "hap signatures delete " + prefix + " --yes", Why: "erase the rule and its decisions"},
+		{Cmd: "hap signatures list --mode autonomous", Why: "only the rules that act without asking"},
+	})
 	return nil
 }
 
 func signaturesShow(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("usage: signatures show <sig-or-prefix>")
+		return fmt.Errorf("usage: signatures show <sig-or-prefix> (see: hap signatures list)")
 	}
 	row, history, err := app.SignatureDetail(ctx, args[0])
 	if err != nil {
@@ -284,6 +348,18 @@ func signaturesShow(ctx context.Context, app *frontend.App, out io.Writer, args 
 		fmt.Fprintf(out, "last audit #%d (%s): %s — %s\n",
 			a.ID, a.Status, a.Action, a.Rationale)
 	}
+	hints := []Hint{
+		{Cmd: "hap signatures reset " + row.Signature + " --yes", Why: "back to shadow: it must re-earn graduation before acting alone"},
+		{Cmd: "hap signatures delete " + row.Signature + " --yes", Why: "erase the rule and its decisions"},
+	}
+	if a := row.LastAudit; a != nil {
+		hints = append(hints, Hint{
+			Cmd: fmt.Sprintf("hap resolve %d --action TEXT", a.ID),
+			Why: "teach it a different answer from that decision",
+		})
+	}
+	hints = append(hints, Hint{Cmd: "hap signatures list", Why: "every learned rule"})
+	PrintNextSteps(out, hints)
 	return nil
 }
 
@@ -299,7 +375,7 @@ func signaturesDelete(ctx context.Context, app *frontend.App, out io.Writer, arg
 		prefix = fs.Arg(0)
 	}
 	if prefix == "" {
-		return fmt.Errorf("usage: signatures delete <sig-or-prefix> [--yes]")
+		return fmt.Errorf("usage: signatures delete <sig-or-prefix> [--yes] (see: hap signatures list)")
 	}
 	// target holds the exact key once shown to the operator: the confirmed
 	// row and the deleted row must be the same even if the daemon learns
@@ -332,6 +408,10 @@ func signaturesDelete(ctx context.Context, app *frontend.App, out io.Writer, arg
 		return err
 	}
 	fmt.Fprintf(out, "deleted signature %s and %d decision(s); audit rows kept\n", sig, decisions)
+	PrintNextSteps(out, []Hint{
+		{Cmd: "hap signatures list", Why: "confirm it is gone"},
+		{Cmd: "hap escalations", Why: "this situation escalates again until it is re-learned"},
+	})
 	return nil
 }
 
@@ -351,7 +431,7 @@ func signaturesReset(ctx context.Context, app *frontend.App, out io.Writer, args
 		prefix = fs.Arg(0)
 	}
 	if prefix == "" {
-		return fmt.Errorf("usage: signatures reset <sig-or-prefix> [--yes]")
+		return fmt.Errorf("usage: signatures reset <sig-or-prefix> [--yes] (see: hap signatures list)")
 	}
 	target := prefix
 	if !*yes {
@@ -379,6 +459,10 @@ func signaturesReset(ctx context.Context, app *frontend.App, out io.Writer, args
 		return err
 	}
 	fmt.Fprintf(out, "reset signature %s to a fresh rule (shadow, streak 0, confidence cleared); decision history kept\n", sig)
+	PrintNextSteps(out, []Hint{
+		{Cmd: "hap signatures show " + sig, Why: "confirm the mode and streak"},
+		{Cmd: "hap escalations", Why: "it asks again now; confirm the right answer to re-teach it"},
+	})
 	return nil
 }
 
@@ -422,7 +506,7 @@ func stdinIsTTY() bool {
 
 func rename(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
 	if len(args) != 2 {
-		return fmt.Errorf("usage: rename <agent-or-name> <new-name>")
+		return fmt.Errorf("usage: rename <agent-or-name> <new-name> (see: hap agents)")
 	}
 	if err := app.RenameAgent(ctx, args[0], args[1]); err != nil {
 		return err
@@ -440,7 +524,7 @@ func setAgentDisabled(ctx context.Context, app *frontend.App, out io.Writer,
 		state = "disabled"
 	}
 	if len(args) != 1 || strings.TrimSpace(args[0]) == "" {
-		return fmt.Errorf("usage: %s <agent-name-or-pane-id>", verb)
+		return fmt.Errorf("usage: %s <agent-name-or-pane-id> (see: hap agents)", verb)
 	}
 	if err := app.SetAgentDisabled(ctx, args[0], disabled); err != nil {
 		return err
@@ -527,6 +611,29 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 		fmt.Fprintf(out, "last kill event:     %s by %s at %s\n",
 			st.LatestKill.State, st.LatestKill.Author, st.LatestKill.CreatedAt.Format(time.RFC3339))
 	}
+	// The footer is built from what this status actually found, so the first
+	// suggestion is always the one that matters: revive the daemon, lift the
+	// kill switch, or work the queue.
+	var hints []Hint
+	if app.DaemonInfo != nil && (!h.Running || h.Hung || h.VersionStale) {
+		hints = append(hints, Hint{Cmd: "hap daemon --ensure", Why: "start, or replace, the daemon"})
+	}
+	if st.Paused {
+		hints = append(hints, Hint{Cmd: "hap resume", Why: "lift the kill switch so hap answers again"})
+	}
+	if st.Drift.Detected {
+		hints = append(hints, Hint{Cmd: "hap signatures reembed", Why: "re-embed rules for the current model"})
+	}
+	if st.PendingEscalations > 0 {
+		hints = append(hints, Hint{Cmd: "hap escalations", Why: fmt.Sprintf("answer the %d waiting decision(s)", st.PendingEscalations)})
+	} else {
+		hints = append(hints, Hint{Cmd: "hap escalations", Why: "the queue of decisions hap wants a human for"})
+	}
+	hints = append(hints,
+		Hint{Cmd: "hap agents", Why: "which agents are watched, and their state"},
+		Hint{Cmd: "hap audit --limit 20", Why: "what hap decided recently, and why"})
+	PrintNextSteps(out, hints)
+
 	// A hung daemon or a latched crash-loop give-up is a failure state: exit
 	// non-zero so scripted checks and the operator notice, even though the
 	// status body already explained it.
@@ -552,6 +659,10 @@ func agents(ctx context.Context, app *frontend.App, out io.Writer) error {
 	}
 	if len(st.MonitoredAgents) == 0 {
 		fmt.Fprintln(out, "no agents detected (is herdr running?)")
+		PrintNextSteps(out, []Hint{
+			{Cmd: "hap status", Why: "check the daemon is running and subscribed"},
+			{Cmd: "hap daemon --ensure", Why: "start it if it is not"},
+		})
 		return nil
 	}
 	// Working directories are fetched only here (and by the TUI): they cost a
@@ -576,13 +687,21 @@ func agents(ctx context.Context, app *frontend.App, out io.Writer) error {
 		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			name, a.AgentID, a.AgentType, a.Status, automation, cwd)
 	}
+	// The first column is the handle every other command takes, so the footer
+	// spells the follow-ups with <agent> in that position.
+	PrintNextSteps(out, []Hint{
+		{Cmd: "hap task <agent> list", Why: "the agent's task list, with its numbers"},
+		{Cmd: "hap rename <agent-or-pane-id> <name>", Why: "give it a short name task sources can select"},
+		{Cmd: "hap capture <agent>", Why: "re-classify its pane now"},
+		{Cmd: "hap disable <agent>", Why: "stop hap answering for this one agent"},
+	})
 	return nil
 }
 
 func escalations(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
 	if len(args) > 0 {
 		if args[0] != "prune" {
-			return fmt.Errorf("usage: escalations [prune [minutes]]")
+			return fmt.Errorf("usage: escalations [prune [minutes]] (see: hap help escalations)")
 		}
 		return escalationsPrune(ctx, app, out, args[1:])
 	}
@@ -592,6 +711,11 @@ func escalations(ctx context.Context, app *frontend.App, out io.Writer, args []s
 	}
 	if len(esc) == 0 {
 		fmt.Fprintln(out, "no pending escalations")
+		PrintNextSteps(out, []Hint{
+			{Cmd: "hap status", Why: "is automation running at all?"},
+			{Cmd: "hap audit --limit 20", Why: "what hap answered without asking"},
+			{Cmd: "hap agents", Why: "which agents are being watched"},
+		})
 		return nil
 	}
 	names, err := app.Names(ctx)
@@ -621,7 +745,17 @@ func escalations(ctx context.Context, app *frontend.App, out io.Writer, args []s
 			fmt.Fprintf(out, "\tembedding failed: %s\n", e.EmbedError)
 		}
 	}
-	fmt.Fprintf(out, "\n%d pending; respond with: confirm <id> | resolve <id> --action TEXT [--send] | dismiss <id>...\n", len(esc))
+	fmt.Fprintf(out, "\n%d pending\n", len(esc))
+	// The footer carries a REAL id — the first row printed, which is the newest
+	// pending one — so a caller can copy a line verbatim instead of translating
+	// a placeholder.
+	id := esc[0].ID
+	PrintNextSteps(out, []Hint{
+		{Cmd: fmt.Sprintf("hap confirm %d --send", id), Why: "the suggestion is right — accept and deliver it"},
+		{Cmd: fmt.Sprintf("hap resolve %d --action TEXT --send", id), Why: "it is wrong — record and send the right answer (@noop = no reply needed)"},
+		{Cmd: fmt.Sprintf("hap dismiss %d", id), Why: "drop it; nothing sent or learned"},
+		{Cmd: "hap escalations prune 120", Why: "dismiss everything older than 2 hours"},
+	})
 	return nil
 }
 
@@ -630,7 +764,7 @@ func escalations(ctx context.Context, app *frontend.App, out io.Writer, args []s
 func escalationsPrune(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
 	minutes := frontend.DefaultPruneMinutes
 	if len(args) > 1 {
-		return fmt.Errorf("usage: escalations prune [minutes]")
+		return fmt.Errorf("usage: escalations prune [minutes] (see: hap help escalations)")
 	}
 	if len(args) == 1 {
 		v, err := strconv.Atoi(args[0])
@@ -644,13 +778,17 @@ func escalationsPrune(ctx context.Context, app *frontend.App, out io.Writer, arg
 		return err
 	}
 	fmt.Fprintf(out, "pruned %d escalation(s) older than %d minute(s); audit rows kept as dismissed\n", n, minutes)
+	PrintNextSteps(out, []Hint{
+		{Cmd: "hap escalations", Why: "what is still pending"},
+		{Cmd: "hap audit --limit 20", Why: "the pruned rows are kept here as dismissed"},
+	})
 	return nil
 }
 
 // dismiss removes pending escalations from the queue without responding.
 func dismiss(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: dismiss <audit-id> [<audit-id>...]")
+		return fmt.Errorf("usage: dismiss <audit-id> [<audit-id>...] (see: hap escalations)")
 	}
 	for _, arg := range args {
 		id, err := strconv.ParseInt(arg, 10, 64)
@@ -726,7 +864,7 @@ func confirm(ctx context.Context, app *frontend.App, out io.Writer, args []strin
 		idArg = fs.Arg(0)
 	}
 	if idArg == "" {
-		return fmt.Errorf("usage: confirm <audit-id> [--send]")
+		return fmt.Errorf("usage: confirm <audit-id> [--send] (see: hap escalations)")
 	}
 	id, err := strconv.ParseInt(idArg, 10, 64)
 	if err != nil {
@@ -768,7 +906,7 @@ func resolve(ctx context.Context, app *frontend.App, out io.Writer, args []strin
 		idArg = fs.Arg(0)
 	}
 	if idArg == "" || *action == "" {
-		return fmt.Errorf("usage: resolve <audit-id> --action TEXT [--send]")
+		return fmt.Errorf("usage: resolve <audit-id> --action TEXT [--send] (see: hap escalations)")
 	}
 	id, err := strconv.ParseInt(idArg, 10, 64)
 	if err != nil {
@@ -813,10 +951,12 @@ func configCmd(ctx context.Context, app *frontend.App, out io.Writer, args []str
 			return err
 		}
 		printConfig(out, cfg)
+		PrintNextSteps(out, configHints())
 		return nil
 	}
 	switch args[0] {
 	case "path":
+		// Bare on purpose: `$(hap config path)` must be the path alone.
 		fmt.Fprintln(out, app.ConfigPath)
 		return nil
 	case "fields":
@@ -827,6 +967,10 @@ func configCmd(ctx context.Context, app *frontend.App, out io.Writer, args []str
 		for _, key := range frontend.ConfigFieldKeys {
 			fmt.Fprintf(out, "%-40s %s\n", key, frontend.FieldValue(cfg, key))
 		}
+		PrintNextSteps(out, []Hint{
+			{Cmd: "hap config set <field> <value>", Why: "change one of the fields above (the daemon reloads)"},
+			{Cmd: "hap config set-threshold approval 0.80", Why: "shorthand for the confidence_thresholds fields"},
+		})
 		return nil
 	case "set":
 		if len(args) < 3 {
@@ -837,10 +981,11 @@ func configCmd(ctx context.Context, app *frontend.App, out io.Writer, args []str
 			return err
 		}
 		fmt.Fprintf(out, "%s set to %s (daemon reloaded)\n", args[1], value)
+		PrintNextSteps(out, configHints())
 		return nil
 	case "set-threshold":
 		if len(args) != 3 {
-			return fmt.Errorf("usage: config set-threshold <minimum|idle|approval|choice|error> <value>")
+			return fmt.Errorf("usage: config set-threshold <minimum|idle|approval|choice|error> <value> (see: hap help config)")
 		}
 		v, err := strconv.ParseFloat(args[2], 64)
 		if err != nil {
@@ -850,9 +995,20 @@ func configCmd(ctx context.Context, app *frontend.App, out io.Writer, args []str
 			return err
 		}
 		fmt.Fprintf(out, "threshold %s set to %.2f (daemon reloaded)\n", args[1], v)
+		PrintNextSteps(out, configHints())
 		return nil
 	}
-	return fmt.Errorf("usage: config [show|fields|path|set <field> <value>|set-threshold <situation> <value>]")
+	return fmt.Errorf("usage: config [show|fields|path|set <field> <value>|set-threshold <situation> <value>] (see: hap help config)")
+}
+
+// configHints are the follow-ups printed after a config read or edit; `config
+// path` deliberately gets none (a script captures it with $(...)).
+func configHints() []Hint {
+	return []Hint{
+		{Cmd: "hap config fields", Why: "every settable field, with its current value"},
+		{Cmd: "hap config set <field> <value>", Why: "change one (the daemon reloads, no restart)"},
+		{Cmd: "hap status", Why: "confirm the daemon picked the change up"},
+	}
 }
 
 // paths prints the resolved config and state paths, labeled, for human use.
@@ -908,6 +1064,10 @@ func rules(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 			}
 			fmt.Fprintf(out, "operator scoped #%d\tagent_types=%s\t%s\n", i, scope, r.Pattern)
 		}
+		PrintNextSteps(out, []Hint{
+			{Cmd: "hap rules add <regex>", Why: "force a matching situation to always ask a human"},
+			{Cmd: "hap rules remove <index>", Why: "drop one of the operator patterns listed above"},
+		})
 		return nil
 	}
 	switch {
@@ -916,6 +1076,7 @@ func rules(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 			return err
 		}
 		fmt.Fprintf(out, "never-auto pattern added: %s\n", args[1])
+		PrintNextSteps(out, rulesEditedHints())
 		return nil
 	case args[0] == "remove" && len(args) == 2:
 		idx, err := strconv.Atoi(args[1])
@@ -934,9 +1095,19 @@ func rules(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 			return err
 		}
 		fmt.Fprintf(out, "operator never-auto pattern #%d removed: %s\n", idx, expected)
+		PrintNextSteps(out, rulesEditedHints())
 		return nil
 	}
-	return fmt.Errorf("usage: rules [list|add <regex>|remove <index>]")
+	return fmt.Errorf("usage: rules [list|add <regex>|remove <index>] (see: hap help rules)")
+}
+
+// rulesEditedHints are the follow-ups after a never-auto pattern changed: the
+// list is what renumbers, and the daemon applies it on its next reload.
+func rulesEditedHints() []Hint {
+	return []Hint{
+		{Cmd: "hap rules list", Why: "the full set, with the indexes `remove` takes"},
+		{Cmd: "hap escalations", Why: "matching situations now always land here"},
+	}
 }
 
 func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
@@ -1016,7 +1187,7 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 				return fmt.Errorf("flags must come before <checklist.md>: %s was read as an argument, not a flag", extra)
 			}
 		}
-		return fmt.Errorf("usage: task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] [--max-tasks N] <checklist.md> | list | set <index> <key> <value> | remove <index>")
+		return fmt.Errorf("usage: task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] [--max-tasks N] <checklist.md> | list | set <index> <key> <value> | remove <index> (see: hap help task-source)")
 	}
 	var opts []frontend.TaskSourceOption
 	if *autoSend {
@@ -1043,7 +1214,7 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 // are meaningful to flip after the fact are exposed; path/agent/workspace are
 // remove-and-re-add, since changing them silently re-points an agent's work.
 func taskSourceSet(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
-	const usage = "usage: task-source set <index> <auto-send-when-idle|max-tasks> <value> (see: task-source list)"
+	const usage = "usage: task-source set <index> <auto-send-when-idle|max-tasks> <value> (see: task-source list, hap help task-source)"
 	if len(args) != 3 {
 		return fmt.Errorf("%s", usage)
 	}
@@ -1099,11 +1270,59 @@ func taskSourceSet(ctx context.Context, app *frontend.App, out io.Writer, args [
 // Every mutating op re-prints the renumbered list so the caller always sees
 // fresh numbers.
 func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
-	usage := "usage: task [<agent> | --path <file>] list [--status all|pending|done] | get <n> | add <text> | start <n> | done <n> | undone <n> | update <n> <text> | remove <n> | send <n> [--yes]\n<n> is a task id from the list (e.g. 3.4), or #<position>"
-	agent, path, args, err := taskTarget(args)
+	agent, path, rest, err := taskTarget(args)
 	if err != nil {
 		return err
 	}
+	if err := taskOp(ctx, app, out, agent, path, rest); err != nil {
+		return err
+	}
+	// One footer for every op, spelled with the target the caller used — the
+	// op-specific output above already said what changed. `list` gets the
+	// shorter set: it has just printed domain.TaskManagementHints, which
+	// already covers start/done and how <n> is addressed.
+	// `list` has just printed domain.TaskManagementHints, and `get`/`show` print
+	// a single line a script may capture: both get the short footer.
+	listing := len(rest) > 0 && (rest[0] == "list" || rest[0] == "ls" ||
+		rest[0] == "get" || rest[0] == "show")
+	PrintNextSteps(out, taskHints(agent, path, listing))
+	return nil
+}
+
+// taskHints are the follow-ups printed under any `hap task` op. They are built
+// from the target the caller addressed the list by (agent name, or --path
+// FILE), so each line can be re-run verbatim.
+func taskHints(agent, path string, listing bool) []Hint {
+	target := agent
+	if target == "" {
+		target = "--path " + domain.ShellQuote(path)
+	}
+	var hints []Hint
+	if listing {
+		hints = []Hint{
+			{Cmd: fmt.Sprintf("hap task %s list --status pending", target), Why: "only what is left"},
+			{Cmd: fmt.Sprintf("hap task %s add \"<text>\"", target), Why: "queue more work"},
+		}
+	} else {
+		hints = []Hint{
+			{Cmd: fmt.Sprintf("hap task %s list", target), Why: "the list with current numbers"},
+			{Cmd: fmt.Sprintf("hap task %s start <n>", target), Why: "mark a task in progress when you begin it"},
+			{Cmd: fmt.Sprintf("hap task %s done <n>", target), Why: "mark it complete"},
+			{Cmd: fmt.Sprintf("hap task %s add \"<text>\"", target), Why: "queue more work"},
+		}
+	}
+	if agent != "" {
+		hints = append(hints, Hint{
+			Cmd: fmt.Sprintf("hap task %s send <n> --yes", agent),
+			Why: "hand a task to the live agent now (it must be idle)",
+		})
+	}
+	return append(hints, Hint{Cmd: "hap help task", Why: "every op, and how <n> is addressed"})
+}
+
+// taskOp runs one checklist operation against an already-resolved target.
+func taskOp(ctx context.Context, app *frontend.App, out io.Writer, agent, path string, args []string) error {
+	usage := "usage: task [<agent> | --path <file>] list [--status all|pending|done] | get <n> | add <text> | start <n> | done <n> | undone <n> | update <n> <text> | remove <n> | send <n> [--yes]\n<n> is a task id from the list (e.g. 3.4), or #<position>\nsee: hap help task"
 	if agent == "" && path == "" {
 		return fmt.Errorf("%s", usage)
 	}
@@ -1126,7 +1345,7 @@ func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) 
 	case "add", "create":
 		text := strings.TrimSpace(strings.Join(rest, " "))
 		if text == "" {
-			return fmt.Errorf("usage: task %s add <text>", taskTargetLabel(agent, path))
+			return fmt.Errorf("usage: task %s add <text> (see: hap help task)", taskTargetLabel(agent, path))
 		}
 		items, idx, err := app.AddTask(agent, path, text)
 		if err != nil {
@@ -1143,7 +1362,7 @@ func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) 
 		return taskToggle(app, out, agent, path, rest, false)
 	case "update", "edit":
 		if len(rest) < 2 {
-			return fmt.Errorf("usage: task %s update <n> <text>", taskTargetLabel(agent, path))
+			return fmt.Errorf("usage: task %s update <n> <text> (see: hap help task)", taskTargetLabel(agent, path))
 		}
 		it, err := taskItemArg(app, agent, path, rest[:1])
 		if err != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -40,6 +40,15 @@ func testApp(t *testing.T) (*frontend.App, *store.Store) {
 	}, st
 }
 
+// listedRows returns the rows a listing printed, dropping the trailing
+// "Next steps" footer the CLI adds for its (often AI) callers.
+func listedRows(out string) []string {
+	if i := strings.Index(out, "\nNext steps:\n"); i >= 0 {
+		out = out[:i]
+	}
+	return strings.Split(strings.TrimSpace(out), "\n")
+}
+
 func run(t *testing.T, app *frontend.App, verb string, args ...string) (string, error) {
 	t.Helper()
 	var out bytes.Buffer
@@ -410,7 +419,7 @@ func TestAgentsListsWorkingDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lines := strings.Split(strings.TrimSpace(out), "\n")
+	lines := listedRows(out)
 	if len(lines) != 2 {
 		t.Fatalf("agents output = %q, want 2 rows", out)
 	}
@@ -1335,8 +1344,13 @@ func TestTaskListPrintsManagementHints(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(out, "start <n>") {
+	// The concise "Next steps" footer is still printed (it is what an agent
+	// reads to continue); what must not repeat is the instruction BLOCK.
+	if strings.Contains(out, "Prefer using the hap CLI to manage your tasks:") {
 		t.Errorf("mutating ops must not repeat the hints, got:\n%s", out)
+	}
+	if strings.Contains(out, "always addresses") {
+		t.Errorf("mutating ops must not repeat the <n> explainer, got:\n%s", out)
 	}
 }
 
@@ -1428,7 +1442,7 @@ func TestTaskSourceListShowsAutoSendFlag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lines := strings.Split(strings.TrimSpace(out), "\n")
+	lines := listedRows(out)
 	if len(lines) != 2 {
 		t.Fatalf("want 2 listed sources, got %d:\n%s", len(lines), out)
 	}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -1,0 +1,912 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+)
+
+// The command registry is the single source of truth for dispatch, help, and
+// next-step footers: `Run` looks a verb up here instead of switching on it, so
+// a verb cannot exist without its documentation.
+
+// Handler runs one CLI verb. out is the writer Run wrapped (see hintWriter),
+// so verbs printing their own footer can consult hintsOn.
+type Handler func(context.Context, *frontend.App, io.Writer, []string) error
+
+// FlagDoc documents one flag of a verb. Arg is the value placeholder ("" for a
+// boolean flag) and Default the value used when the flag is absent.
+type FlagDoc struct {
+	Name    string
+	Arg     string
+	Default string
+	Desc    string
+}
+
+// Command is one CLI verb with everything needed to run and explain it.
+type Command struct {
+	Name    string
+	Aliases []string
+	Group   string
+	Summary string
+	// Usage lists every accepted syntax form, including subcommands.
+	Usage   []string
+	Flags   []FlagDoc
+	Details string
+	// Examples are copy-pasteable command lines.
+	Examples []string
+	// Next is the static footer Run prints after a successful run.
+	Next []Hint
+	// SelfHints marks a verb that prints its own footer (it needs live ids);
+	// Run must not add a second one.
+	SelfHints bool
+	// Bare marks a verb whose stdout is a single value meant to be captured by
+	// a script (`hap state-dir`); it never prints a footer.
+	Bare bool
+	// Handler is nil for verbs dispatched by main (daemon, tui, mcp, …); they
+	// are listed here so `hap help` documents them in one place.
+	Handler Handler
+}
+
+// Command groups, in the order `hap help` prints them.
+const (
+	groupCore      = "Core"
+	groupOperate   = "Operate"
+	groupLearning  = "Learning"
+	groupConfigure = "Configure"
+	groupTasks     = "Tasks"
+	groupData      = "Data"
+)
+
+var groupOrder = []string{groupCore, groupOperate, groupLearning, groupConfigure, groupTasks, groupData}
+
+var (
+	commandsOnce sync.Once
+	commandList  []Command
+	commandIndex map[string]*Command
+)
+
+// Commands returns a copy of the registry. It is built lazily (rather than as a
+// package-level var) so an entry may reference a handler that itself reads the
+// registry — a var initializer would reject that as an initialization loop. The
+// copy keeps callers from mutating the process-wide table.
+func Commands() []Command {
+	commandsOnce.Do(buildCommands)
+	return append([]Command(nil), commandList...)
+}
+
+// Lookup resolves a verb or alias to its command.
+func Lookup(name string) (*Command, bool) {
+	commandsOnce.Do(buildCommands)
+	c, ok := commandIndex[name]
+	return c, ok
+}
+
+func buildCommands() {
+	commandList = []Command{
+		{
+			Name:    "daemon",
+			Group:   groupCore,
+			Summary: "run the monitoring daemon (the process that watches agents and answers them)",
+			Usage:   []string{"hap daemon", "hap daemon --ensure"},
+			Flags: []FlagDoc{
+				{Name: "--ensure", Desc: "start a daemon only if none is running; replace one left by an older binary (this is what herdr's event hook runs, and how you pick up a rebuild)"},
+			},
+			Details: "Without --ensure the daemon runs in the foreground and holds the state-dir lock.\n" +
+				"Exactly one daemon may run per state dir. After upgrading or rebuilding hap, run\n" +
+				"`hap daemon --ensure` — `hap status` reports a daemon from an older binary as STALE.",
+			Examples: []string{"hap daemon --ensure", "hap status"},
+			Next: []Hint{
+				{Cmd: "hap status", Why: "confirm the daemon is running and healthy"},
+				{Cmd: "hap agents", Why: "see which agents it is watching"},
+			},
+		},
+		{
+			Name:     "tui",
+			Group:    groupCore,
+			Summary:  "run the interactive TUI control pane",
+			Usage:    []string{"hap tui"},
+			Details:  "Tabs mirror the CLI: agents, escalations, signatures, tasks, config.\nEverything the TUI does is also available as a CLI verb, which is what scripts and AI agents should use.",
+			Examples: []string{"hap tui"},
+			Next: []Hint{
+				{Cmd: "hap status", Why: "the same overview, non-interactive"},
+			},
+		},
+		{
+			Name:    "mcp",
+			Group:   groupCore,
+			Summary: "run the stdio MCP server used by the LLM fallback",
+			Usage:   []string{"hap mcp"},
+			Details: "Not meant to be run by hand: the consult LLM CLI launches it to call\n" +
+				"get_context / submit_decision. Run it manually only to replay a request id.",
+			Examples: []string{"HAP_REQUEST_ID=<id> hap mcp"},
+			Next: []Hint{
+				{Cmd: "hap audit --limit 20", Why: "see what the LLM decided"},
+			},
+		},
+		{
+			Name:     "version",
+			Group:    groupCore,
+			Summary:  "print the hap version",
+			Usage:    []string{"hap version"},
+			Examples: []string{"hap version"},
+			Next: []Hint{
+				{Cmd: "hap status", Why: "check the running daemon is the same version"},
+			},
+		},
+		{
+			Name:    "help",
+			Group:   groupCore,
+			Summary: "print this overview, or a full guide for one command",
+			Usage:   []string{"hap help", "hap help <command>", "hap <command> --help"},
+			Details: "Every command also accepts --help (or -h) anywhere in its arguments.\n" +
+				"The \"Next steps\" footers under command output can be turned off three ways:\n" +
+				"  hap config set cli.ai_agent_friendly_output false   (persistent, default true)\n" +
+				"  HAP_NO_HINTS=1 hap <command>                        (one environment)\n" +
+				"  hap <command> --no-hints                            (one invocation)\n" +
+				"None of them affect these help pages.",
+			Examples: []string{"hap help", "hap help task", "hap escalations --help"},
+			Next: []Hint{
+				{Cmd: "hap help <command>", Why: "the full guide for one command"},
+				{Cmd: "hap status", Why: "is automation running, and is anything waiting?"},
+			},
+		},
+
+		// ---------------------------------------------------------------- Operate
+		{
+			Name:    "status",
+			Group:   groupOperate,
+			Summary: "automation state, daemon health, pending escalations, agent count",
+			Usage:   []string{"hap status"},
+			Details: "Exits non-zero when the daemon is unhealthy (hung, crash-looping, or the\n" +
+				"crash-loop breaker gave up) — the body explains which, without an \"error:\" line.\n" +
+				"Also reports semantic-matching state and embedding drift when present.",
+			Next: []Hint{
+				{Cmd: "hap escalations", Why: "the queue of decisions hap wants a human for"},
+				{Cmd: "hap agents", Why: "which agents are watched, and their state"},
+				{Cmd: "hap daemon --ensure", Why: "start or replace the daemon"},
+			},
+			Examples:  []string{"hap status"},
+			SelfHints: true,
+			Handler: func(ctx context.Context, app *frontend.App, out io.Writer, _ []string) error {
+				return status(ctx, app, out)
+			},
+		},
+		{
+			Name:    "agents",
+			Group:   groupOperate,
+			Summary: "list monitored agents (name, id, type, status, automation, cwd)",
+			Usage:   []string{"hap agents"},
+			Details: "One tab-separated row per agent. \"automation\" is enabled/disabled (see\n" +
+				"`hap disable`); the last column is the agent's working directory, or \"-\" when\n" +
+				"herdr cannot report one. Give an agent a short name with `hap rename` — task\n" +
+				"sources and `hap task <agent>` address agents by that name.",
+			Next: []Hint{
+				{Cmd: "hap task <agent> list", Why: "the agent's task list"},
+				{Cmd: "hap rename <agent-or-pane-id> <name>", Why: "give it a short name"},
+				{Cmd: "hap capture <agent>", Why: "re-classify its pane now"},
+			},
+			Examples:  []string{"hap agents"},
+			SelfHints: true,
+			Handler: func(ctx context.Context, app *frontend.App, out io.Writer, _ []string) error {
+				return agents(ctx, app, out)
+			},
+		},
+		{
+			Name:    "capture",
+			Group:   groupOperate,
+			Summary: "re-run the normal capture pipeline for one live agent",
+			Usage:   []string{"hap capture <agent-name-or-pane-id>"},
+			Details: "Asks the running daemon to classify that agent's pane right now, as if herdr\n" +
+				"had raised an attention event. Use it when an agent looks blocked but nothing\n" +
+				"showed up in `hap escalations`. Requires a running, current daemon.",
+			Examples: []string{"hap capture vivid-falcon", "hap capture %12"},
+			Next: []Hint{
+				{Cmd: "hap escalations", Why: "see what the capture produced (allow a few seconds)"},
+				{Cmd: "hap audit --limit 10", Why: "see the decision even if it did not escalate"},
+			},
+			Handler: capture,
+		},
+		{
+			Name:    "rename",
+			Group:   groupOperate,
+			Summary: "give an agent a short name used by task sources and `hap task`",
+			Usage:   []string{"hap rename <agent-or-name> <new-name>"},
+			Details: "The first argument is the agent's current pane id or short name. Names are how\n" +
+				"task sources (`--agent`) and `hap task <agent> …` select an agent, so renaming\n" +
+				"an agent re-points those selectors at it.",
+			Examples: []string{"hap rename %12 vivid-falcon", "hap task vivid-falcon list"},
+			Next: []Hint{
+				{Cmd: "hap agents", Why: "confirm the new name"},
+				{Cmd: "hap task-source list", Why: "check which sources select this name"},
+			},
+			Handler: rename,
+		},
+		{
+			Name:    "disable",
+			Group:   groupOperate,
+			Summary: "stop autonomous actions for one agent (it still escalates)",
+			Usage:   []string{"hap disable <agent-name-or-pane-id>"},
+			Details: "Per-agent switch. hap keeps watching and escalating, but never answers that\n" +
+				"agent on its own. `hap pause` is the global equivalent.",
+			Examples: []string{"hap disable vivid-falcon"},
+			Next: []Hint{
+				{Cmd: "hap enable <agent>", Why: "re-enable autonomous actions"},
+				{Cmd: "hap agents", Why: "confirm the automation column"},
+			},
+			Handler: func(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
+				return setAgentDisabled(ctx, app, out, args, true)
+			},
+		},
+		{
+			Name:     "enable",
+			Group:    groupOperate,
+			Summary:  "re-enable autonomous actions for one agent",
+			Usage:    []string{"hap enable <agent-name-or-pane-id>"},
+			Details:  "Undoes `hap disable`. New agents are enabled by default.",
+			Examples: []string{"hap enable vivid-falcon"},
+			Next: []Hint{
+				{Cmd: "hap agents", Why: "confirm the automation column"},
+				{Cmd: "hap status", Why: "check the global kill switch is not also on"},
+			},
+			Handler: func(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
+				return setAgentDisabled(ctx, app, out, args, false)
+			},
+		},
+		{
+			Name:    "escalations",
+			Group:   groupOperate,
+			Summary: "list what is waiting for an answer; prune old ones",
+			Usage:   []string{"hap escalations", "hap escalations prune [minutes]"},
+			Details: "Each row is: #id, time, situation type, reason, agent, LLM confidence,\n" +
+				"the suggested answer, and the learned rule it matched (if any).\n" +
+				"Answer a row with `confirm` (accept the suggestion), `resolve` (supply the right\n" +
+				"answer), or `dismiss` (drop it). `prune` dismisses everything older than N minutes\n" +
+				"(default 360); audit rows are kept and nothing is sent or learned.",
+			Next: []Hint{
+				{Cmd: "hap confirm <id> --send", Why: "accept the suggestion and deliver it"},
+				{Cmd: "hap resolve <id> --action TEXT --send", Why: "send the right answer instead"},
+				{Cmd: "hap dismiss <id>", Why: "drop it; nothing sent or learned"},
+			},
+			Examples:  []string{"hap escalations", "hap confirm 42 --send", "hap escalations prune 120"},
+			SelfHints: true,
+			Handler:   escalations,
+		},
+		{
+			Name:    "confirm",
+			Group:   groupOperate,
+			Summary: "accept an escalation's suggested action (and optionally deliver it)",
+			Usage:   []string{"hap confirm <audit-id> [--send]"},
+			Flags: []FlagDoc{
+				{Name: "--send", Desc: "also deliver the confirmed action to the agent's pane; without it the confirmation is only recorded (and learned)"},
+			},
+			Details: "The id is the #number from `hap escalations`. Confirming is a learning event:\n" +
+				"after enough consecutive confirmations the rule graduates from shadow to\n" +
+				"autonomous (see `hap config` learning.graduation_n).\n" +
+				"When the suggestion is generated TASKS, confirm appends them to the agent's task\n" +
+				"list; --send also hands the first one over. Confirming without --send is how you\n" +
+				"accept work for a busy agent without interrupting it.",
+			Examples: []string{"hap confirm 42", "hap confirm 42 --send"},
+			Next: []Hint{
+				{Cmd: "hap escalations", Why: "see what is still pending"},
+				{Cmd: "hap signatures list", Why: "check whether the rule graduated"},
+				{Cmd: "hap audit --limit 10", Why: "verify the action was recorded/delivered"},
+			},
+			Handler: confirm,
+		},
+		{
+			Name:    "resolve",
+			Aliases: []string{"correct"},
+			Group:   groupOperate,
+			Summary: "record the correct action for an escalation (post-hoc correction)",
+			Usage:   []string{"hap resolve <audit-id> --action TEXT [--send]"},
+			Flags: []FlagDoc{
+				{Name: "--action", Arg: "TEXT", Desc: "the response the agent should have received; @noop means no reply was needed (nothing is ever sent for @noop)"},
+				{Name: "--send", Desc: "also deliver the action to the agent's pane"},
+			},
+			Details: "Use this instead of `confirm` when the suggestion was wrong: the correction is\n" +
+				"what hap learns for this situation. For a numbered menu pass the option's LABEL —\n" +
+				"hap maps it to the digit the agent's TUI actually needs.",
+			Examples: []string{
+				"hap resolve 42 --action \"Yes, proceed\" --send",
+				"hap resolve 42 --action @noop",
+			},
+			Next: []Hint{
+				{Cmd: "hap escalations", Why: "see what is still pending"},
+				{Cmd: "hap signatures show <prefix>", Why: "check what the rule now answers"},
+			},
+			Handler: resolve,
+		},
+		{
+			Name:    "dismiss",
+			Group:   groupOperate,
+			Summary: "drop pending escalation(s) without responding",
+			Usage:   []string{"hap dismiss <audit-id> [<audit-id>...]"},
+			Details: "Nothing is sent and nothing is learned; the audit row is kept as dismissed.\n" +
+				"To clear a backlog by age use `hap escalations prune [minutes]`.",
+			Examples: []string{"hap dismiss 42", "hap dismiss 42 43 44"},
+			Next: []Hint{
+				{Cmd: "hap escalations", Why: "see what is still pending"},
+				{Cmd: "hap escalations prune 120", Why: "drop everything older than 2 hours"},
+			},
+			Handler: dismiss,
+		},
+		{
+			Name:    "audit",
+			Group:   groupOperate,
+			Summary: "show the audit log (every decision, auto or escalated)",
+			Usage:   []string{"hap audit [--limit N]"},
+			Flags: []FlagDoc{
+				{Name: "--limit", Arg: "N", Default: "30", Desc: "number of records, newest first"},
+			},
+			Details: "Columns: #id, time, status, situation type, action, confidence, LLM score,\n" +
+				"rule mode, rationale. This is the record to read when something was answered\n" +
+				"automatically and you want to know why.",
+			Examples: []string{"hap audit", "hap audit --limit 100"},
+			Next: []Hint{
+				{Cmd: "hap signatures show <prefix>", Why: "inspect the rule behind a row"},
+				{Cmd: "hap resolve <id> --action TEXT", Why: "correct a decision after the fact"},
+			},
+			Handler: audit,
+		},
+		{
+			Name:    "pause",
+			Group:   groupOperate,
+			Summary: "global kill switch: stop all autonomous actions",
+			Usage:   []string{"hap pause"},
+			Details: "hap keeps watching and escalating but answers nothing on its own, for every\n" +
+				"agent. Pause before asking a human a question you do not want hap to answer.",
+			Examples: []string{"hap pause"},
+			Next: []Hint{
+				{Cmd: "hap resume", Why: "turn automation back on"},
+				{Cmd: "hap status", Why: "confirm the paused state"},
+				{Cmd: "hap kill-history", Why: "see who paused and when"},
+			},
+			Handler: func(ctx context.Context, app *frontend.App, out io.Writer, _ []string) error {
+				if err := app.Pause(ctx); err != nil {
+					return err
+				}
+				fmt.Fprintln(out, "automation paused (kill switch active)")
+				return nil
+			},
+		},
+		{
+			Name:     "resume",
+			Group:    groupOperate,
+			Summary:  "lift the global kill switch",
+			Usage:    []string{"hap resume"},
+			Details:  "Undoes `hap pause`. Per-agent `hap disable` switches stay as they are.",
+			Examples: []string{"hap resume"},
+			Next: []Hint{
+				{Cmd: "hap status", Why: "confirm automation is running"},
+				{Cmd: "hap escalations", Why: "handle what queued up while paused"},
+			},
+			Handler: func(ctx context.Context, app *frontend.App, out io.Writer, _ []string) error {
+				if err := app.Resume(ctx); err != nil {
+					return err
+				}
+				fmt.Fprintln(out, "automation resumed")
+				return nil
+			},
+		},
+		{
+			Name:     "kill-history",
+			Group:    groupOperate,
+			Summary:  "pause/resume event history (who, when, scope)",
+			Usage:    []string{"hap kill-history"},
+			Details:  "Useful when automation is off and nobody remembers why — the author column\n names the process or operator that flipped the switch.",
+			Examples: []string{"hap kill-history"},
+			Next: []Hint{
+				{Cmd: "hap status", Why: "see the current state"},
+				{Cmd: "hap resume", Why: "lift the kill switch"},
+			},
+			Handler: func(ctx context.Context, app *frontend.App, out io.Writer, _ []string) error {
+				return killHistory(ctx, app, out)
+			},
+		},
+		{
+			Name:     "state-dir",
+			Group:    groupOperate,
+			Summary:  "print the state directory (DB, logs, socket, match index)",
+			Usage:    []string{"hap state-dir"},
+			Details:  "Bare output, for scripting. Works even when the store cannot be opened.\n`hap paths` prints the same information labeled, alongside the config path.",
+			Examples: []string{"hap state-dir", "ls \"$(hap state-dir)\""},
+			// Bare: the whole point is that `$(hap state-dir)` is the path and
+			// nothing else, so this one prints no footer.
+			Bare: true,
+			Handler: func(_ context.Context, app *frontend.App, out io.Writer, _ []string) error {
+				fmt.Fprintln(out, app.StateDir)
+				return nil
+			},
+		},
+		{
+			Name:     "paths",
+			Group:    groupOperate,
+			Summary:  "print the resolved config and state paths",
+			Usage:    []string{"hap paths"},
+			Details:  "Pure diagnostics: resolves paths without creating directories or opening the\ndatabase, so it stays usable in exactly the broken states you run it to inspect.",
+			Examples: []string{"hap paths"},
+			Next: []Hint{
+				{Cmd: "hap config show", Why: "see the effective configuration"},
+				{Cmd: "hap status", Why: "check the daemon using those paths"},
+			},
+			Handler: func(_ context.Context, app *frontend.App, out io.Writer, _ []string) error {
+				return paths(out, app)
+			},
+		},
+
+		// --------------------------------------------------------------- Learning
+		{
+			Name:    "signatures",
+			Aliases: []string{"sigs"},
+			Group:   groupLearning,
+			Summary: "inspect and manage learned rules",
+			Usage: []string{
+				"hap signatures [list] [--type T] [--mode M] [--agent-type A] [--min-conf C]",
+				"hap signatures show <sig-or-prefix>",
+				"hap signatures delete <sig-or-prefix> [--yes]",
+				"hap signatures reset <sig-or-prefix> [--yes]",
+				"hap signatures reembed [--force]",
+			},
+			Flags: []FlagDoc{
+				{Name: "--type", Arg: "T", Desc: "list filter: situation type (idle|approval|choice|error)"},
+				{Name: "--mode", Arg: "M", Desc: "list filter: shadow (learning only) or autonomous (acts on its own)"},
+				{Name: "--agent-type", Arg: "A", Desc: "list filter: agent type (claude, codex, …)"},
+				{Name: "--min-conf", Arg: "C", Default: "0", Desc: "list filter: minimum live confidence (0-1)"},
+				{Name: "--yes", Desc: "delete/reset: skip the interactive confirmation (required when stdin is not a terminal)"},
+				{Name: "--force", Desc: "reembed: re-run even when no model drift is detected"},
+			},
+			Details: "A signature is one learned situation. `list` shows: short signature, situation,\n" +
+				"agent type, mode, confirmation streak / graduation N, confidence, top action.\n" +
+				"`show` adds the original pane excerpt and recent decisions — pass any unique\n" +
+				"prefix. `delete` erases the rule and its decisions (audit rows are kept).\n" +
+				"`reset` keeps the history but returns the rule to shadow with a cleared streak\n" +
+				"and confidence, so it must re-earn graduation — prefer it over delete when a\n" +
+				"rule started answering wrongly. `reembed` re-computes stored embeddings after\n" +
+				"an embedding model change (via the running daemon when there is one).",
+			Examples: []string{
+				"hap signatures list --mode autonomous",
+				"hap signatures show a1b2c3",
+				"hap signatures reset a1b2c3 --yes",
+			},
+			Next: []Hint{
+				{Cmd: "hap signatures show <prefix>", Why: "the original situation and recent decisions"},
+				{Cmd: "hap signatures reset <prefix> --yes", Why: "back to shadow; it must re-earn graduation"},
+				{Cmd: "hap escalations", Why: "confirming there is what teaches a rule"},
+			},
+			SelfHints: true,
+			Handler:   signatures,
+		},
+
+		// -------------------------------------------------------------- Configure
+		{
+			Name:    "config",
+			Group:   groupConfigure,
+			Summary: "show and edit configuration (thresholds, learning, limits, LLM, embedding)",
+			Usage: []string{
+				"hap config [show]",
+				"hap config fields",
+				"hap config path",
+				"hap config set <field> <value>",
+				"hap config set-threshold <minimum|idle|approval|choice|error> <value>",
+			},
+			Details: "`fields` lists every settable field with its current value — that is the\n" +
+				"authoritative list of names for `set` (dotted, e.g. llm.timeout_seconds).\n" +
+				"`set` writes config.toml and reloads the running daemon; no restart needed.\n" +
+				"`set-threshold` is the shorthand for confidence_thresholds.*: how confident a\n" +
+				"rule must be before hap answers that situation type on its own.\n" +
+				"`path` prints the config file location, bare, for scripting.",
+			Examples: []string{
+				"hap config fields",
+				"hap config set learning.graduation_n 3",
+				"hap config set-threshold approval 0.80",
+			},
+			Next: []Hint{
+				{Cmd: "hap config fields", Why: "list every field and its current value"},
+				{Cmd: "hap config show", Why: "see the effective configuration"},
+				{Cmd: "hap status", Why: "confirm the daemon picked up the change"},
+			},
+			// `config path` prints a bare path for scripting, so the footers are
+			// decided per subcommand inside the handler.
+			SelfHints: true,
+			Handler:   configCmd,
+		},
+		{
+			Name:    "rules",
+			Group:   groupConfigure,
+			Summary: "never-auto safety patterns (situations hap must never answer alone)",
+			Usage: []string{
+				"hap rules [list]",
+				"hap rules add <regex>",
+				"hap rules remove <index>",
+			},
+			Details: "`list` prints the shipped seed rules first (strict and heuristic), then your\n" +
+				"operator patterns with the index `remove` takes. A situation matching any rule is\n" +
+				"always escalated to a human, whatever the learned confidence says — this is a\n" +
+				"safety control, not a preference. Patterns are Go regular expressions matched\n" +
+				"against the situation's content.",
+			Examples: []string{
+				"hap rules list",
+				"hap rules add '(?i)force[- ]push'",
+				"hap rules remove 0",
+			},
+			Next: []Hint{
+				{Cmd: "hap rules list", Why: "every rule, with the index `remove` takes"},
+				{Cmd: "hap rules add <regex>", Why: "force a situation to always ask a human"},
+			},
+			// list and add/remove want opposite follow-ups, so the handler picks.
+			SelfHints: true,
+			Handler:   rules,
+		},
+		{
+			Name:    "task-source",
+			Group:   groupConfigure,
+			Summary: "declare which checklist file feeds which agent (the config, not the items)",
+			Usage: []string{
+				"hap task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] [--max-tasks N] <checklist.md>",
+				"hap task-source list",
+				"hap task-source set <index> <auto-send-when-idle|max-tasks> <value>",
+				"hap task-source remove <index>",
+			},
+			Flags: []FlagDoc{
+				{Name: "--agent", Arg: "A", Desc: "agent short name, id, or type this source applies to"},
+				{Name: "--workspace", Arg: "W", Desc: "workspace name this source applies to (\"*\" wildcards, e.g. \"codex-*\")"},
+				{Name: "--template", Arg: "T", Desc: "next-task prompt template; placeholders {next_task_content} {task_list_path} {task_list_path_quoted} {agent_name} {cwd}"},
+				{Name: "--auto-send-when-idle", Desc: "also hand out tasks on the periodic idle poll, not only on a herdr attention event"},
+				{Name: "--max-tasks", Arg: "N", Default: "config default", Desc: "cap on how many items this list may hold before task generation stops refilling it"},
+			},
+			Details: "Flags must come BEFORE the <checklist.md> path — Go's flag parsing stops at the\n" +
+				"first positional argument, so a flag written after the path is silently ignored\n" +
+				"(hap detects that case and refuses).\n" +
+				"`set` edits an existing source; only auto-send-when-idle and max-tasks are\n" +
+				"editable — changing the path/agent/workspace is remove-and-re-add, since it\n" +
+				"silently re-points an agent's work.\n" +
+				"Use `hap task` to manage the ITEMS inside the file.",
+			Examples: []string{
+				"hap task-source add --agent vivid-falcon --max-tasks 20 ./docs/tasks.md",
+				"hap task-source list",
+				"hap task-source set 0 auto-send-when-idle true",
+			},
+			Next: []Hint{
+				{Cmd: "hap task-source list", Why: "confirm the source and its index"},
+				{Cmd: "hap task <agent> list", Why: "see the items the agent will get"},
+			},
+			Handler: taskSource,
+		},
+
+		// ------------------------------------------------------------------ Tasks
+		{
+			Name:    "task",
+			Group:   groupTasks,
+			Summary: "manage the checklist items in an agent's task list (CRUD + send)",
+			Usage: []string{
+				"hap task [<agent> | --path <file>] list [--status all|pending|done]",
+				"hap task [<agent> | --path <file>] get <n>",
+				"hap task [<agent> | --path <file>] add <text>",
+				"hap task [<agent> | --path <file>] start <n>",
+				"hap task [<agent> | --path <file>] done <n>",
+				"hap task [<agent> | --path <file>] undone <n>",
+				"hap task [<agent> | --path <file>] update <n> <text>",
+				"hap task [<agent> | --path <file>] remove <n>",
+				"hap task <agent> send <n> [--yes]",
+			},
+			Flags: []FlagDoc{
+				{Name: "--path", Arg: "FILE", Desc: "operate on any checklist file directly, instead of resolving an agent's configured source"},
+				{Name: "--status", Arg: "S", Default: "all", Desc: "list filter: all, pending, or done"},
+				{Name: "--yes, -y", Desc: "send: skip the y/N confirmation (required when stdin is not a terminal)"},
+			},
+			Details: "<n> is a task REFERENCE, not always a position: when the list numbers its own\n" +
+				"tasks, use that id (e.g. `done 3.4`); '#3' always means the 3rd item in the file\n" +
+				"(quote it — a bare #3 is a shell comment). Every mutating op reprints the list.\n" +
+				"Aliases: ls, show, create, wip, check, uncheck/reopen, edit, rm/delete.\n" +
+				"Marks: [ ] pending, [-] in progress, [x] done.\n" +
+				"`send` hands a pending item to a live, cleanly idle agent NOW and marks it [-];\n" +
+				"idleness is re-checked at delivery, and a failed send returns the item to [ ].\n" +
+				"Normally you do not need `send`: the daemon hands out the next task by itself.",
+			Examples: []string{
+				"hap task vivid-falcon list",
+				"hap task vivid-falcon list --status pending",
+				"hap task vivid-falcon start 3.4",
+				"hap task vivid-falcon done 3.4",
+				"hap task --path ./docs/tasks.md add \"write the migration test\"",
+			},
+			Next: []Hint{
+				{Cmd: "hap task <agent> list", Why: "the items, with their numbers"},
+				{Cmd: "hap task-source list", Why: "which file an agent's list comes from"},
+				{Cmd: "hap agents", Why: "the agent names these commands take"},
+			},
+			SelfHints: true,
+			Handler:   task,
+		},
+
+		// ------------------------------------------------------------------- Data
+		{
+			Name:    "clear-data",
+			Group:   groupData,
+			Summary: "erase learned history and audit data (config is kept)",
+			Usage:   []string{"hap clear-data --yes"},
+			Flags: []FlagDoc{
+				{Name: "--yes", Desc: "required: this is permanent"},
+			},
+			Details: "Every learned signature, decision, and audit row goes. Config (config.toml),\n" +
+				"task sources, and safety rules are untouched. To drop a single rule instead,\n" +
+				"use `hap signatures delete <prefix>` — or `reset` to keep its history.",
+			Examples: []string{"hap clear-data --yes"},
+			Next: []Hint{
+				{Cmd: "hap signatures list", Why: "confirm nothing is left"},
+				{Cmd: "hap status", Why: "check the daemon is still healthy"},
+			},
+			Handler: clearData,
+		},
+	}
+
+	commandIndex = make(map[string]*Command, len(commandList)*2)
+	for i := range commandList {
+		c := &commandList[i]
+		commandIndex[c.Name] = c
+		for _, a := range c.Aliases {
+			commandIndex[a] = c
+		}
+	}
+}
+
+// workflows are the multi-step recipes `hap help` prints after the command
+// list: the sequences an operator (or an AI agent driving hap) actually needs,
+// which no single command's help can show.
+var workflows = []struct {
+	Title string
+	Steps []string
+}{
+	{
+		Title: "Answer what is waiting",
+		Steps: []string{
+			"hap escalations                       # what needs a decision, with #ids",
+			"hap confirm <id> --send               # the suggestion is right — accept and deliver it",
+			"hap resolve <id> --action TEXT --send # it is wrong — send the right answer instead",
+			"hap dismiss <id>                      # no answer needed",
+		},
+	},
+	{
+		Title: "Work an agent's task list",
+		Steps: []string{
+			"hap agents                            # find the agent's short name",
+			"hap task <agent> list                 # the items, with their numbers",
+			"hap task <agent> start <n>            # mark one in progress when you begin",
+			"hap task <agent> done <n>             # mark it complete",
+			"hap task <agent> add \"<text>\"         # queue more work",
+		},
+	},
+	{
+		Title: "Set up a task list for an agent",
+		Steps: []string{
+			"hap rename <pane-id> <name>           # give the agent a stable short name",
+			"hap task-source add --agent <name> ./docs/tasks.md",
+			"hap task-source list                  # confirm it, note the index",
+			"hap task <name> list                  # the agent sees these items",
+		},
+	},
+	{
+		Title: "Review and correct what hap learned",
+		Steps: []string{
+			"hap signatures list --mode autonomous # rules acting without asking",
+			"hap signatures show <prefix>          # the situation and its recent decisions",
+			"hap signatures reset <prefix> --yes   # back to shadow; must re-earn graduation",
+			"hap signatures delete <prefix> --yes  # erase the rule entirely",
+		},
+	},
+	{
+		Title: "Something is stuck",
+		Steps: []string{
+			"hap status                            # daemon health, paused?, drift",
+			"hap daemon --ensure                   # start/replace a stale or dead daemon",
+			"hap capture <agent>                   # re-classify one agent's pane now",
+			"hap audit --limit 20                  # what hap decided, and why",
+		},
+	},
+	{
+		Title: "Stop hap acting for a while",
+		Steps: []string{
+			"hap pause                             # global: stop answering, keep escalating",
+			"hap disable <agent>                   # one agent only",
+			"hap resume / hap enable <agent>       # turn it back on",
+		},
+	},
+}
+
+// Overview renders `hap help`: the grouped command list, the workflows, and the
+// pointers an AI agent needs to go deeper.
+func Overview(out io.Writer) {
+	fmt.Fprintln(out, "hap (Herd Auto Prompter) — keep your Herdr agents unblocked, hands-free")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Usage: hap <command> [arguments]   —   full guide: hap help <command> (or <command> --help)")
+
+	cmds := Commands()
+	width := 0
+	for _, c := range cmds {
+		if n := len(c.Name); n > width {
+			width = n
+		}
+	}
+	for _, g := range groupOrder {
+		printed := false
+		for i := range cmds {
+			c := &cmds[i]
+			if c.Group != g {
+				continue
+			}
+			if !printed {
+				fmt.Fprintf(out, "\n%s:\n", g)
+				printed = true
+			}
+			name := c.Name
+			if len(c.Aliases) > 0 {
+				name += " (" + strings.Join(c.Aliases, ", ") + ")"
+			}
+			fmt.Fprintf(out, "  %-*s  %s\n", width+10, name, c.Summary)
+		}
+	}
+
+	fmt.Fprintln(out, "\nCommon workflows:")
+	for _, w := range workflows {
+		fmt.Fprintf(out, "\n  %s\n", w.Title)
+		for _, s := range w.Steps {
+			fmt.Fprintf(out, "    %s\n", s)
+		}
+	}
+
+	fmt.Fprintln(out, "\nNotes:")
+	fmt.Fprintln(out, "  - Most commands end with a \"Next steps\" footer listing what to run next.")
+	fmt.Fprintln(out, "    Suppress it with --no-hints, HAP_NO_HINTS=1, or permanently with")
+	fmt.Fprintln(out, "    `hap config set cli.ai_agent_friendly_output false` (default true).")
+	fmt.Fprintln(out, "  - Listings are tab-separated; ids shown as #N are passed without the #.")
+	fmt.Fprintln(out, "  - `hap status` exits non-zero when the daemon is unhealthy.")
+
+	PrintNextSteps(out, []Hint{
+		{Cmd: "hap help <command>", Why: "full guide for one command, with every flag"},
+		{Cmd: "hap status", Why: "is automation running, and is anything waiting?"},
+		{Cmd: "hap escalations", Why: "the queue of decisions hap wants a human for"},
+	})
+}
+
+// PrintHelp renders the detail page for one command.
+func PrintHelp(out io.Writer, c *Command) {
+	name := c.Name
+	if len(c.Aliases) > 0 {
+		name += " (alias: " + strings.Join(c.Aliases, ", ") + ")"
+	}
+	fmt.Fprintf(out, "hap %s — %s\n", name, c.Summary)
+
+	if len(c.Usage) > 0 {
+		fmt.Fprintln(out, "\nUsage:")
+		for _, u := range c.Usage {
+			fmt.Fprintf(out, "  %s\n", u)
+		}
+	}
+	if len(c.Flags) > 0 {
+		fmt.Fprintln(out, "\nFlags:")
+		width := 0
+		labels := make([]string, len(c.Flags))
+		for i, f := range c.Flags {
+			labels[i] = f.Name
+			if f.Arg != "" {
+				labels[i] += " " + f.Arg
+			}
+			if n := len(labels[i]); n > width {
+				width = n
+			}
+		}
+		for i, f := range c.Flags {
+			desc := f.Desc
+			if f.Default != "" {
+				desc += fmt.Sprintf(" (default %s)", f.Default)
+			}
+			fmt.Fprintf(out, "  %-*s  %s\n", width, labels[i], desc)
+		}
+	}
+	if c.Details != "" {
+		fmt.Fprintln(out, "\nDetails:")
+		for _, line := range strings.Split(strings.TrimRight(c.Details, "\n"), "\n") {
+			fmt.Fprintf(out, "  %s\n", line)
+		}
+	}
+	if len(c.Examples) > 0 {
+		fmt.Fprintln(out, "\nExamples:")
+		for _, e := range c.Examples {
+			fmt.Fprintf(out, "  %s\n", e)
+		}
+	}
+	next := c.Next
+	if len(next) == 0 {
+		next = []Hint{{Cmd: "hap help", Why: "every command, plus common workflows"}}
+	}
+	PrintNextSteps(out, next)
+}
+
+// valueFlagSet lists every flag that takes a SEPARATE value argument, derived
+// from the registry so it cannot fall behind: a `--help` or `--no-hints` in one
+// of those slots is that flag's value, not a request of ours (see wantsHelp).
+// Both spellings Go's flag package accepts (`--x` and `-x`) are included.
+func valueFlagSet() map[string]bool {
+	valueFlagsOnce.Do(func() {
+		valueFlags = map[string]bool{}
+		for _, c := range Commands() {
+			for _, f := range c.Flags {
+				if f.Arg == "" {
+					continue
+				}
+				for _, name := range FlagSpellings(f.Name) {
+					valueFlags[name] = true
+				}
+			}
+		}
+	})
+	return valueFlags
+}
+
+var (
+	valueFlagsOnce sync.Once
+	valueFlags     map[string]bool
+)
+
+// FlagSpellings expands a FlagDoc name into every spelling the parser accepts:
+// documented aliases are comma-separated ("--yes, -y"), and Go's flag package
+// accepts each of them with one dash or two.
+func FlagSpellings(doc string) []string {
+	var out []string
+	for _, name := range strings.Split(doc, ",") {
+		name = strings.TrimSpace(name)
+		bare := strings.TrimLeft(name, "-")
+		if bare == "" {
+			continue
+		}
+		out = append(out, "--"+bare, "-"+bare)
+	}
+	return out
+}
+
+// WantsCommandHelp reports whether these arguments ask for a known command's
+// guide. main uses it to answer `hap <command> --help` before opening the
+// store — so help works even for the commands main dispatches itself (daemon,
+// tui, mcp) and in states where the database cannot be opened.
+func WantsCommandHelp(verb string, args []string) bool {
+	if _, ok := Lookup(verb); !ok {
+		return false
+	}
+	return wantsHelp(args)
+}
+
+// UnknownCommandError explains a mistyped verb, suggesting the closest known
+// command when there is an obvious one.
+func UnknownCommandError(verb string) error {
+	if s := suggest(verb); s != "" {
+		return fmt.Errorf("unknown command %q — did you mean %q? (run: hap help)", verb, s)
+	}
+	return fmt.Errorf("unknown command %q — run: hap help", verb)
+}
+
+// suggest finds a command whose name shares a prefix with, or contains, the
+// mistyped verb. Deliberately simple: it only has to catch typos like "escalation"
+// or "sig", never to guess.
+func suggest(verb string) string {
+	if verb == "" {
+		return ""
+	}
+	var hits []string
+	for _, c := range Commands() {
+		for _, n := range append([]string{c.Name}, c.Aliases...) {
+			if strings.HasPrefix(n, verb) || strings.HasPrefix(verb, n) || strings.Contains(n, verb) {
+				hits = append(hits, c.Name)
+			}
+		}
+	}
+	if len(hits) == 0 {
+		return ""
+	}
+	sort.Strings(hits)
+	return hits[0]
+}

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -1,0 +1,212 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/cli"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// TestRegistryEntriesAreDocumented pins the invariant that makes the registry
+// worth having: a verb cannot exist without the text that explains it.
+func TestRegistryEntriesAreDocumented(t *testing.T) {
+	seen := map[string]bool{}
+	for _, c := range cli.Commands() {
+		if c.Name == "" {
+			t.Fatal("a command has no name")
+		}
+		for _, n := range append([]string{c.Name}, c.Aliases...) {
+			if seen[n] {
+				t.Errorf("duplicate command or alias %q", n)
+			}
+			seen[n] = true
+			if _, ok := cli.Lookup(n); !ok {
+				t.Errorf("%q does not resolve through Lookup", n)
+			}
+		}
+		if strings.TrimSpace(c.Summary) == "" {
+			t.Errorf("%s: no summary", c.Name)
+		}
+		if len(c.Usage) == 0 {
+			t.Errorf("%s: no usage line", c.Name)
+		}
+		if len(c.Examples) == 0 {
+			t.Errorf("%s: no examples", c.Name)
+		}
+		if len(c.Next) == 0 && !c.SelfHints && !c.Bare {
+			t.Errorf("%s: no next-step hints and not SelfHints — the footer would be empty", c.Name)
+		}
+		if c.Group == "" {
+			t.Errorf("%s: no group, so `hap help` would not list it", c.Name)
+		}
+	}
+	// The verbs the plugin's own docs and prompts hand to agents must exist.
+	for _, want := range []string{"status", "agents", "escalations", "confirm", "resolve",
+		"correct", "dismiss", "task", "task-source", "signatures", "sigs", "config", "help"} {
+		if !seen[want] {
+			t.Errorf("registry lost the %q command", want)
+		}
+	}
+}
+
+// TestCommandHelpPages checks every command answers --help with a page naming
+// it and documenting each flag the registry claims it has.
+func TestCommandHelpPages(t *testing.T) {
+	app, _ := testApp(t)
+	for _, c := range cli.Commands() {
+		out, err := run(t, app, c.Name, "--help")
+		if err != nil {
+			t.Fatalf("%s --help: %v", c.Name, err)
+		}
+		if !strings.Contains(out, "hap "+c.Name) {
+			t.Errorf("%s --help does not name the command:\n%s", c.Name, out)
+		}
+		if !strings.Contains(out, c.Summary) {
+			t.Errorf("%s --help omits its summary", c.Name)
+		}
+		for _, f := range c.Flags {
+			if !strings.Contains(out, f.Name) {
+				t.Errorf("%s --help does not document %s", c.Name, f.Name)
+			}
+		}
+		for _, u := range c.Usage {
+			if !strings.Contains(out, u) {
+				t.Errorf("%s --help omits usage line %q", c.Name, u)
+			}
+		}
+		// `hap help <command>` must render the same page.
+		viaHelp, err := run(t, app, "help", c.Name)
+		if err != nil {
+			t.Fatalf("help %s: %v", c.Name, err)
+		}
+		if viaHelp != out {
+			t.Errorf("help %s and %s --help differ", c.Name, c.Name)
+		}
+	}
+}
+
+// TestHelpFlagAnywhere: an agent may append --help after a subcommand or an
+// argument, which is where a naive "args[0]" check would miss it.
+func TestHelpFlagAnywhere(t *testing.T) {
+	app, _ := testApp(t)
+	for _, args := range [][]string{
+		{"--help"},
+		{"-h"},
+		{"vivid-falcon", "list", "--help"},
+		{"--path", "/tmp/tasks.md", "done", "3", "--help"},
+	} {
+		out, err := run(t, app, "task", args...)
+		if err != nil {
+			t.Fatalf("task %v: %v", args, err)
+		}
+		if !strings.Contains(out, "hap task —") {
+			t.Errorf("task %v did not print the guide:\n%s", args, out)
+		}
+	}
+}
+
+// TestHelpFlagNotSwallowedAsFlagValue guards the one case where --help is not a
+// request for help: it is the VALUE the operator wants recorded.
+func TestHelpFlagNotSwallowedAsFlagValue(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	id, err := st.AppendAudit(ctx, domain.AuditRecord{
+		Signature: "approval:helpflag", SituationType: domain.SituationApproval,
+		Action: "escalated", Status: "escalated", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := run(t, app, "resolve", strconv.FormatInt(id, 10), "--action", "--help")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if strings.Contains(out, "hap resolve —") {
+		t.Fatalf("--action's value was read as a help request:\n%s", out)
+	}
+	if !strings.Contains(out, "recorded correction") {
+		t.Fatalf("the correction was not recorded:\n%s", out)
+	}
+}
+
+// TestWantsCommandHelp guards main.go's dispatch order: `hap version --help` is
+// a help request, while `hap --version` is not — main asks this before its own
+// version branch, so a reshuffle there must fail here.
+func TestWantsCommandHelp(t *testing.T) {
+	cases := []struct {
+		verb string
+		args []string
+		want bool
+	}{
+		{verb: "version", args: []string{"--help"}, want: true},
+		{verb: "daemon", args: []string{"--ensure", "-h"}, want: true},
+		{verb: "task", args: []string{"agent", "list", "--help"}, want: true},
+		{verb: "version", want: false},
+		{verb: "--version", args: []string{"--help"}, want: false},
+		{verb: "not-a-command", args: []string{"--help"}, want: false},
+		{verb: "resolve", args: []string{"1", "--action", "--help"}, want: false},
+	}
+	for _, tc := range cases {
+		if got := cli.WantsCommandHelp(tc.verb, tc.args); got != tc.want {
+			t.Errorf("WantsCommandHelp(%q, %v) = %v, want %v", tc.verb, tc.args, got, tc.want)
+		}
+	}
+}
+
+// TestFlagSpellings pins the expansion behind the value-flag set: both dash
+// forms of every documented alias, and no entry for an empty name.
+func TestFlagSpellings(t *testing.T) {
+	cases := map[string][]string{
+		"--limit":    {"--limit", "-limit"},
+		"--yes, -y":  {"--yes", "-yes", "--y", "-y"},
+		"-status":    {"--status", "-status"},
+		"--a,, --b ": {"--a", "-a", "--b", "-b"},
+	}
+	for doc, want := range cases {
+		got := cli.FlagSpellings(doc)
+		if strings.Join(got, " ") != strings.Join(want, " ") {
+			t.Errorf("FlagSpellings(%q) = %v, want %v", doc, got, want)
+		}
+	}
+}
+
+// TestOverviewCoversEveryCommand: `hap help` is the entry point an agent reads
+// first, so nothing may be missing from it.
+func TestOverviewCoversEveryCommand(t *testing.T) {
+	var buf bytes.Buffer
+	cli.Overview(&buf)
+	out := buf.String()
+	for _, c := range cli.Commands() {
+		if !strings.Contains(out, c.Name) {
+			t.Errorf("hap help does not list %q", c.Name)
+		}
+		if !strings.Contains(out, c.Summary) {
+			t.Errorf("hap help does not summarize %q", c.Name)
+		}
+	}
+	for _, want := range []string{"Common workflows", "Next steps:", "HAP_NO_HINTS"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("hap help is missing the %q section", want)
+		}
+	}
+}
+
+// TestUnknownCommandPointsAtHelp: a mistyped verb must lead somewhere.
+func TestUnknownCommandPointsAtHelp(t *testing.T) {
+	app, _ := testApp(t)
+	_, err := run(t, app, "escalation")
+	if err == nil {
+		t.Fatal("expected an error for an unknown verb")
+	}
+	if !strings.Contains(err.Error(), "hap help") {
+		t.Errorf("error does not point at help: %v", err)
+	}
+	if !strings.Contains(err.Error(), "escalations") {
+		t.Errorf("error does not suggest the near-miss command: %v", err)
+	}
+}

--- a/internal/cli/hints.go
+++ b/internal/cli/hints.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+)
+
+// Hint is one suggested follow-up command printed in a "Next steps" footer.
+// Cmd is written exactly as it should be typed (placeholders in <angle
+// brackets>); Why is the one-clause reason to pick it.
+type Hint struct {
+	Cmd string
+	Why string
+}
+
+// hintWriter carries the per-run "print next-step footers" decision alongside
+// the output writer, so nothing needs a package-level toggle (tests in this
+// package run concurrently) and every verb can consult it through the plain
+// io.Writer it already receives.
+//
+// on covers the decisions fixed for the whole run (the --no-hints flag, the
+// environment, and help output, which is never gated); app is consulted at
+// PRINT time so `hap config set cli.ai_agent_friendly_output <bool>` reflects
+// the value it just wrote, not the one it started with.
+type hintWriter struct {
+	io.Writer
+	on  bool
+	app *frontend.App
+}
+
+// hintsOn reports whether footers should be printed for this output. A writer
+// that never passed through Run (direct unit-test calls) falls back to the
+// environment.
+func hintsOn(out io.Writer) bool {
+	hw, ok := out.(*hintWriter)
+	if !ok {
+		return envHintsEnabled()
+	}
+	if !hw.on {
+		return false
+	}
+	return configAllowsHints(hw.app)
+}
+
+// configAllowsHints reads the `cli.ai_agent_friendly_output` switch. It
+// degrades to the default (on) whenever the config cannot be read — a missing
+// or broken config file must not silently change what commands print, and the
+// footers are the discoverable path back out of that state.
+func configAllowsHints(app *frontend.App) bool {
+	if app == nil || app.ConfigPath == "" {
+		return true
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		return true
+	}
+	return cfg.CLI.AIAgentFriendlyOutput
+}
+
+// envHintsEnabled reports whether the environment allows footers. Scripts that
+// parse the tab-separated listings set HAP_NO_HINTS=1 (the `--no-hints` flag
+// does the same for one invocation).
+func envHintsEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("HAP_NO_HINTS"))) {
+	case "1", "true", "yes", "on":
+		return false
+	}
+	return true
+}
+
+// PrintNextSteps renders the shared "Next steps" footer: a blank separator
+// line, the header, then one bullet per hint. It is the single renderer for
+// every footer in the CLI (static ones from the command registry and the
+// dynamic ones verbs build from live ids), so they can never drift in shape.
+func PrintNextSteps(out io.Writer, hints []Hint) {
+	if len(hints) == 0 || !hintsOn(out) {
+		return
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Next steps:")
+	for _, h := range hints {
+		if h.Why == "" {
+			fmt.Fprintf(out, "- `%s`\n", h.Cmd)
+			continue
+		}
+		fmt.Fprintf(out, "- `%s` — %s\n", h.Cmd, h.Why)
+	}
+}

--- a/internal/cli/hints_test.go
+++ b/internal/cli/hints_test.go
@@ -1,0 +1,309 @@
+package cli_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/cli"
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/control"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
+)
+
+// countHeaders counts "Next steps" footers, which must never double up.
+func countHeaders(out string) int {
+	return strings.Count(out, "\nNext steps:\n")
+}
+
+// TestNextStepsFooterPrinted covers both footer sources: the static one Run
+// prints from the registry, and the dynamic ones a verb builds itself.
+func TestNextStepsFooterPrinted(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	if _, err := st.AppendAudit(ctx, domain.AuditRecord{
+		Signature: "approval:footer", SituationType: domain.SituationApproval,
+		Action: "escalated", Status: "escalated", Suggestion: "Yes", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		verb string
+		args []string
+		want string // a command the footer must suggest
+	}{
+		{verb: "audit", want: "hap signatures show"},                   // static, from the registry
+		{verb: "escalations", want: "hap confirm"},                     // dynamic, carries a live id
+		{verb: "kill-history", want: "hap status"},                     // static
+		{verb: "signatures", want: "hap escalations"},                  // dynamic, empty-state branch
+		{verb: "rules", args: []string{"list"}, want: "hap rules add"}, // dynamic, list branch
+	}
+	for _, tc := range cases {
+		out, err := run(t, app, tc.verb, tc.args...)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.verb, err)
+		}
+		if n := countHeaders(out); n != 1 {
+			t.Errorf("%s printed %d footers, want exactly 1:\n%s", tc.verb, n, out)
+		}
+		if !strings.Contains(out, tc.want) {
+			t.Errorf("%s footer does not suggest %q:\n%s", tc.verb, tc.want, out)
+		}
+	}
+}
+
+// TestNoCommandPrintsTwoFooters sweeps the registry for the mistake SelfHints
+// exists to prevent: a handler that prints its own footer while Run also
+// appends the static one. Verbs that need arguments simply error here, which is
+// fine — the assertion only applies to the ones that ran.
+func TestNoCommandPrintsTwoFooters(t *testing.T) {
+	app, st := testApp(t)
+	seedSignatures(t, st)
+	path := writeTaskFile(t, "- [ ] alpha\n- [ ] beta\n")
+	for _, c := range cli.Commands() {
+		if c.Handler == nil {
+			continue
+		}
+		// Bare, the "list" sub-op, and each documented example — the examples
+		// are what give the argument-taking verbs (task, task-source, rules,
+		// config, signatures) real coverage instead of an immediate usage error.
+		runs := [][]string{nil, {"list"}}
+		for _, ex := range c.Examples {
+			fields := strings.Fields(ex)
+			if len(fields) < 2 || fields[0] != "hap" || fields[1] != c.Name {
+				continue
+			}
+			args := append([]string{}, fields[2:]...)
+			for i, a := range args {
+				// Point every example at a checklist this test owns, so the
+				// task ops actually execute instead of failing to resolve.
+				if strings.HasSuffix(a, ".md") {
+					args[i] = path
+				}
+			}
+			runs = append(runs, args)
+		}
+		for _, args := range runs {
+			out, err := run(t, app, c.Name, args...)
+			if err != nil {
+				continue // needs a live agent, a real id, or a TTY — not our concern here
+			}
+			if n := countHeaders(out); n > 1 {
+				t.Errorf("%s %v printed %d footers (mark it SelfHints):\n%s", c.Name, args, n, out)
+			}
+		}
+	}
+}
+
+// TestEscalationsFooterUsesRealID: an agent should be able to copy the line
+// as-is, so the footer names the pending row rather than a placeholder.
+func TestEscalationsFooterUsesRealID(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	id, err := st.AppendAudit(ctx, domain.AuditRecord{
+		Signature: "approval:realid", SituationType: domain.SituationApproval,
+		Action: "escalated", Status: "escalated", Suggestion: "Yes", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := run(t, app, "escalations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"hap confirm " + strconv.FormatInt(id, 10) + " --send",
+		"hap dismiss " + strconv.FormatInt(id, 10),
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("footer missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestHintsSuppressedByConfig: the operator switch that turns the AI-agent
+// footers off for good. Help pages are documentation and must ignore it.
+func TestHintsSuppressedByConfig(t *testing.T) {
+	app, _ := testApp(t)
+	cfg := config.Default()
+	cfg.CLI.AIAgentFriendlyOutput = false
+	if err := config.Save(app.ConfigPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "audit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countHeaders(out) != 0 {
+		t.Errorf("cli.ai_agent_friendly_output=false did not suppress the footer:\n%s", out)
+	}
+
+	for _, args := range [][]string{{"audit", "--help"}, {"help", "audit"}, {"help"}} {
+		out, err := run(t, app, args[0], args[1:]...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if countHeaders(out) != 1 {
+			t.Errorf("%v: help output must keep its footer whatever the config says:\n%s", args, out)
+		}
+	}
+
+	// Flipping it back restores the footers, so the switch is not one-way.
+	cfg.CLI.AIAgentFriendlyOutput = true
+	if err := config.Save(app.ConfigPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+	out, err = run(t, app, "audit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countHeaders(out) != 1 {
+		t.Errorf("re-enabling the flag did not restore the footer:\n%s", out)
+	}
+}
+
+// TestHintsConfigDefaultsOnForOlderConfigs pins the upgrade path: a config.toml
+// written before this switch existed has no [cli] table, and must keep printing
+// footers (Load unmarshals over Default, so the zero value must never win).
+func TestHintsConfigDefaultsOnForOlderConfigs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want int
+	}{
+		{name: "no [cli] table", body: "[tui]\nterminal_bell = true\n", want: 1},
+		{name: "explicit false", body: "[cli]\nai_agent_friendly_output = false\n", want: 0},
+		{name: "explicit true", body: "[cli]\nai_agent_friendly_output = true\n", want: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app, _ := testApp(t)
+			if err := os.WriteFile(app.ConfigPath, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			out, err := run(t, app, "audit")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n := countHeaders(out); n != tc.want {
+				t.Errorf("got %d footers, want %d:\n%s", n, tc.want, out)
+			}
+		})
+	}
+}
+
+// TestHintsGateReadAtPrintTime: the invocation that flips the switch must obey
+// the value it just wrote, not the one it started with.
+func TestHintsGateReadAtPrintTime(t *testing.T) {
+	app, _ := testApp(t)
+	app.ControlPath = filepath.Join(testutil.SocketDir(t), "hints.sock")
+	srv, err := control.NewServer(app.ControlPath, func(control.Kind) {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	out, err := run(t, app, "config", "set", "cli.ai_agent_friendly_output", "false")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countHeaders(out) != 0 {
+		t.Errorf("turning the switch off must not print a footer:\n%s", out)
+	}
+	out, err = run(t, app, "config", "set", "cli.ai_agent_friendly_output", "true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countHeaders(out) != 1 {
+		t.Errorf("turning the switch on must print a footer:\n%s", out)
+	}
+}
+
+// TestNoHintsNotSwallowedAsFlagValue is the --no-hints twin of the --help case:
+// an operator recording that literal text must get it recorded.
+func TestNoHintsNotSwallowedAsFlagValue(t *testing.T) {
+	app, st := testApp(t)
+	id, err := st.AppendAudit(context.Background(), domain.AuditRecord{
+		Signature: "approval:nohints", SituationType: domain.SituationApproval,
+		Action: "escalated", Status: "escalated", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := run(t, app, "resolve", strconv.FormatInt(id, 10), "--action", "--no-hints")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `"--no-hints"`) {
+		t.Errorf("--action's value was eaten as our flag:\n%s", out)
+	}
+	if countHeaders(out) != 1 {
+		t.Errorf("the footer should still print — --no-hints was a value, not a flag:\n%s", out)
+	}
+}
+
+// TestHintsSuppressed: scripts parsing the tab-separated listings must be able
+// to turn the footers off, by flag or by environment.
+func TestHintsSuppressed(t *testing.T) {
+	app, _ := testApp(t)
+
+	out, err := run(t, app, "audit", "--no-hints")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countHeaders(out) != 0 {
+		t.Errorf("--no-hints did not suppress the footer:\n%s", out)
+	}
+
+	t.Setenv("HAP_NO_HINTS", "1")
+	out, err = run(t, app, "audit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countHeaders(out) != 0 {
+		t.Errorf("HAP_NO_HINTS=1 did not suppress the footer:\n%s", out)
+	}
+}
+
+// TestNoHintsFlagLeavesRealFlagsIntact: stripping --no-hints must not disturb
+// the arguments the verb parses.
+func TestNoHintsFlagLeavesRealFlagsIntact(t *testing.T) {
+	app, st := testApp(t)
+	seedSignatures(t, st)
+	out, err := run(t, app, "signatures", "list", "--no-hints", "--mode", "autonomous")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "shadow") {
+		t.Errorf("--mode autonomous was not applied after stripping --no-hints:\n%s", out)
+	}
+	if countHeaders(out) != 0 {
+		t.Errorf("footer printed despite --no-hints:\n%s", out)
+	}
+}
+
+// TestTaskListKeepsTaskManagementHints: the instructions agents are pointed at
+// from their next-task prompt must survive alongside the new footer, once each.
+func TestTaskListKeepsTaskManagementHints(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] first\n- [x] second\n")
+	out, err := run(t, app, "task", "--path", path, "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "Prefer using the hap CLI to manage your tasks:") {
+		t.Errorf("task list lost the task-management instructions:\n%s", out)
+	}
+	if n := countHeaders(out); n != 1 {
+		t.Errorf("task list printed %d footers, want 1:\n%s", n, out)
+	}
+	if !strings.Contains(out, "--path "+domain.ShellQuote(path)) {
+		t.Errorf("footer does not address the list the way the caller did:\n%s", out)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -390,6 +390,18 @@ type TUI struct {
 	TerminalBell bool `toml:"terminal_bell"`
 }
 
+// CLI configures the `hap` command-line output (as opposed to the TUI).
+type CLI struct {
+	// AIAgentFriendlyOutput appends a short "Next steps" footer to command output,
+	// naming the commands that follow this one (with real ids filled in). It
+	// exists because the CLI's main caller is often an AI coding agent, which
+	// cannot discover the next verb the way a human reads a man page.
+	// Default true. It never affects `hap help` or `<command> --help`, whose
+	// footers are part of the guide, and never the bare-value verbs
+	// (`hap state-dir`, `hap config path`), which print no footer at all.
+	AIAgentFriendlyOutput bool `toml:"ai_agent_friendly_output"`
+}
+
 // PaletteOverrides are optional per-role color overrides for the TUI
 // palette. Values are terminal color strings lipgloss accepts ("205",
 // "#ff5faf"). Edited via config.toml only — the TUI shows them read-only.
@@ -417,6 +429,7 @@ type Config struct {
 	LLM                  LLM                  `toml:"llm"`
 	Embedding            Embedding            `toml:"embedding"`
 	TUI                  TUI                  `toml:"tui"`
+	CLI                  CLI                  `toml:"cli"`
 	TaskSources          []TaskSource         `toml:"task_sources"`
 	Classifier           []ClassifierRule     `toml:"classifier"`
 	// CaptureDelays are optional per-agent-type overrides for the delayed
@@ -453,6 +466,7 @@ func Default() Config {
 			BM25MinScore:        0.35,
 		},
 		TUI: TUI{TerminalBell: true},
+		CLI: CLI{AIAgentFriendlyOutput: true},
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1463,3 +1463,51 @@ func TestTaskSourceMatchesAgent(t *testing.T) {
 		})
 	}
 }
+
+// TestSampleConfigParsesWithDocumentedDefaults loads the shipped
+// sample/config.toml — the file operators copy — and checks it both parses and
+// still describes the real defaults. The sample is documentation that can drift
+// silently; this makes a wrong value (or a section that stops parsing) a test
+// failure instead of a support question.
+func TestSampleConfigParsesWithDocumentedDefaults(t *testing.T) {
+	path := filepath.Join("..", "..", "sample", "config.toml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read sample config: %v", err)
+	}
+	cfg, logs, err := loadWithLogs(path)
+	if err != nil {
+		t.Fatalf("sample config must parse: %v", err)
+	}
+	if strings.Contains(logs, "deprecated") {
+		t.Errorf("sample config uses a deprecated key:\n%s", logs)
+	}
+
+	def := Default()
+	// Every documented value the sample states outright must be the default it
+	// claims to be; the [cli] switch is the one this test was added for.
+	if !strings.Contains(string(raw), "ai_agent_friendly_output") {
+		t.Error("sample config does not document [cli].ai_agent_friendly_output")
+	}
+	if !cfg.CLI.AIAgentFriendlyOutput {
+		t.Error("sample config must leave the AI-agent footers on")
+	}
+	if cfg.CLI.AIAgentFriendlyOutput != def.CLI.AIAgentFriendlyOutput {
+		t.Errorf("sample [cli].ai_agent_friendly_output = %v, default is %v",
+			cfg.CLI.AIAgentFriendlyOutput, def.CLI.AIAgentFriendlyOutput)
+	}
+	if cfg.ConfidenceThresholds != def.ConfidenceThresholds {
+		t.Errorf("sample confidence_thresholds = %+v, defaults are %+v",
+			cfg.ConfidenceThresholds, def.ConfidenceThresholds)
+	}
+	if cfg.Learning != def.Learning {
+		t.Errorf("sample learning = %+v, defaults are %+v", cfg.Learning, def.Learning)
+	}
+	if cfg.Limits != def.Limits {
+		t.Errorf("sample limits = %+v, defaults are %+v", cfg.Limits, def.Limits)
+	}
+	if cfg.TUI.TerminalBell != def.TUI.TerminalBell {
+		t.Errorf("sample tui.terminal_bell = %v, default is %v",
+			cfg.TUI.TerminalBell, def.TUI.TerminalBell)
+	}
+}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -1880,6 +1880,7 @@ var ConfigFields = []ConfigFieldDef{
 	{Key: "tui.max_content_height", TUIEditable: true},
 	{Key: "tui.theme", TUIEditable: true},
 	{Key: "tui.terminal_bell", TUIEditable: true},
+	{Key: "cli.ai_agent_friendly_output", TUIEditable: true},
 }
 
 // ConfigFieldKeys lists every scalar config field editable via SetField, in
@@ -2033,6 +2034,8 @@ func FieldValue(cfg config.Config, key string) string {
 		return cfg.TUI.Theme
 	case "tui.terminal_bell":
 		return strconv.FormatBool(cfg.TUI.TerminalBell)
+	case "cli.ai_agent_friendly_output":
+		return strconv.FormatBool(cfg.CLI.AIAgentFriendlyOutput)
 	}
 	return ""
 }
@@ -2269,6 +2272,13 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 				return fmt.Errorf("tui.terminal_bell must be true or false, got %q", value)
 			}
 			cfg.TUI.TerminalBell = v
+			return nil
+		case "cli.ai_agent_friendly_output":
+			v, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("cli.ai_agent_friendly_output must be true or false, got %q", value)
+			}
+			cfg.CLI.AIAgentFriendlyOutput = v
 			return nil
 		}
 		return fmt.Errorf("unknown config field %q", key)

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -2184,6 +2184,7 @@ func TestConfigFieldRegistryParity(t *testing.T) {
 		"tui.max_content_height":                  "12",
 		"tui.theme":                               "dark",
 		"tui.terminal_bell":                       "true",
+		"cli.ai_agent_friendly_output":            "false",
 	}
 
 	registry := make(map[string]bool, len(frontend.ConfigFieldKeys))

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -210,6 +210,18 @@ terminal_bell = true       # ring the terminal bell (\a) on new escalations and 
 # warn = "214"
 # help = ""
 
+# ── CLI output ──────────────────────────────────────────────────────
+[cli]
+ai_agent_friendly_output = true   # append a "Next steps" footer to command output,
+                                  # naming the commands that follow this one (with
+                                  # real ids filled in) — the CLI's main caller is
+                                  # often an AI coding agent, which cannot discover
+                                  # the next verb the way a human reads a man page.
+                                  # `hap help` and `<command> --help` always print
+                                  # theirs; `hap state-dir` and `hap config path`
+                                  # never do (a bare value stays capturable).
+                                  # Per-run equivalents: --no-hints, HAP_NO_HINTS=1
+
 # ── Declared task lists for idle agents (repeatable) ────────────────
 # Without a declared source, the plugin falls back to inferring the next
 # task from the agent's own todo rendering, gated only by confidence_thresholds


### PR DESCRIPTION
## Why

The `hap` CLI is driven as much by AI coding agents as by humans, and an agent cannot discover the next verb the way a human reads a man page. Today only `hap task … list` teaches what to run next (`domain.TaskManagementHints`); everywhere else the output stops dead. Discovery was weak too: `hap help` printed one hand-maintained `usage` const that had drifted from reality, and no subcommand accepted `--help` (`hap confirm --help` was a flag error).

## What

**A command registry (`internal/cli/help.go`) is now the single source of truth** for dispatch, help text, and footers. `Run`'s `switch` is gone — a verb cannot exist without its documentation, and a test enforces summary/usage/examples/hints on every entry.

- **`hap help`** — generated overview, grouped (Core / Operate / Learning / Configure / Tasks / Data), plus six **Common workflows** recipes written for an agent: answer escalations, work a task list, set up a task source, review learned rules, something is stuck, stop hap acting.
- **`<command> --help` / `hap help <command>`** — every usage form, every flag with its default, semantics and gotchas, examples. `--help` is honored anywhere in the arguments (`hap task foo list --help`) but not when it is a flag's value (`hap resolve 1 --action --help` records the literal text).
- **"Next steps" footers** on command output, modeled on the existing task-list hints. Dynamic where it pays: `escalations` fills in a real id (`hap confirm 42 --send`), `signatures list` a real prefix, `status` leads with the remedy it actually found (daemon down / paused / embedding drift).
- **Gating** — config `cli.ai_agent_friendly_output` (default `true`, evaluated at print time so `config set` of the switch obeys its own result), plus `--no-hints` and `HAP_NO_HINTS=1`. None of them affect help pages. `hap state-dir` / `hap config path` stay bare so `$(…)` keeps working.
- Every `usage:` error now names a follow-up; an unknown verb suggests the near-miss and points at `hap help`.

Documented in `README.md`, `.claude/skills/hap/SKILL.md`, and `sample/config.toml` — whose documented defaults are now covered by a test.

## Testing

- New `internal/cli/help_test.go` / `hints_test.go`: registry completeness, every command's `--help` documenting every flag it claims, `--help`/`--no-hints` not swallowed as flag values, `WantsCommandHelp` dispatch order (`hap version --help` vs `hap --version`), footer present/suppressed by flag, env, and config, no command printing two footers, older configs with no `[cli]` table still printing footers.
- Full suite green: `go test -tags "vectors cpu" ./... -count=1` — 24 packages, 0 failures.
- `gofmt`, `go vet`, and `golangci-lint run --build-tags "vectors,cpu"` all clean.
- Manual smoke against a real build: `hap help`, `hap help task`, `hap task --help`, `hap status`, `hap agents`, footer on/off via all three switches.

Two rounds of subagent code review were applied (double footer on `rules`, value-flag set now derived from the registry, `hap version --help`, the print-time config gate, and the added test coverage).

https://claude.ai/code/session_019oaepE4739f2yCZTtE4HuL