### PR TITLE
#1 fix: tolerate TUI jitter in the deferred-send staleness check

### DIFF
--- a/docs/architect/herd-auto-prompter-architecture.md
+++ b/docs/architect/herd-auto-prompter-architecture.md
@@ -278,12 +278,17 @@ The domain depends only on interfaces. **Core ports:** `HerdrPort` (send/read),
   `staleDeferredSendJitterPercent` (15%, a separate daemon constant) by trigram
   Jaccard, so an agent CLI's dynamic status line repainting during a minutes-long
   consult does not read as "the pane moved on" and escalate a confident answer.
-  Situation type is asserted separately (the fuzzy compare sees salients only),
-  an over-masked signature never matches at all (its hash is empty), and a
-  tolerated drift re-screens the fresh pane through never-auto + suspected-
-  irreversible — the pre-consult screen no longer covers text that changed since.
-  Measured at the default salient window: a status-line repaint is 9-13% away, the
-  nearest false accept (same scrollback, question line swapped) 21%.
+  The fuzzy path is confined to **unstructured pane-tail salients**: a structured
+  salient (approval verb + options, choice options, error summary) is short and
+  identity-bearing, so a one-word target swap ("apply … to the *test* service" →
+  "*live* service") stays ~86% similar and would fuse two different approvals —
+  those require an exact match (`domain.StructuredSalient`). Situation type is
+  asserted separately (the fuzzy compare sees salients only), an over-masked
+  signature never matches at all (its hash is empty), and a tolerated drift
+  re-screens the fresh pane through never-auto + suspected-irreversible — the
+  pre-consult screen no longer covers text that changed since. Measured at the
+  default salient window: a status-line repaint is 9-13% away, the nearest
+  pane-tail false accept (same scrollback, question line swapped) 21%.
 
 ### Learning Subsystem *(domain, daemon-owned writer)*
 

--- a/docs/architect/herd-auto-prompter-architecture.md
+++ b/docs/architect/herd-auto-prompter-architecture.md
@@ -267,9 +267,23 @@ The domain depends only on interfaces. **Core ports:** `HerdrPort` (send/read),
   blocked, appends a `delivery_failed` diagnostic audit row.
 - **Escalation** *(daemon)* — routes uncertain paths to escalate + audit + notify,
   with a **dedup window** (fixed internal constants `escalationDedupWindow` +
-  `escalationDedupJitterPercent` in the daemon package — not operator-configurable,
-  `domain.NormalizeForDedup`) so a re-fired identical situation doesn't spam the
-  operator; a resolved-window dedup gates on a *delivered* answer.
+  `escalationDedupJitterPercent` = 5% in the daemon package — not
+  operator-configurable, `domain.NormalizeForDedup`) so a re-fired identical
+  situation doesn't spam the operator; a resolved-window dedup gates on a
+  *delivered* answer.
+- **Deferred-send staleness** *(daemon)* — before injecting an answer that waited
+  on an LLM consult or action review, the pane is re-read and the situation must
+  still be the one that was decided (`domain.SignatureHeldStill`). Exact content
+  hash is the primary test; when it fails, the salients may still differ by up to
+  `staleDeferredSendJitterPercent` (15%, a separate daemon constant) by trigram
+  Jaccard, so an agent CLI's dynamic status line repainting during a minutes-long
+  consult does not read as "the pane moved on" and escalate a confident answer.
+  Situation type is asserted separately (the fuzzy compare sees salients only),
+  an over-masked signature never matches at all (its hash is empty), and a
+  tolerated drift re-screens the fresh pane through never-auto + suspected-
+  irreversible — the pre-consult screen no longer covers text that changed since.
+  Measured at the default salient window: a status-line repaint is 9-13% away, the
+  nearest false accept (same scrollback, question line swapped) 21%.
 
 ### Learning Subsystem *(domain, daemon-owned writer)*
 

--- a/internal/daemon/consultstaleness_test.go
+++ b/internal/daemon/consultstaleness_test.go
@@ -151,3 +151,50 @@ func TestLLMConsultRejectsSwappedQuestionOnSharedScrollback(t *testing.T) {
 		t.Errorf("want an %s escalation, got rationale %q", domain.ReasonLLMNoSubmit, esc[0].Rationale)
 	}
 }
