### PR TITLE
#1 fix: self-heal auto_send_when_idle hand-outs that never reached the agent

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -555,6 +555,18 @@ and the *Config* tab's `t` prompt takes the same words:
   row's trigger reads `auto-idle-send`.
 - an agent that is disabled, rate-paused, blocked, or has an open escalation is
   skipped.
+- **every sweep decides from current state, not from the last send.** a
+  successful send only means herdr took the keystrokes — text typed into a CLI
+  that is restarting or unfocused is silently lost, and the item would sit `[-]`
+  forever. so each hand-out is recorded, and confirmed only when herdr reports
+  that agent *working*. an unconfirmed hand-out whose agent is parked again
+  after ~2 minutes is returned to `[ ]` (audit status `reclaimed`) and re-offered
+  in the same sweep — to that agent or any other idle one. a `[-]` hap did not
+  write itself (yours, or one an agent marked) is never touched.
+- after **3** hand-outs of the same item that were never started, hap stops
+  resending it: the item is left `[-]` and an escalation
+  (`task_never_started:…`) asks you to look. clear it with
+  `hap task <name> undone <n>` once the agent is healthy.
 
 
 ### manage the task items (CRUD)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,23 @@ whose manifest carries exactly that version).
   through ticking that very form. Keep all three invariant tests when touching this
   (`TestMultiTabSweepMultiSelectOwnTogglesComplete` / `…ForeignSelectionEscalates` /
   `…UnattributedTogglesEscalate`).
+- **An unattended task hand-out is only "delivered" once the agent works** — a successful
+  `agent send` proves herdr took the keystrokes, not that the agent acted on them, so the
+  `[-]` written at delivery is recorded in `task_reservations` and confirmed only by a
+  `working` transition (`daemon.handleTransition`). `daemon.reclaimStrandedTasks` returns an
+  unconfirmed item to `[ ]` once its agent is parked again past `reclaimGrace`, which is what
+  makes each sweep decide from current state rather than a past send. Four bounds are
+  load-bearing and must survive any change here: the daemon releases ONLY a `[-]` it holds a
+  ledger row for (an operator's or an agent's own mark is never cleared); **one unconfirmed
+  hand-out per agent** (`agentsAwaitingHandout`), because confirmation is per-agent and a
+  second hand-out would let one resumption confirm — and so strand — the untaken first;
+  confirm and reclaim both compare `terminal_id`, since herdr recycles pane ids and an agent
+  id IS a pane id; and an item handed out `maxTaskHandouts` times without ever being started
+  is left `[-]` and escalated instead of resent forever. Keep the invariant tests in
+  `autosendidle_test.go` (`…ReclaimsStrandedHandoutAndResends` /
+  `…ConfirmedHandoutIsNeverReclaimed` / `…ReclaimIgnoresForeignInProgressItems` /
+  `…OneUnconfirmedHandoutPerAgent` / `…RecycledPaneCannotConfirmItsPredecessorsHandout` /
+  `…HandoutCapEscalatesInsteadOfResending`).
 - **Don't stall the main loop** — the daemon's select loop handles all agents; anything that
   shells out repeatedly (LLM CLI, deep pane reads) belongs in a goroutine that funnels
   results back through a channel (see `consultLLM` / `llmResults`).

--- a/docs/architect/herd-auto-prompter-architecture.md
+++ b/docs/architect/herd-auto-prompter-architecture.md
@@ -485,6 +485,12 @@ automated action.
   hand-outs are exempt from the consecutive counter and never pause on the
   per-minute ceiling (they defer to a later sweep), since the operator opted
   into unattended repeated sending for that source.
+- **Stranded-hand-out reclaim, with a ceiling.** A reserved `[-]` item is
+  returned to `[ ]` when its hand-out was never confirmed and the agent is
+  parked again (`task_reservations`), so the queue self-heals instead of
+  draining into permanently reserved items. Two bounds keep that from becoming
+  its own runaway: only a `[-]` the daemon reserved is ever released, and after
+  **3** unstarted hand-outs of one item it is left `[-]` and escalated.
 - **Escalation on uncertainty.** Every uncertain path routes to escalate + audit
   + notify — never a silent drop.
 
@@ -786,7 +792,7 @@ the sections they gate.
 | **FR-008** | Confidence-gated autonomous action | Auto-execute the learned action only when confidence exceeds the per-situation threshold and no safety control blocks; otherwise escalate. |
 | **FR-009** | Per-situation-type thresholds | Support a distinct, operator-configurable (TOML) confidence threshold per situation type (idle, approval, choice, error). |
 | **FR-010** | Hybrid decision with LLM fallback | Optionally consult a configured local LLM/agent CLI when no confident rule applies; any LLM-derived action is re-gated by the confidence gate + safety controls, and on LLM unavailability escalate. |
-| **FR-011** | Idle / finished behavior | Prompt the next task via (1) operator-declared task source, else (2) an explicit structured pane-history todo gated by the minimum-agreement floor; if neither is sufficiently confident, escalate — never synthesize an arbitrary "continue". A source may opt into `enable_auto_send_task_when_idle`, which re-drives agents idle past a one-minute threshold on the periodic sweep (same pipeline and gates); agents matched by one source are paired with distinct pending items and the delivered item is reserved `[-]` at send time, so a task never reaches two agents. |
+| **FR-011** | Idle / finished behavior | Prompt the next task via (1) operator-declared task source, else (2) an explicit structured pane-history todo gated by the minimum-agreement floor; if neither is sufficiently confident, escalate — never synthesize an arbitrary "continue". A source may opt into `enable_auto_send_task_when_idle`, which re-drives agents idle past a one-minute threshold on the periodic sweep (same pipeline and gates); agents matched by one source are paired with distinct pending items and the delivered item is reserved `[-]` at send time, so a task never reaches two agents. Each hand-out is recorded in a durable ledger and confirmed only when herdr reports that agent WORKING (a successful send proves only that herdr accepted the keystrokes); an unconfirmed hand-out whose agent is parked again past a two-minute grace is returned to `[ ]` and re-offered, so a sweep never depends on a past send. Only a `[-]` the daemon itself reserved may be released, and an item handed out three times without ever being started is left `[-]` and escalated rather than resent forever. |
 | **FR-012** | Approval / permission behavior | Select the learned yes/no response when confident and not blocked by the never-auto allowlist. |
 | **FR-013** | Multiple-choice behavior | Select the learned option matching the choice signature; if the option set is unfamiliar, escalate. |
 | **FR-014** | Error / retry behavior | Choose the learned retry/skip/escalate action, bounded to a max of 2 automated retries per error signature, after which force escalation. |

