### PR TITLE
#1 feat: per-command environment variables for the LLM CLIs

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -381,6 +381,13 @@ edits made through `hap config set` / `set-threshold` apply live — the command
 | `llm.task_generate_command` | (unset) | argv template for the one-shot task suggestion given to an idle agent with NO task source, or a declared source that ran out (see task sources); empty keeps escalate-only behavior |
 | `llm.task_generate_command_start` | (unset) | argv template for the FIRST task generation per agent (no-source case only; empty inherits `llm.task_generate_command`); an exhausted declared source only generates more tasks when BOTH this and `llm.task_generate_command` are set, and always uses `llm.task_generate_command` (never this) since a list already exists |
 | `llm.task_generate_timeout_seconds` | 0 (inherits `timeout_seconds`) | timeout for one task-generation run |
+| `llm.env` / `llm.env_file` | (unset) | environment shared by all four llm commands: an inline `[llm.env]` table, and/or a path to a `.env` file (`KEY=VALUE`, `#` comments, `export`, quotes, `~/` expanded) |
+| `llm.command_env` / `llm.command_env_file` | (unset) | environment for `llm.command` only, layered over the shared one |
+| `llm.command_start_env` / `llm.command_start_env_file` | (unset) | environment for `llm.command_start` only |
+| `llm.task_generate_command_env` / `llm.task_generate_command_env_file` | (unset) | environment for `llm.task_generate_command` only — e.g. a cheaper model or a different key for task ideas |
+| `llm.task_generate_command_start_env` / `llm.task_generate_command_start_env_file` | (unset) | environment for `llm.task_generate_command_start` only |
+
+per-command env notes: layering is daemon env → `env_file` → `env` → the command's `…_env_file` → the command's `…_env`, with hap's own `HAP_*` variables injected last; names starting with `HAP_`/`HERDR_` are reserved and ignored. env files are read when the CLI is SPAWNED (edits apply with no restart, and secrets never enter `config.toml`); a configured file that cannot be read, has a malformed line, or defines nothing fails that run rather than launching the CLI without its credentials. values accept the command template's placeholders except `{pane_excerpt}`. `hap config` shows variable NAMES and file paths only — never values.
 | `embedding.disabled` | false | disable semantic matching entirely |
 | `embedding.model_path` | (bundled all-minilm-l6-v2-q8_0.gguf) | path to a .gguf embedding model |
 | `embedding.similarity_threshold` | 0.90 | min cosine similarity to reuse a learned signature |

--- a/README.md
+++ b/README.md
@@ -995,6 +995,56 @@ command       = [ "claude", "-p", "...ongoing consult prompt...", "--model", "ha
 command_start = [ "claude", "-p", "...first-touch kickoff prompt...", "--model", "opus" ]
 ```
 
+#### A separate environment per command
+
+Each of the four command templates — `command`, `command_start`,
+`task_generate_command`, `task_generate_command_start` — can be spawned with
+its own environment, so one CLI can run against a different key, provider,
+model, or proxy than another. Set the variables inline, or keep them in a
+`.env` file:
+
+```toml
+[llm]
+env_file = "~/.config/hap/llm.env"                              # shared by all four
+command_env_file = "/path/to/claude_consult.env"
+task_generate_command_env_file = "/path/to/claude_task_generate.env"
+# command_start_env_file / task_generate_command_start_env_file likewise
+
+# Inline tables must come after every plain `key = value` in [llm]:
+[llm.env]
+ANTHROPIC_BASE_URL = "https://proxy.internal"
+[llm.command_env]
+ANTHROPIC_MODEL = "opus"
+[llm.task_generate_command_env]
+ANTHROPIC_MODEL = "haiku"                                       # cheaper for task ideas
+```
+
+The `.env` format is the usual one: `KEY=VALUE` per line, `#` comments, an
+optional `export` prefix, and single/double quotes (`\n`, `\t`, `\"`, `\\`
+escapes inside double quotes). `~/` is expanded. In an *unquoted* value a
+` #` starts a comment, so quote any value that contains one; a value that
+opens a quote without closing it (a pasted multi-line key) is rejected
+rather than passed on truncated. **Secrets belong in the file, not in
+`config.toml`**: it is read when the CLI is *spawned*, so its contents never
+pass through the config, and editing it applies to the next run with no
+restart.
+
+Layering, last wins: the daemon's own environment → `env_file` → `env` →
+the command's `…_env_file` → the command's `…_env`. Names starting with
+`HAP_` or `HERDR_` are reserved and ignored with a warning (they wire the
+MCP handshake and the plugin's own directories, so redirecting them would
+point a nested `hap`/`herdr` at another installation). Values accept the
+same placeholders as the command template, except `{pane_excerpt}`
+(untrusted pane text is never put in a child's environment).
+
+A configured env file that cannot be read, has a malformed line, or defines
+no variables at all **fails that run** — it escalates instead of launching
+the CLI without its credentials, which would otherwise surface much later as
+an opaque authentication error. The failure names the file and the line
+number, never the line's content. And because these values are credentials,
+`hap config` prints variable **names** and file paths only; no value is ever
+displayed or logged.
+
 The preferred template also has a one-shot **fast-fail fallback**. If it
 exits with an error in under one second without staging a decision, hap tries
 the other template (`command` ↔ `command_start`) once. This works in both

--- a/README.md
+++ b/README.md
@@ -1037,6 +1037,11 @@ point a nested `hap`/`herdr` at another installation). Values accept the
 same placeholders as the command template, except `{pane_excerpt}`
 (untrusted pane text is never put in a child's environment).
 
+A `PATH` set this way is honoured for finding the CLI itself: the command is
+resolved against the environment the child will actually run with, not the
+daemon's. An inline key that is not a valid variable name (TOML lets you
+quote anything) fails the run rather than being reinterpreted.
+
 A configured env file that cannot be read, has a malformed line, or defines
 no variables at all **fails that run** — it escalates instead of launching
 the CLI without its credentials, which would otherwise surface much later as

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -246,6 +246,15 @@ func runDaemon(ctx context.Context, paths config.Paths, args []string) error {
 			TaskGenTemplate:      cfg.LLM.GenerateTaskCommand,
 			TaskGenStartTemplate: cfg.LLM.GenerateTaskCommandStart,
 			TaskGenTimeout:       cfg.GenerateTaskTimeout(),
+			// The `.env` files are never read here: the adapter reads them
+			// when it spawns a CLI, so editing a file applies to the next
+			// run, and changing the configured PATH applies on the next
+			// config reload (which rebuilds this adapter).
+			BaseEnv:         llm.EnvSpec{Vars: cfg.LLM.Env, File: cfg.LLM.EnvFile},
+			CommandEnv:      llm.EnvSpec{Vars: cfg.LLM.CommandEnv, File: cfg.LLM.CommandEnvFile},
+			CommandStartEnv: llm.EnvSpec{Vars: cfg.LLM.CommandStartEnv, File: cfg.LLM.CommandStartEnvFile},
+			TaskGenEnv:      llm.EnvSpec{Vars: cfg.LLM.GenerateTaskEnv, File: cfg.LLM.GenerateTaskEnvFile},
+			TaskGenStartEnv: llm.EnvSpec{Vars: cfg.LLM.GenerateTaskStartEnv, File: cfg.LLM.GenerateTaskStartEnvFile},
 		}
 	}
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1028,12 +1028,33 @@ func printConfig(out io.Writer, cfg config.Config) {
 		cfg.Limits.MaxConsecutiveAutoPrompts, cfg.Limits.MaxAutoPromptsPerMinute, cfg.Limits.MaxErrorRetries)
 	fmt.Fprintf(out, "llm:        configured=%v timeout=%ds auto_act_confidence_threshold=%d\n",
 		len(cfg.LLM.Command) > 0, cfg.LLM.TimeoutSeconds, cfg.LLM.AutoActConfidenceThreshold)
+	for _, env := range cfg.LLM.EnvSummaries() {
+		// Names and the file path only — these variables carry API keys, so
+		// no value ever reaches an operator-facing surface.
+		fmt.Fprintf(out, "llm env:    %s: %s\n", env.Scope, describeEnvSummary(env))
+	}
 	seedCount := domain.SeedNeverAutoRuleCount()
 	if cfg.Safety.DisableNeverAutoSeedPatterns {
 		seedCount = 0
 	}
 	fmt.Fprintf(out, "task sources: %d, operator never-auto rules: %d (+%d seed)\n",
 		len(cfg.TaskSources), len(cfg.Safety.NeverAutoPatterns)+len(cfg.Safety.NeverAutoRules), seedCount)
+}
+
+// describeEnvSummary renders one command's environment for display. It prints
+// variable NAMES and the `.env` path only: the values are credentials, so they
+// must never reach the terminal (nor a log, nor the audit trail). The file's
+// contents are deliberately not read here — the count of variables it defines
+// is not worth opening a secrets file to display.
+func describeEnvSummary(env config.LLMEnvSummary) string {
+	var parts []string
+	if len(env.Keys) > 0 {
+		parts = append(parts, fmt.Sprintf("%d var(s) [%s]", len(env.Keys), strings.Join(env.Keys, ", ")))
+	}
+	if env.File != "" {
+		parts = append(parts, "file "+env.File)
+	}
+	return strings.Join(parts, ", ")
 }
 
 func rules(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1969,3 +1969,39 @@ func TestTaskSourceAddMaxTasks(t *testing.T) {
 		t.Errorf("a refused add must not register a source, got %+v", saved.TaskSources)
 	}
 }