+
+// A STRUCTURED approval (permission verb + options) whose target swaps one word
+// during the consult must escalate, not deliver: its salient stays ~86% similar
+// so an order-insensitive tolerance would fuse "test service" and "live
+// service" and send a yes learned for one into the other. domain.SignatureHeldStill
+// keeps structured salients on exact matching. This is the PR #230 collision,
+// end to end.
+func TestLLMConsultRejectsStructuredTargetSwap(t *testing.T) {
+	before := "Bash(deploy)\n\nDo you want to apply the requested change to the test service?\n❯ 1. Yes\n  2. No\n"
+	during := "Bash(deploy)\n\nDo you want to apply the requested change to the live service?\n❯ 1. Yes\n  2. No\n"
+
+	// Premise: both are structured approvals (verb extracted) with distinct
+	// hashes, and their salients ARE within the tolerance — only the
+	// structured-salient guard keeps them apart.
+	sb := domain.ComputeSignature(classifierForTest().Classify("claude", "blocked", before))
+	sd := domain.ComputeSignature(classifierForTest().Classify("claude", "blocked", during))
+	if sb.Verdict != domain.GuardOK || sd.Verdict != domain.GuardOK || sb.Raw == sd.Raw {
+		t.Fatalf("premise broken: verdicts %v/%v raw-equal=%v", sb.Verdict, sd.Verdict, sb.Raw == sd.Raw)
+	}
+	if !domain.StructuredSalient(sb.Salient) {
+		t.Fatalf("premise broken: expected a structured salient, got %q", sb.Salient)
+	}
+	if !domain.SimilarWithin(sb.Salient, sd.Salient, staleDeferredSendJitterPercent) {
+		t.Fatalf("premise broken: the swap is already beyond tolerance, so the guard is untested (%q vs %q)",
+			sb.Salient, sd.Salient)
+	}
+
+	h := newHarness(t, consultCfg)
+	h.herdr.setPane(before)
+	h.seedAutonomous(before, domain.SituationApproval, "1")
+	h.llm.configured = true
+	h.llm.consult = stageConsult(h, "1", during)
+
+	ctx := context.Background()
+	var esc []domain.AuditRecord
+	h.push("agent-target", "blocked")
+	waitFor(t, 5*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	if sent := h.herdr.sentInputs(); len(sent) != 0 {
+		t.Errorf("a changed approval target must never receive the staged digit, sent %v", sent)
+	}
+	if !strings.Contains(esc[0].Rationale, string(domain.ReasonLLMNoSubmit)) {
+		t.Errorf("want an %s escalation, got rationale %q", domain.ReasonLLMNoSubmit, esc[0].Rationale)
+	}
+}

--- a/internal/daemon/consultstaleness_test.go
+++ b/internal/daemon/consultstaleness_test.go
@@ -1,0 +1,153 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// A verbless approval: no permission verb is extracted, so the signature falls
+// back to the trailing pane content (domain.salientContent) — the shape whose
+// hash a repainting status line changes. `%s` carries that status line.
+const jitterApprovalPaneTemplate = "The previous step finished and the summary is above. " +
+	"It processed the remaining files and reported no problems. " +
+	"It processed the remaining files and reported no problems. " +
+	"It processed the remaining files and reported no problems. " +
+	"It processed the remaining files and reported no problems. " +
+	"It processed the remaining files and reported no problems. " +
+	"It processed the remaining files and reported no problems.\n" +
+	"Waiting for your approval to overwrite the generated file.\n" +
+	"❯ 1. Yes\n  2. No\n%s\n"
+
+func jitterApprovalPane(statusLine string) string {
+	return fmt.Sprintf(jitterApprovalPaneTemplate, statusLine)
+}
+
+// consultCfg pins approval confidence high enough that a fully-agreeing history
+// still takes the consult path, and the LLM auto-act threshold low enough that
+// the returned score promotes.
+const consultCfg = "[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n" +
+	"[confidence_thresholds]\napproval = 1.5\n"
+
+// stageConsult returns a consult hook that stages a real decision row (as the
+// production path requires) and repaints the pane to `paneDuring` first, so the
+// post-consult staleness re-read sees a pane that moved while the LLM ran.
+func stageConsult(h *harness, action, paneDuring string) func(context.Context, domain.LLMRequest) (*domain.LLMDecision, error) {
+	return func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+		h.herdr.setPane(paneDuring)
+		id, err := h.raw.InsertLLMDecision(ctx, domain.LLMDecision{
+			RequestID: req.RequestID, Signature: req.Signature,
+			SituationType: req.SituationType, AgentType: req.AgentType,
+			Action: action, Rationale: "matches the operator's usual answer",
+			ConfidentScore: 90, Status: "pending", CreatedAt: time.Now(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &domain.LLMDecision{
+			ID: id, RequestID: req.RequestID, Action: action,
+			Rationale: "matches the operator's usual answer", ConfidentScore: 90, Status: "pending",
+		}, nil
+	}
+}
+
+// A confident LLM answer must survive the agent CLI repainting its status line
+// while the consult runs: the situation is unchanged, so escalating it strands
+// the agent for nothing.
+func TestLLMConsultToleratesStatusLineJitter(t *testing.T) {
+	before := jitterApprovalPane("esc to interrupt · 812 tokens · 41% context")
+	during := jitterApprovalPane("esc to interrupt · 947 tokens · 43% context")
+
+	// Premise: the two panes are the same situation but do NOT hash equal, so
+	// only the jitter tolerance can carry this test.
+	sigBefore := domain.ComputeSignature(classifierForTest().Classify("claude", "blocked", before))
+	sigDuring := domain.ComputeSignature(classifierForTest().Classify("claude", "blocked", during))
+	if sigBefore.Verdict != domain.GuardOK || sigDuring.Verdict != domain.GuardOK {
+		t.Fatalf("premise broken: verdicts %v / %v", sigBefore.Verdict, sigDuring.Verdict)
+	}
+	if sigBefore.Raw == sigDuring.Raw {
+		t.Fatal("premise broken: the repainted pane must hash differently")
+	}
+
+	h := newHarness(t, consultCfg)
+	h.herdr.setPane(before)
+	h.seedAutonomous(before, domain.SituationApproval, "1")
+	h.llm.configured = true
+	h.llm.consult = stageConsult(h, "1", during)
+
+	h.push("agent-jitter", "blocked")
+	waitFor(t, 5*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	if got := h.herdr.sentInputs()[0]; got != "1" {
+		t.Errorf("delivered %q, want the promoted action \"1\"", got)
+	}
+	esc, _ := h.raw.PendingEscalations(context.Background())
+	if len(esc) != 0 {
+		t.Errorf("a pane that only repainted must not escalate, got %+v", esc)
+	}
+}
+
+// The tolerance must not blur a pane that genuinely moved on: a different
+// screen still escalates instead of receiving the staged answer.
+func TestLLMConsultRejectsChangedPaneBeyondJitter(t *testing.T) {
+	before := jitterApprovalPane("esc to interrupt · 812 tokens · 41% context")
+	during := "Waiting for your approval to delete the release branch and force-push the rewritten history.\n" +
+		"This is a different question about a different operation entirely, asked after the first resolved.\n" +
+		"❯ 1. Yes\n  2. No\n"
+
+	h := newHarness(t, consultCfg)
+	h.herdr.setPane(before)
+	h.seedAutonomous(before, domain.SituationApproval, "1")
+	h.llm.configured = true
+	h.llm.consult = stageConsult(h, "1", during)
+
+	ctx := context.Background()
+	h.push("agent-moved", "blocked")
+	var esc []domain.AuditRecord
+	waitFor(t, 5*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	if sent := h.herdr.sentInputs(); len(sent) != 0 {
+		t.Errorf("nothing may be delivered into a pane that moved on, sent %v", sent)
+	}
+	if !strings.Contains(esc[0].Rationale, string(domain.ReasonLLMNoSubmit)) {
+		t.Errorf("want an %s escalation, got rationale %q", domain.ReasonLLMNoSubmit, esc[0].Rationale)
+	}
+}
+
+// The tolerance's real adversary is not a whole new screen but the SAME
+// scrollback with the decision line swapped — the shape whose shared text
+// flatters the similarity metric. This pins the constant: it must sit below
+// that pair's distance (measured ~21% at the default 500-rune salient window)
+// and above an ordinary status-line repaint (~9-13%).
+func TestLLMConsultRejectsSwappedQuestionOnSharedScrollback(t *testing.T) {
+	status := "esc to interrupt · 812 tokens · 41% context"
+	before := jitterApprovalPane(status)
+	during := strings.Replace(before,
+		"Waiting for your approval to overwrite the generated file.",
+		"Waiting for your approval to publish the release to the public registry.", 1)
+
+	h := newHarness(t, consultCfg)
+	h.herdr.setPane(before)
+	h.seedAutonomous(before, domain.SituationApproval, "1")
+	h.llm.configured = true
+	h.llm.consult = stageConsult(h, "1", during)
+
+	ctx := context.Background()
+	var esc []domain.AuditRecord
+	h.push("agent-swapped", "blocked")
+	waitFor(t, 5*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	if sent := h.herdr.sentInputs(); len(sent) != 0 {
+		t.Errorf("a different question must never receive the staged digit, sent %v", sent)
+	}
+	if !strings.Contains(esc[0].Rationale, string(domain.ReasonLLMNoSubmit)) {
+		t.Errorf("want an %s escalation, got rationale %q", domain.ReasonLLMNoSubmit, esc[0].Rationale)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1155,6 +1155,28 @@ const (
 	// large tail-window captures (>= half the snapshot cap); small captures still
 	// require an exact match so two short but distinct questions never collapse.
 	escalationDedupJitterPercent = 5
+	// staleDeferredSendJitterPercent is how much a situation's salient may drift while
+	// a deferred send waits (LLM consult, action review) and still count as the
+	// same standing situation — see domain.SignatureHeldStill, which applies it
+	// only after the exact hash compare has already failed. Unlike the dedup
+	// constant it carries no minimum-capture gate: a small salient that barely
+	// changed is still the screen that was decided, and a genuinely different
+	// question is nowhere near this close.
+	//
+	// Deliberately looser than escalationDedupJitterPercent and deliberately a
+	// SEPARATE constant: a consult runs for seconds to minutes of status-line
+	// repaint (spinner, elapsed time, token counters), far longer than the window
+	// the duplicate-ask check spans, and tuning one must never loosen the other.
+	//
+	// 15 sits in a measured band at the DEFAULT ~500-rune salient window: an
+	// ordinary status-line repaint lands 9-13% away, while the nearest false
+	// accept — the same scrollback with only the question line swapped — is 21%
+	// away and a different command 29%
+	// (TestLLMConsultRejectsSwappedQuestionOnSharedScrollback pins the lower
+	// edge). Note the band narrows if embedding.pane_salient_chars is raised far
+	// above the default: a longer window dilutes a changed question line into
+	// more unchanged scrollback.
+	staleDeferredSendJitterPercent = 15
 )
 
 func (d *Daemon) duplicatePendingEscalation(ctx context.Context, s domain.Situation) bool {
@@ -3168,12 +3190,21 @@ func (d *Daemon) handleActionReviewOutcome(ctx context.Context, res actionReview
 		// Compare raw content hashes: the staged signature may have been
 		// semantically remapped onto another key, but Raw always reflects
 		// the pane content as read, so equal Raw means the pane held still.
-		if freshSig := domain.ComputeSignatureN(current, cfg.Embedding.PaneSalientChars); freshSig.Raw != res.sig.Raw {
+		// A large pane-tail salient may also have drifted by up to
+		// staleDeferredSendJitterPercent while the review ran — the situation type is
+		// already asserted equal above, which is what the fuzzy compare cannot
+		// see (see domain.SignatureHeldStill).
+		freshSig := domain.ComputeSignatureN(current, cfg.Embedding.PaneSalientChars)
+		if !domain.SignatureHeldStill(res.sig, freshSig, staleDeferredSendJitterPercent) {
 			slog.Info("signature changed during action review; dropping send", "agent", s.AgentID)
 			if res.decision != nil {
 				d.opt.Store.UpdateLLMDecisionStatus(ctx, res.decision.ID, "expired")
 			}
 			return
+		}
+		if freshSig.Raw != res.sig.Raw {
+			slog.Info("pane drifted within the jitter tolerance during action review; proceeding",
+				"agent", s.AgentID, "jitter_percent", staleDeferredSendJitterPercent)
 		}
 	}
 	// The idle policy tolerates changed content, so the FRESH pane must be
@@ -3582,13 +3613,45 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 			reject(domain.ReasonLLMNoSubmit, "stale: form changed during consult")
 			return
 		}
-	} else if freshSig := domain.ComputeSignatureN(current, cfg.Embedding.PaneSalientChars); freshSig.Raw != res.sig.Raw {
+	} else if current.Type != s.Type {
+		// The situation type is folded into the signature, so the hash compare
+		// below covered a type flip implicitly; the jitter-tolerant compare it
+		// now uses works on salients alone and cannot see one, so assert it
+		// explicitly (the action-review path does the same).
+		reject(domain.ReasonLLMNoSubmit, "stale: situation changed during consult")
+		return
+	} else {
 		// Compare raw content hashes: the staged signature may have been
 		// semantically remapped onto another key, but Raw always reflects
 		// the pane content as read, so equal Raw means the pane did not
-		// move on.
-		reject(domain.ReasonLLMNoSubmit, "stale: situation changed during consult")
-		return
+		// move on. A large pane-tail salient (idle, task hand-outs, verbless
+		// approvals) may additionally have drifted by up to
+		// staleDeferredSendJitterPercent while the consult ran — status-line repaint
+		// is not the pane moving on (see domain.SignatureHeldStill).
+		freshSig := domain.ComputeSignatureN(current, cfg.Embedding.PaneSalientChars)
+		if !domain.SignatureHeldStill(res.sig, freshSig, staleDeferredSendJitterPercent) {
+			reject(domain.ReasonLLMNoSubmit, "stale: situation changed during consult")
+			return
+		}
+		if freshSig.Raw != res.sig.Raw {
+			// The safety screens above ran on the PRE-consult content. Under
+			// exact-hash equality that also screened what is on screen now; a
+			// tolerated drift means the pane carries text nothing has screened,
+			// so re-screen it exactly as the action-review path does before
+			// letting a keystroke land on it.
+			if hit, matched := allow.Match(s.AgentType,
+				domain.IrreversibleScanContent(current, "")); matched {
+				reject(domain.ReasonNeverAutoMatch, hit.Diagnostic()+" (at post-consult re-read)")
+				return
+			}
+			if hit, sus := allow.SuspectedIrreversible(s.AgentType,
+				domain.IrreversibleScanContent(current, "")); sus {
+				reject(domain.ReasonSuspectedIrrevers, hit.Diagnostic()+" (at post-consult re-read)")
+				return
+			}
+			slog.Info("pane drifted within the jitter tolerance during consult; proceeding",
+				"agent", s.AgentID, "jitter_percent", staleDeferredSendJitterPercent)
+		}
 	}
 
 	// Task-review send: the review took up to the LLM timeout, so besides the

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1158,10 +1158,10 @@ const (
 	// staleDeferredSendJitterPercent is how much a situation's salient may drift while
 	// a deferred send waits (LLM consult, action review) and still count as the
 	// same standing situation — see domain.SignatureHeldStill, which applies it
-	// only after the exact hash compare has already failed. Unlike the dedup
-	// constant it carries no minimum-capture gate: a small salient that barely
-	// changed is still the screen that was decided, and a genuinely different
-	// question is nowhere near this close.
+	// only after the exact hash compare has already failed and only to
+	// UNSTRUCTURED pane-tail salients. Unlike the dedup constant it carries no
+	// minimum-capture gate: a small pane-tail salient that barely changed is still
+	// the screen that was decided.
 	//
 	// Deliberately looser than escalationDedupJitterPercent and deliberately a
 	// SEPARATE constant: a consult runs for seconds to minutes of status-line
@@ -1169,13 +1169,16 @@ const (
 	// the duplicate-ask check spans, and tuning one must never loosen the other.
 	//
 	// 15 sits in a measured band at the DEFAULT ~500-rune salient window: an
-	// ordinary status-line repaint lands 9-13% away, while the nearest false
-	// accept — the same scrollback with only the question line swapped — is 21%
-	// away and a different command 29%
+	// ordinary status-line repaint lands 9-13% away, while the nearest pane-tail
+	// false accept — the same scrollback with only the question line swapped — is
+	// 21% away and a different command 29%
 	// (TestLLMConsultRejectsSwappedQuestionOnSharedScrollback pins the lower
 	// edge). Note the band narrows if embedding.pane_salient_chars is raised far
 	// above the default: a longer window dilutes a changed question line into
-	// more unchanged scrollback.
+	// more unchanged scrollback. Structured salients (approval verb + options,
+	// choice options, error summary) don't take this path at all — a one-word
+	// target swap there stays ~86% similar, so they require an exact match
+	// (domain.StructuredSalient; the test-vs-live collision from PR #230).
 	staleDeferredSendJitterPercent = 15
 )
 

--- a/internal/domain/signature.go
+++ b/internal/domain/signature.go
@@ -243,12 +243,14 @@ func ApprovalRemapCompatible(salient, candidate string) bool {
 //   - The salients compared are already MaskVolatile'd, so timestamps, paths and
 //     large numbers are folded BEFORE the tolerance is applied — what is left for
 //     the tolerance to absorb is genuinely unrecognized chrome.
-//   - Unlike DuplicatesPendingEscalation, no minimum-size gate applies: the
-//     question here is "is THIS screen still the one that was decided", not "are
-//     these two screens the same question", and a short structured salient
-//     ("permission:run npm install | options:…") that changes at all changes a
-//     large fraction of its trigrams, so a genuinely different question falls far
-//     below any sane tolerance on its own.
+//   - The fuzzy path is confined to UNSTRUCTURED pane-tail salients
+//     (StructuredSalient == false). A structured salient — an approval's verb +
+//     options, a choice's option set, an error summary — is short and
+//     identity-bearing: "permission:apply … to the test service | options:no;yes"
+//     vs "… live service …" differs by one word yet shares ~86% of its trigrams,
+//     so an order-insensitive Jaccard compare would accept a materially different
+//     approval. Those keep exact matching; only raw screen text, where the drift
+//     is genuinely repainted chrome, is fuzzed.
 //
 // It does NOT compare situation type: the type is folded into the hash, so
 // callers taking the fuzzy path must assert type equality themselves.
@@ -266,6 +268,9 @@ func SignatureHeldStill(prev, fresh SignatureResult, jitterPct int) bool {
 		return true
 	}
 	if jitterPct <= 0 {
+		return false
+	}
+	if StructuredSalient(prev.Salient) || StructuredSalient(fresh.Salient) {
 		return false
 	}
 	return SimilarWithin(prev.Salient, fresh.Salient, jitterPct)
@@ -340,6 +345,36 @@ func salientContent(s Situation, salientChars int) string {
 		content = string(r[len(r)-salientChars:])
 	}
 	return content
+}
+
+// structuredSalientPrefixes are the identity markers salientContent emits for
+// its NON-pane-tail branches: a choice's option set, an approval's permission
+// verb, an error's summary. Their presence means the salient is a distilled,
+// order-bearing identity rather than raw screen text. Like ApprovalRemapCompatible
+// this reads the MaskVolatile'd salient, so it relies on MaskVolatile never
+// rewriting these literal prefixes (none of its patterns touch them) — keep that
+// invariant if MaskVolatile ever grows a new masker.
+var structuredSalientPrefixes = []string{"permission:", "options:", "error:"}
+
+// StructuredSalient reports whether a salient came from one of salientContent's
+// structured branches (approval verb + options, choice options, error summary)
+// rather than the pane-tail fallback. Such salients are short and
+// identity-bearing: a one-word target swap ("apply … to the test service" →
+// "… live service") leaves most of the string — and most of its trigrams —
+// intact, so an order-insensitive similarity check cannot tell two materially
+// different approvals apart. Callers use this to keep structured salients on
+// exact matching while a repainting pane-tail salient may match fuzzily.
+//
+// A raw pane-tail salient that happens to begin with one of these markers is
+// misread as structured and held to exact matching — the safe direction (it
+// escalates a benign repaint rather than risk a mis-send).
+func StructuredSalient(salient string) bool {
+	for _, p := range structuredSalientPrefixes {
+		if strings.HasPrefix(salient, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // overMaskVerdict applies the over-masking floor.

--- a/internal/domain/signature.go
+++ b/internal/domain/signature.go
@@ -224,6 +224,53 @@ func ApprovalRemapCompatible(salient, candidate string) bool {
 	return inter*2 >= union
 }
 
+// SignatureHeldStill reports whether a re-read of the same pane still shows the
+// situation `prev` was computed from — the staleness gate every deferred send
+// (LLM consult, action review) runs before injecting an answer.
+//
+// The primary test is exact equality of the never-remapped content hash. It is
+// widened only because a consult can take minutes, during which an agent CLI
+// repaints a dynamic status line (spinner, elapsed time, token/context
+// counters). For situations whose salient IS the pane tail (idle, task
+// hand-outs, verbless approvals — see salientContent) that repaint lands inside
+// the hashed content, so an unchanged, still-blocked screen reads as stale and
+// a confident answer is escalated instead of delivered.
+//
+// The widening stays safe because refusing is the safe direction:
+//   - It only runs when the hashes already differ, so the common path is
+//     unchanged.
+//   - An over-masked signature has no usable content, so it never fuzzy-matches.
+//   - The salients compared are already MaskVolatile'd, so timestamps, paths and
+//     large numbers are folded BEFORE the tolerance is applied — what is left for
+//     the tolerance to absorb is genuinely unrecognized chrome.
+//   - Unlike DuplicatesPendingEscalation, no minimum-size gate applies: the
+//     question here is "is THIS screen still the one that was decided", not "are
+//     these two screens the same question", and a short structured salient
+//     ("permission:run npm install | options:…") that changes at all changes a
+//     large fraction of its trigrams, so a genuinely different question falls far
+//     below any sane tolerance on its own.
+//
+// It does NOT compare situation type: the type is folded into the hash, so
+// callers taking the fuzzy path must assert type equality themselves.
+// jitterPct <= 0 makes this exactly the old hash comparison.
+func SignatureHeldStill(prev, fresh SignatureResult, jitterPct int) bool {
+	if prev.Verdict != GuardOK || fresh.Verdict != GuardOK {
+		// An over-masked signature has an EMPTY Raw, so a plain hash compare
+		// would call two unrelated over-masked screens "the same". They carry no
+		// content to compare either way, so refuse both the exact and the fuzzy
+		// answer and let the caller escalate (deferred sends never reach here
+		// today: an over-masked situation escalates at Decide).
+		return false
+	}
+	if prev.Raw == fresh.Raw {
+		return true
+	}
+	if jitterPct <= 0 {
+		return false
+	}
+	return SimilarWithin(prev.Salient, fresh.Salient, jitterPct)
+}
+
 // splitOptionSet is NormalizedOptionSet's inverse: it splits the encoding on
 // unescaped ";" back into a set of unescaped labels, dropping empty entries.
 func splitOptionSet(s string) map[string]bool {

--- a/internal/domain/signature_test.go
+++ b/internal/domain/signature_test.go
@@ -10,6 +10,17 @@ func sit(t SituationType, agentType, content string) Situation {
 	return Situation{Type: t, AgentType: agentType, Content: content}
 }
 
+// approvalSit builds an approval whose salient is STRUCTURED, mirroring what
+// classify.enrich populates (a permission verb + option labels) so
+// salientContent emits "permission:<verb> | options:…" rather than the
+// pane-tail fallback.
+func approvalSit(verb string, options ...string) Situation {
+	return Situation{
+		Type: SituationApproval, AgentType: "claude",
+		Content: "Do you want to " + verb + "?", PermissionVerb: verb, Options: options,
+	}
+}
+
 func TestMaskVolatile(t *testing.T) {
 	cases := []struct {
 		name, in, want string
@@ -361,14 +372,18 @@ func TestSignatureHeldStill(t *testing.T) {
 	after := sit(SituationIdle, "claude", body+"esc to interrupt tokens 947 context 43%")
 	other := sit(SituationIdle, "claude", "a completely different screen asking whether to remove the build directory before continuing with the release, plus more unrelated words")
 
-	// Short STRUCTURED salients: no size gate applies (a small capture that
-	// barely changed is still the same standing screen), so the trigram
-	// distance alone must keep two genuinely different approvals apart.
-	shortA := sit(SituationApproval, "claude", "Do you want to run the npm install command?\n1. Yes\n2. No")
-	shortB := sit(SituationApproval, "claude", "Do you want to run the npm publish command?\n1. Yes\n2. No")
-	// ...while the same short approval whose option label merely gained a word
-	// still counts as standing.
-	shortDrift := sit(SituationApproval, "claude", "Do you want to run the npm install command?\n1. Yes\n2. No, tell me")
+	// Short pane-tail salients (verbless approvals — no PermissionVerb, so
+	// salientContent falls back to raw content): a small capture that barely
+	// changed is still the same standing screen, so these take the fuzzy path.
+	shortA := sit(SituationApproval, "claude", "Ready to write the generated notes file?\nesc to interrupt tokens 812")
+	shortDrift := sit(SituationApproval, "claude", "Ready to write the generated notes file?\nesc to interrupt tokens 947")
+
+	// STRUCTURED salients (approval verb + options, as enrich builds them): a
+	// one-word target swap keeps ~86% of the trigrams, so an order-insensitive
+	// compare must NOT fuse them — they stay on exact matching. This is the
+	// collision charliecreates[bot] flagged on PR #230.
+	structTest := approvalSit("apply the requested change to the test service", "Yes", "No")
+	structLive := approvalSit("apply the requested change to the live service", "Yes", "No")
 
 	cases := []struct {
 		name       string
@@ -380,8 +395,8 @@ func TestSignatureHeldStill(t *testing.T) {
 		{"status-line repaint holds still within tolerance", before, after, 15, true},
 		{"status-line repaint is stale with jitter disabled", before, after, 0, false},
 		{"a different screen is stale even at tolerance", before, other, 15, false},
-		{"a different short approval is still stale", shortA, shortB, 15, false},
-		{"a barely-changed short approval holds still", shortA, shortDrift, 15, true},
+		{"a barely-changed pane-tail approval holds still", shortA, shortDrift, 15, true},
+		{"a one-word structured target swap is stale", structTest, structLive, 15, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -418,5 +433,41 @@ func TestSignatureHeldStill(t *testing.T) {
 	}
 	if SignatureHeldStill(ComputeSignature(before), over, 15) {
 		t.Error("an over-masked re-read must never match fuzzily")
+	}
+
+	// The structured collision must genuinely exercise the guard: absent it,
+	// the two salients ARE within 15% by trigram Jaccard, so the guard — not
+	// mere distance — is what keeps them apart.
+	st := ComputeSignature(structTest)
+	sl := ComputeSignature(structLive)
+	if st.Raw == sl.Raw {
+		t.Fatal("premise broken: the two structured approvals must hash differently")
+	}
+	// The margin here is ~1pt (the pair measures ~86% vs the 85% threshold): a
+	// "premise broken" failure means a MaskVolatile or sample-text edit nudged
+	// similarity below 85%, NOT that the guard regressed — widen the shared verb
+	// text to restore margin rather than deleting the guard.
+	if !SimilarWithin(st.Salient, sl.Salient, 15) {
+		t.Errorf("premise broken: the collision needs the StructuredSalient guard to reject it, "+
+			"but trigram distance alone already does (%q vs %q)", st.Salient, sl.Salient)
+	}
+}
+
+func TestStructuredSalient(t *testing.T) {
+	cases := []struct {
+		salient string
+		want    bool
+	}{
+		{"permission:apply the change | options:no;yes", true},
+		{"permission:select remote environment", true},
+		{"options:apple;banana", true},
+		{"error:usage limit reached", true},
+		{"The previous step finished. esc to interrupt", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := StructuredSalient(c.salient); got != c.want {
+			t.Errorf("StructuredSalient(%q) = %v, want %v", c.salient, got, c.want)
+		}
 	}
 }

--- a/internal/domain/signature_test.go
+++ b/internal/domain/signature_test.go
@@ -351,3 +351,72 @@ func TestComputeSignatureNWindow(t *testing.T) {
 		t.Errorf("DefaultPaneSalientChars = %d, want 500", DefaultPaneSalientChars)
 	}
 }
+
+func TestSignatureHeldStill(t *testing.T) {
+	// A pane-tail salient plus the same screen with only its status line
+	// repainted — the shape that made a still-standing situation read as stale
+	// after an LLM consult.
+	body := "waiting for input. " + strings.Repeat("the previous step completed and the summary is above. ", 12)
+	before := sit(SituationIdle, "claude", body+"esc to interrupt tokens 812 context 41%")
+	after := sit(SituationIdle, "claude", body+"esc to interrupt tokens 947 context 43%")
+	other := sit(SituationIdle, "claude", "a completely different screen asking whether to remove the build directory before continuing with the release, plus more unrelated words")
+
+	// Short STRUCTURED salients: no size gate applies (a small capture that
+	// barely changed is still the same standing screen), so the trigram
+	// distance alone must keep two genuinely different approvals apart.
+	shortA := sit(SituationApproval, "claude", "Do you want to run the npm install command?\n1. Yes\n2. No")
+	shortB := sit(SituationApproval, "claude", "Do you want to run the npm publish command?\n1. Yes\n2. No")
+	// ...while the same short approval whose option label merely gained a word
+	// still counts as standing.
+	shortDrift := sit(SituationApproval, "claude", "Do you want to run the npm install command?\n1. Yes\n2. No, tell me")
+
+	cases := []struct {
+		name       string
+		prev, next Situation
+		jitter     int
+		want       bool
+	}{
+		{"identical panes match on the exact hash", before, before, 15, true},
+		{"status-line repaint holds still within tolerance", before, after, 15, true},
+		{"status-line repaint is stale with jitter disabled", before, after, 0, false},
+		{"a different screen is stale even at tolerance", before, other, 15, false},
+		{"a different short approval is still stale", shortA, shortB, 15, false},
+		{"a barely-changed short approval holds still", shortA, shortDrift, 15, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			prev := ComputeSignature(c.prev)
+			next := ComputeSignature(c.next)
+			if prev.Verdict != GuardOK || next.Verdict != GuardOK {
+				t.Fatalf("premise broken: verdicts %v / %v", prev.Verdict, next.Verdict)
+			}
+			if prev.Raw == next.Raw && !c.want {
+				t.Fatalf("premise broken: %q and %q hash equal, so nothing is being tested",
+					prev.Salient, next.Salient)
+			}
+			if got := SignatureHeldStill(prev, next, c.jitter); got != c.want {
+				t.Errorf("SignatureHeldStill = %v, want %v (salients %q vs %q)",
+					got, c.want, prev.Salient, next.Salient)
+			}
+		})
+	}
+
+	// The status-line case must actually exercise the fuzzy path: if the
+	// hashes matched, the table above would pass for the wrong reason.
+	if ComputeSignature(before).Raw == ComputeSignature(after).Raw {
+		t.Error("premise broken: the repainted pane must hash differently")
+	}
+
+	// An over-masked signature carries no usable content: it may only match by
+	// (empty) hash, never fuzzily.
+	over := ComputeSignature(sit(SituationIdle, "claude", "/a/b/c 12345"))
+	if over.Verdict == GuardOK {
+		t.Fatalf("premise broken: expected an over-masked signature")
+	}
+	if SignatureHeldStill(over, over, 15) {
+		t.Error("over-masked reads share an EMPTY Raw; matching on it would call two unrelated screens the same")
+	}
+	if SignatureHeldStill(ComputeSignature(before), over, 15) {
+		t.Error("an over-masked re-read must never match fuzzily")
+	}
+}

--- a/test/integration/semantic_test.go
+++ b/test/integration/semantic_test.go
@@ -73,8 +73,20 @@ func (f *semHerdr) ReadPane(_ context.Context, paneID string, _ int) (string, er
 	return f.panes[paneID], nil
 }
 
+// ListAgents reports every pane this fake knows as a live agent. The daemon
+// auto-dismisses an escalation whose agent is no longer in this list
+// (autoDismissAgentNotLive), so a fake that returns nothing turns every
+// expected escalation into a "dismissed" audit row.
 func (f *semHerdr) ListAgents(_ context.Context) ([]domain.AgentTransition, error) {
-	return nil, nil
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]domain.AgentTransition, 0, len(f.panes))
+	for paneID := range f.panes {
+		out = append(out, domain.AgentTransition{
+			AgentID: paneID, PaneID: paneID, AgentType: "claude", Status: "blocked",
+		})
+	}
+	return out, nil
 }
 
 func (f *semHerdr) Notify(_ context.Context, _, _ string) error { return nil }
@@ -185,10 +197,21 @@ func TestRealEmbeddingSemanticMatch(t *testing.T) {
 	emb := embedder.NewReexecClient(config.Embedding{ModelPath: modelPath})
 	defer emb.Close()
 
+	// Everything else is defaults, but the capture delay must be tiny: events
+	// are delay-captured and a burst COALESCES (latest wins, one capture per
+	// burst), so with the default 10s/2s delays the readiness probe below —
+	// which re-pushes every 250ms — reschedules the capture timer forever and
+	// no pane is ever classified. Same wildcard rule the unit harness uses.
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath,
+		[]byte("[[capture_delay]]\nagent_type = \"*\"\nstart_ms = 1\nevent_ms = 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
 	fh := &semHerdr{}
 	fe := &semEvents{ch: make(chan domain.AgentTransition, 64)}
 	d, err := daemon.New(daemon.Options{
-		ConfigPath:        filepath.Join(dir, "config.toml"), // absent: defaults
+		ConfigPath:        cfgPath,
 		ControlSocketPath: filepath.Join(testutil.SocketDir(t), "c.sock"),
 		Store:             st,
 		Herdr:             fh,


### PR DESCRIPTION
## Problem

After an LLM consult (or action review), the daemon re-reads the pane and refuses to deliver the decided answer unless the situation is provably unchanged. That check was **exact content-hash equality**. A consult takes seconds to minutes, during which an agent CLI repaints a dynamic status line (spinner, elapsed time, token/context counters). For situations whose salient is the pane tail (idle, task hand-outs, verbless approvals — `domain.salientContent` falls back to the trailing `pane_salient_chars`), that repaint changes the hash, so a high-confidence suggestion was **escalated instead of sent** even though nothing about the question changed.

## Fix

`domain.SignatureHeldStill(prev, fresh, jitterPct)` — exact hash first, then a trigram-Jaccard tolerance (the existing `domain.SimilarWithin`) over the masked salients, at a new daemon constant `staleDeferredSendJitterPercent = 15`. Used by **both** deferred-send staleness gates (LLM consult + action review). `escalationDedupJitterPercent` stays 5% and is a separate constant.

Safety, kept narrow (refusing is the safe direction):
- The fuzzy path runs **only** when the exact hash already differs — no change on the common path.
- Situation **type** is asserted separately at each call site (the type is folded into the hash; the salient-only fuzzy compare can't see a type flip).
- An **over-masked** signature never matches (its `Raw` is empty; a plain compare would call two unrelated screens identical).
- A **tolerated drift re-screens** the fresh pane through never-auto + suspected-irreversible before any keystroke lands — the pre-consult safety screen no longer covers content that changed since.
- Multi-tab form staleness and the idle exemption are untouched.

The salients compared are already `MaskVolatile`d, so timestamps/paths/large numbers are folded before the tolerance applies. Measured band at the default ~500-rune window: a status-line repaint is 9–13% away, while the nearest false accept — same scrollback, question line swapped — is 21% and a different command 29%. 15 sits between, pinned by a test.

## Tests

- `TestSignatureHeldStill` (domain): status-line repaint holds still, whole-screen change is stale, a different short approval is stale, a barely-changed short approval holds still, over-masked pair, jitter=0 ≡ hash equality.
- `internal/daemon/consultstaleness_test.go`: real consult whose pane moves mid-flight — repaint delivers; whole-screen change escalates; **same scrollback with the question line swapped** escalates (pins the 15% lower edge).

## Also in this branch (test-only)

`test/integration/semantic_test.go`'s `TestRealEmbeddingSemanticMatch` was failing on `main` (readiness timeout) once FAISS + the model are present — two breakages, the second hidden behind the first: the readiness probe starved itself against delay-capture coalescing, and the fake's `ListAgents` returned nil so escalations auto-dismissed. Both fixed; the test now passes in ~2s. The full local integration suite (incl. real-Claude MCQ delivery cases) is green.

## Verification

- `go test -tags "vectors cpu" ./... -count=1` — 24 packages green
- `go vet` + `golangci-lint run --build-tags "vectors,cpu"` — clean
- `go test -tags "integration vectors cpu" ./test/integration/` and `HAP_ITEST_CLAUDE=1 …` — green