--- a/internal/daemon/autosendidle.go
+++ b/internal/daemon/autosendidle.go
@@ -45,7 +45,39 @@ const (
 	// either starting work (which clears it) or the episode being re-driven.
 	// A stale claim would otherwise pin an agent to a task the operator has
 	// since re-prioritized.
-	autoTaskClaimTTL = 10 * time.Minute
+	//
+	// It is deliberately the same window as reclaimGrace, and for the same
+	// reason: a claim only has to survive the capture → (optionally
+	// LLM-reviewed) delivery pipeline, which is seconds. Anything longer makes
+	// the sweep depend on a past send — a claim both skips its agent
+	// (eligibleIdleAgents) and hides its task from every OTHER agent
+	// (unclaimedPendingTasks), so a claim that outlives its episode stalls
+	// exactly the hand-out it was meant to order.
+	autoTaskClaimTTL = reclaimGrace
+	// reclaimGrace is how long an unconfirmed hand-out is given to show up as
+	// "working" before the sweep treats it as never delivered and returns its
+	// checklist item to "[ ]". It has to cover the capture delay plus a pre-send
+	// LLM review plus the agent's own start-up, and to stay well under a human's
+	// patience for a stalled queue.
+	reclaimGrace = 2 * time.Minute
+	// maxTaskHandouts caps how many times ONE checklist item may be handed out
+	// without ever being started. Past it the item is left "[-]" and the
+	// operator is asked, because something about that task or that agent is
+	// broken in a way another resend will not fix.
+	maxTaskHandouts = 3
+	// maxHandoutRestamps bounds how many daemon startups may renew an
+	// unconfirmed hand-out's grace window (see TouchTaskReservations). The
+	// window is the only thing that ages a hand-out toward being reclaimed, so
+	// an unbounded renewal would let a crash-looping daemon strand a task
+	// silently, without even reaching the escalation ceiling.
+	maxHandoutRestamps = 3
+	// staleHandoutTTL is the backstop that keeps an unresolvable hand-out from
+	// benching its agent forever: an open row bars that agent from every
+	// pairing, so a row that no sweep can settle (unreadable source, an agent
+	// that never parks) is eventually given up on. Generous — reclaim normally
+	// happens two orders of magnitude sooner — because reaching this at all
+	// means the ordinary paths did not work.
+	staleHandoutTTL = time.Hour
 	// taskLockWait bounds how long a reservation waits for another hap
 	// process's file lock. The reserve runs on the main select loop, so an
 	// unbounded wait would stall every agent behind one wedged CLI; giving up
@@ -61,6 +93,27 @@ func (d *Daemon) autoSendIdleTasks(ctx context.Context, agents []domain.AgentTra
 	now := d.opt.Clock.Now()
 	d.noteIdleAgents(agents, now)
 
+	// FR-017: the kill switch stands the whole daemon down. Fail closed — an
+	// unreadable kill state must not license unattended sends, and it must not
+	// license the reclaim's file writes either.
+	kill, err := d.opt.Store.LatestKillEvent(ctx)
+	if err != nil {
+		slog.Warn("auto-send: kill-switch read failed; skipping this sweep", "error", err)
+		return
+	}
+	if domain.KillStateActive(kill) {
+		return
+	}
+
+	// Return stranded hand-outs to "[ ]" BEFORE pairing, so this same sweep can
+	// re-offer them. Nothing below reads the ledger.
+	//
+	// Deliberately ahead of the "no auto-send sources configured" return: a
+	// source switched off (or removed) while hand-outs were in flight would
+	// otherwise leave its items "[-]" forever with nothing left to retire the
+	// ledger rows. The ledger, not the config, decides what needs cleaning up.
+	d.reclaimStrandedTasks(ctx, agents, now)
+
 	cfg, _, _ := d.snapshot()
 	sources := make([]config.TaskSource, 0, len(cfg.TaskSources))
 	for _, src := range cfg.TaskSources {
@@ -69,17 +122,6 @@ func (d *Daemon) autoSendIdleTasks(ctx context.Context, agents []domain.AgentTra
 		}
 	}
 	if len(sources) == 0 {
-		return
-	}
-
-	// FR-017: the kill switch stands the whole daemon down. Fail closed — an
-	// unreadable kill state must not license unattended sends.
-	kill, err := d.opt.Store.LatestKillEvent(ctx)
-	if err != nil {
-		slog.Warn("auto-send: kill-switch read failed; skipping this sweep", "error", err)
-		return
-	}
-	if domain.KillStateActive(kill) {
 		return
 	}
 
@@ -96,9 +138,17 @@ func (d *Daemon) autoSendIdleTasks(ctx context.Context, agents []domain.AgentTra
 		escalated[e.AgentID] = true
 	}
 
+	// Agents holding a hand-out the daemon has not seen taken up yet. Piling a
+	// second task on one is not just noisy: a later "working" transition
+	// confirms EVERY open row for that agent, so the untaken first task would be
+	// marked delivered and its "[-]" would stand forever — the exact stranding
+	// this sweep exists to undo. An agent stays out only until its hand-out is
+	// confirmed or reclaimed, both bounded by reclaimGrace.
+	awaiting := d.agentsAwaitingHandout(ctx)
+
 	driven := map[string]bool{} // agents already given a task this sweep
 	for _, src := range sources {
-		eligible := d.eligibleIdleAgents(ctx, src, agents, now, driven, escalated)
+		eligible := d.eligibleIdleAgents(ctx, src, agents, now, driven, escalated, awaiting)
 		if len(eligible) == 0 {
 			continue
 		}
@@ -138,6 +188,273 @@ func (d *Daemon) autoSendIdleTasks(ctx context.Context, agents []domain.AgentTra
 			d.scheduleCapture(ctx, tr)
 		}
 	}
+}
+
+// reclaimStrandedTasks is what makes each sweep decide from CURRENT state
+// rather than from a past send.
+//
+// A hand-out marks its checklist item "[-]" BEFORE the send, and the send is
+// rolled back only when herdr reports an error. But a successful `agent send`
+// means "herdr accepted these keystrokes", not "the agent acted on them": text
+// typed into a CLI that is restarting, repainting, or not focused is silently
+// lost. Before this sweep existed, such an item stayed "[-]" forever —
+// PendingDeclaredTasks only yields "[ ]", so no agent was ever offered it
+// again, and a few of those in a row leave every agent idle beside a checklist
+// that still has work.
+//
+// So every unattended hand-out is recorded in the ledger and confirmed only
+// when herdr reports its agent WORKING (handleTransition). Here, per row:
+//
+//	confirmed                     → retire the row; the "[-]" stands
+//	item is no longer "[-]"       → retire the row (completed, released, edited)
+//	agent is working or blocked   → leave alone; it may be underway right now
+//	still inside reclaimGrace     → leave alone; the send may yet land
+//	otherwise                     → return the item to "[ ]" and re-offer it
+//
+// Two safety properties are load-bearing:
+//   - the daemon only ever releases a "[-]" it holds a ledger row for, so an
+//     operator's or an agent's own in-progress mark is never cleared;
+//   - an item that has been handed out maxTaskHandouts times without ever being
+//     started is NOT reclaimed again — it is left "[-]" and escalated, because
+//     the loop is otherwise unbounded.
+//
+// It is a best-effort pass throughout: an unreadable source or a failed release
+// resolves to "leave it alone", which is the state the daemon was already in.
+func (d *Daemon) reclaimStrandedTasks(ctx context.Context, agents []domain.AgentTransition, now time.Time) {
+	reservations, err := d.opt.Store.OpenTaskReservations(ctx)
+	if err != nil {
+		slog.Warn("auto-send: hand-out ledger unreadable; not reclaiming this sweep", "error", err)
+		return
+	}
+	if len(reservations) == 0 {
+		return
+	}
+	live := make(map[string]domain.AgentTransition, len(agents))
+	for _, a := range agents {
+		live[a.AgentID] = a
+	}
+	// One read per source per sweep, dropped whenever this pass rewrites the
+	// file so a later row on the same source sees its own effect.
+	content := map[string]string{}
+	read := func(path string) (string, bool) {
+		if c, ok := content[path]; ok {
+			return c, true
+		}
+		data, err := d.opt.ReadTaskFile(path)
+		if err != nil {
+			slog.Warn("auto-send: task source unreadable; not reclaiming its hand-outs",
+				"path", path, "error", err)
+			return "", false
+		}
+		content[path] = string(data)
+		return content[path], true
+	}
+
+	for _, r := range reservations {
+		if !r.ConfirmedAt.IsZero() {
+			d.retireReservation(ctx, r)
+			continue
+		}
+		// A row this old is not going to settle. It survives only when every
+		// sweep since has hit "leave it alone" — a source that stopped being
+		// readable, or an agent that has been busy the whole time — and an open
+		// row keeps its agent out of every future pairing
+		// (agentsAwaitingHandout). Holding one agent hostage to a hand-out
+		// nothing can resolve is worse than giving up on it: retire the row and
+		// leave the "[-]" for the operator, which is exactly where this feature
+		// stood before the ledger existed.
+		if now.Sub(r.ReservedAt) > staleHandoutTTL {
+			slog.Warn("auto-send: hand-out never settled; giving up on it — the item stays [-] until you clear it",
+				"agent", r.AgentID, "path", r.SourcePath, "task", r.TaskText,
+				"age", now.Sub(r.ReservedAt).Round(time.Second))
+			d.retireReservation(ctx, r)
+			continue
+		}
+		c, ok := read(r.SourcePath)
+		if !ok {
+			continue
+		}
+		if !inProgressTask(c, r.TaskText) {
+			// The item moved on under us: the agent completed it, an operator
+			// edited or released it, or a rollback already took it back. Either
+			// way there is nothing left to reclaim and no hand-out to count.
+			d.retireReservation(ctx, r)
+			continue
+		}
+		// A live agent that is not parked may be working on exactly this task.
+		// An agent that is gone — or whose id now belongs to a DIFFERENT
+		// terminal, since herdr recycles pane ids — is reclaimable: the tenant
+		// this task was handed to cannot resume it, and without the identity
+		// check a busy successor would pin the item "[-]" indefinitely, never
+		// aging toward either a reclaim or the escalation ceiling.
+		if a, present := live[r.AgentID]; present && sameTenant(a, r) && !autoSendParked(a.Status) {
+			continue
+		}
+		if now.Sub(r.ReservedAt) <= reclaimGrace {
+			continue
+		}
+
+		attempts, err := d.opt.Store.TaskHandoutAttempts(ctx, r.SourcePath, r.TaskText)
+		if err != nil {
+			slog.Warn("auto-send: hand-out counter unreadable; not reclaiming",
+				"path", r.SourcePath, "error", err)
+			continue
+		}
+		if attempts >= maxTaskHandouts {
+			d.escalateNeverStartedTask(ctx, r, live[r.AgentID], attempts, now)
+			continue
+		}
+		if err := d.opt.MutateTaskFile(r.SourcePath, taskfile.Reclaim(r.ItemIndex, r.TaskText)); err != nil {
+			slog.Warn("auto-send: stranded task could not be returned to [ ]",
+				"path", r.SourcePath, "task", r.TaskText, "error", err)
+			continue
+		}
+		delete(content, r.SourcePath)
+		// The pairing dies with the reservation: holding it would keep this
+		// agent out of the very sweep that is about to re-offer the task.
+		d.dropAutoTaskClaimFor(r)
+		if err := d.opt.Store.DeleteTaskReservation(ctx, r.ID); err != nil {
+			slog.Warn("auto-send: hand-out row could not be retired", "id", r.ID, "error", err)
+		}
+		a := live[r.AgentID]
+		if _, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
+			AgentID: r.AgentID, AgentType: a.AgentType, Trigger: "auto-send-reclaim",
+			SituationType: domain.SituationIdle,
+			Action:        domain.AuditActionTaskReclaimedPrefix + domain.DisplayTaskText(r.TaskText),
+			Rationale: fmt.Sprintf("[%s] handed to %s %s ago and never started; returned to [ ] for the next idle agent",
+				domain.ReasonTaskNeverStarted, r.AgentID, now.Sub(r.ReservedAt).Round(time.Second)),
+			Status: domain.AuditStatusReclaimed, CreatedAt: now,
+		}); err != nil {
+			slog.Warn("auto-send: reclaim audit write failed", "error", err)
+		}
+		slog.Info("auto-send: returned a stranded task to the pending list",
+			"agent", r.AgentID, "path", r.SourcePath, "task", r.TaskText, "attempt", attempts)
+	}
+}
+
+// retireReservation drops a ledger row that has done its job — the hand-out was
+// confirmed, or the item is no longer the "[-]" it reserved — and forgets the
+// item's attempt counter so a future hand-out starts from zero.
+func (d *Daemon) retireReservation(ctx context.Context, r domain.TaskReservation) {
+	if err := d.opt.Store.DeleteTaskReservation(ctx, r.ID); err != nil {
+		slog.Warn("auto-send: hand-out row could not be retired", "id", r.ID, "error", err)
+		return
+	}
+	if err := d.opt.Store.ClearTaskHandouts(ctx, r.SourcePath, r.TaskText); err != nil {
+		slog.Warn("auto-send: hand-out counter could not be cleared",
+			"path", r.SourcePath, "task", r.TaskText, "error", err)
+	}
+}
+
+// escalateNeverStartedTask stops the reclaim loop for one item: after
+// maxTaskHandouts deliveries that were never taken up, resending is not going to
+// work, so the item is LEFT "[-]" (which is exactly what keeps it out of the
+// pending list) and the operator is asked.
+//
+// Note the escalation also parks this agent's auto-sends until it is resolved —
+// eligibleIdleAgents skips an agent with a pending escalation. That is
+// deliberate: a task nobody can start usually means the agent, not the task.
+func (d *Daemon) escalateNeverStartedTask(ctx context.Context, r domain.TaskReservation,
+	a domain.AgentTransition, attempts int, now time.Time) {
+
+	if err := d.opt.Store.DeleteTaskReservation(ctx, r.ID); err != nil {
+		slog.Warn("auto-send: hand-out row could not be retired", "id", r.ID, "error", err)
+		// Fall through: the escalation matters more than the bookkeeping, and a
+		// surviving row simply re-escalates next sweep (deduped by the counter
+		// staying at the ceiling).
+	}
+	d.dropAutoTaskClaimFor(r)
+	// Forget the counter with the row. Nothing can hand this item out again
+	// while it is "[-]", so the only way it comes back is an operator releasing
+	// it — and that human intervention is exactly what the ceiling was waiting
+	// for. Keeping the count would make the very first hand-out after the fix
+	// escalate again.
+	if err := d.opt.Store.ClearTaskHandouts(ctx, r.SourcePath, r.TaskText); err != nil {
+		slog.Warn("auto-send: hand-out counter could not be cleared",
+			"path", r.SourcePath, "task", r.TaskText, "error", err)
+	}
+	// Deliberately NO Suggestion and NO Input: a confirm sends the suggestion to
+	// the pane as literal text (frontend.SuggestedAction), and there is nothing
+	// to send here — the operator has to look at the agent. An empty suggestion
+	// makes the row informational: explained by its rationale, dismissible, not
+	// confirmable.
+	if _, err := d.opt.Store.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: r.AgentID, AgentType: a.AgentType, Trigger: "auto-send-reclaim",
+		SituationType: domain.SituationIdle,
+		Action:        domain.AuditActionTaskNeverStartedPrefix + domain.DisplayTaskText(r.TaskText),
+		// Addressed by --path, not by agent: an agent can match several sources,
+		// so `hap task <agent>` need not resolve the file this item lives in —
+		// and the agent may be gone by the time anyone reads this.
+		Rationale: fmt.Sprintf("[%s] handed to %s %d times and never started; left [-] so it is not resent. "+
+			"Check the agent, then `hap task --path %s undone <n>` to re-queue the item.",
+			domain.ReasonTaskNeverStarted, r.AgentID, attempts, r.SourcePath),
+		Status: "escalated", CreatedAt: now,
+	}); err != nil {
+		slog.Error("auto-send: never-started escalation could not be recorded", "error", err)
+		return
+	}
+	slog.Warn("auto-send: task handed out repeatedly and never started; escalating",
+		"agent", r.AgentID, "path", r.SourcePath, "task", r.TaskText, "attempts", attempts)
+}
+
+// agentsAwaitingHandout returns the agents that still hold a hand-out the
+// daemon has not seen taken up. They are skipped by this sweep's pairing:
+// confirmation is per AGENT (a "working" transition says nothing about WHICH
+// task it is working on), so a second hand-out layered over an unconfirmed
+// first would let one resumption confirm both — permanently stranding the task
+// the agent never actually received.
+//
+// Fails OPEN: a ledger it cannot read hands out nothing new only if it also
+// cannot reclaim, and stalling the feature on a transient read error is worse
+// than one extra hand-out. This runs right after reclaimStrandedTasks, so rows
+// past their grace window are already gone by the time it reads.
+func (d *Daemon) agentsAwaitingHandout(ctx context.Context) map[string]bool {
+	reservations, err := d.opt.Store.OpenTaskReservations(ctx)
+	if err != nil {
+		slog.Warn("auto-send: hand-out ledger unreadable; pairing without it this sweep", "error", err)
+		return nil
+	}
+	out := map[string]bool{}
+	for _, r := range reservations {
+		if r.ConfirmedAt.IsZero() {
+			out[r.AgentID] = true
+		}
+	}
+	return out
+}
+
+// sameTenant reports whether a live agent is still the one a hand-out was made
+// to. herdr reuses compact pane ids (and an agent id IS a pane id), so matching
+// ids alone can name a different terminal — its terminal_id is what tells them
+// apart. Fails OPEN on an unknown id on either side (older herdr, event-socket
+// transitions), like every other terminal-identity check here: an unprovable
+// difference must never be treated as one.
+func sameTenant(a domain.AgentTransition, r domain.TaskReservation) bool {
+	return a.TerminalID == "" || r.TerminalID == "" || a.TerminalID == r.TerminalID
+}
+
+// dropAutoTaskClaimFor releases the agent's pairing only when it is still THIS
+// hand-out's. An unrelated claim belongs to a delivery that is in flight right
+// now (a capture or an LLM review can outlive a sweep); dropping it would
+// re-expose that task to another agent in this same sweep, whose delivery then
+// loses the reservation race — no double send, but a wasted episode.
+func (d *Daemon) dropAutoTaskClaimFor(r domain.TaskReservation) {
+	if c, ok := d.autoTaskClaimFor(r.AgentID); !ok ||
+		c.sourcePath != r.SourcePath || c.taskText != r.TaskText {
+		return
+	}
+	d.dropAutoTaskClaim(r.AgentID)
+}
+
+// inProgressTask reports whether content still carries taskText as a "[-]"
+// item — the exact mark a hand-out wrote, and the only one it may take back.
+func inProgressTask(content, taskText string) bool {
+	for _, it := range domain.ParseChecklist(content) {
+		if it.Text == taskText && it.Mark == domain.MarkInProgress {
+			return true
+		}
+	}
+	return false
 }
 
 // canonicalTaskPath resolves a task-source path to the one key that identifies