+
+// TestConfigShowsEnvKeysNeverValues pins the secrecy rule for the per-command
+// LLM environment: `hap config` names the variables and the .env file so the
+// operator can debug the wiring, but the values are API keys and must never
+// reach the terminal.
+func TestConfigShowsEnvKeysNeverValues(t *testing.T) {
+	app, _ := testApp(t)
+	cfg := config.Default()
+	cfg.LLM.Command = []string{"claude", "-p", "hi"}
+	cfg.LLM.Env = map[string]string{"ANTHROPIC_BASE_URL": "https://proxy.example.test"}
+	cfg.LLM.CommandEnv = map[string]string{"ANTHROPIC_API_KEY": "sk-ant-supersecret"}
+	cfg.LLM.GenerateTaskEnvFile = "/etc/hap/taskgen.env"
+	if err := config.Save(app.ConfigPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"ANTHROPIC_BASE_URL",    // shared key name
+		"ANTHROPIC_API_KEY",     // per-command key name
+		"/etc/hap/taskgen.env",  // the file path is not a secret
+		"task_generate_command", // the scope it belongs to
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("config output missing %q:\n%s", want, out)
+		}
+	}
+	for _, secret := range []string{"sk-ant-supersecret", "https://proxy.example.test"} {
+		if strings.Contains(out, secret) {
+			t.Errorf("config output leaked an env VALUE (%q):\n%s", secret, out)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,8 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -167,6 +169,50 @@ type LLM struct {
 	// GenerateTaskTimeoutSeconds bounds one task-generation run; zero or
 	// omitted inherits timeout_seconds.
 	GenerateTaskTimeoutSeconds int `toml:"task_generate_timeout_seconds,omitempty"`
+
+	// ── Per-command environment ──────────────────────────────────────
+	// Each of the four command templates can carry its own environment, so
+	// one CLI can run against a different provider/model/key than another.
+	// Values may be listed inline (`*_env` tables) or kept out of the config
+	// in a `.env` file (`*_env_file`), which is the right home for secrets:
+	// the file is read when the CLI is SPAWNED, never at load time, so Save
+	// can never copy its contents into config.toml and an edit applies to
+	// the next run without a restart. A configured-but-unreadable file fails
+	// the run (escalation) rather than silently launching without its key.
+	//
+	// Layering, last wins: the daemon's own environment, then EnvFile, Env
+	// (the shared base, applied to all four commands), then the command's
+	// own *EnvFile and *Env. hap's HAP_* variables are always injected last.
+	// Values support the same placeholders as the command template, minus
+	// {pane_excerpt} (untrusted pane text is never put in the environment).
+	//
+	// EnvFile is the shared `.env` file applied to every command; `~/` is
+	// expanded, and a relative path resolves against the daemon's cwd.
+	EnvFile string `toml:"env_file,omitempty"`
+	// CommandEnvFile is the `.env` file for Command only.
+	CommandEnvFile string `toml:"command_env_file,omitempty"`
+	// CommandStartEnvFile is the `.env` file for CommandStart only.
+	CommandStartEnvFile string `toml:"command_start_env_file,omitempty"`
+	// GenerateTaskEnvFile is the `.env` file for GenerateTaskCommand only.
+	GenerateTaskEnvFile string `toml:"task_generate_command_env_file,omitempty"`
+	// GenerateTaskStartEnvFile is the `.env` file for
+	// GenerateTaskCommandStart only.
+	GenerateTaskStartEnvFile string `toml:"task_generate_command_start_env_file,omitempty"`
+
+	// Env is the shared inline environment applied to every command.
+	// Map fields are declared last: the TOML encoder emits sub-tables after
+	// the scalars of their parent table, and keeping the declaration order
+	// aligned with the emitted order keeps a re-saved config readable.
+	Env map[string]string `toml:"env,omitempty"`
+	// CommandEnv is the inline environment for Command only.
+	CommandEnv map[string]string `toml:"command_env,omitempty"`
+	// CommandStartEnv is the inline environment for CommandStart only.
+	CommandStartEnv map[string]string `toml:"command_start_env,omitempty"`
+	// GenerateTaskEnv is the inline environment for GenerateTaskCommand only.
+	GenerateTaskEnv map[string]string `toml:"task_generate_command_env,omitempty"`
+	// GenerateTaskStartEnv is the inline environment for
+	// GenerateTaskCommandStart only.
+	GenerateTaskStartEnv map[string]string `toml:"task_generate_command_start_env,omitempty"`
 }
 
 // Embedding configures semantic signature matching: situations are matched
@@ -872,6 +918,50 @@ func (c *Config) fillZeroes() {
 	if c.Embedding.BM25MinScore <= 0 || c.Embedding.BM25MinScore > 1 {
 		c.Embedding.BM25MinScore = d.Embedding.BM25MinScore
 	}
+}
+
+// LLMEnvSummary describes the environment configured for ONE command, with
+// the values deliberately left out: these hold API keys and tokens, so
+// anything operator-facing (`hap config`, the TUI) shows key NAMES only. The
+// file path is included — it is not itself a secret and the operator needs it
+// to debug — but its contents are never read for display.
+type LLMEnvSummary struct {
+	// Scope names the command the environment belongs to ("shared" for the
+	// base applied to all four).
+	Scope string
+	// Keys are the inline variable NAMES, sorted. Never their values.
+	Keys []string
+	// File is the configured `.env` path, or "" when none is set.
+	File string
+}
+
+// EnvSummaries reports the configured per-command environments, omitting the
+// scopes that configure nothing. See LLMEnvSummary: values are never included.
+func (l LLM) EnvSummaries() []LLMEnvSummary {
+	scopes := []struct {
+		name string
+		vars map[string]string
+		file string
+	}{
+		{"shared", l.Env, l.EnvFile},
+		{"command", l.CommandEnv, l.CommandEnvFile},
+		{"command_start", l.CommandStartEnv, l.CommandStartEnvFile},
+		{"task_generate_command", l.GenerateTaskEnv, l.GenerateTaskEnvFile},
+		{"task_generate_command_start", l.GenerateTaskStartEnv, l.GenerateTaskStartEnvFile},
+	}
+	var out []LLMEnvSummary
+	for _, s := range scopes {
+		if len(s.vars) == 0 && strings.TrimSpace(s.file) == "" {
+			continue
+		}
+		keys := make([]string, 0, len(s.vars))
+		for k := range s.vars {
+			keys = append(keys, k)
+		}
+		slices.Sort(keys)
+		out = append(out, LLMEnvSummary{Scope: s.name, Keys: keys, File: s.file})
+	}
+	return out
 }
 
 // LLMTimeout returns the configured LLM timeout as a duration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1530,3 +1530,113 @@ func TestSampleConfigParsesWithDocumentedDefaults(t *testing.T) {
 			cfg.TUI.TerminalBell, def.TUI.TerminalBell)
 	}
 }
