### PR TITLE
#1 fix: tighten never-auto token rule to skip route/status false positives

### DIFF
--- a/internal/domain/safety.go
+++ b/internal/domain/safety.go
@@ -49,8 +49,10 @@ var SeedNeverAutoPatterns = []string{
 	`(?i)\bgcloud\s+[^\n]*\bdelete\b`,
 	`(?i)\baz\s+[^\n]*\bdelete\b`,
 	// Credentials / secrets / auth
-	`(?i)(rotat|revok|delet|regenerat)(e|ing|ion)[^\n]*\b(credential|secret|api[- ]?key|token|password)s?\b`,
-	`(?i)\b(credential|secret|api[- ]?key|token|password)s?\b[^\n]*\b(rotat|revok|delet|regenerat)(e|ing|ion)`,
+	`(?i)(rotat|revok|delet|regenerat)(e|ing|ion)[^\n]*\b(credential|secret|api[- ]?key|password)s?\b`,
+	`(?i)\b(credential|secret|api[- ]?key|password)s?\b[^\n]*\b(rotat|revok|delet|regenerat)(e|ing|ion)`,
+	`(?i)\b(rotat|revok|delet|regenerat|invalidat)(e[sd]?|ing|ion)\b[^\n]{0,40}?\b(api|deploy|pat|service)[- ]?tokens?\b`,
+	`(?i)\b(api|deploy|pat|service)[- ]?tokens?\b[^\n]{0,40}?\b(rotat|revok|delet|regenerat|invalidat)(e[sd]?|ing|ion)\b`,
 	`(?i)gh\s+auth\s+(logout|refresh)`,
 	// System state
 	`(?i)\b(shutdown|reboot|poweroff|halt)\b`,


### PR DESCRIPTION
## Problem

A bare `token` in the strict credentials never-auto patterns escalated on everyday API/route prompts that revoke nothing — e.g. a task line like:

> Implement the unauthenticated read path `GET /api/public/links/:token` … returning 404/410 when `status='revoked'`

matched `token … revoked`, forcing an unnecessary escalation.

## Change

`internal/domain/safety.go` — the strict credentials group:

- Removed bare `token` from the two credential patterns (credential/secret/api-key/password).
- Added a **two-direction qualified-token pair**: a destructive verb (`rotate|revoke|delete|regenerate|invalidate`) within 40 chars of a **persistent-credential** token (`api|deploy|pat|service`), matching in both word orders (verb→token and token→verb), consistent with the existing credential-pair convention.
- **Session-based tokens excluded on purpose** (`access|refresh|bearer|session|jwt|id|oauth|auth|sso|csrf`) — they are short-lived and cheap to re-issue, so revoking/deleting them is low risk.

## Behavior

| Prompt | Before | After |
|---|---|---|
| `GET /links/:token … status='revoked'` (read path) | ❌ escalated (false positive) | ✅ passes |
| session/bearer/access/refresh/JWT token revocation | ❌ escalated | ✅ passes |
| `revoke the deploy token` / `rotate the api token` / `delete the service token` | ✅ escalates | ✅ escalates (both word orders) |

Situation text and outbound/rewritten answer text are screened independently by the same `NeverAutoList`, so this narrows only the false-positive surface without weakening the outbound screen.

## Tests

- `go test -tags "vectors cpu" ./internal/domain/ -count=1` — all pass.
- `TestSeedNeverAutoCatchesCorpus` — **51/51** (the `deploy token` corpus entry is now covered by a strict rule, not just the heuristic).
- `TestNeverAutoDoesNotMatchBenignPrompts`, `TestSuspectedIrreversibleHeuristic`, full NeverAuto/Safety regression matrix — green.
- Code-reviewed; the reviewer's directional-coverage note is addressed by the two-direction pair. RE2 engine → no ReDoS risk.

Patch-level change — auto-release handles the version bump on merge.

https://claude.ai/code/session_019oaepE4739f2yCZTtE4HuL