@@ -208,11 +525,15 @@ func (d *Daemon) noteIdleAgents(agents []domain.AgentTransition, now time.Time) 
 // deterministic run to run). Every gate here is a reason NOT to send; the
 // decision core re-applies its own on the pipeline path.
 func (d *Daemon) eligibleIdleAgents(ctx context.Context, src config.TaskSource,
-	agents []domain.AgentTransition, now time.Time, driven, escalated map[string]bool) []domain.AgentTransition {
+	agents []domain.AgentTransition, now time.Time, driven, escalated, awaiting map[string]bool) []domain.AgentTransition {
 
 	var out []domain.AgentTransition
 	for _, a := range agents {
 		if driven[a.AgentID] || !autoSendParked(a.Status) {
+			continue
+		}
+		// One unconfirmed hand-out at a time per agent — see agentsAwaitingHandout.
+		if awaiting[a.AgentID] {
 			continue
 		}
 		if !d.idleLongEnough(a, now) {
@@ -389,21 +710,26 @@ func reservedByAction(action, reviewed string, pending []string) string {
 // different pending task, and the operator can edit the list meanwhile. A
 // failure means somebody else already took the task, and the caller must NOT
 // send.
-func (d *Daemon) reserveDeclaredTask(declared *domain.DeclaredTask, taskText string) (rollback func(), err error) {
+//
+// index is the checklist position that was marked, and is 0 when nothing was:
+// a non-zero value means the caller must record a ledger row after the send
+// (the no-op cases — a source that does not reserve, an exhausted list — must
+// not), and it is the position a later reclaim prefers over a bare text match.
+func (d *Daemon) reserveDeclaredTask(declared *domain.DeclaredTask, taskText string) (rollback func(), index int, err error) {
 	if declared == nil || !declared.Reserve || taskText == "" || taskText == domain.NoTaskContent {
-		return func() {}, nil
+		return func() {}, 0, nil
 	}
 	path := declared.Path
 	mutate, claimed := taskfile.ReserveFirstPending(taskText)
 	if err := d.opt.MutateTaskFile(path, mutate); err != nil {
-		return nil, fmt.Errorf("reserving the task in %s: %w", path, err)
+		return nil, 0, fmt.Errorf("reserving the task in %s: %w", path, err)
 	}
 	// Defensive: a MutateTaskFile implementation that reports success without
 	// running fn leaves no index to roll back, and Release(-1, …) would only
 	// produce a confusing error. Nothing was marked, so nothing needs undoing.
-	index := *claimed
+	index = *claimed
 	if index < 0 {
-		return func() {}, nil
+		return func() {}, 0, nil
 	}
 	return func() {
 		if err := d.opt.MutateTaskFile(path, taskfile.Release(index, taskText)); err != nil {
@@ -411,5 +737,5 @@ func (d *Daemon) reserveDeclaredTask(declared *domain.DeclaredTask, taskText str
 				"it stays [-] and no agent will pick it up until you clear it",
 				"path", path, "task", index, "error", err)
 		}
-	}, nil
+	}, index, nil
 }

--- a/internal/daemon/autosendidle.go
+++ b/internal/daemon/autosendidle.go
@@ -112,7 +112,17 @@ func (d *Daemon) autoSendIdleTasks(ctx context.Context, agents []domain.AgentTra
 	// source switched off (or removed) while hand-outs were in flight would
 	// otherwise leave its items "[-]" forever with nothing left to retire the
 	// ledger rows. The ledger, not the config, decides what needs cleaning up.
-	d.reclaimStrandedTasks(ctx, agents, now)
+	//
+	// awaiting names the agents whose hand-out this pass could NOT settle. They
+	// are barred from the pairing below: confirmation is per AGENT (a "working"
+	// transition says nothing about WHICH task), so a second hand-out layered on
+	// an unconfirmed first would let one resumption confirm both — permanently
+	// stranding the task the agent never received. A ledger it could not read at
+	// all stands the sweep down rather than pairing blind, for the same reason.
+	awaiting, ok := d.reclaimStrandedTasks(ctx, agents, now)
+	if !ok {
+		return
+	}
 
 	cfg, _, _ := d.snapshot()
 	sources := make([]config.TaskSource, 0, len(cfg.TaskSources))
@@ -137,14 +147,6 @@ func (d *Daemon) autoSendIdleTasks(ctx context.Context, agents []domain.AgentTra
 	for _, e := range open {
 		escalated[e.AgentID] = true
 	}
-
-	// Agents holding a hand-out the daemon has not seen taken up yet. Piling a
-	// second task on one is not just noisy: a later "working" transition
-	// confirms EVERY open row for that agent, so the untaken first task would be
-	// marked delivered and its "[-]" would stand forever — the exact stranding
-	// this sweep exists to undo. An agent stays out only until its hand-out is
-	// confirmed or reclaimed, both bounded by reclaimGrace.
-	awaiting := d.agentsAwaitingHandout(ctx)
 
 	driven := map[string]bool{} // agents already given a task this sweep
 	for _, src := range sources {
@@ -218,16 +220,28 @@ func (d *Daemon) autoSendIdleTasks(ctx context.Context, agents []domain.AgentTra
 //     started is NOT reclaimed again — it is left "[-]" and escalated, because
 //     the loop is otherwise unbounded.
 //
-// It is a best-effort pass throughout: an unreadable source or a failed release
+// It is a best-effort pass PER ROW: an unreadable source or a failed release
 // resolves to "leave it alone", which is the state the daemon was already in.
-func (d *Daemon) reclaimStrandedTasks(ctx context.Context, agents []domain.AgentTransition, now time.Time) {
+//
+// It returns the agents still holding a hand-out it could not settle, which the
+// pairing below uses to enforce one unconfirmed hand-out per agent, plus ok=false
+// when the ledger itself could not be read. That is why the two are computed
+// together from ONE read: a second, independent read could fail on its own and
+// report "nobody is awaiting", which would license exactly the second hand-out
+// the invariant forbids. ok=false stands the whole sweep down — the alternative,
+// pairing while blind to the ledger, lets a later "working" transition confirm
+// two rows at once and strands the task the agent never received.
+func (d *Daemon) reclaimStrandedTasks(ctx context.Context, agents []domain.AgentTransition,
+	now time.Time) (awaiting map[string]bool, ok bool) {
+
 	reservations, err := d.opt.Store.OpenTaskReservations(ctx)
 	if err != nil {
-		slog.Warn("auto-send: hand-out ledger unreadable; not reclaiming this sweep", "error", err)
-		return
+		slog.Warn("auto-send: hand-out ledger unreadable; standing down this sweep", "error", err)
+		return nil, false
 	}
+	awaiting = map[string]bool{}
 	if len(reservations) == 0 {
-		return
+		return awaiting, true
 	}
 	live := make(map[string]domain.AgentTransition, len(agents))
 	for _, a := range agents {
@@ -270,8 +284,11 @@ func (d *Daemon) reclaimStrandedTasks(ctx context.Context, agents []domain.Agent
 			d.retireReservation(ctx, r)
 			continue
 		}
-		c, ok := read(r.SourcePath)
-		if !ok {
+		// From here on, every "leave it alone" branch keeps the row open, so its
+		// agent must not be handed anything else this sweep.
+		c, readable := read(r.SourcePath)
+		if !readable {
+			awaiting[r.AgentID] = true
 			continue
 		}
 		if !inProgressTask(c, r.TaskText) {
@@ -288,9 +305,11 @@ func (d *Daemon) reclaimStrandedTasks(ctx context.Context, agents []domain.Agent
 		// check a busy successor would pin the item "[-]" indefinitely, never
 		// aging toward either a reclaim or the escalation ceiling.
 		if a, present := live[r.AgentID]; present && sameTenant(a, r) && !autoSendParked(a.Status) {
+			awaiting[r.AgentID] = true
 			continue
 		}
 		if now.Sub(r.ReservedAt) <= reclaimGrace {
+			awaiting[r.AgentID] = true
 			continue
 		}
 
@@ -298,15 +317,19 @@ func (d *Daemon) reclaimStrandedTasks(ctx context.Context, agents []domain.Agent
 		if err != nil {
 			slog.Warn("auto-send: hand-out counter unreadable; not reclaiming",
 				"path", r.SourcePath, "error", err)
+			awaiting[r.AgentID] = true
 			continue
 		}
 		if attempts >= maxTaskHandouts {
+			// The row is retired here, so the agent is not held awaiting — the
+			// escalation this raises is what keeps it out of the pairing.
 			d.escalateNeverStartedTask(ctx, r, live[r.AgentID], attempts, now)
 			continue
 		}
 		if err := d.opt.MutateTaskFile(r.SourcePath, taskfile.Reclaim(r.ItemIndex, r.TaskText)); err != nil {
 			slog.Warn("auto-send: stranded task could not be returned to [ ]",
 				"path", r.SourcePath, "task", r.TaskText, "error", err)
+			awaiting[r.AgentID] = true
 			continue
 		}
 		delete(content, r.SourcePath)
@@ -330,6 +353,7 @@ func (d *Daemon) reclaimStrandedTasks(ctx context.Context, agents []domain.Agent
 		slog.Info("auto-send: returned a stranded task to the pending list",
 			"agent", r.AgentID, "path", r.SourcePath, "task", r.TaskText, "attempt", attempts)
 	}
+	return awaiting, true
 }
 
 // retireReservation drops a ledger row that has done its job — the hand-out was
@@ -395,32 +419,6 @@ func (d *Daemon) escalateNeverStartedTask(ctx context.Context, r domain.TaskRese
 	}
 	slog.Warn("auto-send: task handed out repeatedly and never started; escalating",
 		"agent", r.AgentID, "path", r.SourcePath, "task", r.TaskText, "attempts", attempts)
-}
-
-// agentsAwaitingHandout returns the agents that still hold a hand-out the
-// daemon has not seen taken up. They are skipped by this sweep's pairing:
-// confirmation is per AGENT (a "working" transition says nothing about WHICH
-// task it is working on), so a second hand-out layered over an unconfirmed
-// first would let one resumption confirm both — permanently stranding the task
-// the agent never actually received.
-//
-// Fails OPEN: a ledger it cannot read hands out nothing new only if it also
-// cannot reclaim, and stalling the feature on a transient read error is worse
-// than one extra hand-out. This runs right after reclaimStrandedTasks, so rows
-// past their grace window are already gone by the time it reads.
-func (d *Daemon) agentsAwaitingHandout(ctx context.Context) map[string]bool {
-	reservations, err := d.opt.Store.OpenTaskReservations(ctx)
-	if err != nil {
-		slog.Warn("auto-send: hand-out ledger unreadable; pairing without it this sweep", "error", err)
-		return nil
-	}
-	out := map[string]bool{}
-	for _, r := range reservations {
-		if r.ConfirmedAt.IsZero() {
-			out[r.AgentID] = true
-		}
-	}
-	return out
 }
 
 // sameTenant reports whether a live agent is still the one a hand-out was made

--- a/internal/daemon/autosendidle_test.go
+++ b/internal/daemon/autosendidle_test.go
@@ -914,3 +914,385 @@ func TestAutoSendIdleReassignsAfterLLMReviewDeclines(t *testing.T) {
 		t.Error("the released task was not delivered to the second agent")
 	}
 }
+
+// --- Reclaiming stranded hand-outs -------------------------------------------
+//
+// A successful `agent send` only proves herdr accepted the keystrokes, not that
+// the agent acted on them. These tests cover the ledger that lets each sweep
+// decide from CURRENT state instead of trusting the previous send.
+
+// backdateHandouts ages every unconfirmed hand-out by d, so the reclaim sweep's
+// grace window has elapsed without the test waiting minutes of wall time. It
+// goes through the production re-stamp method rather than poking the DB.
+func backdateHandouts(t *testing.T, h *harness, d time.Duration) {
+	t.Helper()
+	if err := h.raw.TouchTaskReservations(context.Background(), maxHandoutRestamps, time.Now().Add(-d)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func openHandouts(t *testing.T, h *harness) []domain.TaskReservation {
+	t.Helper()
+	rs, err := h.raw.OpenTaskReservations(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rs
+}
+
+func TestAutoSendIdleReclaimsStrandedHandoutAndResends(t *testing.T) {
+	// The core regression: the send "succeeded" (herdr took the keystrokes) but
+	// the agent never started — it is still idle and never reported working. The
+	// item must NOT stay [-] forever; the next sweep returns it to [ ] and hands
+	// it out again, to this agent or any other.
+	h, taskFile := autoSendFixture(t, "agent-rc1", "- [ ] step two\n", true)
+	agents := parkIdle(h, 2*time.Minute, "agent-rc1")
+	ctx := context.Background()
+
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	waitFor(t, 3*time.Second, func() bool {
+		return strings.Contains(readTasks(t, taskFile), "- [-] step two")
+	})
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 1 })
+
+	// The agent never worked; age the hand-out past the grace window.
+	backdateHandouts(t, h, 2*reclaimGrace)
+	h.daemon.autoSendIdleTasks(ctx, agents)
+
+	// Re-offered in the SAME sweep that released it.
+	waitFor(t, 5*time.Second, func() bool { return len(h.herdr.sentInputs()) == 2 })
+	if got := h.herdr.sentInputs()[1]; !strings.Contains(got, "step two") {
+		t.Errorf("the reclaimed task was not resent; got %q", got)
+	}
+	waitFor(t, 3*time.Second, func() bool {
+		return strings.Contains(readTasks(t, taskFile), "- [-] step two")
+	})
+	if !auditFor(t, h, "agent-rc1", domain.AuditStatusReclaimed) {
+		t.Error("the reclaim was not audited")
+	}
+}
+
+func TestAutoSendIdleConfirmedHandoutIsNeverReclaimed(t *testing.T) {
+	// The agent went to working after the send, which is proof the hand-out
+	// landed. Its [-] must survive every later sweep — including the sweeps
+	// after the agent finishes and parks again, which is why confirmation is a
+	// latch and not a status poll.
+	h, taskFile := autoSendFixture(t, "agent-rc2", "- [ ] step two\n", true)
+	agents := parkIdle(h, 2*time.Minute, "agent-rc2")
+	ctx := context.Background()
+
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 1 })
+
+	h.push("agent-rc2", "working")
+	waitFor(t, 3*time.Second, func() bool {
+		rs := openHandouts(t, h)
+		return len(rs) == 1 && !rs[0].ConfirmedAt.IsZero()
+	})
+
+	// Agent parks again with the task still [-] (it never ran `hap task done`).
+	backdateHandouts(t, h, 2*reclaimGrace) // no-op: only unconfirmed rows move
+	h.daemon.autoSendIdleTasks(ctx, agents)
+
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 0 })
+	if got := readTasks(t, taskFile); !strings.Contains(got, "- [-] step two") {
+		t.Errorf("a confirmed hand-out was reclaimed; the file must still read [-]:\n%s", got)
+	}
+	if n := len(h.herdr.sentInputs()); n != 1 {
+		t.Errorf("a confirmed task was resent (%d sends)", n)
+	}
+}
+
+func TestAutoSendIdleReclaimIgnoresForeignInProgressItems(t *testing.T) {
+	// Safety invariant: only a [-] the daemon has a ledger row for may be
+	// released. An operator's (or an agent's own) in-progress mark has no row
+	// and must never be cleared — doing so would re-hand out work underway.
+	h, taskFile := autoSendFixture(t, "agent-rc3", "- [-] somebody else is on this\n- [ ] step two\n", true)
+	agents := parkIdle(h, 2*time.Minute, "agent-rc3")
+	ctx := context.Background()
+
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	backdateHandouts(t, h, 2*reclaimGrace)
+	h.daemon.autoSendIdleTasks(ctx, agents)
+
+	waitFor(t, 3*time.Second, func() bool {
+		return strings.Contains(readTasks(t, taskFile), "- [-] step two")
+	})
+	if got := readTasks(t, taskFile); !strings.Contains(got, "- [-] somebody else is on this") {
+		t.Errorf("the reclaim cleared a [-] the daemon never reserved:\n%s", got)
+	}
+}
+
+func TestAutoSendIdleReclaimHonorsGraceWindow(t *testing.T) {
+	// A hand-out inside the grace window is left alone: the send may still be
+	// landing, and reclaiming it would race a delivery that is about to work.
+	h, taskFile := autoSendFixture(t, "agent-rc4", "- [ ] step two\n", true)
+	agents := parkIdle(h, 2*time.Minute, "agent-rc4")
+	ctx := context.Background()
+
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 1 })
+
+	h.daemon.autoSendIdleTasks(ctx, agents) // fresh reservation, not yet aged
+
+	// Give a would-be reclaim + resend time to happen before asserting it did not.
+	time.Sleep(500 * time.Millisecond)
+	if got := readTasks(t, taskFile); !strings.Contains(got, "- [-] step two") {
+		t.Errorf("a hand-out inside the grace window was reclaimed:\n%s", got)
+	}
+	if n := len(h.herdr.sentInputs()); n != 1 {
+		t.Errorf("expected no resend inside the grace window, got %d sends", n)
+	}
+}
+
+func TestAutoSendIdleReclaimSkipsWorkingAgent(t *testing.T) {
+	// A hand-out whose agent is busy right now may be exactly what it is busy
+	// with. Even unconfirmed and past the grace window, it is left alone —
+	// missing a confirmation must never re-open live work.
+	h, taskFile := autoSendFixture(t, "agent-rc5", "- [ ] step two\n", true)
+	agents := parkIdle(h, 2*time.Minute, "agent-rc5")
+	ctx := context.Background()
+
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 1 })
+	backdateHandouts(t, h, 2*reclaimGrace)
+
+	busy := []domain.AgentTransition{{
+		AgentID: "agent-rc5", PaneID: "agent-rc5", AgentType: "claude", Status: "working",
+	}}
+	h.herdr.setAgents(busy)
+	h.daemon.autoSendIdleTasks(ctx, busy)
+
+	if rs := openHandouts(t, h); len(rs) != 1 {
+		t.Fatalf("a working agent's hand-out was retired: %d rows left", len(rs))
+	}
+	if got := readTasks(t, taskFile); !strings.Contains(got, "- [-] step two") {
+		t.Errorf("a working agent's task was reclaimed:\n%s", got)
+	}
+}
+
+func TestAutoSendIdleHandoutCapEscalatesInsteadOfResending(t *testing.T) {
+	// Reclaiming is unbounded on its own: a task that can never be delivered
+	// would be resent every sweep forever. After maxTaskHandouts unstarted
+	// hand-outs the item is LEFT [-] (so it drops out of the pending list) and
+	// the operator is asked instead.
+	h, taskFile := autoSendFixture(t, "agent-rc6", "- [ ] step two\n", true)
+	agents := parkIdle(h, 2*time.Minute, "agent-rc6")
+	ctx := context.Background()
+
+	for i := 1; i <= maxTaskHandouts; i++ {
+		h.daemon.autoSendIdleTasks(ctx, agents)
+		want := i
+		waitFor(t, 5*time.Second, func() bool { return len(h.herdr.sentInputs()) == want })
+		if n := len(h.herdr.sentInputs()); n != want {
+			t.Fatalf("hand-out %d: got %d sends, want %d", i, n, want)
+		}
+		waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 1 })
+		backdateHandouts(t, h, 2*reclaimGrace)
+	}
+
+	// The ceiling sweep: no fourth send, the item stays [-], operator asked.
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 0 })
+
+	if n := len(h.herdr.sentInputs()); n != maxTaskHandouts {
+		t.Errorf("task was handed out %d times; the cap is %d", n, maxTaskHandouts)
+	}
+	if got := readTasks(t, taskFile); !strings.Contains(got, "- [-] step two") {
+		t.Errorf("a capped task must stay [-] so it is not resent:\n%s", got)
+	}
+	open, err := h.raw.PendingEscalations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, e := range open {
+		if strings.HasPrefix(e.Action, domain.AuditActionTaskNeverStartedPrefix) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no never-started escalation was raised; pending: %+v", open)
+	}
+}
+
+func TestAutoSendIdleOneUnconfirmedHandoutPerAgent(t *testing.T) {
+	// Regression on the reclaim design itself: confirmation is per AGENT (a
+	// "working" transition says nothing about WHICH task), so an agent must not
+	// be handed a second task while the first is unconfirmed. Otherwise one
+	// resumption confirms BOTH rows, and the task the agent never received
+	// stays [-] forever — the exact stranding this feature exists to undo.
+	h, taskFile := autoSendFixture(t, "agent-rc7", "- [ ] step two\n- [ ] step three\n", true)
+	agents := parkIdle(h, 2*time.Minute, "agent-rc7")
+	ctx := context.Background()
+
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 1 })
+
+	// Still idle, still unconfirmed, still inside the grace window.
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	time.Sleep(500 * time.Millisecond)
+
+	if n := len(h.herdr.sentInputs()); n != 1 {
+		t.Errorf("agent got %d hand-outs while the first was unconfirmed; want 1", n)
+	}
+	if got := readTasks(t, taskFile); !strings.Contains(got, "- [ ] step three") {
+		t.Errorf("a second task was reserved on top of an unconfirmed hand-out:\n%s", got)
+	}
+}
+
+func TestAutoSendIdleReclaimsWhenPaneWasRecycled(t *testing.T) {
+	// herdr reuses compact pane ids, and an agent id IS a pane id. A hand-out
+	// whose agent id now belongs to a DIFFERENT terminal was made to a tenant
+	// that no longer exists, so a busy successor must not pin it: without the
+	// identity check the item would sit [-] indefinitely, never aging toward a
+	// reclaim or the escalation ceiling.
+	h, taskFile := autoSendFixture(t, "agent-rc8", "- [ ] step two\n", true)
+	agents := parkIdleOnTerminal(h, "agent-rc8", "term-1")
+	h.herdr.setPaneInfo(domain.PaneInfo{TerminalID: "term-1"})
+	ctx := context.Background()
+
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 1 })
+	if got := openHandouts(t, h)[0].TerminalID; got != "term-1" {
+		t.Fatalf("hand-out recorded terminal %q, want term-1", got)
+	}
+	backdateHandouts(t, h, 2*reclaimGrace)
+
+	// A new agent recycled onto the same pane id, hard at work on its own thing.
+	successor := []domain.AgentTransition{{
+		AgentID: "agent-rc8", PaneID: "agent-rc8", TerminalID: "term-2",
+		AgentType: "claude", Status: "working",
+	}}
+	h.herdr.setAgents(successor)
+	h.daemon.autoSendIdleTasks(ctx, successor)
+
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 0 })
+	if got := readTasks(t, taskFile); !strings.Contains(got, "- [ ] step two") {
+		t.Errorf("a hand-out to a terminal that is gone was not reclaimed:\n%s", got)
+	}
+}
+
+func TestAutoSendIdleRecycledPaneCannotConfirmItsPredecessorsHandout(t *testing.T) {
+	// The confirm side of the same identity rule: a fresh agent on a recycled
+	// pane id doing any work must not stamp the PREVIOUS tenant's untaken
+	// hand-out as delivered, which would strand it permanently.
+	h, taskFile := autoSendFixture(t, "agent-rc9", "- [ ] step two\n", true)
+	agents := parkIdleOnTerminal(h, "agent-rc9", "term-1")
+	h.herdr.setPaneInfo(domain.PaneInfo{TerminalID: "term-1"})
+	ctx := context.Background()
+
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 1 })
+
+	h.events.ch <- domain.AgentTransition{
+		AgentID: "agent-rc9", PaneID: "agent-rc9", TerminalID: "term-2",
+		AgentType: "claude", Status: "working",
+	}
+	// Let the transition be processed, then assert it did NOT confirm.
+	time.Sleep(500 * time.Millisecond)
+	rs := openHandouts(t, h)
+	if len(rs) != 1 {
+		t.Fatalf("expected the hand-out row to survive, got %d rows", len(rs))
+	}
+	if !rs[0].ConfirmedAt.IsZero() {
+		t.Fatal("a successor terminal confirmed its predecessor's hand-out; the task would be stranded")
+	}
+
+	// And it is therefore still reclaimable.
+	backdateHandouts(t, h, 2*reclaimGrace)
+	h.daemon.autoSendIdleTasks(ctx, parkIdleOnTerminal(h, "agent-rc9", "term-2"))
+	waitFor(t, 3*time.Second, func() bool {
+		return strings.Contains(readTasks(t, taskFile), "- [ ] step two") ||
+			strings.Contains(readTasks(t, taskFile), "- [-] step two")
+	})
+	if len(openHandouts(t, h)) == 1 && !openHandouts(t, h)[0].ConfirmedAt.IsZero() {
+		t.Error("the stale hand-out was confirmed rather than reclaimed")
+	}
+}
+
+func TestAutoSendIdleReclaimsWhenTheAgentIsGone(t *testing.T) {
+	// An agent that vanished from herdr's listing cannot resume, so its untaken
+	// task must go back to the pool for whoever is left.
+	h, taskFile := autoSendFixture(t, "agent-rc10", "- [ ] step two\n", true)
+	agents := parkIdle(h, 2*time.Minute, "agent-rc10")
+	ctx := context.Background()
+
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 1 })
+	backdateHandouts(t, h, 2*reclaimGrace)
+
+	h.herdr.setAgents(nil)
+	h.daemon.autoSendIdleTasks(ctx, nil)
+
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 0 })
+	if got := readTasks(t, taskFile); !strings.Contains(got, "- [ ] step two") {
+		t.Errorf("a departed agent's task was not returned to the pool:\n%s", got)
+	}
+}
+
+func TestAutoSendIdleConfirmationResetsTheHandoutBudget(t *testing.T) {
+	// The attempt counter must not accumulate across healthy hand-outs, or an
+	// agent that has simply been given many tasks would eventually escalate on
+	// a task it never failed. A confirmed hand-out clears the count.
+	h, _ := autoSendFixture(t, "agent-rc11", "- [ ] step two\n", true)
+	agents := parkIdle(h, 2*time.Minute, "agent-rc11")
+	ctx := context.Background()
+
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 1 })
+	row := openHandouts(t, h)[0]
+	if n, err := h.raw.TaskHandoutAttempts(ctx, row.SourcePath, row.TaskText); err != nil || n != 1 {
+		t.Fatalf("attempts after one hand-out = %d (err %v), want 1", n, err)
+	}
+
+	// The agent takes it up, then the sweep retires the confirmed row.
+	h.push("agent-rc11", "working")
+	waitFor(t, 3*time.Second, func() bool {
+		rs := openHandouts(t, h)
+		return len(rs) == 1 && !rs[0].ConfirmedAt.IsZero()
+	})
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 0 })
+
+	n, err := h.raw.TaskHandoutAttempts(ctx, row.SourcePath, row.TaskText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("attempts after a confirmed hand-out = %d, want 0 — the budget must reset "+
+			"or a healthy agent eventually escalates on a task it never failed", n)
+	}
+}
+
+func TestAutoSendIdleUnsettleableHandoutStopsBenchingItsAgent(t *testing.T) {
+	// An open hand-out bars its agent from every pairing, so a row no sweep can
+	// settle — here a task source that stopped being readable — would bench
+	// that agent forever. Past staleHandoutTTL the daemon gives up on the row
+	// and the agent goes back to work; the [-] is left for the operator, which
+	// is where this feature stood before the ledger existed.
+	h, taskFile := autoSendFixture(t, "agent-rc12", "- [ ] step two\n- [ ] step three\n", true)
+	agents := parkIdle(h, 2*time.Minute, "agent-rc12")
+	ctx := context.Background()
+
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 1 })
+
+	// The source becomes unreadable, so the reclaim can never resolve the row.
+	if err := os.Remove(taskFile); err != nil {
+		t.Fatal(err)
+	}
+	backdateHandouts(t, h, 2*reclaimGrace)
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	if len(openHandouts(t, h)) != 1 {
+		t.Fatal("an unreadable source must not have its hand-out retired early")
+	}
+
+	backdateHandouts(t, h, 2*staleHandoutTTL)
+	h.daemon.autoSendIdleTasks(ctx, agents)
+
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 0 })
+}