+
+func TestLLMCommandEnvRoundTrip(t *testing.T) {
+	// Every command carries its own environment; a Save must preserve all of
+	// them and must not disturb the scalar keys of the [llm] table (the TOML
+	// encoder emits sub-tables after scalars — this pins that).
+	path := filepath.Join(t.TempDir(), "config.toml")
+	cfg := Default()
+	cfg.LLM.Command = []string{"claude", "-p", "hi"}
+	cfg.LLM.TimeoutSeconds = 120
+	cfg.LLM.EnvFile = "~/.config/hap/llm.env"
+	cfg.LLM.Env = map[string]string{"ANTHROPIC_BASE_URL": "https://example.test"}
+	cfg.LLM.CommandEnvFile = "/etc/hap/consult.env"
+	cfg.LLM.CommandEnv = map[string]string{"ANTHROPIC_MODEL": "opus"}
+	cfg.LLM.CommandStartEnvFile = "/etc/hap/start.env"
+	cfg.LLM.CommandStartEnv = map[string]string{"ANTHROPIC_MODEL": "sonnet"}
+	cfg.LLM.GenerateTaskEnvFile = "/etc/hap/taskgen.env"
+	cfg.LLM.GenerateTaskEnv = map[string]string{"ANTHROPIC_MODEL": "haiku"}
+	cfg.LLM.GenerateTaskStartEnvFile = "/etc/hap/taskgen_start.env"
+	cfg.LLM.GenerateTaskStartEnv = map[string]string{"ANTHROPIC_MODEL": "haiku-start"}
+	if err := Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.LLM.TimeoutSeconds != 120 || len(got.LLM.Command) != 3 {
+		t.Fatalf("scalar [llm] keys corrupted by the env sub-tables: %+v", got.LLM)
+	}
+	for _, tc := range []struct {
+		name  string
+		file  string
+		vars  map[string]string
+		wantF string
+		wantV string
+	}{
+		{"shared", got.LLM.EnvFile, got.LLM.Env, "~/.config/hap/llm.env", "https://example.test"},
+		{"command", got.LLM.CommandEnvFile, got.LLM.CommandEnv, "/etc/hap/consult.env", "opus"},
+		{"command_start", got.LLM.CommandStartEnvFile, got.LLM.CommandStartEnv, "/etc/hap/start.env", "sonnet"},
+		{"task_generate", got.LLM.GenerateTaskEnvFile, got.LLM.GenerateTaskEnv, "/etc/hap/taskgen.env", "haiku"},
+		{"task_generate_start", got.LLM.GenerateTaskStartEnvFile, got.LLM.GenerateTaskStartEnv, "/etc/hap/taskgen_start.env", "haiku-start"},
+	} {
+		if tc.file != tc.wantF {
+			t.Errorf("%s env file = %q, want %q", tc.name, tc.file, tc.wantF)
+		}
+		if len(tc.vars) != 1 {
+			t.Errorf("%s env vars = %v, want one entry", tc.name, tc.vars)
+			continue
+		}
+		for _, v := range tc.vars {
+			if v != tc.wantV {
+				t.Errorf("%s env value = %q, want %q", tc.name, v, tc.wantV)
+			}
+		}
+	}
+}
+
+func TestLLMEnvKeysAbsentByDefault(t *testing.T) {
+	// The feature is opt-in: an untouched config gains no env keys on save.
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := Save(path, Default()); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"env_file", "[llm.env]", "command_env", "task_generate_command_env"} {
+		if strings.Contains(string(data), key) {
+			t.Errorf("default config emitted %q:\n%s", key, data)
+		}
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summaries := got.LLM.EnvSummaries(); len(summaries) != 0 {
+		t.Errorf("summaries = %+v, want none for a default config", summaries)
+	}
+}
+
+func TestLLMEnvSummariesHideValues(t *testing.T) {
+	cfg := Default()
+	cfg.LLM.Env = map[string]string{"ANTHROPIC_BASE_URL": "https://example.test"}
+	cfg.LLM.CommandEnv = map[string]string{"ZZZ_TOKEN": "s3cret", "AAA_KEY": "s3cret"}
+	cfg.LLM.CommandEnvFile = "/etc/hap/consult.env"
+	cfg.LLM.GenerateTaskStartEnvFile = "/etc/hap/taskgen_start.env"
+
+	got := cfg.LLM.EnvSummaries()
+	if len(got) != 3 {
+		t.Fatalf("summaries = %+v, want only the three configured scopes", got)
+	}
+	if got[0].Scope != "shared" || got[1].Scope != "command" || got[2].Scope != "task_generate_command_start" {
+		t.Errorf("scopes = %+v, want them in command order", got)
+	}
+	if len(got[1].Keys) != 2 || got[1].Keys[0] != "AAA_KEY" || got[1].Keys[1] != "ZZZ_TOKEN" {
+		t.Errorf("command keys = %v, want them sorted", got[1].Keys)
+	}
+	if got[1].File != "/etc/hap/consult.env" {
+		t.Errorf("command file = %q, want the configured path", got[1].File)
+	}
+	if len(got[2].Keys) != 0 {
+		t.Errorf("file-only scope reported keys: %v", got[2].Keys)
+	}
+	// The whole point: no value may appear anywhere in a summary.
+	if strings.Contains(fmt.Sprintf("%+v", got), "s3cret") ||
+		strings.Contains(fmt.Sprintf("%+v", got), "https://example.test") {
+		t.Errorf("summary leaked a value: %+v", got)
+	}
+}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -1865,6 +1865,15 @@ var ConfigFields = []ConfigFieldDef{
 	{Key: "llm.task_generate_command"},            // argv template (idle task suggestion)
 	{Key: "llm.task_generate_command_start"},      // argv template (first generation; inherits task_generate_command)
 	{Key: "llm.task_generate_timeout_seconds", TUIEditable: true},
+	// Only the `.env` PATHS are registered. The inline `[llm.*_env]` tables
+	// hold API keys, and every key in this registry is rendered by the TUI
+	// and `config fields`, so they stay config.toml-only; `hap config`
+	// summarizes them by name. A path is not a secret.
+	{Key: "llm.env_file", TUIEditable: true},
+	{Key: "llm.command_env_file", TUIEditable: true},
+	{Key: "llm.command_start_env_file", TUIEditable: true},
+	{Key: "llm.task_generate_command_env_file", TUIEditable: true},
+	{Key: "llm.task_generate_command_start_env_file", TUIEditable: true},
 	{Key: "embedding.disabled", TUIEditable: true},
 	{Key: "embedding.model_path"}, // path
 	{Key: "embedding.similarity_threshold", TUIEditable: true},
@@ -1986,6 +1995,16 @@ func FieldValue(cfg config.Config, key string) string {
 			return "(inherits timeout_seconds)"
 		}
 		return strconv.Itoa(cfg.LLM.GenerateTaskTimeoutSeconds)
+	case "llm.env_file":
+		return envFileValue(cfg.LLM.EnvFile)
+	case "llm.command_env_file":
+		return envFileValue(cfg.LLM.CommandEnvFile)
+	case "llm.command_start_env_file":
+		return envFileValue(cfg.LLM.CommandStartEnvFile)
+	case "llm.task_generate_command_env_file":
+		return envFileValue(cfg.LLM.GenerateTaskEnvFile)
+	case "llm.task_generate_command_start_env_file":
+		return envFileValue(cfg.LLM.GenerateTaskStartEnvFile)
 	case "embedding.disabled":
 		return strconv.FormatBool(cfg.Embedding.Disabled)
 	case "embedding.model_path":
@@ -2157,6 +2176,25 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 			return nil
 		case "embedding.model_path":
 			cfg.Embedding.ModelPath = value // empty restores the bundled default
+			return nil
+		// The env file paths accept any text (empty, or blank, clears the
+		// file). The path is NOT validated here: the file is read when the
+		// CLI is spawned, so a path that appears later still works, and an
+		// unreadable one fails that run loudly.
+		case "llm.env_file":
+			cfg.LLM.EnvFile = strings.TrimSpace(value)
+			return nil
+		case "llm.command_env_file":
+			cfg.LLM.CommandEnvFile = strings.TrimSpace(value)
+			return nil
+		case "llm.command_start_env_file":
+			cfg.LLM.CommandStartEnvFile = strings.TrimSpace(value)
+			return nil
+		case "llm.task_generate_command_env_file":
+			cfg.LLM.GenerateTaskEnvFile = strings.TrimSpace(value)
+			return nil
+		case "llm.task_generate_command_start_env_file":
+			cfg.LLM.GenerateTaskStartEnvFile = strings.TrimSpace(value)
 			return nil
 		case "embedding.similarity_threshold":
 			return setFloat(&cfg.Embedding.SimilarityThreshold)
@@ -3303,4 +3341,14 @@ func (a *App) ClearData(ctx context.Context) error {
 		return err
 	}
 	return a.nudge(ctx, control.KindReload)
+}
+
+// envFileValue renders a configured `.env` path for the config field
+// registry. Only the PATH is ever shown — the file holds credentials and is
+// never opened for display.
+func envFileValue(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return "(none)"
+	}
+	return path
 }

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -2142,40 +2142,45 @@ func TestConfigFieldRegistryParity(t *testing.T) {
 	// One valid sample value per registry key. When you add a field to
 	// frontend.ConfigFields, add a sample here or this test fails loudly.
 	samples := map[string]string{
-		"confidence_thresholds.minimum":           "0.55",
-		"confidence_thresholds.idle":              "0.70",
-		"confidence_thresholds.approval":          "0.85",
-		"confidence_thresholds.choice":            "0.85",
-		"confidence_thresholds.error":             "0.90",
-		"learning.graduation_n":                   "5",
-		"learning.confirmation_weight":            "2.5",
-		"embedding.pane_salient_chars":            "800",
-		"limits.max_consecutive_auto_prompts":     "5",
-		"limits.max_auto_prompts_per_minute":      "10",
-		"limits.max_error_retries":                "2",
-		"safety.disable_never_auto_seed_patterns": "true",
-		"llm.command":                             `claude -p "decide"`,
-		"llm.command_start":                       `claude -p "first: decide"`,
-		"llm.timeout_seconds":                     "60",
-		"llm.auto_act_confidence_threshold":       "70",
-		"llm.pane_excerpt_chars":                  "4000",
-		"llm.enable_rewrite_action":               "true",
-		"llm.rewrite_action_fallback_template":    "Act on: {original_text}",
-		"llm.task_generate_command":               `claude -p "suggest a task"`,
-		"llm.task_generate_command_start":         `claude -p "first suggest a task"`,
-		"llm.task_generate_timeout_seconds":       "45",
-		"embedding.disabled":                      "false",
-		"embedding.model_path":                    "/models/custom.gguf",
-		"embedding.similarity_threshold":          "0.90",
-		"embedding.bm25_min_score":                "0.35",
-		"embedding.model_context_window":          "512",
-		"embedding.embed_timeout_ms":              "8000",
-		"embedding.warm_timeout_ms":               "120000",
-		"tui.max_content_width":                   "140",
-		"tui.max_content_height":                  "12",
-		"tui.theme":                               "dark",
-		"tui.terminal_bell":                       "true",
-		"cli.ai_agent_friendly_output":            "false",
+		"confidence_thresholds.minimum":            "0.55",
+		"confidence_thresholds.idle":               "0.70",
+		"confidence_thresholds.approval":           "0.85",
+		"confidence_thresholds.choice":             "0.85",
+		"confidence_thresholds.error":              "0.90",
+		"learning.graduation_n":                    "5",
+		"learning.confirmation_weight":             "2.5",
+		"embedding.pane_salient_chars":             "800",
+		"limits.max_consecutive_auto_prompts":      "5",
+		"limits.max_auto_prompts_per_minute":       "10",
+		"limits.max_error_retries":                 "2",
+		"safety.disable_never_auto_seed_patterns":  "true",
+		"llm.command":                              `claude -p "decide"`,
+		"llm.command_start":                        `claude -p "first: decide"`,
+		"llm.timeout_seconds":                      "60",
+		"llm.auto_act_confidence_threshold":        "70",
+		"llm.pane_excerpt_chars":                   "4000",
+		"llm.enable_rewrite_action":                "true",
+		"llm.rewrite_action_fallback_template":     "Act on: {original_text}",
+		"llm.task_generate_command":                `claude -p "suggest a task"`,
+		"llm.task_generate_command_start":          `claude -p "first suggest a task"`,
+		"llm.task_generate_timeout_seconds":        "45",
+		"llm.env_file":                             "/etc/hap/llm.env",
+		"llm.command_env_file":                     "/etc/hap/consult.env",
+		"llm.command_start_env_file":               "/etc/hap/start.env",
+		"llm.task_generate_command_env_file":       "/etc/hap/taskgen.env",
+		"llm.task_generate_command_start_env_file": "/etc/hap/taskgen_start.env",
+		"embedding.disabled":                       "false",
+		"embedding.model_path":                     "/models/custom.gguf",
+		"embedding.similarity_threshold":           "0.90",
+		"embedding.bm25_min_score":                 "0.35",
+		"embedding.model_context_window":           "512",
+		"embedding.embed_timeout_ms":               "8000",
+		"embedding.warm_timeout_ms":                "120000",
+		"tui.max_content_width":                    "140",
+		"tui.max_content_height":                   "12",
+		"tui.theme":                                "dark",
+		"tui.terminal_bell":                        "true",
+		"cli.ai_agent_friendly_output":             "false",
 	}
 
 	registry := make(map[string]bool, len(frontend.ConfigFieldKeys))
@@ -4744,5 +4749,33 @@ func TestConfirmTaskGenNoopLearnsNoopWithoutTaskSource(t *testing.T) {
 	}
 	if mine[0].Sent {
 		t.Error("a confirmed decline must not be recorded as delivered")
+	}
+}
+
+// TestConfigFieldsNeverRenderEnvValues guards the secrecy rule for the
+// per-command LLM environment: the field registry is rendered verbatim by the
+// TUI config screen and `hap config fields`, so no inline env VALUE may be
+// reachable through it. Only the `.env` paths are registered.
+func TestConfigFieldsNeverRenderEnvValues(t *testing.T) {
+	cfg := config.Default()
+	const secret = "sk-ant-supersecret"
+	cfg.LLM.Env = map[string]string{"ANTHROPIC_API_KEY": secret}
+	cfg.LLM.CommandEnv = map[string]string{"ANTHROPIC_API_KEY": secret}
+	cfg.LLM.CommandStartEnv = map[string]string{"ANTHROPIC_API_KEY": secret}
+	cfg.LLM.GenerateTaskEnv = map[string]string{"ANTHROPIC_API_KEY": secret}
+	cfg.LLM.GenerateTaskStartEnv = map[string]string{"ANTHROPIC_API_KEY": secret}
+	cfg.LLM.CommandEnvFile = "/etc/hap/consult.env"
+
+	for _, key := range frontend.ConfigFieldKeys {
+		if got := frontend.FieldValue(cfg, key); strings.Contains(got, secret) {
+			t.Errorf("field %q rendered an env value: %q", key, got)
+		}
+	}
+	// The path itself is not a secret and must stay visible.
+	if got := frontend.FieldValue(cfg, "llm.command_env_file"); got != "/etc/hap/consult.env" {
+		t.Errorf("llm.command_env_file = %q, want the configured path", got)
+	}
+	if got := frontend.FieldValue(cfg, "llm.env_file"); got != "(none)" {
+		t.Errorf("unset env file = %q, want a clear placeholder", got)
 	}
 }

--- a/internal/llm/commandenv_test.go
+++ b/internal/llm/commandenv_test.go
@@ -219,3 +219,88 @@ func TestConsultDoesNotRetryIdenticalCommandAndEnv(t *testing.T) {
 		t.Errorf("runs = %v, want exactly one — an identical alternate is not retried", got)
 	}
 }
