### PR TITLE
#1 feat: first-class @noop decline for generated tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,11 +721,28 @@ flow. Dismiss it with `x`; if generation failed or timed out, press `l` to
 retry. Suggestions are dropped or refused if the agent has started working, or
 now has a task source with a real pending item, in the meantime.
 
+The command can also decline: replying with `@noop` (also accepted: `noop`,
+`no_op`, `no-op`, in any case, optionally bulleted or in a code span) means "no
+new task is needed". When that is the *whole* reply it escalates as a
+confirmable `do nothing (no reply needed)`, and confirming it learns a `@noop`
+rule that parks the situation. Tell the model about the sentinel in your
+prompt, or it will never use it.
+
+The sentinel line is always stripped, so `@noop` is never written into the task
+list — and so can never be typed into an agent's pane by a later
+`confirm --send`. Anything the model puts *beside* it is still treated as work,
+so a reply like `@noop` followed by a line of explanation queues that
+explanation as a task; ask for the sentinel alone.
+
+An *empty* reply is not a decline: it is indistinguishable from a crashed or
+misconfigured CLI, so it stays a retryable failure. Output that parses to no
+task at all (a bare `---`, punctuation only) is treated the same way.
+
 ```toml
 [llm]
 task_generate_command = [
   "claude", "-p",
-  "Suggest concrete next tasks, most important first. Reply with only the tasks, one per line.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
+  "Suggest concrete next tasks, most important first. Reply with only the tasks, one per line. If no new task is needed, reply with exactly @noop and nothing else.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
   "--model", "haiku",
 ]
 # Optional first generation for each agent this daemon lifetime:

--- a/README.md
+++ b/README.md
@@ -328,8 +328,17 @@ gates and remain visible in the same audit trail.
    question (no Submit pseudo-option); delivery verifies every live question
    transition and explicitly submits the completed form.
 2. **Confirm or correct.** In the TUI's *Escalations* tab press `enter` to
-   confirm the suggestion (and send it), or `c` to type the correct
-   response — `v` shows the full record (trigger, rationale, LLM output,
+   confirm the suggestion **and send it**, `y` to confirm **without sending**
+   (the rule is learned exactly the same way, but nothing reaches the agent —
+   the TUI half of `hap confirm <id>` with no `--send`), or `c` to type the
+   correct response. `y` also acts on a whole `space`-marked batch, which
+   `enter` deliberately does not: recording agreement touches no agent, while
+   one keypress firing keystrokes into several live panes would. Two things `y`
+   does *not* do: it does not answer the agent — the escalation leaves the
+   queue but a blocked pane stays blocked until something replies — and on a
+   **generated-task** suggestion it still queues the tasks to the agent's list
+   and registers its task source (only the pane delivery is skipped). `v` shows
+   the full record (trigger, rationale, LLM output,
    agent type, and the **matched rule** — the exact learned signature this
    situation resolved to, with its mode/streak/confidence/top action, or
    "none yet" for a first sighting) when the list line is truncated; it

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2403,6 +2403,48 @@ func (d *Daemon) handleTaskGenOutcome(ctx context.Context, res taskGenOutcome) {
 		return
 	}
 
+	// Drop the noop sentinel before anything else looks at the text, so it can
+	// never be written into a checklist — and later typed into a pane — as if
+	// it were work. What is left is still RAW: the confirm path normalizes, and
+	// NormalizeGeneratedTasks is not idempotent, so pre-normalizing here would
+	// make the two passes disagree and silently drop items (see
+	// StripNoopGeneratedLines).
+	task, declined := domain.StripNoopGeneratedLines(res.task)
+
+	// Parse only to VALIDATE. Output that yields no task (a bare horizontal
+	// rule, a punctuation-only reply) would otherwise become a confirmable
+	// escalation that can ONLY fail when the operator acts on it — the confirm
+	// path runs this same parse and refuses. Deciding it here keeps the two
+	// verdicts ("is there a task" / "can this be confirmed") from disagreeing.
+	if len(domain.NormalizeGeneratedTasks(task)) == 0 {
+		// Nothing but sentinels: the model's explicit decline. Park the
+		// situation by suggesting the human-readable noop (never the raw
+		// sentinel), matching the exhausted-source escalation in domain.Decide
+		// — confirming it learns a plain @noop rule through the existing
+		// SuggestedAction round-trip. Deliberately NOT ReasonTaskGenFailed: the
+		// CLI worked, so offering `l: retry LLM` would only re-ask a model that
+		// already answered. Note this rides on res.reason, so a decline for an
+		// exhausted DECLARED source learns an operator-backed noop over that
+		// source — which takes precedence in Decide but still yields to real
+		// pending items (ReasonNoopVsPendingTasks), so a later refill is not
+		// parked by it.
+		if declined {
+			d.escalate(ctx, s, res.sig, domain.Decision{
+				Action: domain.ActionEscalate, Reason: res.reason,
+				Rationale:  "generate-task declined: no new task needed",
+				Suggestion: domain.ActionNoopSuggestion,
+			}, res.tr, now)
+			return
+		}
+		// No sentinel and no task IS a broken CLI — keep it retryable so
+		// `l: retry LLM` can re-ask.
+		d.escalate(ctx, s, res.sig, domain.Decision{
+			Action: domain.ActionEscalate, Reason: domain.ReasonTaskGenFailed,
+			Rationale: "generate-task produced no usable task",
+		}, res.tr, now)
+		return
+	}
+
 	// Success: surface the suggestion for confirmation. The reason carries
 	// what triggered this generation (no_task_source, or
 	// task_source_exhausted for a declared source that ran out) so the
@@ -2410,7 +2452,7 @@ func (d *Daemon) handleTaskGenOutcome(ctx context.Context, res taskGenOutcome) {
 	// — while the suggestion carries the generated task for the confirm path.
 	d.escalate(ctx, s, res.sig, domain.Decision{
 		Action: domain.ActionEscalate, Reason: res.reason,
-		Suggestion: domain.SuggestTaskPrefix + res.task,
+		Suggestion: domain.SuggestTaskPrefix + task,
 	}, res.tr, now)
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2630,6 +2630,159 @@ func TestIdleGeneratesTaskSuggestionEscalation(t *testing.T) {
 	}
 }
 
+func TestIdleTaskGenNoopParksInsteadOfPersisting(t *testing.T) {
+	// The model's explicit decline must NOT be written into a checklist as a
+	// literal "@noop" task, and must NOT masquerade as a broken CLI: it
+	// surfaces as the human-readable noop suggestion, which the confirm path
+	// round-trips to a learned @noop.
+	for _, raw := range []string{"@noop", "  @noop\n", "- @noop", "`@noop`", "NO-OP", "```\n@noop\n```", "- @noop\n- noop"} {
+		t.Run(strings.ReplaceAll(strings.TrimSpace(raw), "\n", "|"), func(t *testing.T) {
+			h, _ := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+				return raw, nil
+			})
+			h.herdr.setPane("Task is complete.\n")
+
+			ctx := context.Background()
+			h.push("agent-20", "idle")
+			var esc []domain.AuditRecord
+			waitFor(t, 3*time.Second, func() bool {
+				esc, _ = h.raw.PendingEscalations(ctx)
+				return len(esc) == 1
+			})
+			if esc[0].Suggestion != domain.ActionNoopSuggestion {
+				t.Errorf("suggestion = %q, want the noop suggestion %q",
+					esc[0].Suggestion, domain.ActionNoopSuggestion)
+			}
+			if strings.HasPrefix(esc[0].Suggestion, domain.SuggestTaskPrefix) {
+				t.Error("a decline must never be surfaced as a confirmable generated task")
+			}
+			// The CLI worked, so offering `l: retry LLM` would only re-ask a
+			// model that already answered.
+			if domain.IsRetryableLLMEscalation(&esc[0]) {
+				t.Errorf("a decline must not be retryable, got rationale %q", esc[0].Rationale)
+			}
+			if strings.Contains(esc[0].Rationale, string(domain.ReasonTaskGenFailed)) {
+				t.Errorf("a decline must not be tagged as a failure, got %q", esc[0].Rationale)
+			}
+			// Confirming it learns @noop, never the literal sentinel text.
+			if got := suggestionAction(&esc[0]); got != domain.ActionNoop {
+				t.Errorf("suggestionAction = %q, want %q", got, domain.ActionNoop)
+			}
+			if len(h.herdr.sentInputs()) != 0 {
+				t.Errorf("nothing may be sent to the pane, sent %v", h.herdr.sentInputs())
+			}
+			if pending, _ := h.raw.HasPendingLLMConsult(ctx, "agent-20"); pending {
+				t.Error("a resolved task generation must not leave a pending request")
+			}
+		})
+	}
+}
+
+func TestIdleTaskGenStripsNoopFromRealTasks(t *testing.T) {
+	// A model told to reply "@noop" often adds real tasks (or a justification)
+	// beside it. The real work must survive, but the sentinel must NEVER reach
+	// the suggestion — from there a confirm --send would type the literal
+	// "@noop" into the agent's pane.
+	cases := map[string]string{
+		"- @noop\n- Add the missing parser tests": "- Add the missing parser tests",
+		"- Add the missing parser tests\n- @noop": "- Add the missing parser tests",
+	}
+	for raw, wantTask := range cases {
+		t.Run(strings.ReplaceAll(raw, "\n", "|"), func(t *testing.T) {
+			h, _ := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+				return raw, nil
+			})
+			h.herdr.setPane("Task is complete.\n")
+
+			ctx := context.Background()
+			h.push("agent-20", "idle")
+			var esc []domain.AuditRecord
+			waitFor(t, 3*time.Second, func() bool {
+				esc, _ = h.raw.PendingEscalations(ctx)
+				return len(esc) == 1
+			})
+			if want := domain.SuggestTaskPrefix + wantTask; esc[0].Suggestion != want {
+				t.Errorf("suggestion = %q, want %q", esc[0].Suggestion, want)
+			}
+			// Belt and braces: whatever the confirm path would write must not
+			// contain the sentinel.
+			confirmable := strings.TrimPrefix(esc[0].Suggestion, domain.SuggestTaskPrefix)
+			for _, task := range domain.NormalizeGeneratedTasks(confirmable) {
+				if domain.IsNoopAction(domain.NormalizeNoopAction(task)) {
+					t.Errorf("sentinel survived into confirmable task %q", task)
+				}
+			}
+		})
+	}
+}
+
+func TestIdleTaskGenUnusableOutputIsRetryableEscalation(t *testing.T) {
+	// Output that is non-empty but parses to no task (a bare horizontal rule,
+	// punctuation only) used to become a confirmable escalation that could
+	// ONLY fail at confirm time. It is a broken CLI, so it is retryable —
+	// unlike the decline above, which is the CLI working as asked.
+	for _, raw := range []string{"---", "***", "- \n- ", "..."} {
+		t.Run(strings.TrimSpace(raw), func(t *testing.T) {
+			h, _ := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+				return raw, nil
+			})
+			h.herdr.setPane("Task is complete.\n")
+
+			ctx := context.Background()
+			h.push("agent-21", "idle")
+			var esc []domain.AuditRecord
+			waitFor(t, 3*time.Second, func() bool {
+				esc, _ = h.raw.PendingEscalations(ctx)
+				return len(esc) == 1
+			})
+			if strings.HasPrefix(esc[0].Suggestion, domain.SuggestTaskPrefix) {
+				t.Errorf("unusable output must not be confirmable, got suggestion %q", esc[0].Suggestion)
+			}
+			if esc[0].Suggestion == domain.ActionNoopSuggestion {
+				t.Error("unusable output is a broken CLI, not a decline")
+			}
+			if !domain.IsRetryableLLMEscalation(&esc[0]) {
+				t.Errorf("unusable output should be retryable, got rationale %q", esc[0].Rationale)
+			}
+		})
+	}
+}
+
+func TestIdleTaskGenEscalatesRawSoConfirmParsesOnce(t *testing.T) {
+	// The daemon must NOT pre-normalize: NormalizeGeneratedTasks is not
+	// idempotent, so a normalized "1. Fix the parser" would re-read as an
+	// ordered-list marker on the confirm path's own parse and silently drop
+	// the unmarked item beside it. Escalating the raw text keeps that to one
+	// pass. The sentinel line is still removed.
+	h, _ := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+		return "- 1. Fix the parser\n- Add tests\n- @noop", nil
+	})
+	h.herdr.setPane("Task is complete.\n")
+
+	ctx := context.Background()
+	h.push("agent-20", "idle")
+	var esc []domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	want := domain.SuggestTaskPrefix + "- 1. Fix the parser\n- Add tests"
+	if esc[0].Suggestion != want {
+		t.Fatalf("suggestion = %q, want the raw (sentinel-stripped) %q", esc[0].Suggestion, want)
+	}
+	// What the confirm path would actually write: both tasks, neither lost.
+	got := domain.NormalizeGeneratedTasks(strings.TrimPrefix(esc[0].Suggestion, domain.SuggestTaskPrefix))
+	wantTasks := []string{"1. Fix the parser", "Add tests"}
+	if len(got) != len(wantTasks) {
+		t.Fatalf("confirm would write %q, want %q", got, wantTasks)
+	}
+	for i := range wantTasks {
+		if got[i] != wantTasks[i] {
+			t.Errorf("task %d = %q, want %q", i, got[i], wantTasks[i])
+		}
+	}
+}
+
 func TestIdleTaskGenFailureIsRetryableEscalation(t *testing.T) {
 	// A failed generation surfaces the rationale and is retryable with `l`.
 	h, _ := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {

--- a/internal/domain/taskgen.go
+++ b/internal/domain/taskgen.go
@@ -185,6 +185,60 @@ func NormalizeGeneratedTasks(raw string) []string {
 	return tasks
 }
 
+// StripNoopGeneratedLines removes the noop sentinel from a generate-task CLI's
+// raw stdout, returning the remaining text and whether any sentinel was found.
+// The sentinel is the model's explicit "no new task is needed" decline — the
+// ONLY way a generation can decline without looking like a broken CLI, since an
+// empty response is indistinguishable from a crashed or misconfigured command
+// (that stays a retryable ReasonTaskGenFailed). A response that is NOTHING but
+// sentinels leaves no text, which is how the caller recognizes the decline and
+// routes it to an ActionNoopSuggestion escalation instead.
+//
+// It works LINE-WISE on the raw text rather than on NormalizeGeneratedTasks'
+// output for two reasons. First, the sentinel must never survive into the task
+// list: a model told to reply "@noop" often adds a line of justification, and
+// judging the response as a whole would then classify it as real work and write
+// "@noop" into tasks.md — where a later confirm --send would type the literal
+// sentinel into the agent's pane. Dropping just the sentinel line closes that
+// regardless of what else the model said. Second, the remaining text stays RAW
+// so the confirm path normalizes exactly once; NormalizeGeneratedTasks is not
+// idempotent (a normalized "1. Fix parser" re-reads as an ordered-list marker,
+// which would flip a second pass into list mode and silently drop the unmarked
+// items beside it), so the daemon must not hand it pre-normalized text.
+//
+// A line is a sentinel when its bare task text — marker and Markdown emphasis
+// stripped, exactly as NormalizeGeneratedTasks would reduce it — is one of
+// NormalizeNoopAction's spellings ("@noop", "noop", "no_op", "no-op",
+// case-insensitive). Reusing that keeps this in step with the consult path's
+// sentinel rather than defining a second one. Fence lines are left alone; the
+// parser skips them anyway.
+func StripNoopGeneratedLines(raw string) (string, bool) {
+	lines := strings.Split(raw, "\n")
+	kept := make([]string, 0, len(lines))
+	sawNoop := false
+	for _, line := range lines {
+		if !isFenceLine(line) && isNoopLine(line) {
+			sawNoop = true
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n")), sawNoop
+}
+
+// isNoopLine reports whether one raw line reduces to the noop sentinel. It
+// mirrors NormalizeGeneratedTasks' per-line reduction (optional list/checkbox
+// marker, then inline emphasis) so "@noop", "- @noop", "`@noop`" and
+// "- [ ] NO-OP" are all recognized.
+func isNoopLine(line string) bool {
+	t := line
+	if m := listItemRE.FindStringSubmatch(line); m != nil {
+		t = m[1]
+	}
+	t = strings.TrimSpace(stripInlineEmphasis(strings.TrimSpace(t)))
+	return IsNoopAction(NormalizeNoopAction(t))
+}
+
 // hasAlphanumeric reports whether s contains any letter or digit.
 func hasAlphanumeric(s string) bool {
 	for _, r := range s {

--- a/internal/domain/taskgen_test.go
+++ b/internal/domain/taskgen_test.go
@@ -284,3 +284,88 @@ func TestGeneratedTaskIdentityEscapedID(t *testing.T) {
 		}
 	}
 }
+
+// TestStripNoopGeneratedLines: the sentinel is how a model says "no new task
+// is needed" without looking like a broken CLI. It must be recognized in the
+// shapes a model actually emits, must never survive into the remaining text
+// (where it would be written into a checklist and could be typed into a pane),
+// and must leave any real task beside it intact. An all-sentinel response
+// leaves nothing, which is how the caller tells a decline from real work.
+func TestStripNoopGeneratedLines(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		want    string
+		wantSaw bool
+	}{
+		{"bare", "@noop", "", true},
+		{"padded", "  @noop  \n", "", true},
+		{"bulleted", "- @noop", "", true},
+		{"checkbox", "- [ ] @noop", "", true},
+		{"code span", "`@noop`", "", true},
+		{"bold", "**@noop**", "", true},
+		{"numbered", "1. @noop", "", true},
+		{"no prefix", "noop", "", true},
+		{"underscore", "no_op", "", true},
+		{"hyphen", "no-op", "", true},
+		{"upper", "NO-OP", "", true},
+		{"two declines", "- @noop\n- noop", "", true},
+		// Real work beside the sentinel survives — but the sentinel itself is
+		// always removed, so it can never reach a task list or a pane.
+		{"with real task", "- @noop\n- Add parser tests", "- Add parser tests", true},
+		{"sentinel last", "- Add parser tests\n- @noop", "- Add parser tests", true},
+		// No sentinel: the text is returned unchanged (only trimmed), so the
+		// confirm path still normalizes exactly once.
+		{"free text", "do nothing", "do nothing", false},
+		{"noop inside a task", "Make @noop the default", "Make @noop the default", false},
+		{"prose decline", "No new task is needed.", "No new task is needed.", false},
+		{"ordinary task", "Fix the flaky login test", "Fix the flaky login test", false},
+		{"markdown list untouched", "Here are the tasks:\n- **Fix** the login test\n- Backfill `parser` tests",
+			"Here are the tasks:\n- **Fix** the login test\n- Backfill `parser` tests", false},
+		// Empty is NOT a decline: it is indistinguishable from a crashed CLI,
+		// so the caller keeps it a retryable failure.
+		{"empty", "", "", false},
+		{"blank lines", "\n\n", "", false},
+		{"horizontal rule", "---", "---", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, saw := StripNoopGeneratedLines(tc.raw)
+			if got != tc.want || saw != tc.wantSaw {
+				t.Errorf("StripNoopGeneratedLines(%q) = (%q, %v), want (%q, %v)",
+					tc.raw, got, saw, tc.want, tc.wantSaw)
+			}
+			// Whatever survives must never still carry the sentinel.
+			for _, task := range NormalizeGeneratedTasks(got) {
+				if IsNoopAction(NormalizeNoopAction(task)) {
+					t.Errorf("sentinel survived into task %q", task)
+				}
+			}
+		})
+	}
+}
+
+// TestStripNoopGeneratedLinesKeepsConfirmParseSingle: the daemon escalates the
+// stripped text RAW and the confirm path parses it. NormalizeGeneratedTasks is
+// not idempotent, so this pins that one pass over the stripped text yields what
+// one pass over the original (minus the sentinel) would — i.e. the daemon never
+// pre-normalizes and makes the two passes disagree.
+func TestStripNoopGeneratedLinesKeepsConfirmParseSingle(t *testing.T) {
+	// An ordered marker inside an item is exactly what a second pass would
+	// re-read as a list marker, dropping the unmarked item beside it.
+	raw := "- 1. Fix the parser\n- Add tests\n- @noop"
+	stripped, saw := StripNoopGeneratedLines(raw)
+	if !saw {
+		t.Fatal("sentinel should have been detected")
+	}
+	got := NormalizeGeneratedTasks(stripped)
+	want := []string{"1. Fix the parser", "Add tests"}
+	if len(got) != len(want) {
+		t.Fatalf("NormalizeGeneratedTasks(%q) = %q, want %q", stripped, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("task %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -4689,3 +4689,69 @@ func TestRemoveTaskSourceDuplicatePathReordered(t *testing.T) {
 		t.Errorf("wrong source removed: %+v", cfg.TaskSources)
 	}
 }
+
+// TestConfirmTaskGenNoopLearnsNoopWithoutTaskSource: a generate-task decline
+// escalates as the human-readable noop suggestion, NOT as a generated task.
+// Confirming it must learn a plain @noop rule and touch nothing else — no
+// tasks.md, no registered task source, and nothing typed into the pane, even
+// with --send.
+func TestConfirmTaskGenNoopLearnsNoopWithoutTaskSource(t *testing.T) {
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w9:p9")
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w9:p9", SituationType: domain.SituationIdle, Trigger: "t",
+		Signature: "sig-noop", AgentType: "claude",
+		Action: "escalated", Status: "escalated",
+		Suggestion: domain.ActionNoopSuggestion, CreatedAt: time.Now(),
+	})
+
+	// The escalation resolves to the sentinel, never to a generated task.
+	audit, err := st.GetAudit(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := frontend.SuggestedAction(audit); got != domain.ActionNoop {
+		t.Fatalf("SuggestedAction = %q, want %q", got, domain.ActionNoop)
+	}
+
+	// --send must still send nothing: a noop is learned, never typed.
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatalf("confirming a decline: %v", err)
+	}
+	if len(fake.inputs) != 0 {
+		t.Errorf("a confirmed decline must send nothing, sent %v", fake.inputs)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "tasks", name+".md")); !os.IsNotExist(err) {
+		t.Error("a confirmed decline must not write a tasks file")
+	}
+	cfg, _ := config.Load(app.ConfigPath)
+	if len(cfg.TaskSources) != 0 {
+		t.Errorf("a confirmed decline must not register a task source, got %d", len(cfg.TaskSources))
+	}
+	// The learned action is the sentinel, so the raw text never reaches a pane.
+	corrs, err := st.UnprocessedCorrections(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mine []domain.CorrectionRecord
+	for _, c := range corrs {
+		if c.AuditID == id {
+			mine = append(mine, c)
+		}
+	}
+	if len(mine) != 1 {
+		t.Fatalf("want 1 recorded correction for the escalation, got %d", len(mine))
+	}
+	if mine[0].CorrectedAction != domain.ActionNoop {
+		t.Errorf("learned action = %q, want %q", mine[0].CorrectedAction, domain.ActionNoop)
+	}
+	if mine[0].Sent {
+		t.Error("a confirmed decline must not be recorded as delivered")
+	}
+}

--- a/internal/tui/confirm_nosend_test.go
+++ b/internal/tui/confirm_nosend_test.go
@@ -1,0 +1,293 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// The Escalations tab splits the two halves of a confirm, matching the CLI's
+// `hap confirm <id>` with and without --send:
+//
+//	enter → confirm AND send (unchanged)
+//	y     → confirm only: the rule is learned, nothing reaches a pane
+//
+// These pin the split, the y-batch semantics, and — most importantly — that y
+// never sends.
+
+// noSendModel parks a model on the Escalations tab with n pending escalations
+// loaded (cursor at the top) and returns their ids in list order.
+func noSendModel(t *testing.T, n int) (Model, *store.Store, *fakeHerdrTUI, []int64) {
+	t.Helper()
+	m, st, fh := correctTestModel(t)
+	ctx := context.Background()
+	var ids []int64
+	var rows []domain.AuditRecord
+	for i := 0; i < n; i++ {
+		// The suggested action is deliberately NOT "y": the shared fixture
+		// suggests "respond: y", which is the same character as the key under
+		// test, so a regression recording the KEYSTROKE instead of the
+		// suggestion would pass unnoticed.
+		id, err := st.AppendAudit(ctx, domain.AuditRecord{
+			AgentID: "w1:p1", Signature: "sig", Trigger: "t",
+			SituationType: domain.SituationApproval, Action: "escalated",
+			Status: "escalated", Suggestion: "respond: 2", CreatedAt: time.Now(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rec, err := st.GetAudit(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+		rows = append(rows, *rec)
+	}
+	m.tab = tabEscalations
+	m.data.escalations = rows
+	m.cursors[tabEscalations] = 0
+	return m, st, fh, ids
+}
+
+// noSendCorrections returns every recorded correction for an audit id.
+func noSendCorrections(t *testing.T, st *store.Store, id int64) []domain.CorrectionRecord {
+	t.Helper()
+	all, err := st.UnprocessedCorrections(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mine []domain.CorrectionRecord
+	for _, c := range all {
+		if c.AuditID == id {
+			mine = append(mine, c)
+		}
+	}
+	return mine
+}
+
+// pressAct sends one key to the model and RUNS whatever command it returns,
+// failing on an action error. The shared press helper discards the command,
+// which is exactly the part these tests need.
+func pressAct(t *testing.T, m Model, key string) (Model, actionResultMsg) {
+	t.Helper()
+	upd, cmd := m.Update(pressKeyMsg(key))
+	m = upd.(Model)
+	if cmd == nil {
+		return m, actionResultMsg{}
+	}
+	msg, ok := cmd().(actionResultMsg)
+	if !ok {
+		return m, actionResultMsg{}
+	}
+	if msg.err != nil {
+		t.Fatalf("action failed: %v", msg.err)
+	}
+	return m, msg
+}
+
+func TestEscalationYConfirmsWithoutSending(t *testing.T) {
+	m, st, fh, ids := noSendModel(t, 1)
+
+	_, msg := pressAct(t, m, "y")
+
+	// The whole point: nothing reaches the agent.
+	if len(fh.inputs) != 0 {
+		t.Errorf("y must not send to the pane, sent %v", fh.inputs)
+	}
+	// The toast must say BOTH: nothing was sent, and the agent is therefore
+	// still unanswered — "confirm only" must not read as "send it later".
+	for _, want := range []string{"nothing sent", "not answered"} {
+		if !strings.Contains(msg.message, want) {
+			t.Errorf("message = %q, missing %q", msg.message, want)
+		}
+	}
+	// But the rule IS learned, exactly as a confirm+send would learn it.
+	corrs := noSendCorrections(t, st, ids[0])
+	if len(corrs) != 1 {
+		t.Fatalf("want 1 recorded correction, got %d", len(corrs))
+	}
+	if corrs[0].Sent {
+		t.Error("a y-confirm must be recorded as NOT delivered")
+	}
+	if corrs[0].CorrectedAction != "2" {
+		t.Errorf("learned action = %q, want the SUGGESTION's action %q (not the pressed key)",
+			corrs[0].CorrectedAction, "2")
+	}
+	// (The escalation row is flipped to resolved by the daemon when it
+	// processes the correction — same for enter, so nothing to assert here.)
+}
+
+func TestEscalationEnterStillConfirmsAndSends(t *testing.T) {
+	// Enter keeps the old behavior — the split must not quietly disarm it.
+	m, st, fh, ids := noSendModel(t, 1)
+
+	pressAct(t, m, "enter")
+
+	if len(fh.inputs) == 0 {
+		t.Fatal("enter must still deliver to the pane")
+	}
+	corrs := noSendCorrections(t, st, ids[0])
+	if len(corrs) != 1 || !corrs[0].Sent {
+		t.Errorf("enter must record the correction as delivered, got %+v", corrs)
+	}
+}
+
+func TestEscalationYConfirmsMarkedBatchWithoutSending(t *testing.T) {
+	// y acts on the marked batch (x's semantics), because recording agreement
+	// touches no agent. Enter deliberately stays single-row.
+	m, st, fh, ids := noSendModel(t, 3)
+	ctx := context.Background()
+	// Mark the first and third, leave the cursor on the first.
+	m.marked = map[int64]bool{ids[0]: true, ids[2]: true}
+
+	pressAct(t, m, "y")
+
+	if len(fh.inputs) != 0 {
+		t.Errorf("a batch y must not send anything, sent %v", fh.inputs)
+	}
+	for _, id := range []int64{ids[0], ids[2]} {
+		if got := noSendCorrections(t, st, id); len(got) != 1 {
+			t.Errorf("marked #%d: want 1 correction, got %d", id, len(got))
+		} else if got[0].Sent {
+			t.Errorf("marked #%d must not be recorded as delivered", id)
+		}
+	}
+	// The unmarked row is untouched — a batch must not sweep up neighbours.
+	if got := noSendCorrections(t, st, ids[1]); len(got) != 0 {
+		t.Errorf("unmarked #%d must be left alone, got %d correction(s)", ids[1], len(got))
+	}
+	if after, _ := st.GetAudit(ctx, ids[1]); after.Status != "escalated" {
+		t.Errorf("unmarked #%d status = %q, want it still pending", ids[1], after.Status)
+	}
+}
+
+func TestEscalationYFallsBackToCursorRowWhenNothingMarked(t *testing.T) {
+	m, st, fh, ids := noSendModel(t, 2)
+	m.cursors[tabEscalations] = 1 // second row
+
+	pressAct(t, m, "y")
+
+	if got := noSendCorrections(t, st, ids[1]); len(got) != 1 {
+		t.Errorf("cursor row #%d: want 1 correction, got %d", ids[1], len(got))
+	}
+	if got := noSendCorrections(t, st, ids[0]); len(got) != 0 {
+		t.Errorf("row #%d is neither marked nor under the cursor, got %d correction(s)", ids[0], len(got))
+	}
+	if len(fh.inputs) != 0 {
+		t.Errorf("y must not send, sent %v", fh.inputs)
+	}
+}
+
+func TestEscalationDetailYConfirmsSnapshotWithoutSending(t *testing.T) {
+	// The detail overlay's y mirrors the list's, acting on the snapshotted id.
+	m, st, fh, ids := noSendModel(t, 1)
+	m.detail = &detailView{confirmID: ids[0]}
+
+	m, _ = pressAct(t, m, "y")
+
+	if m.detail != nil {
+		t.Error("y should close the detail overlay")
+	}
+	if len(fh.inputs) != 0 {
+		t.Errorf("detail y must not send, sent %v", fh.inputs)
+	}
+	if got := noSendCorrections(t, st, ids[0]); len(got) != 1 || got[0].Sent {
+		t.Errorf("detail y must record an undelivered correction, got %+v", got)
+	}
+}
+
+func TestEscalationYClearsMarksSoRepeatPressDoesNotDoubleRecord(t *testing.T) {
+	// A confirmed row stays "escalated" until the DAEMON processes the
+	// correction, and Confirm has no status guard — so an impatient second y
+	// over a surviving batch would insert a second correction per id, i.e. a
+	// second operator decision for one act of agreement. Clearing the marks on
+	// dispatch keeps the repeat press to the cursor row.
+	m, st, fh, ids := noSendModel(t, 3)
+	m.marked = map[int64]bool{ids[0]: true, ids[2]: true}
+
+	upd, cmd := m.Update(pressKeyMsg("y"))
+	m = upd.(Model)
+	if len(m.marked) != 0 {
+		t.Errorf("marks = %v, want them cleared on dispatch", m.marked)
+	}
+	if cmd != nil {
+		if msg, ok := cmd().(actionResultMsg); ok && msg.err != nil {
+			t.Fatalf("batch confirm failed: %v", msg.err)
+		}
+	}
+	// Second press: with no marks it targets the cursor row (ids[0]) only, so
+	// the OTHER batch member must not gain a second correction.
+	pressAct(t, m, "y")
+	if got := noSendCorrections(t, st, ids[2]); len(got) != 1 {
+		t.Errorf("#%d gained %d corrections across two presses, want 1", ids[2], len(got))
+	}
+	if len(fh.inputs) != 0 {
+		t.Errorf("y must not send, sent %v", fh.inputs)
+	}
+}
+
+func TestEscalationYSkipsFailuresAndConfirmsTheRest(t *testing.T) {
+	// Skip-and-continue: a failing id (here one whose audit row does not
+	// exist) must not abort the batch — the healthy rows still confirm and the
+	// error names what was skipped.
+	m, st, fh, ids := noSendModel(t, 2)
+	const ghost int64 = 999999
+	m.data.escalations = append(m.data.escalations, domain.AuditRecord{
+		ID: ghost, AgentID: "w1:p1", Status: "escalated", Suggestion: "respond: 2",
+	})
+	m.marked = map[int64]bool{ids[0]: true, ghost: true, ids[1]: true}
+
+	upd, cmd := m.Update(pressKeyMsg("y"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("y must produce an action command")
+	}
+	msg, ok := cmd().(actionResultMsg)
+	if !ok {
+		t.Fatalf("y produced %T, want actionResultMsg", cmd())
+	}
+	if msg.err == nil {
+		t.Fatal("a failing id must surface an error")
+	}
+	if !strings.Contains(msg.err.Error(), "confirmed 2") ||
+		!strings.Contains(msg.err.Error(), fmt.Sprintf("#%d", ghost)) {
+		t.Errorf("error = %q, should report 2 confirmed and name the skipped id", msg.err)
+	}
+	for _, id := range ids {
+		if got := noSendCorrections(t, st, id); len(got) != 1 {
+			t.Errorf("#%d: want 1 correction despite the failing sibling, got %d", id, len(got))
+		}
+	}
+	if len(fh.inputs) != 0 {
+		t.Errorf("y must not send, sent %v", fh.inputs)
+	}
+}
+
+func TestEscalationYOnEmptyListDoesNothing(t *testing.T) {
+	m, _, fh, _ := noSendModel(t, 0)
+
+	_, cmd := m.Update(pressKeyMsg("y"))
+	if cmd != nil {
+		if msg, ok := cmd().(actionResultMsg); ok && (msg.err != nil || msg.message != "") {
+			t.Errorf("y on an empty list produced %+v, want no action", msg)
+		}
+	}
+	if len(fh.inputs) != 0 {
+		t.Errorf("y must not send, sent %v", fh.inputs)
+	}
+}
+
+func TestEscalationHelpAdvertisesTheSplit(t *testing.T) {
+	m, _, _, _ := noSendModel(t, 1)
+	help := m.helpLine()
+	for _, want := range []string{"enter: confirm+send", "y: confirm only (marked)"} {
+		if !strings.Contains(help, want) {
+			t.Errorf("escalations help line %q missing %q", help, want)
+		}
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1114,6 +1114,12 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			m.detail = nil
 		case "y":
+			// On an escalation's detail, y confirms the snapshotted record
+			// WITHOUT sending — the list's y in overlay form.
+			if id := m.detail.confirmID; id != 0 {
+				m.detail = nil
+				return m.confirmIDWithoutSend(id)
+			}
 			if r := m.detail.task; r != nil {
 				m.detail = nil
 				return m.sendTaskRow(*r)
@@ -1379,7 +1385,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "y":
 		switch m.tab {
 		case tabEscalations:
-			return m.confirmSelected()
+			// y is confirm WITHOUT send (Enter is confirm+send): the rule is
+			// learned, nothing reaches a pane. Matches `hap confirm` with no
+			// --send.
+			return m.confirmWithoutSend()
 		case tabTasks:
 			return m.sendSelectedTask()
 		}
@@ -1647,6 +1656,84 @@ func (m Model) confirmAuditID(id int64) (tea.Model, tea.Cmd) {
 	}
 }
 
+// confirmWithoutSend is what y targets: it agrees with the suggestion — the
+// correction is recorded, so the rule is learned and graduates exactly as a
+// confirm+send would — but nothing is delivered to any pane. This is the TUI
+// half of the CLI's `hap confirm <id>` (no --send); Enter remains confirm+send.
+//
+// Unlike Enter it acts on the marked BATCH (or the cursor row when nothing is
+// marked), mirroring x. The asymmetry is deliberate: recording agreement
+// touches no agent, so doing it to a run of rows is safe, whereas one keypress
+// firing keystrokes into several live panes at once is not — a batch Enter
+// would be the dangerous half of the pair. Skip-and-continue like the delete
+// batch: a failed id usually means the row was resolved concurrently, and the
+// rest still confirm.
+//
+// Two hazards this has to handle, both from the row staying "escalated" until
+// the DAEMON processes the correction (it is what flips the status), which can
+// be a sweep away:
+//
+//   - Repeat presses would each insert another correction — a second operator
+//     decision for one act of agreement, inflating the signature's confidence.
+//     Confirm has no status guard to catch it (unlike Dismiss), so the marks
+//     are cleared on dispatch: an impatient second y then targets only the
+//     cursor row instead of silently re-confirming the whole batch.
+//   - The Cmd must join m.inflight, or quitting right after a batch can exit
+//     the update loop mid-write and drop learning events that were never
+//     recorded. A lost dismiss is recoverable; a lost learning event is not.
+//
+// Note what y does NOT do: the escalation leaves the queue, but the agent is
+// never answered — it stays blocked until something else replies. And on a
+// generated-task suggestion this still writes the agent's tasks.md and
+// registers its task source (Confirm's send flag only gates pane delivery),
+// so a batch is several config mutations. Nothing reaches a pane either way.
+func (m Model) confirmWithoutSend() (tea.Model, tea.Cmd) {
+	ids := m.targetEscalationIDs()
+	if len(ids) == 0 {
+		return m, nil
+	}
+	app, ctx, wg := m.app, m.ctx, m.inflight
+	desc := describeEscalations(ids)
+	m.beginAction()
+	m.marked = nil
+	if wg != nil {
+		wg.Add(1)
+	}
+	return m, func() tea.Msg {
+		if wg != nil {
+			defer wg.Done()
+		}
+		confirmed := 0
+		var skipped []string
+		var firstErr error
+		for _, id := range ids {
+			if err := app.Confirm(ctx, id, false); err != nil {
+				skipped = append(skipped, fmt.Sprintf("#%d", id))
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			confirmed++
+		}
+		if firstErr != nil {
+			return actionResultMsg{err: fmt.Errorf("confirmed %d, skipped %s: %w",
+				confirmed, strings.Join(skipped, " "), firstErr)}
+		}
+		return actionResultMsg{message: fmt.Sprintf(
+			"confirmed %s — learned, nothing sent (the agent is not answered)", desc)}
+	}
+}
+
+// confirmIDWithoutSend confirms one escalation by id without sending — the
+// detail overlay's y, acting on the record it snapshotted rather than the live
+// cursor (and never on the list's marks, which the overlay does not show).
+func (m Model) confirmIDWithoutSend(id int64) (tea.Model, tea.Cmd) {
+	m.beginAction()
+	return m, m.do(fmt.Sprintf("confirmed #%d — learned, nothing sent (the agent is not answered)", id),
+		func(ctx context.Context) error { return m.app.Confirm(ctx, id, false) })
+}
+
 // openAddPrompt asks whether to queue a stale generated-task suggestion onto the
 // agent's declared task list without sending — the agent is busy, so a send
 // would interrupt it, but the task itself is still valid. Answering "y" accepts
@@ -1794,9 +1881,9 @@ func (m Model) toggleMarkSelected() (tea.Model, tea.Cmd) {
 		m.marked[rec.ID] = true
 	}
 	if len(m.marked) == 0 {
-		m.message = "no marks — x deletes the row under the cursor"
+		m.message = "no marks — x/y act on the row under the cursor"
 	} else {
-		m.message = fmt.Sprintf("%d marked — x deletes them", len(m.marked))
+		m.message = fmt.Sprintf("%d marked — x deletes them, y confirms them without sending", len(m.marked))
 	}
 	if m.cursors[m.tab] < m.rowCount()-1 {
 		m.cursors[m.tab]++
@@ -1808,9 +1895,18 @@ func (m Model) toggleMarkSelected() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// deleteEscalationIDs is what x targets: the marked escalations (in list
-// order), or just the cursor row when nothing is marked.
-func (m Model) deleteEscalationIDs() []int64 {
+// targetEscalationIDs is the batch both x (delete) and y (confirm without
+// sending) act on: the marked escalations (in list order), or just the cursor
+// row when nothing is marked. Enter deliberately does NOT use it — see
+// confirmWithoutSend.
+//
+// Marks are read from ALL pending escalations while the cursor fallback follows
+// the visible (filtered) list, so with an active "/" filter the batch can
+// include marked rows that are currently off screen. That is deliberate — a
+// filter narrows the view, not the selection the operator already made — but it
+// means y can record learning events for rows the operator cannot see, so clear
+// the marks (or the filter) before batching if that matters.
+func (m Model) targetEscalationIDs() []int64 {
 	var ids []int64
 	for _, e := range m.data.escalations {
 		if m.marked[e.ID] {
@@ -1825,7 +1921,7 @@ func (m Model) deleteEscalationIDs() []int64 {
 	return ids
 }
 
-// describeEscalations names the delete targets compactly: "escalation #41"
+// describeEscalations names the action targets compactly: "escalation #41"
 // or "3 escalations (#41 #40 #39)", eliding a long id list.
 func describeEscalations(ids []int64) string {
 	if len(ids) == 1 {
@@ -1846,7 +1942,7 @@ func describeEscalations(ids []int64) string {
 // confirmation: dismissing is safe (nothing is sent or learned) and the
 // audit rows are kept with status "dismissed".
 func (m Model) deleteEscalations() (tea.Model, tea.Cmd) {
-	ids := m.deleteEscalationIDs()
+	ids := m.targetEscalationIDs()
 	if len(ids) == 0 {
 		return m, nil
 	}
@@ -4105,7 +4201,7 @@ func (m Model) helpLine() string {
 			if m.detail.escRetryable {
 				retry = "  l: retry LLM"
 			}
-			return "enter: confirm+send  c: correct (+send?)  x: delete  f: focus in herdr" + rule + retry +
+			return "enter: confirm+send  y: confirm only  c: correct (+send?)  x: delete  f: focus in herdr" + rule + retry +
 				preview + "  ↑/↓: scroll  tab: switch tab  " + closeKeys
 		}
 		if m.detail.agent != nil {
@@ -4146,7 +4242,7 @@ func (m Model) helpLine() string {
 	case tabTasks:
 		return "enter/y: send to agent  v: details  a: add  e: edit  d: done/undone  x: delete (source on a header)  space: mark  f: focus in herdr  /: search  " + common
 	case tabEscalations:
-		return "enter/y: confirm+send  c: correct (+send?)  l: retry LLM  f: focus in herdr  t: see rule  space: mark  x: delete  X: prune old  v: details  /: search  " + common
+		return "enter: confirm+send  y: confirm only (marked)  c: correct (+send?)  l: retry LLM  f: focus in herdr  t: see rule  space: mark  x: delete  X: prune old  v: details  /: search  " + common
 	case tabAudit:
 		return "c: correct decision  v: details  t: see rule  /: search  " + common
 	case tabSignatures:

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -137,16 +137,25 @@ pane_excerpt_chars = 5000          # pane context included in the consult
 # that case, so task_generate_command is always used, never *_start. Without
 # both set, an exhausted source escalates a confirmable @noop suggestion
 # ("No more pending tasks") instead of the old "none" prompt.
+#
+# The command can DECLINE: replying with "@noop" (also "noop", "no_op",
+# "no-op") means "no new task is needed". As the WHOLE reply it escalates as a
+# confirmable "do nothing" and confirming it learns a @noop rule. The sentinel
+# line is always stripped, so it is never written into the task list (and so
+# never typed into a pane by a later confirm --send) — but anything beside it
+# still counts as work, so ask for the sentinel alone. An EMPTY reply is not a
+# decline (it looks like a crashed CLI) and stays a retryable failure. The
+# prompt must name the sentinel for the model to ever use it.
 # (Renamed from generate_task_command; the old key no longer loads — update it.)
 task_generate_command = [
   "claude", "--model", "opus", "-p",
-  "Suggest up to 3 concrete next tasks for this project's coding agent, in priority order. Reply ONLY with tasks, one per line.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
+  "Suggest up to 3 concrete next tasks for this project's coding agent, in priority order. Reply ONLY with tasks, one per line. If no new task is needed, reply with exactly @noop and nothing else.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
 ]
 
 # ── Idle task suggestion — OpenAI Codex (commented; swap in to use codex) ──
 # task_generate_command = [
 #   "codex", "--model", "gpt-5.6-sol", "exec", "--skip-git-repo-check",
-#   "Suggest up to 3 concrete next tasks for this project's coding agent, in priority order. Reply ONLY with tasks, one per line.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
+#   "Suggest up to 3 concrete next tasks for this project's coding agent, in priority order. Reply ONLY with tasks, one per line. If no new task is needed, reply with exactly @noop and nothing else.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
 # ]
 
 # task_generate_command_start runs INSTEAD on the agent's first task generation


### PR DESCRIPTION
## Problem

The LLM task-generation feature had **no way for the model to say "no new task is needed."**

- An **empty** reply became a retryable `task_gen_failed` — indistinguishable from a crashed or misconfigured CLI.
- **`@noop`** was not recognized at all on this path (it only existed for the consult/`submit_decision` flow). It has alphanumerics, so it survived `NormalizeGeneratedTasks` and was written into `tasks.md` as a literal task `1. @noop` — which a later `confirm --send` would type straight into the agent's pane.
- Output that was non-empty but parsed to **no task** (a bare `---`, punctuation only) was escalated raw and became a confirmable escalation that could **only** fail when the operator acted on it, since the confirm path runs that same parse and refuses.

## Change

`@noop` is now a first-class decline that routes to an `ActionNoopSuggestion` escalation, which the existing `SuggestedAction` round-trip confirms into a learned `@noop` rule that parks the situation. It is deliberately **not** `task_gen_failed`: the CLI worked, so offering `l: retry LLM` would only re-ask a model that already answered.

Three design points worth reviewing:

**The sentinel is stripped line-wise from the raw response**, not judged from the normalized list. A model told to reply `@noop` often adds a line of justification; judging the whole response would then classify it as real work and let the literal sentinel reach a task list and a pane. Dropping just the sentinel line closes that regardless of what else the model said. Accepted spellings come from the existing `NormalizeNoopAction`, so this stays in step with the consult path rather than defining a second sentinel.

**The escalated text stays RAW.** `NormalizeGeneratedTasks` is not idempotent — a normalized `1. Fix parser` re-reads as an ordered-list marker, which would flip the confirm path's own pass into list mode and silently drop the unmarked items beside it. The daemon parses only to **validate**, so the "is there a task" and "can this be confirmed" verdicts can no longer disagree.

**Empty stays a retryable failure.** It looks like a crashed CLI, not a decision — only the explicit sentinel parks.

Docs: the sample prompt templates (`sample/config.toml`, README) now name the sentinel — a model that is not told about it will never use it — and both note that anything the model puts *beside* the sentinel is still treated as work.

## Tests

- `internal/domain` — table test over the shapes a model actually emits (bare, bulleted, checkbox, code-spanned, bold, numbered, fenced, all four spellings, mixed case), plus an invariant that the sentinel never survives into any returned task, and a round-trip case pinning that one parse over the stripped text keeps both items of `- 1. Fix the parser\n- Add tests`.
- `internal/daemon` — a decline escalates the noop suggestion, is non-retryable, is not tagged as a failure, resolves to `@noop`, sends nothing, and leaves no pending request; a sentinel mixed with real tasks keeps the work and drops the sentinel; unusable output stays retryable; the suggestion is escalated raw so the confirm parse stays single-pass.
- `internal/frontend` — end-to-end confirm: a confirmed decline learns `@noop`, writes no `tasks.md`, registers no task source, and sends nothing **even with `--send`**.

Full suite (`-tags "vectors cpu"`), `go vet`, and `golangci-lint` all pass.

> Note: `TestIdleTaskGenAutoDismissesWhenAgentExits` fails when run under a `-run` filter but passes in a full package run. Verified pre-existing on untouched `main` (98f8693), unrelated to this change.

https://claude.ai/code/session_019oaepE4739f2yCZTtE4HuL



---

# Also in this PR: the TUI splits `enter` from `y`

The Escalations tab bound `enter` and `y` to the same confirm+send, so the CLI's `hap confirm <id>` **without** `--send` — record agreement, learn the rule, deliver nothing — had no TUI equivalent.

| key | behavior |
|---|---|
| `enter` | confirm **and send** (unchanged, cursor row) |
| `y` | **confirm only**: the correction is recorded so the rule is learned and graduates identically, but nothing reaches a pane |

`y` acts on the `space`-marked batch (or the cursor row when nothing is marked), mirroring `x`. **`enter` deliberately stays single-row**: recording agreement touches no agent, whereas one keypress firing keystrokes into several live panes is the dangerous half of the pair.

### Two hazards handled

Both come from the row staying `escalated` until the *daemon* processes the correction:

- **Marks are cleared on dispatch.** `Confirm` has no status guard (unlike `Dismiss`), so a repeat press over a surviving batch would insert a second correction per id — a second operator decision for one act of agreement, inflating the signature's confidence.
- **The batch Cmd joins `m.inflight`**, so quitting right after a batch cannot exit the update loop mid-write. A lost dismiss is recoverable; a lost learning event is not.

### What `y` does *not* do

Called out in both the toast and the README, because "confirm only" could otherwise read as "send it later":

- It does **not answer the agent** — the escalation leaves the queue, but a blocked pane stays blocked until something replies.
- On a **generated-task** suggestion it still queues the tasks and registers the task source. `Confirm`'s `send` flag gates only *pane delivery*.

### Verification

The safety claim — `y` can never reach a pane — was traced through `App.Confirm(ctx, id, false)`: `willSend` is the single delivery gate, and the one non-`willSend` branch (`acceptGeneratedTask`) gates its own delivery on the same flag.

Nine new tests in `internal/tui/confirm_nosend_test.go`: `y` doesn't send but does learn; `enter` still sends; the marked batch confirms without touching unmarked neighbours; cursor fallback; detail-overlay `y`; marks cleared so a repeat press can't double-record; skip-and-continue past a failing id; empty list is a no-op; the help line advertises the split. The learned-action assertion uses a suggestion (`respond: 2`) deliberately different from the pressed key, so a regression recording the *keystroke* cannot pass.

Full suite, `go vet`, and `golangci-lint` (0 issues) all pass.