--- a/internal/daemon/autosendidle_test.go
+++ b/internal/daemon/autosendidle_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
 	"github.com/0xGosu/herdr-auto-pilot/internal/taskfile"
 )
 
@@ -1295,4 +1296,91 @@ func TestAutoSendIdleUnsettleableHandoutStopsBenchingItsAgent(t *testing.T) {
 	h.daemon.autoSendIdleTasks(ctx, agents)
 
 	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 0 })
+}
+
+// ledgerFailingStore makes the hand-out ledger read fail on demand, so a test
+// can drive the sweep's fail-closed path without racing the daemon's startup
+// reads (the wrapper is installed before Run, per newHarnessCore).
+type ledgerFailingStore struct {
+	ports.StorePort
+	mu   sync.Mutex
+	fail bool
+}
+
+func (s *ledgerFailingStore) setFail(v bool) { s.mu.Lock(); s.fail = v; s.mu.Unlock() }
+
+func (s *ledgerFailingStore) OpenTaskReservations(ctx context.Context) ([]domain.TaskReservation, error) {
+	s.mu.Lock()
+	fail := s.fail
+	s.mu.Unlock()
+	if fail {
+		return nil, errors.New("ledger unavailable")
+	}
+	return s.StorePort.OpenTaskReservations(ctx)
+}
+
+func TestAutoSendIdleStandsDownWhenTheLedgerCannotBeRead(t *testing.T) {
+	// Fail CLOSED on an unreadable ledger. The sweep cannot see which agents
+	// already hold an unconfirmed hand-out, and pairing blind would give one a
+	// second task; a later "working" transition then confirms BOTH rows, leaving
+	// the untaken first [-] forever — the stranding this whole feature undoes.
+	// A skipped sweep costs a minute; a stranded task costs a human.
+	dir := t.TempDir()
+	taskFile := filepath.Join(dir, "tasks.md")
+	if err := os.WriteFile(taskFile, []byte("- [ ] step two\n- [ ] step three\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := fmt.Sprintf("[[task_sources]]\nagent = %q\npath = %q\nenable_auto_send_task_when_idle = true\n",
+		"agent-rc13", taskFile)
+	var gate *ledgerFailingStore
+	fl := &fakeLLM{}
+	h := newHarnessCore(t, cfg, nil, fl, fl, func(inner ports.StorePort) ports.StorePort {
+		gate = &ledgerFailingStore{StorePort: inner}
+		return gate
+	})
+	h.herdr.setPane(autoSendIdlePane)
+	h.seedAutonomous(autoSendIdlePane, domain.SituationIdle, domain.ActionNextDeclaredTask)
+	agents := parkIdle(h, 2*time.Minute, "agent-rc13")
+	ctx := context.Background()
+
+	gate.setFail(true)
+	h.daemon.autoSendIdleTasks(ctx, agents)
+
+	quietFor(t, h, 500*time.Millisecond)
+	if got := readTasks(t, taskFile); strings.Contains(got, "[-]") {
+		t.Errorf("a task was handed out while the ledger was unreadable:\n%s", got)
+	}
+
+	// The ledger comes back; the sweep resumes normally.
+	gate.setFail(false)
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+}
+
+func TestAutoSendIdleLeavesAnAmbiguousDuplicateAlone(t *testing.T) {
+	// A checklist repeating one task text: the reserved copy was completed while
+	// ANOTHER copy sits [-] under somebody else. The reclaim cannot prove which
+	// copy was its own, so it must release neither — clearing the wrong one would
+	// re-hand out work already underway.
+	h, taskFile := autoSendFixture(t, "agent-rc14", "- [ ] repeat me\n- [ ] repeat me\n", true)
+	agents := parkIdle(h, 2*time.Minute, "agent-rc14")
+	ctx := context.Background()
+
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 1 })
+	waitFor(t, 3*time.Second, func() bool {
+		return strings.Contains(readTasks(t, taskFile), "- [-] repeat me\n- [ ] repeat me")
+	})
+
+	// The daemon reserved #1. The operator completes #1 and starts #2 themselves.
+	if err := os.WriteFile(taskFile, []byte("- [x] repeat me\n- [-] repeat me\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	backdateHandouts(t, h, 2*reclaimGrace)
+	h.daemon.autoSendIdleTasks(ctx, agents)
+	time.Sleep(300 * time.Millisecond)
+
+	if got := readTasks(t, taskFile); got != "- [x] repeat me\n- [-] repeat me\n" {
+		t.Errorf("the reclaim touched an ambiguous duplicate it could not prove was its own:\n%s", got)
+	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -678,6 +678,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 		d.processCorrections(ctx)
 		d.processLLMRetries(ctx)
 		d.expireStaleLLMWork(ctx)
+		// Confirmation of an unattended hand-out is an in-flight "agent went
+		// working" observation, so a restart loses it for hand-outs that WERE
+		// taken up. Give every outstanding one a full grace window again rather
+		// than reclaiming — and re-sending — work an agent is doing right now.
+		if err := d.opt.Store.TouchTaskReservations(ctx, maxHandoutRestamps, d.opt.Clock.Now()); err != nil {
+			slog.Warn("auto-send: hand-out ledger could not be re-stamped at startup", "error", err)
+		}
 		d.reconcileAttention(ctx)
 		return nil
 	})
@@ -859,6 +866,16 @@ func (d *Daemon) handleTransition(ctx context.Context, tr domain.AgentTransition
 		delete(d.idleSince, tr.AgentID)
 		delete(d.autoTaskClaim, tr.AgentID)
 		d.mu.Unlock()
+		// The agent is doing something, which is the ONLY evidence that an
+		// unattended hand-out actually reached it (a successful `agent send`
+		// only proves herdr accepted the keystrokes). Latch it here rather than
+		// polling status in the sweep: an agent can take a task, finish it, and
+		// park again between two sweeps and still deserves to be confirmed.
+		// A failure leaves the row unconfirmed, so the sweep reclaims the task —
+		// the safe direction, and it is re-sent rather than lost.
+		if err := d.opt.Store.ConfirmTaskReservations(ctx, tr.AgentID, tr.TerminalID, now); err != nil {
+			slog.Warn("auto-send: hand-out could not be confirmed", "agent", tr.AgentID, "error", err)
+		}
 		return
 	case "idle", "done", "blocked":
 		// Attention-requiring: the pane read is DELAYED so the agent TUI
@@ -1750,7 +1767,7 @@ func (d *Daemon) deliverAutonomousClaimed(ctx context.Context, s domain.Situatio
 	// Claim the checklist item BEFORE the send: marking it after delivery
 	// would leave a window in which the very same "[ ]" line is handed to a
 	// second idle agent. A refusal here means somebody already took it.
-	rollback, err := d.reserveDeclaredTask(del.declared, del.taskText)
+	rollback, reservedIndex, err := d.reserveDeclaredTask(del.declared, del.taskText)
 	if err != nil {
 		slog.Warn("declared task could not be reserved; not sending", "agent", s.AgentID, "error", err)
 		d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
@@ -1771,6 +1788,27 @@ func (d *Daemon) deliverAutonomousClaimed(ctx context.Context, s domain.Situatio
 	d.mu.Lock()
 	d.lastAutoSend[s.AgentID] = now
 	d.mu.Unlock()
+
+	// The keystrokes are out, but herdr accepting them is not proof the agent
+	// acted on them. Record the hand-out so the idle sweep can decide from what
+	// happens NEXT — the agent going "working" confirms it; the agent parking
+	// again without ever doing so returns the item to "[ ]" for a fresh attempt
+	// (reclaimStrandedTasks). Recorded AFTER the send, so the failed-send path
+	// above — which rolls the item back itself — never leaves a row behind.
+	if reservedIndex > 0 {
+		if _, err := d.opt.Store.RecordTaskReservation(ctx, domain.TaskReservation{
+			SourcePath: canonicalTaskPath(del.declared.Path), TaskText: del.taskText,
+			ItemIndex: reservedIndex,
+			AgentID:   s.AgentID, PaneID: s.PaneID, TerminalID: s.TerminalID,
+			AuditID: auditID, ReservedAt: now,
+		}); err != nil {
+			// Losing the row costs the self-healing for THIS hand-out (the item
+			// stays "[-]" until an operator clears it), exactly the old
+			// behavior — never a double send.
+			slog.Error("auto-send: hand-out could not be recorded; this task will not self-heal if it is never started",
+				"agent", s.AgentID, "task", del.taskText, "error", err)
+		}
+	}
 
 	// Learning + counters (daemon-owned hot-path rows). The action-review
 	// path pins the learned action at decision time; the synchronous path
@@ -3673,7 +3711,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 			}
 			// Same claim-before-send rule as the rule path: an auto-send source's
 			// item is marked "[-]" before the text reaches the pane.
-			rollback, rerr := d.reserveDeclaredTask(taskReserve, reserveText)
+			rollback, reservedIndex, rerr := d.reserveDeclaredTask(taskReserve, reserveText)
 			if rerr != nil {
 				d.dropAutoTaskClaim(s.AgentID)
 				slog.Warn("reviewed task could not be reserved; not sending", "agent", s.AgentID, "error", rerr)
@@ -3692,6 +3730,20 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 				d.opt.Store.UpdateAuditStatus(ctx, auditID, "escalated")
 				d.notify(ctx, "Herd Auto Prompter: action delivery failed", err.Error())
 				return
+			}
+			// Same as the rule path: the send landing in herdr is not proof the
+			// agent took the task, so record the hand-out for the idle sweep to
+			// confirm or reclaim (see reclaimStrandedTasks).
+			if reservedIndex > 0 {
+				if _, rerr := d.opt.Store.RecordTaskReservation(ctx, domain.TaskReservation{
+					SourcePath: canonicalTaskPath(taskReserve.Path), TaskText: reserveText,
+					ItemIndex: reservedIndex,
+					AgentID:   s.AgentID, PaneID: s.PaneID, TerminalID: s.TerminalID,
+					AuditID: auditID, ReservedAt: now,
+				}); rerr != nil {
+					slog.Error("auto-send: reviewed hand-out could not be recorded; this task will not self-heal if it is never started",
+						"agent", s.AgentID, "task", reserveText, "error", rerr)
+				}
 			}
 			d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "accepted")
 			d.opt.Store.RecordDecision(ctx, domain.DecisionRecord{

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -313,7 +313,56 @@ const (
 	// AuditStatusDeliveryFailed: a delivered action left the agent still
 	// blocked (verifyunblock's diagnostic).
 	AuditStatusDeliveryFailed = "delivery_failed"
+	// AuditStatusReclaimed: an unattended task hand-out was never taken up by
+	// the agent, so its checklist item was returned to "[ ]" for the next sweep.
+	AuditStatusReclaimed = "reclaimed"
 )
+
+// Audit action prefixes for the auto-send-when-idle reclaim path.
+const (
+	// AuditActionTaskReclaimedPrefix prefixes the action of a reclaim row: the
+	// checklist item went back to "[ ]" because the agent it was handed to never
+	// started working.
+	AuditActionTaskReclaimedPrefix = "task_reclaimed:"
+	// AuditActionTaskNeverStartedPrefix prefixes the escalation raised when an
+	// item has been handed out MaxTaskHandouts times without ever being started.
+	AuditActionTaskNeverStartedPrefix = "task_never_started:"
+	// ReasonTaskNeverStarted is the bracketed rationale tag of that escalation
+	// (the daemon's convention for machine-readable reasons).
+	ReasonTaskNeverStarted = "task_never_started"
+)
+
+// TaskReservation is one unattended task hand-out recorded at delivery: the
+// checklist item the daemon marked "[-]" as it sent it, and the agent it was
+// sent to. It is the evidence that a given "[-]" is HAP's own, still-unconfirmed
+// reservation rather than work an operator or an agent marked itself — which is
+// what makes it safe to return the item to "[ ]" when the hand-out never landed.
+//
+// ConfirmedAt is stamped the moment herdr reports the agent working again: that
+// is the only proof the keystrokes reached the agent, since a successful
+// `agent send` only means herdr accepted them. A confirmed row is retired; an
+// unconfirmed one whose agent is parked again past the grace window is reclaimed.
+type TaskReservation struct {
+	ID         int64
+	SourcePath string // canonical (absolute, symlinks resolved) task-source path
+	TaskText   string // raw checklist text, the key ReserveFirstPending claimed on
+	// ItemIndex is the checklist position that was marked. It disambiguates a
+	// list carrying the SAME text twice, where releasing "the first match"
+	// could clear an item somebody else owns. It is a HINT, not an address:
+	// positions renumber on every insert or delete, so a release prefers this
+	// index only while the item there still carries the reserved text.
+	ItemIndex  int
+	AgentID    string
+	PaneID     string
+	TerminalID string
+	AuditID    int64
+	ReservedAt time.Time
+	// Restamps counts how many daemon startups have renewed ReservedAt. The
+	// grace window is the only thing that ages a hand-out toward reclaim, so
+	// this bounds a restart loop from renewing it forever.
+	Restamps    int
+	ConfirmedAt time.Time // zero until the agent was observed working
+}
 
 // AgentStats are lifetime per-agent counters derived from audit_log, keyed by
 // the herdr pane id. A rename preserves them (same pane id); a restart yields

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -212,6 +212,35 @@ type DaemonStore interface {
 	// SaveSignatureSnapshot records the pane excerpt a signature was first
 	// seen with (rule provenance; first sighting wins, later calls no-op).
 	SaveSignatureSnapshot(ctx context.Context, signature, excerpt string, at time.Time) error
+
+	// --- Unattended task hand-out ledger (auto_send_when_idle) ---
+	// The ledger is what lets the idle sweep decide from CURRENT state instead
+	// of trusting a past send: it records which "[-]" marks the daemon wrote,
+	// and whether the agent handed the task was ever seen working afterwards.
+
+	// RecordTaskReservation logs one hand-out and bumps that item's attempt
+	// counter, atomically.
+	RecordTaskReservation(ctx context.Context, r domain.TaskReservation) (int64, error)
+	// OpenTaskReservations returns every recorded hand-out, oldest first.
+	OpenTaskReservations(ctx context.Context) ([]domain.TaskReservation, error)
+	// ConfirmTaskReservations stamps an agent's unconfirmed hand-outs as taken
+	// up — called when herdr reports the agent working again, the only proof
+	// the keystrokes landed. terminalID scopes it to the tenant the hand-out
+	// was made to, so an agent recycled onto the same pane id cannot confirm
+	// (and thereby strand) its predecessor's task; an empty id on either side
+	// matches, as elsewhere in the terminal-identity checks.
+	ConfirmTaskReservations(ctx context.Context, agentID, terminalID string, at time.Time) error
+	// DeleteTaskReservation retires one ledger row.
+	DeleteTaskReservation(ctx context.Context, id int64) error
+	// TouchTaskReservations re-stamps unconfirmed hand-outs so a daemon restart
+	// grants each a full grace window instead of reclaiming live work, up to
+	// maxRestamps times — past that a row ages normally, so a restart loop
+	// cannot renew the window forever.
+	TouchTaskReservations(ctx context.Context, maxRestamps int, at time.Time) error
+	// TaskHandoutAttempts reports how many times an item has been handed out.
+	TaskHandoutAttempts(ctx context.Context, sourcePath, taskText string) (int, error)
+	// ClearTaskHandouts forgets an item's attempt counter.
+	ClearTaskHandouts(ctx context.Context, sourcePath, taskText string) error
 }
 
 // FrontendStore is the front-end (TUI/CLI) write surface plus shared reads.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -208,6 +208,35 @@ CREATE TABLE IF NOT EXISTS signature_snapshots (
 	pane_excerpt TEXT NOT NULL,
 	created_at INTEGER NOT NULL
 );
+-- Ledger of unattended task hand-outs: which "[-]" marks the daemon wrote
+-- itself, for which agent, and whether that agent was ever seen working
+-- afterwards. Unconfirmed rows whose agent parked again are what the idle
+-- sweep returns to "[ ]"; a "[-]" with no row here is somebody else's and is
+-- never touched.
+CREATE TABLE IF NOT EXISTS task_reservations (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	source_path TEXT NOT NULL,
+	task_text TEXT NOT NULL,
+	item_index INTEGER NOT NULL DEFAULT 0,
+	agent_id TEXT NOT NULL,
+	pane_id TEXT NOT NULL,
+	terminal_id TEXT NOT NULL DEFAULT '',
+	audit_id INTEGER NOT NULL DEFAULT 0,
+	reserved_at INTEGER NOT NULL,
+	restamps INTEGER NOT NULL DEFAULT 0,
+	confirmed_at INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_task_res_agent ON task_reservations(agent_id);
+-- Per-item hand-out counter, kept SEPARATELY from task_reservations so it
+-- survives the reservation row being retired on every reclaim. It is what caps
+-- an item that can never be delivered from being resent forever.
+CREATE TABLE IF NOT EXISTS task_handouts (
+	source_path TEXT NOT NULL,
+	task_text TEXT NOT NULL,
+	attempts INTEGER NOT NULL DEFAULT 0,
+	updated_at INTEGER NOT NULL,
+	PRIMARY KEY (source_path, task_text)
+);
 `
 
 func (s *Store) migrate() error {
@@ -1445,6 +1474,133 @@ func (s *Store) GetAgentRate(ctx context.Context, agentID string) (*domain.Agent
 	r.WindowStart = fromUnix(windowStart)
 	r.Paused = paused != 0
 	return &r, nil
+}
+
+// --- Unattended task hand-out ledger (auto_send_when_idle) ---
+
+// RecordTaskReservation logs one unattended hand-out and bumps that item's
+// attempt counter, as a single transaction: the counter is what stops an item
+// that can never be delivered from being reclaimed and resent forever, so it
+// must not be able to drift from the reservations it counts.
+func (s *Store) RecordTaskReservation(ctx context.Context, r domain.TaskReservation) (int64, error) {
+	var id int64
+	err := s.tx(ctx, func(tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, `
+			INSERT INTO task_reservations
+				(source_path, task_text, item_index, agent_id, pane_id, terminal_id, audit_id,
+				 reserved_at, restamps, confirmed_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 0)`,
+			r.SourcePath, r.TaskText, r.ItemIndex, r.AgentID, r.PaneID, r.TerminalID,
+			r.AuditID, unix(r.ReservedAt))
+		if err != nil {
+			return err
+		}
+		if id, err = res.LastInsertId(); err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO task_handouts (source_path, task_text, attempts, updated_at)
+			VALUES (?, ?, 1, ?)
+			ON CONFLICT(source_path, task_text)
+			DO UPDATE SET attempts = attempts + 1, updated_at = excluded.updated_at`,
+			r.SourcePath, r.TaskText, unix(r.ReservedAt))
+		return err
+	})
+	return id, err
+}
+
+// OpenTaskReservations returns every recorded hand-out, oldest first. Rows are
+// retired by the reclaim sweep, so this stays small (one row per in-flight
+// hand-out); no LIMIT is needed and none is wanted — a dropped row would strand
+// the "[-]" it describes.
+func (s *Store) OpenTaskReservations(ctx context.Context) ([]domain.TaskReservation, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, source_path, task_text, item_index, agent_id, pane_id, terminal_id, audit_id,
+		       reserved_at, restamps, confirmed_at
+		FROM task_reservations ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []domain.TaskReservation
+	for rows.Next() {
+		var r domain.TaskReservation
+		var reserved, confirmed int64
+		if err := rows.Scan(&r.ID, &r.SourcePath, &r.TaskText, &r.ItemIndex, &r.AgentID, &r.PaneID,
+			&r.TerminalID, &r.AuditID, &reserved, &r.Restamps, &confirmed); err != nil {
+			return nil, err
+		}
+		r.ReservedAt, r.ConfirmedAt = fromUnix(reserved), fromUnix(confirmed)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ConfirmTaskReservations stamps an agent's still-unconfirmed hand-outs as
+// taken up. Its caller is the "agent is working again" transition, which is the
+// only evidence the keystrokes actually reached the agent — a successful
+// `agent send` only proves herdr accepted them.
+//
+// terminalID scopes it to the SAME tenant the hand-out was made to. herdr
+// reuses compact pane ids, and an agent id is a pane id: without this, a fresh
+// agent recycled onto that id would confirm — and so permanently strand — the
+// previous tenant's untaken task the first time it did any work. Rows and
+// transitions that carry no terminal id (older herdr, event-socket transitions)
+// match anything, so this can never block confirmation on a herdr that does not
+// report terminal identity — the same fail-open rule as paneRecycled.
+func (s *Store) ConfirmTaskReservations(ctx context.Context, agentID, terminalID string, at time.Time) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE task_reservations SET confirmed_at = ?
+		WHERE agent_id = ? AND confirmed_at = 0
+		  AND (terminal_id = '' OR ? = '' OR terminal_id = ?)`,
+		unix(at), agentID, terminalID, terminalID)
+	return err
+}
+
+// DeleteTaskReservation retires one ledger row (confirmed, reclaimed, or gone
+// from the file).
+func (s *Store) DeleteTaskReservation(ctx context.Context, id int64) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM task_reservations WHERE id = ?`, id)
+	return err
+}
+
+// TouchTaskReservations re-stamps unconfirmed hand-outs' reserved_at, giving
+// each a full grace window again. The daemon calls it at startup: confirmation
+// is an in-flight "agent went working" observation, so a restart loses it for
+// hand-outs that WERE taken up, and reclaiming immediately would re-open work an
+// agent is doing right now.
+//
+// maxRestamps bounds it, because the grace window is the ONLY thing that ages a
+// hand-out toward being reclaimed: an unbounded re-stamp means a crash-looping
+// or frequently-restarted daemon renews the window forever and the task is
+// stranded silently, with the attempt counter never advancing to the escalation.
+// Past the bound a row keeps its original timestamp and ages normally.
+func (s *Store) TouchTaskReservations(ctx context.Context, maxRestamps int, at time.Time) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE task_reservations SET reserved_at = ?, restamps = restamps + 1
+		WHERE confirmed_at = 0 AND restamps < ?`, unix(at), maxRestamps)
+	return err
+}
+
+// TaskHandoutAttempts reports how many times an item has been handed out
+// (0 when never).
+func (s *Store) TaskHandoutAttempts(ctx context.Context, sourcePath, taskText string) (int, error) {
+	var n int
+	err := s.db.QueryRowContext(ctx, `
+		SELECT attempts FROM task_handouts WHERE source_path = ? AND task_text = ?`,
+		sourcePath, taskText).Scan(&n)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	return n, err
+}
+
+// ClearTaskHandouts forgets an item's attempt counter, so a task that is picked
+// up (or completed, or edited) starts from zero if it is ever handed out again.
+func (s *Store) ClearTaskHandouts(ctx context.Context, sourcePath, taskText string) error {
+	_, err := s.db.ExecContext(ctx, `
+		DELETE FROM task_handouts WHERE source_path = ? AND task_text = ?`, sourcePath, taskText)
+	return err
 }
 
 // GetErrorRetry returns the retry counter for an error signature (zero when absent).

--- a/internal/taskfile/taskfile.go
+++ b/internal/taskfile/taskfile.go
@@ -199,16 +199,24 @@ func ReserveFirstPending(taskText string) (func(string) (string, error), *int) {
 // sweep can hand it out again. It is the daemon's counterpart to
 // ReserveFirstPending, undoing a hand-out the agent never took up.
 //
-// It prefers the position the reservation recorded and falls back to the first
-// text match, because neither key alone is sound here: positions renumber on
-// every insert or delete, so an index resolved minutes ago can address a
-// different line; but text is not unique either — a checklist may well repeat
-// "run tests", and clearing the FIRST such "[-]" when the reservation claimed
-// the second would take back an item somebody else owns. Preferring the index
-// while it still carries the reserved text gets both. Pass index <= 0 when
-// none was recorded (rows written before the column existed).
+// Neither of the two available keys is sound alone: positions renumber on every
+// insert or delete, so an index resolved minutes ago can address a different
+// line; but text is not unique either — a checklist may well repeat "run tests".
+// So it resolves in two steps, and the second one FAILS CLOSED:
 //
-// Deliberately narrow, because the caller is unattended:
+//  1. the recorded position, while it still carries the reserved text as "[-]" —
+//     unambiguous, and the normal case;
+//  2. otherwise the sole "[-]" carrying that text, but ONLY when the text
+//     appears once in the whole checklist. A duplicated text means the caller
+//     cannot prove which copy its reservation claimed, and clearing the wrong one
+//     would take back an item somebody else owns — precisely the invariant this
+//     is meant to uphold. Refusing leaves the item "[-]", which is where the
+//     feature stood before any of this existed.
+//
+// Pass index <= 0 when none was recorded (rows written before the position was
+// stored); step 2 then decides on its own, under the same uniqueness rule.
+//
+// Deliberately narrow otherwise, because the caller is unattended:
 //   - only a "[-]" item is touched. An item now "[x]" was completed and an item
 //     already "[ ]" needs nothing — either way, silently re-opening it would
 //     re-arm work somebody finished.
@@ -221,16 +229,27 @@ func ReserveFirstPending(taskText string) (func(string) (string, error), *int) {
 func Reclaim(index int, taskText string) func(string) (string, error) {
 	return func(content string) (string, error) {
 		items := domain.ParseChecklist(content)
+		occurrences, inProgress := 0, -1
 		for _, it := range items {
-			if it.Index == index && it.Text == taskText && it.Mark == domain.MarkInProgress {
+			if it.Text != taskText {
+				continue
+			}
+			occurrences++
+			if it.Mark != domain.MarkInProgress {
+				continue
+			}
+			if it.Index == index {
 				return domain.SetChecklistItemDone(content, it.Index, false)
 			}
+			inProgress = it.Index
 		}
-		for _, it := range items {
-			if it.Text == taskText && it.Mark == domain.MarkInProgress {
-				return domain.SetChecklistItemDone(content, it.Index, false)
-			}
+		if inProgress < 0 {
+			return "", fmt.Errorf("no in-progress task matching %q remains in the list — it was completed, released or edited", taskText)
 		}
-		return "", fmt.Errorf("no in-progress task matching %q remains in the list — it was completed, released or edited", taskText)
+		if occurrences > 1 {
+			return "", fmt.Errorf("task #%d is not the %q this send reserved and the text appears %d times — "+
+				"refusing to release a copy that may not be ours", index, taskText, occurrences)
+		}
+		return domain.SetChecklistItemDone(content, inProgress, false)
 	}
 }

--- a/internal/taskfile/taskfile.go
+++ b/internal/taskfile/taskfile.go
@@ -194,3 +194,43 @@ func ReserveFirstPending(taskText string) (func(string) (string, error), *int) {
 		return "", fmt.Errorf("no pending task matching %q remains in the list — it was completed, claimed or edited", taskText)
 	}, claimed
 }
+
+// Reclaim returns one "[-]" item carrying taskText to "[ ]", so the next idle
+// sweep can hand it out again. It is the daemon's counterpart to
+// ReserveFirstPending, undoing a hand-out the agent never took up.
+//
+// It prefers the position the reservation recorded and falls back to the first
+// text match, because neither key alone is sound here: positions renumber on
+// every insert or delete, so an index resolved minutes ago can address a
+// different line; but text is not unique either — a checklist may well repeat
+// "run tests", and clearing the FIRST such "[-]" when the reservation claimed
+// the second would take back an item somebody else owns. Preferring the index
+// while it still carries the reserved text gets both. Pass index <= 0 when
+// none was recorded (rows written before the column existed).
+//
+// Deliberately narrow, because the caller is unattended:
+//   - only a "[-]" item is touched. An item now "[x]" was completed and an item
+//     already "[ ]" needs nothing — either way, silently re-opening it would
+//     re-arm work somebody finished.
+//   - "no such item" is an error, not a no-op, so the caller can tell "left it
+//     alone" from "reclaimed it" and audit accordingly.
+//
+// The caller must additionally prove the "[-]" is the daemon's OWN reservation
+// (a task_reservations row); this helper cannot distinguish an operator's or an
+// agent's own in-progress mark from HAP's.
+func Reclaim(index int, taskText string) func(string) (string, error) {
+	return func(content string) (string, error) {
+		items := domain.ParseChecklist(content)
+		for _, it := range items {
+			if it.Index == index && it.Text == taskText && it.Mark == domain.MarkInProgress {
+				return domain.SetChecklistItemDone(content, it.Index, false)
+			}
+		}
+		for _, it := range items {
+			if it.Text == taskText && it.Mark == domain.MarkInProgress {
+				return domain.SetChecklistItemDone(content, it.Index, false)
+			}
+		}
+		return "", fmt.Errorf("no in-progress task matching %q remains in the list — it was completed, released or edited", taskText)
+	}
+}

--- a/internal/taskfile/taskfile_test.go
+++ b/internal/taskfile/taskfile_test.go
@@ -141,9 +141,9 @@ func TestLockPathIsStableAcrossEquivalentPaths(t *testing.T) {
 
 func TestReclaim(t *testing.T) {
 	// The daemon's reclaim path takes back a hand-out the agent never started.
-	// It may only touch an item that is still [-], and it prefers the recorded
-	// position over a bare text match so a list repeating one task cannot have
-	// the wrong copy released.
+	// It may only touch an item that is still [-], and on a list repeating one
+	// task it releases the recorded position or nothing at all — releasing "the
+	// first [-] with this text" could clear a copy somebody else owns.
 	const list = "- [ ] alpha\n- [-] beta\n- [x] gamma\n- [-] beta\n"
 	tests := []struct {
 		name    string
@@ -160,17 +160,17 @@ func TestReclaim(t *testing.T) {
 			want: "- [ ] alpha\n- [-] beta\n- [x] gamma\n- [ ] beta\n",
 		},
 		{
-			name: "falls back to the first text match when the list renumbered",
-			// Positions shift on every insert or delete, so an index that no
-			// longer carries the reserved text is a stale address, not a veto.
-			index: 3, task: "beta",
-			want: "- [ ] alpha\n- [ ] beta\n- [x] gamma\n- [-] beta\n",
+			name: "refuses an ambiguous duplicate when the position does not match",
+			// The recorded position no longer carries the text, so the only
+			// candidates are copies we cannot prove are ours — one of which may
+			// be the operator's own in-progress mark. Fail closed.
+			index: 3, task: "beta", wantErr: true,
 		},
 		{
-			name: "falls back when no position was recorded",
-			// Rows written before the position was stored carry 0.
-			index: 0, task: "beta",
-			want: "- [ ] alpha\n- [ ] beta\n- [x] gamma\n- [-] beta\n",
+			name: "refuses a duplicate when no position was recorded",
+			// Rows written before the position was stored carry 0, which cannot
+			// disambiguate a repeated text either.
+			index: 0, task: "beta", wantErr: true,
 		},
 		{
 			// Completed work must never be silently re-opened and re-handed out.
@@ -188,18 +188,59 @@ func TestReclaim(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := Reclaim(tc.index, tc.task)(list)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("expected an error, got %q", got)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got != tc.want {
-				t.Errorf("got:\n%s\nwant:\n%s", got, tc.want)
-			}
+			checkReclaim(t, got, err, tc.want, tc.wantErr)
 		})
+	}
+}
+
+func TestReclaimUniqueText(t *testing.T) {
+	// With the text appearing once there is nothing to confuse, so a stale
+	// position (the list renumbered under the reservation) is just an address
+	// that missed — it must not veto the release.
+	const list = "- [ ] alpha\n- [-] beta\n- [x] gamma\n"
+	tests := []struct {
+		name    string
+		index   int
+		task    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "releases on the recorded position",
+			index: 2, task: "beta",
+			want: "- [ ] alpha\n- [ ] beta\n- [x] gamma\n",
+		},
+		{
+			name:  "releases despite a stale position",
+			index: 7, task: "beta",
+			want: "- [ ] alpha\n- [ ] beta\n- [x] gamma\n",
+		},
+		{
+			name:  "releases when no position was recorded",
+			index: 0, task: "beta",
+			want: "- [ ] alpha\n- [ ] beta\n- [x] gamma\n",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Reclaim(tc.index, tc.task)(list)
+			checkReclaim(t, got, err, tc.want, tc.wantErr)
+		})
+	}
+}
+
+func checkReclaim(t *testing.T, got string, err error, want string, wantErr bool) {
+	t.Helper()
+	if wantErr {
+		if err == nil {
+			t.Fatalf("expected an error, got %q", got)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
 	}
 }

--- a/internal/taskfile/taskfile_test.go
+++ b/internal/taskfile/taskfile_test.go
@@ -138,3 +138,68 @@ func TestLockPathIsStableAcrossEquivalentPaths(t *testing.T) {
 		t.Errorf("lock path differs for equivalent paths: %s vs %s", LockPath(path), LockPath(viaDot))
 	}
 }
+
+func TestReclaim(t *testing.T) {
+	// The daemon's reclaim path takes back a hand-out the agent never started.
+	// It may only touch an item that is still [-], and it prefers the recorded
+	// position over a bare text match so a list repeating one task cannot have
+	// the wrong copy released.
+	const list = "- [ ] alpha\n- [-] beta\n- [x] gamma\n- [-] beta\n"
+	tests := []struct {
+		name    string
+		index   int
+		task    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "releases the recorded position",
+			// The list repeats "beta"; the hand-out reserved #4, so #2 — which
+			// may be somebody else's in-progress mark — must stay put.
+			index: 4, task: "beta",
+			want: "- [ ] alpha\n- [-] beta\n- [x] gamma\n- [ ] beta\n",
+		},
+		{
+			name: "falls back to the first text match when the list renumbered",
+			// Positions shift on every insert or delete, so an index that no
+			// longer carries the reserved text is a stale address, not a veto.
+			index: 3, task: "beta",
+			want: "- [ ] alpha\n- [ ] beta\n- [x] gamma\n- [-] beta\n",
+		},
+		{
+			name: "falls back when no position was recorded",
+			// Rows written before the position was stored carry 0.
+			index: 0, task: "beta",
+			want: "- [ ] alpha\n- [ ] beta\n- [x] gamma\n- [-] beta\n",
+		},
+		{
+			// Completed work must never be silently re-opened and re-handed out.
+			name: "refuses a completed item", index: 3, task: "gamma", wantErr: true,
+		},
+		{
+			// Already pending: nothing to take back, and the caller must be able
+			// to tell that apart from a real reclaim for its audit row.
+			name: "refuses a pending item", index: 1, task: "alpha", wantErr: true,
+		},
+		{
+			name: "refuses a text that is gone", index: 1, task: "delta", wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Reclaim(tc.index, tc.task)(list)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Errorf("got:\n%s\nwant:\n%s", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
An `enable_auto_send_task_when_idle` source marks a checklist item `[-]` before sending it, and rolls that back **only** when herdr's send call errors. But a successful `agent send` proves herdr accepted the keystrokes — not that the agent acted on them. Text typed into a CLI that is restarting, repainting, or unfocused is silently lost.

The item then sat `[-]` forever: `domain.PendingDeclaredTasks` yields only `[ ]`, so no agent was ever offered it again. A few of those and the queue drains into permanently reserved items, every agent idle beside a checklist that still has work, the log reading `auto-send: no pending task left for idle agent`.

## What changed

Each sweep now decides from **current state** instead of trusting the last send:

- every hand-out is recorded in a new `task_reservations` ledger, and confirmed only when herdr reports that agent **working** (`handleTransition`) — a latch, so an agent that takes a task, finishes, and parks again between sweeps still counts as confirmed;
- `reclaimStrandedTasks` returns an unconfirmed hand-out's item to `[ ]` once its agent is parked again past `reclaimGrace` (2 min), and re-offers it **in the same sweep** — to that agent or any other idle one.

## Bounds that keep it from becoming its own runaway

- **Only a `[-]` the daemon holds a ledger row for is ever released.** An operator's or an agent's own in-progress mark is never cleared.
- **One unconfirmed hand-out per agent.** Confirmation is per-agent (a `working` transition says nothing about *which* task), so a second hand-out layered on an unconfirmed first would let one resumption confirm — and thereby permanently strand — the task the agent never received.
- **Confirm and reclaim both compare `terminal_id`.** herdr recycles compact pane ids and an agent id *is* a pane id, so a successor must not confirm (or indefinitely pin) its predecessor's untaken task.
- **`maxTaskHandouts` (3) unstarted hand-outs of one item** ⇒ it is left `[-]` and escalated (`task_never_started:…`) rather than resent forever. The escalation is informational (no `Suggestion`, so a confirm cannot type prose into the pane) and names the file via `--path`.

Two further stalls closed: the startup grace re-stamp is bounded (`maxHandoutRestamps`), since a crash loop would otherwise renew the window forever and strand tasks silently; and a `staleHandoutTTL` backstop gives up on a row no sweep can settle (e.g. a task source that stopped being readable), which would otherwise bench its agent from every future pairing.

`autoTaskClaimTTL` drops from 10 min to `reclaimGrace`: a claim only has to survive capture → delivery, and a longer one both skips its agent and hides its task from every other.

Duplicate task texts are handled by recording the reserved checklist position and preferring it on release, falling back to text only when the list renumbered — releasing "the first `[-]` matching this text" could otherwise clear an item somebody else owns.

## Tests

12 new cases in `internal/daemon/autosendidle_test.go` and `internal/taskfile/taskfile_test.go`, covering: reclaim + resend, confirmed-never-reclaimed, foreign `[-]` untouched, grace window, working agent, departed agent, recycled pane on both the reclaim and confirm sides, one-hand-out-per-agent, attempt-counter reset, the escalation cap, the stale backstop, and `taskfile.Reclaim`'s index/text resolution.

Full suite green (`go test -tags "vectors cpu" ./... -count=1`); `golangci-lint` 0 issues.