+
+func TestGenerateTaskResolvesCommandAgainstConfiguredPath(t *testing.T) {
+	// A command may configure its own PATH. exec.Command resolves a bare name
+	// against the DAEMON's PATH, so without resolving against the child's the
+	// configured PATH would be silently ignored.
+	binDir := t.TempDir()
+	script := filepath.Join(binDir, "fake-llm-cli")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho 'task from the configured PATH'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	a := &Adapter{
+		TaskGenTemplate: []string{"fake-llm-cli"}, // bare name, not on the daemon's PATH
+		TaskGenTimeout:  5 * time.Second,
+		TaskGenEnv:      EnvSpec{Vars: map[string]string{"PATH": binDir}},
+	}
+	got, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{})
+	if err != nil {
+		t.Fatalf("a command on the configured PATH must be runnable: %v", err)
+	}
+	if got != "task from the configured PATH" {
+		t.Errorf("output = %q, want the script's output", got)
+	}
+}
+
+func TestGenerateTaskRejectsCommandMissingFromConfiguredPath(t *testing.T) {
+	// The mirror case: the daemon can run it, the child could not. Failing the
+	// preflight beats an opaque "command not found" from the shell.
+	binDir := t.TempDir()
+	a := &Adapter{
+		TaskGenTemplate: []string{"sh"}, // on the daemon's PATH, not on this one
+		TaskGenTimeout:  5 * time.Second,
+		TaskGenEnv:      EnvSpec{Vars: map[string]string{"PATH": binDir}},
+	}
+	_, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{})
+	if err == nil || !strings.Contains(err.Error(), "not found in PATH") {
+		t.Fatalf("error = %v, want a PATH complaint", err)
+	}
+}
+
+func TestConsultResolvesCommandAgainstConfiguredPath(t *testing.T) {
+	st, db := testStore(t)
+	binDir := t.TempDir()
+	out := filepath.Join(t.TempDir(), "ran.txt")
+	script := filepath.Join(binDir, "fake-consult-cli")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho ran > "+out+"\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	a := &Adapter{
+		CommandTemplate: []string{"fake-consult-cli"},
+		Timeout:         5 * time.Second,
+		DBPath:          db, Store: st, SelfPath: "/bin/true",
+		CommandEnv: EnvSpec{Vars: map[string]string{"PATH": binDir}},
+	}
+	req := domain.LLMRequest{RequestID: "req-path", CreatedAt: time.Now()}
+	if _, err := st.StageLLMRequest(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.InsertLLMDecision(context.Background(), domain.LLMDecision{
+		RequestID: "req-path", Action: "ok", Status: "pending", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.Consult(context.Background(), req); err != nil {
+		t.Fatalf("a command on the configured PATH must be runnable: %v", err)
+	}
+	if strings.TrimSpace(readOptional(t, out)) != "ran" {
+		t.Error("the CLI on the configured PATH was not run")
+	}
+}
+
+func TestInlineEnvKeyMustBeValid(t *testing.T) {
+	// TOML allows a quoted key like "A=B"; merging it verbatim would set the
+	// variable A to "B=…" — a different variable than configured. Fail closed.
+	for _, key := range []string{"A=B", "HAS SPACE", "1LEADING_DIGIT", ""} {
+		a := &Adapter{
+			TaskGenTemplate: []string{"/bin/echo", "hi"},
+			TaskGenTimeout:  5 * time.Second,
+			TaskGenEnv:      EnvSpec{Vars: map[string]string{key: "value"}},
+		}
+		_, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{})
+		if err == nil {
+			t.Errorf("key %q: expected the run to fail on an invalid variable name", key)
+		}
+	}
+}

--- a/internal/llm/commandenv_test.go
+++ b/internal/llm/commandenv_test.go
@@ -1,0 +1,221 @@
+package llm
+
+// Tests that each command template is spawned with ITS OWN environment: the
+// four templates (command, command_start, task_generate_command,
+// task_generate_command_start) can point at different providers, so a run must
+// never inherit another command's credentials.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// envEchoScript writes a fake CLI that logs the named variables, one
+// `KEY=value` line per variable, and prints them on stdout too (so the
+// task-generation path, which reads stdout, can assert on the same output).
+func envEchoScript(t *testing.T, vars ...string) string {
+	t.Helper()
+	var b strings.Builder
+	for _, v := range vars {
+		fmt.Fprintf(&b, "printf '%s=%%s\\n' \"$%s\"\n", v, v)
+	}
+	return writeScript(t, b.String())
+}
+
+func TestGenerateTaskUsesPerCommandEnv(t *testing.T) {
+	script := envEchoScript(t, "SHARED", "PROVIDER", "ONLY_TASKGEN")
+	envFile := writeEnvFile(t, "PROVIDER=from-file\nONLY_TASKGEN=yes\n")
+	a := &Adapter{
+		TaskGenTemplate: []string{script},
+		TaskGenTimeout:  5 * time.Second,
+		BaseEnv:         EnvSpec{Vars: map[string]string{"SHARED": "base", "PROVIDER": "base"}},
+		TaskGenEnv:      EnvSpec{File: envFile, Vars: map[string]string{"PROVIDER": "from-vars"}},
+	}
+	got, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "SHARED=base\nPROVIDER=from-vars\nONLY_TASKGEN=yes"
+	if got != want {
+		t.Errorf("child env = %q, want %q", got, want)
+	}
+}
+
+func TestGenerateTaskStartTemplateGetsItsOwnEnv(t *testing.T) {
+	script := envEchoScript(t, "WHICH")
+	a := &Adapter{
+		TaskGenTemplate:      []string{script},
+		TaskGenStartTemplate: []string{script},
+		TaskGenTimeout:       5 * time.Second,
+		TaskGenEnv:           EnvSpec{Vars: map[string]string{"WHICH": "base"}},
+		TaskGenStartEnv:      EnvSpec{Vars: map[string]string{"WHICH": "start"}},
+	}
+	first, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{First: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != "WHICH=start" {
+		t.Errorf("first generation env = %q, want the start template's env", first)
+	}
+	later, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{First: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if later != "WHICH=base" {
+		t.Errorf("later generation env = %q, want the base template's env", later)
+	}
+}
+
+func TestGenerateTaskEnvDoesNotCarryPaneExcerpt(t *testing.T) {
+	// Pane text is untrusted and unbounded; it is expanded into argv only.
+	script := envEchoScript(t, "LEAK")
+	a := &Adapter{
+		TaskGenTemplate: []string{script},
+		TaskGenTimeout:  5 * time.Second,
+		TaskGenEnv:      EnvSpec{Vars: map[string]string{"LEAK": "[{pane_excerpt}]"}},
+	}
+	got, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{PaneExcerpt: "secret pane text"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "LEAK=[{pane_excerpt}]" {
+		t.Errorf("env value = %q, want the placeholder left unexpanded", got)
+	}
+}
+
+func TestGenerateTaskFailsOnUnreadableEnvFile(t *testing.T) {
+	// Fail the run rather than spawn the CLI without its credentials: the
+	// daemon surfaces this as a retryable escalation.
+	marker := filepath.Join(t.TempDir(), "ran")
+	script := writeScript(t, "touch "+marker+"\necho task\n")
+	a := &Adapter{
+		TaskGenTemplate: []string{script},
+		TaskGenTimeout:  5 * time.Second,
+		TaskGenEnv:      EnvSpec{File: filepath.Join(t.TempDir(), "absent.env")},
+	}
+	if _, err := a.GenerateTask(context.Background(), domain.TaskGenRequest{}); err == nil {
+		t.Fatal("a missing env file must fail the generation")
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("the CLI must not be spawned when its env file is unreadable")
+	}
+}
+
+func TestConsultUsesPerCommandEnv(t *testing.T) {
+	st, db := testStore(t)
+	out := filepath.Join(t.TempDir(), "env.txt")
+	script := writeScript(t, "printf 'PROVIDER=%s AGENT=%s REQ=%s\\n' \"$PROVIDER\" \"$AGENT_TAG\" \"$HAP_REQUEST_ID\" > "+out+"\n")
+	envFile := writeEnvFile(t, "PROVIDER=from-file\n")
+	a := &Adapter{
+		CommandTemplate: []string{script},
+		Timeout:         5 * time.Second,
+		DBPath:          db, Store: st, SelfPath: "/bin/true",
+		BaseEnv:    EnvSpec{Vars: map[string]string{"PROVIDER": "base"}},
+		CommandEnv: EnvSpec{File: envFile, Vars: map[string]string{"AGENT_TAG": "agent-{agent_name}"}},
+	}
+	req := domain.LLMRequest{RequestID: "req-env", AgentName: "brave-otter", CreatedAt: time.Now()}
+	if _, err := st.StageLLMRequest(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.InsertLLMDecision(context.Background(), domain.LLMDecision{
+		RequestID: "req-env", Action: "ok", Status: "pending", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.Consult(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	got := strings.TrimSpace(readOptional(t, out))
+	want := "PROVIDER=from-file AGENT=agent-brave-otter REQ=req-env"
+	if got != want {
+		t.Errorf("child env = %q, want %q", got, want)
+	}
+}
+
+func TestConsultFastFailRetryUsesAlternateTemplatesEnv(t *testing.T) {
+	// The rescue run must carry the ALTERNATE template's environment — mixing
+	// one command's argv with another's key is exactly what a per-command env
+	// is meant to prevent.
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "log")
+	sentinel := filepath.Join(dir, "sentinel")
+	script := writeScript(t, fmt.Sprintf(
+		"printf '%%s:%%s ' \"$1\" \"$WHICH_ENV\" >> %s\nif [ \"$1\" = start ]; then touch %s; exit 0; fi\nexit 1\n",
+		logFile, sentinel))
+	a := &Adapter{
+		CommandTemplate:      []string{script, "base"},
+		CommandStartTemplate: []string{script, "start"},
+		Timeout:              5 * time.Second,
+		DBPath:               filepath.Join(dir, "hap.db"),
+		SelfPath:             "/bin/true",
+		Store:                gatedStore{sentinel: sentinel, requestID: "req-r"},
+		CommandEnv:           EnvSpec{Vars: map[string]string{"WHICH_ENV": "base-env"}},
+		CommandStartEnv:      EnvSpec{Vars: map[string]string{"WHICH_ENV": "start-env"}},
+	}
+	if _, err := a.Consult(context.Background(), domain.LLMRequest{RequestID: "req-r", CreatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	got := markers(t, logFile)
+	want := []string{"base:base-env", "start:start-env"}
+	if !slices.Equal(got, want) {
+		t.Errorf("runs = %v, want %v", got, want)
+	}
+}
+
+func TestConsultRetriesWhenOnlyTheEnvDiffers(t *testing.T) {
+	// The two templates may be the same CLI invocation with a different key
+	// or model — differing only in environment. That is exactly the case the
+	// fast-fail retry should still cover.
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "log")
+	sentinel := filepath.Join(dir, "sentinel")
+	script := writeScript(t, fmt.Sprintf(
+		"printf '%%s ' \"$WHICH_ENV\" >> %s\nif [ \"$WHICH_ENV\" = start-env ]; then touch %s; exit 0; fi\nexit 1\n",
+		logFile, sentinel))
+	a := &Adapter{
+		CommandTemplate:      []string{script},
+		CommandStartTemplate: []string{script}, // identical argv
+		Timeout:              5 * time.Second,
+		DBPath:               filepath.Join(dir, "hap.db"),
+		SelfPath:             "/bin/true",
+		Store:                gatedStore{sentinel: sentinel, requestID: "req-e"},
+		CommandEnv:           EnvSpec{Vars: map[string]string{"WHICH_ENV": "base-env"}},
+		CommandStartEnv:      EnvSpec{Vars: map[string]string{"WHICH_ENV": "start-env"}},
+	}
+	if _, err := a.Consult(context.Background(), domain.LLMRequest{RequestID: "req-e", CreatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := markers(t, logFile), []string{"base-env", "start-env"}; !slices.Equal(got, want) {
+		t.Errorf("runs = %v, want %v — a differing env must still trigger the retry", got, want)
+	}
+}
+
+func TestConsultDoesNotRetryIdenticalCommandAndEnv(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "log")
+	script := writeScript(t, "printf 'x ' >> "+logFile+"\nexit 1\n")
+	a := &Adapter{
+		CommandTemplate:      []string{script},
+		CommandStartTemplate: []string{script},
+		Timeout:              5 * time.Second,
+		DBPath:               filepath.Join(dir, "hap.db"),
+		SelfPath:             "/bin/true",
+		Store:                gatedStore{sentinel: filepath.Join(dir, "never"), requestID: "req-i"},
+		CommandEnv:           EnvSpec{Vars: map[string]string{"WHICH_ENV": "same"}},
+		CommandStartEnv:      EnvSpec{Vars: map[string]string{"WHICH_ENV": "same"}},
+	}
+	if _, err := a.Consult(context.Background(), domain.LLMRequest{RequestID: "req-i", CreatedAt: time.Now()}); err == nil {
+		t.Fatal("expected the consult to fail")
+	}
+	if got := markers(t, logFile); len(got) != 1 {
+		t.Errorf("runs = %v, want exactly one — an identical alternate is not retried", got)
+	}
+}

--- a/internal/llm/env.go
+++ b/internal/llm/env.go
@@ -2,8 +2,10 @@ package llm
 
 import (
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -55,6 +57,13 @@ func (s EnvSpec) entries(repl *strings.Replacer) ([]string, error) {
 	}
 	slices.Sort(keys)
 	for _, k := range keys {
+		// TOML accepts quoted keys that are not valid variable names, and a
+		// key containing "=" would be re-split when the entry is merged —
+		// silently setting a DIFFERENT variable than the one configured.
+		// Fail closed instead. The name is safe to quote; the value is not.
+		if !validEnvKey(k) {
+			return nil, fmt.Errorf("invalid environment variable name %q in llm env config", k)
+		}
 		out = append(out, k+"="+s.Vars[k])
 	}
 	out = slices.DeleteFunc(out, func(e string) bool {
@@ -94,6 +103,58 @@ func buildEnv(base, cmd EnvSpec, repl *strings.Replacer, injected ...string) ([]
 	}
 	env.merge(injected)
 	return env.slice(), nil
+}
+
+// envValue returns the value of key in a composed environment, or "".
+func envValue(env []string, key string) string {
+	for _, e := range env {
+		if k, v, ok := strings.Cut(e, "="); ok && k == key {
+			return v
+		}
+	}
+	return ""
+}
+
+// lookPathIn resolves a bare command name against the PATH of the environment
+// the CHILD will actually run with, which is not necessarily the daemon's:
+// a command can configure its own PATH. `exec.LookPath` and `exec.Command`
+// both consult the CURRENT process's PATH, so a configured one is only
+// honoured by resolving here and handing exec an already-resolved path.
+// It returns "" when the caller should keep the name as written (a name that
+// already contains a separator, or a PATH entry too odd to resolve safely).
+func lookPathIn(env []string, name string) (string, error) {
+	if strings.ContainsRune(name, os.PathSeparator) {
+		return "", nil // not a PATH lookup; the caller checks it directly
+	}
+	path := envValue(env, "PATH")
+	for _, dir := range filepath.SplitList(path) {
+		if dir == "" {
+			dir = "."
+		}
+		candidate := filepath.Join(dir, name)
+		if err := executableFile(candidate); err != nil {
+			continue
+		}
+		if !filepath.IsAbs(candidate) {
+			// A relative PATH entry would resolve against the child's working
+			// directory, not ours. Leave it to exec rather than guess.
+			return "", nil
+		}
+		return candidate, nil
+	}
+	return "", exec.ErrNotFound
+}
+
+// executableFile reports whether path is a regular file the daemon may execute.
+func executableFile(path string) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if fi.IsDir() || fi.Mode()&0o111 == 0 {
+		return fs.ErrPermission
+	}
+	return nil
 }
 
 // reservedEnvKey reports whether a variable belongs to hap/herdr rather than

--- a/internal/llm/env.go
+++ b/internal/llm/env.go
@@ -1,0 +1,281 @@
+package llm
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// This file builds the environment each LLM CLI is spawned with. Every one of
+// the four command templates (command, command_start, task_generate_command,
+// task_generate_command_start) can carry its own variables, either inline in
+// the config or in a `.env` file whose path the operator configures.
+//
+// Values are treated as secrets throughout: they are never logged, never
+// echoed, and never included in an error message. Failures name the file and
+// the line number only.
+
+// maxEnvFileBytes caps a `.env` file. A credentials file is a few hundred
+// bytes; anything larger is a misconfigured path (a log, a binary), and
+// reading it into the child's environment would be both useless and unsafe.
+const maxEnvFileBytes = 1 << 20
+
+// EnvSpec is one layer of environment for a command: inline variables plus an
+// optional `.env` file. The file is read at spawn time, so its contents never
+// pass through the config file and an edit applies to the next run.
+type EnvSpec struct {
+	// Vars are inline KEY→VALUE pairs; they override the file.
+	Vars map[string]string
+	// File is an optional path to a `.env` file ("~/" is expanded). A
+	// configured file that cannot be read fails the run.
+	File string
+}
+
+// IsEmpty reports whether the spec contributes nothing.
+func (s EnvSpec) IsEmpty() bool { return len(s.Vars) == 0 && strings.TrimSpace(s.File) == "" }
+
+// entries renders the spec as ordered KEY=VALUE strings — file first, then the
+// inline vars (sorted, so the result is deterministic) — with placeholders in
+// the values expanded by repl. A nil repl leaves values verbatim.
+func (s EnvSpec) entries(repl *strings.Replacer) ([]string, error) {
+	var out []string
+	if path := strings.TrimSpace(s.File); path != "" {
+		fileEntries, err := LoadEnvFile(path)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, fileEntries...)
+	}
+	keys := make([]string, 0, len(s.Vars))
+	for k := range s.Vars {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	for _, k := range keys {
+		out = append(out, k+"="+s.Vars[k])
+	}
+	out = slices.DeleteFunc(out, func(e string) bool {
+		key, _, _ := strings.Cut(e, "=")
+		if !reservedEnvKey(key) {
+			return false
+		}
+		// Naming the key is safe; its value is not. hap's own wiring (the
+		// MCP handshake, the plugin's state/config dirs, the herdr binary)
+		// must stay under hap's control, including for any nested `hap` or
+		// `herdr` the CLI runs.
+		slog.Warn("ignoring reserved variable in llm environment", "key", key)
+		return true
+	})
+	if repl == nil {
+		return out, nil
+	}
+	for i, e := range out {
+		k, v, _ := strings.Cut(e, "=")
+		out[i] = k + "=" + repl.Replace(v)
+	}
+	return out, nil
+}
+
+// buildEnv composes the environment for one CLI run, last layer winning:
+// the daemon's own environment, the shared base spec, the command's own spec,
+// and finally hap's injected HAP_* variables — which stay authoritative so an
+// operator's env can never break the MCP wiring.
+func buildEnv(base, cmd EnvSpec, repl *strings.Replacer, injected ...string) ([]string, error) {
+	env := newEnvSet(os.Environ())
+	for _, layer := range []EnvSpec{base, cmd} {
+		entries, err := layer.entries(repl)
+		if err != nil {
+			return nil, err
+		}
+		env.merge(entries)
+	}
+	env.merge(injected)
+	return env.slice(), nil
+}
+
+// reservedEnvKey reports whether a variable belongs to hap/herdr rather than
+// the operator. These name the MCP request, the plugin's state and config
+// dirs, and the herdr binary: letting a configured environment override them
+// would not just break this run's wiring, it would silently point any nested
+// `hap`/`herdr` the CLI runs at a different installation.
+func reservedEnvKey(key string) bool {
+	return strings.HasPrefix(key, "HAP_") || strings.HasPrefix(key, "HERDR_")
+}
+
+// envSet is an ordered KEY=VALUE set: a later assignment replaces an earlier
+// one in place rather than appending a duplicate. Duplicate keys in an
+// environment are resolved inconsistently across platforms, so the winner is
+// decided here instead of being left to exec.
+type envSet struct {
+	order []string
+	index map[string]int
+}
+
+func newEnvSet(entries []string) *envSet {
+	s := &envSet{index: make(map[string]int, len(entries))}
+	s.merge(entries)
+	return s
+}
+
+func (s *envSet) merge(entries []string) {
+	for _, e := range entries {
+		key, _, ok := strings.Cut(e, "=")
+		if !ok || key == "" {
+			continue
+		}
+		if i, seen := s.index[key]; seen {
+			s.order[i] = e
+			continue
+		}
+		s.index[key] = len(s.order)
+		s.order = append(s.order, e)
+	}
+}
+
+func (s *envSet) slice() []string { return s.order }
+
+// LoadEnvFile parses a `.env` file into ordered KEY=VALUE entries. It supports
+// the common dotenv shape: comments, blank lines, an optional `export` prefix,
+// and single-, double-, or un-quoted values. A file with a malformed line, or
+// one that defines nothing at all, is an error naming the line NUMBER but
+// never its content.
+func LoadEnvFile(path string) ([]string, error) {
+	resolved, err := expandEnvPath(path)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("read env file %s: %w", resolved, err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("read env file %s: is a directory", resolved)
+	}
+	if info.Size() > maxEnvFileBytes {
+		return nil, fmt.Errorf("env file %s is too large (%d bytes > %d cap)",
+			resolved, info.Size(), maxEnvFileBytes)
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("read env file %s: %w", resolved, err)
+	}
+	entries, malformed := parseEnvFile(string(data))
+	// A file the operator pointed at that yields nothing usable is a
+	// misconfiguration which would otherwise surface minutes later as an
+	// opaque authentication error inside the CLI. Fail here instead, where
+	// the message can name the file — but never a line's content, which is
+	// exactly where a secret would be.
+	if len(malformed) > 0 {
+		return nil, fmt.Errorf("env file %s has %d malformed line(s), first at line %d",
+			resolved, len(malformed), malformed[0])
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("env file %s defines no variables", resolved)
+	}
+	return entries, nil
+}
+
+// parseEnvFile does the line work for LoadEnvFile: it returns the parsed
+// entries plus the 1-based numbers of the lines it could not parse.
+func parseEnvFile(content string) (entries []string, malformed []int) {
+	content = strings.TrimPrefix(content, "\ufeff") // editors that write a BOM
+	for i, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(strings.TrimSuffix(raw, "\r"))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		key, rawValue, ok := strings.Cut(line, "=")
+		key = strings.TrimSpace(key)
+		value, valueOK := unquoteEnvValue(rawValue)
+		if !ok || !validEnvKey(key) || !valueOK {
+			malformed = append(malformed, i+1)
+			continue
+		}
+		entries = append(entries, key+"="+value)
+	}
+	return entries, malformed
+}
+
+// unquoteEnvValue resolves the value half of a `.env` assignment. A
+// single-quoted value is literal; a double-quoted one honours the usual
+// escapes; an unquoted one is trimmed and loses a trailing ` # comment`.
+// A value that opens a quote and never closes it — a pasted multi-line key,
+// say — is rejected rather than handed to the CLI mangled.
+func unquoteEnvValue(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if q, quoted := openingQuote(value); quoted {
+		if len(value) < 2 || value[len(value)-1] != q {
+			return "", false
+		}
+		inner := value[1 : len(value)-1]
+		if q == '\'' {
+			return inner, true
+		}
+		return doubleQuoteReplacer.Replace(inner), true
+	}
+	// An unquoted value ends at an inline comment, which must be preceded by
+	// whitespace so that values like `pass#1` survive intact. Quote a value
+	// that legitimately contains " #".
+	if i := strings.Index(value, " #"); i >= 0 {
+		value = value[:i]
+	}
+	if i := strings.Index(value, "\t#"); i >= 0 {
+		value = value[:i]
+	}
+	return strings.TrimSpace(value), true
+}
+
+// openingQuote reports the quote character a value starts with, if any.
+func openingQuote(value string) (byte, bool) {
+	if value == "" {
+		return 0, false
+	}
+	q := value[0]
+	return q, q == '\'' || q == '"'
+}
+
+var doubleQuoteReplacer = strings.NewReplacer(
+	`\n`, "\n",
+	`\r`, "\r",
+	`\t`, "\t",
+	`\"`, `"`,
+	`\\`, `\`,
+)
+
+// validEnvKey reports whether name is a usable environment variable name
+// ([A-Za-z_][A-Za-z0-9_]*).
+func validEnvKey(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		switch {
+		case r == '_':
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// expandEnvPath resolves "~" / "~/…" in a configured env file path.
+func expandEnvPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("expand env file path %q: %w", path, err)
+	}
+	if path == "~" {
+		return home, nil
+	}
+	return filepath.Join(home, path[2:]), nil
+}

--- a/internal/llm/env_test.go
+++ b/internal/llm/env_test.go
@@ -1,0 +1,263 @@
+package llm
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func writeEnvFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "vars.env")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestParseEnvFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+		wantBad []int
+	}{
+		{"plain", "FOO=bar\n", []string{"FOO=bar"}, nil},
+		{"export prefix", "export FOO=bar\n", []string{"FOO=bar"}, nil},
+		{"blank and comment lines", "\n# a comment\n\nFOO=bar\n  # indented comment\n", []string{"FOO=bar"}, nil},
+		{"surrounding whitespace", "  FOO =  bar  \n", []string{"FOO=bar"}, nil},
+		{"empty value", "FOO=\n", []string{"FOO="}, nil},
+		{"value with equals", "URL=https://x/?a=b\n", []string{"URL=https://x/?a=b"}, nil},
+		{"double quotes keep spaces", "FOO=\"  bar baz \"\n", []string{"FOO=  bar baz "}, nil},
+		{"double quote escapes", `FOO="a\nb\tc\"d\\e"` + "\n", []string{"FOO=a\nb\tc\"d\\e"}, nil},
+		{"single quotes are literal", `FOO='a\nb # c'` + "\n", []string{`FOO=a\nb # c`}, nil},
+		{"inline comment stripped", "FOO=bar # trailing\n", []string{"FOO=bar"}, nil},
+		{"hash without space kept", "FOO=pass#1\n", []string{"FOO=pass#1"}, nil},
+		{"crlf line endings", "FOO=bar\r\nBAZ=qux\r\n", []string{"FOO=bar", "BAZ=qux"}, nil},
+		{"utf-8 bom", "\ufeffFOO=bar\n", []string{"FOO=bar"}, nil},
+		{"file order preserved", "B=2\nA=1\n", []string{"B=2", "A=1"}, nil},
+		{"malformed lines reported", "no equals here\n1BAD=x\nBAD KEY=x\n=novalue\nFOO=bar\n", []string{"FOO=bar"}, []int{1, 2, 3, 4}},
+		{"unterminated quote is malformed", "FOO=\"-----BEGIN KEY-----\nBAR=ok\n", []string{"BAR=ok"}, []int{1}},
+		{"lone quote is malformed", "FOO='\n", nil, []int{1}},
+		{"underscore and digits in key", "_A1_B=v\n", []string{"_A1_B=v"}, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, malformed := parseEnvFile(tc.content)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("parseEnvFile = %q, want %q", got, tc.want)
+			}
+			if !slices.Equal(malformed, tc.wantBad) {
+				t.Errorf("malformed lines = %v, want %v", malformed, tc.wantBad)
+			}
+		})
+	}
+}
+
+func TestLoadEnvFileErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("missing file", func(t *testing.T) {
+		// A configured-but-missing file must fail the run: silently launching
+		// the CLI without its credentials is the worse outcome.
+		if _, err := LoadEnvFile(filepath.Join(dir, "nope.env")); err == nil {
+			t.Fatal("missing env file must error")
+		}
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		if _, err := LoadEnvFile(dir); err == nil {
+			t.Fatal("directory env file must error")
+		}
+	})
+
+	t.Run("oversized", func(t *testing.T) {
+		big := filepath.Join(dir, "big.env")
+		if err := os.WriteFile(big, []byte(strings.Repeat("A", maxEnvFileBytes+1)), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := LoadEnvFile(big)
+		if err == nil || !strings.Contains(err.Error(), "too large") {
+			t.Fatalf("oversized env file error = %v, want a size complaint", err)
+		}
+	})
+}
+
+func TestLoadEnvFileExpandsHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "hap.env"), []byte("FOO=bar\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadEnvFile("~/hap.env")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(got, []string{"FOO=bar"}) {
+		t.Errorf("entries = %q, want FOO=bar", got)
+	}
+}
+
+// lookupEnv finds a key in a composed environment slice.
+func lookupEnv(t *testing.T, env []string, key string) (string, bool) {
+	t.Helper()
+	var value string
+	var found bool
+	for _, e := range env {
+		if k, v, ok := strings.Cut(e, "="); ok && k == key {
+			if found {
+				t.Fatalf("key %s appears more than once in the composed environment", key)
+			}
+			value, found = v, true
+		}
+	}
+	return value, found
+}
+
+func TestBuildEnvPrecedence(t *testing.T) {
+	t.Setenv("LLMENV_INHERITED", "from-os")
+	t.Setenv("LLMENV_LAYERED", "from-os")
+
+	baseFile := writeEnvFile(t, "LLMENV_LAYERED=base-file\nBASE_ONLY=base-file\n")
+	cmdFile := writeEnvFile(t, "LLMENV_LAYERED=cmd-file\nCMD_ONLY=cmd-file\n")
+
+	env, err := buildEnv(
+		EnvSpec{File: baseFile, Vars: map[string]string{"LLMENV_LAYERED": "base-vars"}},
+		EnvSpec{File: cmdFile, Vars: map[string]string{"LLMENV_LAYERED": "cmd-vars"}},
+		nil,
+		"HAP_REQUEST_ID=req-1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct{ key, want string }{
+		{"LLMENV_INHERITED", "from-os"}, // untouched os environment survives
+		{"BASE_ONLY", "base-file"},
+		{"CMD_ONLY", "cmd-file"},
+		{"LLMENV_LAYERED", "cmd-vars"}, // os < base file < base vars < cmd file < cmd vars
+		{"HAP_REQUEST_ID", "req-1"},
+	} {
+		got, ok := lookupEnv(t, env, tc.key)
+		if !ok {
+			t.Errorf("%s missing from composed environment", tc.key)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.key, got, tc.want)
+		}
+	}
+}
+
+func TestBuildEnvInjectedVarsWinOverOperatorEnv(t *testing.T) {
+	// The HAP_* wiring is hap's own protocol with its MCP server; an operator
+	// env must not be able to redirect it.
+	env, err := buildEnv(
+		EnvSpec{Vars: map[string]string{"HAP_REQUEST_ID": "spoofed"}},
+		EnvSpec{Vars: map[string]string{"HAP_DB_PATH": "/tmp/spoofed.db"}},
+		nil,
+		"HAP_REQUEST_ID=req-1", "HAP_DB_PATH=/state/hap.db",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := lookupEnv(t, env, "HAP_REQUEST_ID"); got != "req-1" {
+		t.Errorf("HAP_REQUEST_ID = %q, want the injected req-1", got)
+	}
+	if got, _ := lookupEnv(t, env, "HAP_DB_PATH"); got != "/state/hap.db" {
+		t.Errorf("HAP_DB_PATH = %q, want the injected path", got)
+	}
+}
+
+func TestBuildEnvSubstitutesPlaceholders(t *testing.T) {
+	file := writeEnvFile(t, "FROM_FILE=agent-{agent_name}\n")
+	repl := strings.NewReplacer("{agent_name}", "brave-otter", "{request_id}", "req-9")
+	env, err := buildEnv(
+		EnvSpec{},
+		EnvSpec{File: file, Vars: map[string]string{"FROM_VARS": "req-{request_id}"}},
+		repl,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := lookupEnv(t, env, "FROM_FILE"); got != "agent-brave-otter" {
+		t.Errorf("FROM_FILE = %q, want the expanded agent name", got)
+	}
+	if got, _ := lookupEnv(t, env, "FROM_VARS"); got != "req-req-9" {
+		t.Errorf("FROM_VARS = %q, want the expanded request id", got)
+	}
+}
+
+func TestBuildEnvPropagatesFileError(t *testing.T) {
+	_, err := buildEnv(EnvSpec{}, EnvSpec{File: filepath.Join(t.TempDir(), "absent.env")}, nil)
+	if err == nil {
+		t.Fatal("an unreadable env file must fail the run, not be skipped")
+	}
+}
+
+func TestEnvSpecIsEmpty(t *testing.T) {
+	if !(EnvSpec{}).IsEmpty() {
+		t.Error("zero spec must be empty")
+	}
+	if !(EnvSpec{File: "  "}).IsEmpty() {
+		t.Error("blank file path must be empty")
+	}
+	if (EnvSpec{Vars: map[string]string{"A": "b"}}).IsEmpty() {
+		t.Error("spec with vars must not be empty")
+	}
+	if (EnvSpec{File: "/x.env"}).IsEmpty() {
+		t.Error("spec with a file must not be empty")
+	}
+}
+
+func TestBuildEnvRejectsReservedKeys(t *testing.T) {
+	// HAP_*/HERDR_* name hap's own wiring: the MCP handshake, the plugin
+	// state/config dirs, the herdr binary. An operator env that redefined
+	// them would point a nested hap/herdr at another installation.
+	file := writeEnvFile(t, "HERDR_BIN_PATH=/tmp/fake-herdr\nKEEP=yes\n")
+	env, err := buildEnv(
+		EnvSpec{Vars: map[string]string{"HAP_DB_PATH": "/tmp/spoof.db"}},
+		EnvSpec{File: file},
+		nil,
+		"HAP_DB_PATH=/state/hap.db",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := lookupEnv(t, env, "HAP_DB_PATH"); got != "/state/hap.db" {
+		t.Errorf("HAP_DB_PATH = %q, want the injected path", got)
+	}
+	if got, ok := lookupEnv(t, env, "HERDR_BIN_PATH"); ok && got == "/tmp/fake-herdr" {
+		t.Error("an env file must not be able to redirect HERDR_BIN_PATH")
+	}
+	if got, _ := lookupEnv(t, env, "KEEP"); got != "yes" {
+		t.Errorf("KEEP = %q, want the file's other variables to survive", got)
+	}
+}
+
+func TestLoadEnvFileWithNoVariablesErrors(t *testing.T) {
+	// A comments-only or empty file is a misconfiguration: launching the CLI
+	// with no credentials would surface as an opaque auth failure later.
+	path := writeEnvFile(t, "# just a comment\n\n")
+	if _, err := LoadEnvFile(path); err == nil {
+		t.Fatal("an env file defining nothing must fail the run")
+	}
+}
+
+func TestLoadEnvFileErrorsNeverEchoContent(t *testing.T) {
+	// The message may name the file and the line; the line's TEXT is exactly
+	// where a secret lives, so it must never appear.
+	path := writeEnvFile(t, "API_KEY sk-ant-supersecret\n")
+	_, err := LoadEnvFile(path)
+	if err == nil {
+		t.Fatal("a malformed line must fail the run")
+	}
+	if strings.Contains(err.Error(), "sk-ant-supersecret") {
+		t.Errorf("error echoed the line content: %v", err)
+	}
+	if !strings.Contains(err.Error(), "line 1") {
+		t.Errorf("error should name the line number, got: %v", err)
+	}
+}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -41,6 +42,14 @@ type Adapter struct {
 	DBPath               string
 	ControlPath          string
 	Store                ports.ReadStore
+	// BaseEnv is the environment shared by every command template; the
+	// per-command specs below layer on top of it (see buildEnv).
+	BaseEnv EnvSpec
+	// CommandEnv / CommandStartEnv are the environments for their matching
+	// consult templates. The env travels WITH the template through the
+	// fast-fail retry, so a rescue run never gets the other command's keys.
+	CommandEnv      EnvSpec
+	CommandStartEnv EnvSpec
 	// SelfPath overrides the {self} placeholder (defaults to os.Executable).
 	SelfPath string
 	// TaskGenTemplate is the argv template for the one-shot idle task
@@ -52,6 +61,10 @@ type Adapter struct {
 	TaskGenStartTemplate []string
 	// TaskGenTimeout bounds one task-generation run (<=0 falls back to Timeout).
 	TaskGenTimeout time.Duration
+	// TaskGenEnv / TaskGenStartEnv are the environments for their matching
+	// task-generation templates, layered over BaseEnv.
+	TaskGenEnv      EnvSpec
+	TaskGenStartEnv EnvSpec
 }
 
 // Configured reports whether an LLM CLI is configured (IR-005).
@@ -109,10 +122,13 @@ func (a *Adapter) Consult(ctx context.Context, req domain.LLMRequest) (*domain.L
 	}
 	// The first consult for an agent prefers command_start when configured;
 	// the other template is the fast-fail fallback and, absent a start
-	// template, First simply reuses the base command.
-	primary, alt := a.CommandTemplate, a.CommandStartTemplate
+	// template, First simply reuses the base command. Each template carries
+	// its own environment so a retry cannot mix one command's argv with the
+	// other's credentials.
+	primary := commandSpec{argv: a.CommandTemplate, env: a.CommandEnv}
+	alt := commandSpec{argv: a.CommandStartTemplate, env: a.CommandStartEnv}
 	if req.First && len(a.CommandStartTemplate) > 0 {
-		primary, alt = a.CommandStartTemplate, a.CommandTemplate
+		primary, alt = alt, primary
 	}
 
 	timeout := a.Timeout
@@ -131,7 +147,10 @@ func (a *Adapter) Consult(ctx context.Context, req domain.LLMRequest) (*domain.L
 	// parent context is already cancelled (shutdown makes every run "fail
 	// fast") or the alternate is absent / identical.
 	var retryErr error
-	if att.fastFailed() && ctx.Err() == nil && len(alt) > 0 && !slices.Equal(alt, primary) {
+	// An alternate that is identical in BOTH argv and environment would just
+	// repeat the same failure; one that differs in either is worth a try (the
+	// two templates can share an argv and differ only in key or model).
+	if att.fastFailed() && ctx.Err() == nil && len(alt.argv) > 0 && !alt.sameAs(primary) {
 		altAtt, rerr := a.runConsult(ctx, alt, self, req, timeout)
 		switch {
 		case rerr != nil:
@@ -169,18 +188,41 @@ func (a *Adapter) resolveSelf() (string, error) {
 	return self, nil
 }
 
+// consultReplacer builds the placeholder expander shared by the argv template
+// and the configured environment values, so the two can never drift apart.
+func (a *Adapter) consultReplacer(self string, req domain.LLMRequest) *strings.Replacer {
+	return strings.NewReplacer(
+		"{self}", self,
+		"{request_id}", req.RequestID,
+		"{db}", a.DBPath,
+		"{control}", a.ControlPath,
+		"{agent_name}", req.AgentName,
+	)
+}
+
+// commandSpec pairs one argv template with the environment configured for it,
+// so the two travel together through Consult's primary/alternate swap.
+type commandSpec struct {
+	argv []string
+	env  EnvSpec
+}
+
+// sameAs reports whether two specs would run the same command with the same
+// environment — in which case retrying one after the other is pointless.
+func (s commandSpec) sameAs(other commandSpec) bool {
+	return slices.Equal(s.argv, other.argv) &&
+		strings.TrimSpace(s.env.File) == strings.TrimSpace(other.env.File) &&
+		maps.Equal(s.env.Vars, other.env.Vars)
+}
+
 // runConsult runs one CLI attempt with the given template and reports the
 // outcome. It never re-stages the request (the daemon already did); it only
 // launches the CLI and reads back whatever decision was staged.
-func (a *Adapter) runConsult(ctx context.Context, tmpl []string, self string, req domain.LLMRequest, timeout time.Duration) (*consultAttempt, error) {
-	argv := make([]string, len(tmpl))
-	for i, arg := range tmpl {
-		arg = strings.ReplaceAll(arg, "{self}", self)
-		arg = strings.ReplaceAll(arg, "{request_id}", req.RequestID)
-		arg = strings.ReplaceAll(arg, "{db}", a.DBPath)
-		arg = strings.ReplaceAll(arg, "{control}", a.ControlPath)
-		arg = strings.ReplaceAll(arg, "{agent_name}", req.AgentName)
-		argv[i] = arg
+func (a *Adapter) runConsult(ctx context.Context, spec commandSpec, self string, req domain.LLMRequest, timeout time.Duration) (*consultAttempt, error) {
+	repl := a.consultReplacer(self, req)
+	argv := make([]string, len(spec.argv))
+	for i, arg := range spec.argv {
+		argv[i] = repl.Replace(arg)
 	}
 	// Auto-repair known CLI misconfigurations (e.g. claude's prompt placed
 	// after other flags) so a slightly-off operator config still works.
@@ -193,6 +235,18 @@ func (a *Adapter) runConsult(ctx context.Context, tmpl []string, self string, re
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	// The operator's environment is composed before spawning: an unreadable
+	// env file must fail the run rather than launch the CLI without its
+	// credentials. The HAP_* variables are injected last and always win.
+	env, err := buildEnv(a.BaseEnv, spec.env, repl,
+		"HAP_REQUEST_ID="+req.RequestID,
+		"HAP_DB_PATH="+a.DBPath,
+		"HAP_CONTROL_PATH="+a.ControlPath,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	cmd := exec.CommandContext(runCtx, argv[0], argv[1:]...)
 	cmd.Dir = a.WorkDir()
 	// After the timeout kills the CLI, don't wait on lingering
@@ -201,11 +255,7 @@ func (a *Adapter) runConsult(ctx context.Context, tmpl []string, self string, re
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
-	cmd.Env = append(os.Environ(),
-		"HAP_REQUEST_ID="+req.RequestID,
-		"HAP_DB_PATH="+a.DBPath,
-		"HAP_CONTROL_PATH="+a.ControlPath,
-	)
+	cmd.Env = env
 	started := time.Now()
 	runErr := cmd.Run()
 	elapsed := time.Since(started)

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -228,16 +228,10 @@ func (a *Adapter) runConsult(ctx context.Context, spec commandSpec, self string,
 	// after other flags) so a slightly-off operator config still works.
 	argv = NormalizeLLMCommand(argv)
 
-	if err := preflight(argv[0]); err != nil {
-		return nil, err
-	}
-
-	runCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	// The operator's environment is composed before spawning: an unreadable
-	// env file must fail the run rather than launch the CLI without its
-	// credentials. The HAP_* variables are injected last and always win.
+	// The operator's environment is composed FIRST: an unreadable env file
+	// must fail the run rather than launch the CLI without its credentials,
+	// and the command is resolved against the child's PATH, which this env
+	// may redefine. The HAP_* variables are injected last and always win.
 	env, err := buildEnv(a.BaseEnv, spec.env, repl,
 		"HAP_REQUEST_ID="+req.RequestID,
 		"HAP_DB_PATH="+a.DBPath,
@@ -247,7 +241,15 @@ func (a *Adapter) runConsult(ctx context.Context, spec commandSpec, self string,
 		return nil, err
 	}
 
-	cmd := exec.CommandContext(runCtx, argv[0], argv[1:]...)
+	bin, err := preflight(argv[0], env)
+	if err != nil {
+		return nil, err
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, bin, argv[1:]...)
 	cmd.Dir = a.WorkDir()
 	// After the timeout kills the CLI, don't wait on lingering
 	// grandchildren holding the output pipes open — fail safe promptly.
@@ -305,19 +307,34 @@ func dirLives(dir string) bool {
 	return err == nil && fi.IsDir()
 }
 
-// preflight verifies the CLI is runnable before spawning. The daemon's PATH
-// can be narrower than the operator's shell (GUI- or hook-launched); surface
-// that as itself instead of a bare exit error. A command containing a
-// separator never consults PATH, so it gets a message that doesn't
-// misdiagnose a missing file as a PATH problem.
-func preflight(argv0 string) error {
+// preflight verifies the CLI is runnable before spawning and returns the path
+// to run. The daemon's PATH can be narrower than the operator's shell (GUI- or
+// hook-launched); surface that as itself instead of a bare exit error. A
+// command containing a separator never consults PATH, so it gets a message
+// that doesn't misdiagnose a missing file as a PATH problem.
+//
+// The lookup uses the CHILD's environment, not the daemon's: a command may
+// configure its own PATH, and `exec.Command` would otherwise resolve the name
+// against the daemon's — rejecting a CLI the child could find, or resolving
+// one the child's PATH doesn't have. Passing the resolved path back to exec is
+// what makes the configured PATH take effect.
+func preflight(argv0 string, env []string) (string, error) {
+	resolved, err := lookPathIn(env, argv0)
+	if err != nil {
+		return "", fmt.Errorf("llm command %q not found in PATH (the daemon's PATH, or this command's configured PATH, may differ from your shell): %w", argv0, err)
+	}
+	if resolved != "" {
+		return resolved, nil
+	}
+	// Either a path with a separator, or a PATH entry we chose not to resolve
+	// ourselves — check runnability and let exec do the rest.
 	if _, err := exec.LookPath(argv0); err != nil {
 		if strings.ContainsRune(argv0, os.PathSeparator) {
-			return fmt.Errorf("llm command %q not runnable: %w", argv0, err)
+			return "", fmt.Errorf("llm command %q not runnable: %w", argv0, err)
 		}
-		return fmt.Errorf("llm command %q not found in PATH (the daemon's PATH may differ from your shell): %w", argv0, err)
+		return "", fmt.Errorf("llm command %q not found in PATH (the daemon's PATH may differ from your shell): %w", argv0, err)
 	}
-	return nil
+	return argv0, nil
 }
 
 func truncate(s string, n int) string {

--- a/internal/llm/taskgen.go
+++ b/internal/llm/taskgen.go
@@ -72,7 +72,21 @@ func (a *Adapter) GenerateTask(ctx context.Context, req domain.TaskGenRequest) (
 		argv[i] = argvRepl.Replace(arg)
 	}
 
-	if err := preflight(argv[0]); err != nil {
+	// Compose the environment BEFORE the preflight: an unreadable env file
+	// must fail the run rather than launch the CLI without its credentials,
+	// and the command is resolved against the child's PATH, which this env
+	// may redefine.
+	childEnv, err := buildEnv(a.BaseEnv, env, envRepl,
+		"HAP_AGENT_NAME="+req.AgentName,
+		"HAP_AGENT_TYPE="+req.AgentType,
+		"HAP_CWD="+req.Cwd,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	bin, err := preflight(argv[0], childEnv)
+	if err != nil {
 		return "", err
 	}
 
@@ -83,21 +97,11 @@ func (a *Adapter) GenerateTask(ctx context.Context, req domain.TaskGenRequest) (
 	if timeout <= 0 {
 		timeout = 60 * time.Second
 	}
-	// Compose the environment before spawning: an unreadable env file must
-	// fail the run rather than launch the CLI without its credentials.
-	childEnv, err := buildEnv(a.BaseEnv, env, envRepl,
-		"HAP_AGENT_NAME="+req.AgentName,
-		"HAP_AGENT_TYPE="+req.AgentType,
-		"HAP_CWD="+req.Cwd,
-	)
-	if err != nil {
-		return "", err
-	}
 
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(runCtx, argv[0], argv[1:]...)
+	cmd := exec.CommandContext(runCtx, bin, argv[1:]...)
 	cmd.Dir = a.WorkDir()
 	// After the timeout kills the CLI, don't wait on lingering grandchildren
 	// holding the output pipes open — fail safe promptly.

--- a/internal/llm/taskgen.go
+++ b/internal/llm/taskgen.go
@@ -46,19 +46,30 @@ func (a *Adapter) GenerateTask(ctx context.Context, req domain.TaskGenRequest) (
 	// Auto-repair BEFORE substitution: the normalizer pattern-matches argv
 	// shapes, and substituted pane text is untrusted — it must not be able to
 	// perturb the repair (same fixes as Consult/Rewrite).
-	base := a.TaskGenTemplate
+	base, env := a.TaskGenTemplate, a.TaskGenEnv
 	if req.First && len(a.TaskGenStartTemplate) > 0 {
-		base = a.TaskGenStartTemplate
+		base, env = a.TaskGenStartTemplate, a.TaskGenStartEnv
 	}
 	template := NormalizeLLMCommand(base)
+	// The environment shares every placeholder EXCEPT {pane_excerpt}:
+	// untrusted, unbounded pane text has no business in a child's
+	// environment, so it is expanded into argv only.
+	envRepl := strings.NewReplacer(
+		"{self}", self,
+		"{agent_name}", req.AgentName,
+		"{agent_type}", req.AgentType,
+		"{cwd}", req.Cwd,
+	)
+	argvRepl := strings.NewReplacer(
+		"{self}", self,
+		"{agent_name}", req.AgentName,
+		"{agent_type}", req.AgentType,
+		"{pane_excerpt}", req.PaneExcerpt,
+		"{cwd}", req.Cwd,
+	)
 	argv := make([]string, len(template))
 	for i, arg := range template {
-		arg = strings.ReplaceAll(arg, "{self}", self)
-		arg = strings.ReplaceAll(arg, "{agent_name}", req.AgentName)
-		arg = strings.ReplaceAll(arg, "{agent_type}", req.AgentType)
-		arg = strings.ReplaceAll(arg, "{pane_excerpt}", req.PaneExcerpt)
-		arg = strings.ReplaceAll(arg, "{cwd}", req.Cwd)
-		argv[i] = arg
+		argv[i] = argvRepl.Replace(arg)
 	}
 
 	if err := preflight(argv[0]); err != nil {
@@ -72,6 +83,17 @@ func (a *Adapter) GenerateTask(ctx context.Context, req domain.TaskGenRequest) (
 	if timeout <= 0 {
 		timeout = 60 * time.Second
 	}
+	// Compose the environment before spawning: an unreadable env file must
+	// fail the run rather than launch the CLI without its credentials.
+	childEnv, err := buildEnv(a.BaseEnv, env, envRepl,
+		"HAP_AGENT_NAME="+req.AgentName,
+		"HAP_AGENT_TYPE="+req.AgentType,
+		"HAP_CWD="+req.Cwd,
+	)
+	if err != nil {
+		return "", err
+	}
+
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -83,11 +105,7 @@ func (a *Adapter) GenerateTask(ctx context.Context, req domain.TaskGenRequest) (
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	cmd.Env = append(os.Environ(),
-		"HAP_AGENT_NAME="+req.AgentName,
-		"HAP_AGENT_TYPE="+req.AgentType,
-		"HAP_CWD="+req.Cwd,
-	)
+	cmd.Env = childEnv
 	runErr := cmd.Run()
 
 	if runErr != nil {

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -94,6 +94,44 @@ timeout_seconds = 120              # codex is slower to start; 180 is a safer va
 auto_act_confidence_threshold = 99  # auto-act only when the LLM confidence (0-100) is >= this; default 99 (near-certain only); set >100 (e.g. 999) to never auto-act and always surface for confirmation
 pane_excerpt_chars = 5000          # pane context included in the consult
 
+# ── Per-command environment (optional) ──
+# Each of the four command templates (command, command_start,
+# task_generate_command, task_generate_command_start) can be spawned with its
+# own environment — a different key, provider, model, or proxy per command.
+#
+# Two ways to set it, and they combine:
+#   * inline, in a `[llm.…_env]` table (values live in this file);
+#   * in a `.env` file, via `…_env_file` (KEY=VALUE lines, `#` comments,
+#     `export` and quotes accepted, `~/` expanded — quote any value with a
+#     " #" in it, which otherwise starts a comment). SECRETS BELONG HERE — the
+#     file is read when the CLI is spawned, so its contents never enter this
+#     config, and editing it applies to the next run without a restart. A
+#     configured file that cannot be read, has a malformed line, or defines
+#     nothing FAILS the run (escalation) rather than launching the CLI without
+#     its credentials.
+#
+# Layering, last wins: the daemon's own environment, then env_file, env (the
+# shared base for all four commands), then the command's own …_env_file and
+# …_env. Names starting with HAP_ or HERDR_ are reserved for hap's own wiring
+# and are ignored. Values accept the same placeholders as the command
+# template, except {pane_excerpt}.
+#
+# `hap config` prints variable NAMES and file paths only, never values.
+#
+# env_file = "~/.config/hap/llm.env"                          # shared by all four
+# command_env_file = "/path/to/claude_consult.env"
+# command_start_env_file = "/path/to/claude_start.env"
+# task_generate_command_env_file = "/path/to/claude_task_generate.env"
+# task_generate_command_start_env_file = "/path/to/claude_task_generate_start.env"
+#
+# Inline tables must come AFTER every plain `key = value` in [llm]:
+# [llm.env]
+# ANTHROPIC_BASE_URL = "https://proxy.internal"
+# [llm.command_env]
+# ANTHROPIC_MODEL = "opus"
+# [llm.task_generate_command_env]
+# ANTHROPIC_MODEL = "haiku"                                   # cheaper for task ideas
+
 # ── Outbound action review (optional) ──
 # When a LEARNED rule resolves to free text (an idle next-task prompt, an
 # error retry command, a free-text approval reply — never menu digits, and


### PR DESCRIPTION
## What

Each of the four LLM command templates can now be spawned with its own environment, so one CLI can run against a different key, provider, model, or proxy than another.

| Key | Scope |
|---|---|
| `llm.env` / `llm.env_file` | shared by all four commands |
| `llm.command_env` / `llm.command_env_file` | `llm.command` |
| `llm.command_start_env` / `llm.command_start_env_file` | `llm.command_start` |
| `llm.task_generate_command_env` / `…_env_file` | `llm.task_generate_command` |
| `llm.task_generate_command_start_env` / `…_env_file` | `llm.task_generate_command_start` |

```toml
[llm]
env_file = "~/.config/hap/llm.env"
task_generate_command_env_file = "/path/to/claude_task_generate.env"

[llm.command_env]
ANTHROPIC_MODEL = "opus"
[llm.task_generate_command_env]
ANTHROPIC_MODEL = "haiku"
```

Layering, last wins: daemon env → `env_file` → `env` → the command's `…_env_file` → its `…_env` → hap's own `HAP_*` (always authoritative). Values accept the command template's placeholders except `{pane_excerpt}` — untrusted, unbounded pane text is never put in a child's environment.

## Secrets

- Env files are read when the CLI is **spawned**, never at config load, so `config.Save` can never copy their contents into `config.toml`, and editing a file applies to the next run with no restart.
- No value reaches an operator surface: `hap config` prints variable **names** and file paths only; the TUI/`config fields` registry carries only the `.env` **paths**; parse errors name a file and line number, never content.
- `HAP_*` / `HERDR_*` names are reserved and ignored with a warning — an operator env can't redirect the MCP wiring or point a nested `hap`/`herdr` at another installation.

## Fail-safe

A configured env file that cannot be read, has a malformed line (including an unterminated quote), or defines nothing at all **fails that run** — the daemon escalates instead of launching the CLI without its credentials, which would otherwise surface much later as an opaque auth error. The CLI is not spawned in that case.

The env travels with its template through the fast-fail retry, so a rescue run never gets the other command's key; and two templates that differ *only* in environment now still qualify for that retry.

## Tests

New: `internal/llm/env_test.go` (parser table + `buildEnv` precedence, reserved keys, placeholder rules, error paths), `internal/llm/commandenv_test.go` (real subprocesses asserting each template gets its own env). Extended: config Save/Load round-trip and defaults, `hap config` masking, a frontend guard that no registry field can render an env value.

Full suite green (`go test -tags "vectors cpu" ./...`), `go vet` and `golangci-lint` clean. One daemon test (`TestAutoSendIdleBelowThreshold`) flaked once under full-suite load and passed in isolation and on re-runs — pre-existing, unrelated to this change.