### PR TITLE
#1 feat: semantic (embedding) search for signatures — TUI & CLI

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -260,6 +260,21 @@ hap signatures list --agent-type claude       # by agent type
 hap signatures list --min-conf 0.85          # by minimum cached confidence
 ```
 
+search learned signatures — keyword (case-insensitive substring over the rule's fields
+and its salient text) by default, or `--semantic` to embed the whole query and rank rules
+by meaning (cosine similarity; needs the embedding model). the same `--type` / `--mode` /
+`--agent-type` / `--min-conf` filters compose with either:
+
+```bash
+hap signatures search terraform                       # keyword substring
+hap signatures search "approve the file write" --semantic   # ranked by meaning
+hap signatures search "run tests" --semantic --limit 10 --min-score 0.5
+```
+
+the TUI mirrors this on the Rules tab: `/` starts a live keyword filter, and typing a
+2+-word query surfaces a hint to press **enter** for a semantic search (results show a
+`SEM` cosine column; editing the query returns to live keyword filtering).
+
 show full detail for a signature (recent decisions, last audit context):
 
 ```bash

--- a/docs/architect/herd-auto-prompter-architecture.md
+++ b/docs/architect/herd-auto-prompter-architecture.md
@@ -333,6 +333,16 @@ directly (and stamps a `decision_floor_id`).
   configured model (re-embeds rows whose model/dims drift), shared by
   `initSemantic` and the `hap signatures reembed` maintenance path; a newer
   generation can abort a stale pass.
+- **Signature search** *(`App.SearchSignatures`, front-end read)* — operator-facing
+  search over learned rules, exposed as `hap signatures search` and the TUI Rules-tab
+  `/`. Keyword mode is a case-insensitive substring over each rule's fields + salient
+  text. Semantic mode embeds the whole query with a **standalone** embedder (like
+  Reembed — the control socket carries no reply channel, so front-ends embed directly)
+  and ranks rules by cosine over the stored vectors — a linear scan (vectors are
+  L2-normalized, so cosine is a dot product), so it needs neither the daemon nor the
+  `vectors` tag, only the embedding model. Recall-oriented: top-N above a lenient floor,
+  scores shown; drifted/dimension-mismatched vectors are skipped, and it degrades to a
+  clear error (never a partial ranking) when embedding is disabled or the model is absent.
 
 ### MCP LLM Adapter *(`LLMPort` — `internal/llm`, `internal/mcpserver`)*
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -268,10 +268,24 @@ func signaturesSearch(ctx context.Context, app *frontend.App, out io.Writer, arg
 	agentType := fs.String("agent-type", "", "filter by agent type")
 	minConf := fs.Float64("min-conf", 0, "filter by minimum live confidence")
 	fs.SetOutput(out)
-	if err := fs.Parse(args); err != nil {
-		return err
+	// Go's flag parser stops at the first non-flag argument, so a natural
+	// `search <query words> --semantic` would leave --semantic unparsed inside
+	// the query. Permute: peel positional words off and keep parsing the rest,
+	// so flags may appear before, after, or among the query words.
+	var words []string
+	rest := args
+	for len(rest) > 0 {
+		if err := fs.Parse(rest); err != nil {
+			return err
+		}
+		rest = fs.Args()
+		if len(rest) == 0 {
+			break
+		}
+		words = append(words, rest[0])
+		rest = rest[1:]
 	}
-	query := strings.TrimSpace(strings.Join(fs.Args(), " "))
+	query := strings.TrimSpace(strings.Join(words, " "))
 	if query == "" {
 		return fmt.Errorf("usage: signatures search <query> [--semantic] [--limit N] [--min-score S] [filters] (see: hap help signatures)")
 	}
@@ -306,6 +320,12 @@ func signaturesSearch(ctx context.Context, app *frontend.App, out io.Writer, arg
 		if !*semantic {
 			hints = append(hints, Hint{Cmd: "hap signatures search " + query + " --semantic",
 				Why: "search by meaning instead of exact words"})
+		} else if drift, derr := app.EmbeddingDrift(ctx); derr == nil && drift.Detected {
+			// Rules exist but their vectors were embedded by a previous model,
+			// so semantic search skips them all — this reads as "no rules" until
+			// they are re-embedded for the current model.
+			hints = append(hints, Hint{Cmd: "hap signatures reembed",
+				Why: "rules embedded with an older model are skipped until re-embedded"})
 		}
 		PrintNextSteps(out, hints)
 		return nil

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -171,12 +171,14 @@ func signatures(ctx context.Context, app *frontend.App, out io.Writer, args []st
 		return signaturesReset(ctx, app, out, args)
 	case "reembed":
 		return signaturesReembed(ctx, app, out, args)
+	case "search":
+		return signaturesSearch(ctx, app, out, args)
 	}
 	// Bare `signatures --type X` style: treat unknown leading flag as list.
 	if strings.HasPrefix(sub, "-") {
 		return signaturesList(ctx, app, out, append([]string{sub}, args...))
 	}
-	return fmt.Errorf("usage: signatures [list|show <sig-or-prefix>|delete <sig-or-prefix> [--yes]|reset <sig-or-prefix> [--yes]|reembed [--force]] (see: hap help signatures)")
+	return fmt.Errorf("usage: signatures [list|search <query>|show <sig-or-prefix>|delete <sig-or-prefix> [--yes]|reset <sig-or-prefix> [--yes]|reembed [--force]] (see: hap help signatures)")
 }
 
 // signaturesReembed re-computes stored signature embeddings for the
@@ -249,6 +251,84 @@ func signaturesReembed(ctx context.Context, app *frontend.App, out io.Writer, ar
 		{Cmd: "hap status", Why: "confirm the drift line is gone"},
 		{Cmd: "hap signatures list", Why: "the rules that were re-embedded"},
 	})
+	return nil
+}
+
+// signaturesSearch finds learned rules by keyword (substring over the rule's
+// fields and its salient text) or, with --semantic, by embedding the query and
+// ranking rules by cosine similarity. Keyword is the default; --semantic needs
+// the configured embedding model.
+func signaturesSearch(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
+	fs := flag.NewFlagSet("signatures search", flag.ContinueOnError)
+	semantic := fs.Bool("semantic", false, "embedding search: rank rules by meaning (needs the embedding model)")
+	limit := fs.Int("limit", frontend.DefaultSemanticSearchLimit, "semantic: max matches to return")
+	minScore := fs.Float64("min-score", frontend.DefaultSemanticSearchFloor, "semantic: minimum cosine score (0-1)")
+	situation := fs.String("type", "", "filter by situation type (idle|approval|choice|error)")
+	mode := fs.String("mode", "", "filter by mode (shadow|autonomous)")
+	agentType := fs.String("agent-type", "", "filter by agent type")
+	minConf := fs.Float64("min-conf", 0, "filter by minimum live confidence")
+	fs.SetOutput(out)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	query := strings.TrimSpace(strings.Join(fs.Args(), " "))
+	if query == "" {
+		return fmt.Errorf("usage: signatures search <query> [--semantic] [--limit N] [--min-score S] [filters] (see: hap help signatures)")
+	}
+	switch *situation {
+	case "", "idle", "approval", "choice", "error":
+	default:
+		return fmt.Errorf("invalid --type %q (idle|approval|choice|error)", *situation)
+	}
+	switch *mode {
+	case "", string(domain.ModeShadow), string(domain.ModeAutonomous):
+	default:
+		return fmt.Errorf("invalid --mode %q (shadow|autonomous)", *mode)
+	}
+	results, err := app.SearchSignatures(ctx, query,
+		frontend.SignatureSearchOpts{Semantic: *semantic, Limit: *limit, MinScore: *minScore},
+		domain.SignatureFilter{
+			SituationType: domain.SituationType(*situation),
+			AgentType:     *agentType,
+			Mode:          domain.Mode(*mode),
+			MinConfidence: *minConf,
+		})
+	if err != nil {
+		return err
+	}
+	kind := "keyword"
+	if *semantic {
+		kind = "semantic"
+	}
+	if len(results) == 0 {
+		fmt.Fprintf(out, "no rules match the %s search %q\n", kind, query)
+		hints := []Hint{{Cmd: "hap signatures list", Why: "every learned rule, unfiltered"}}
+		if !*semantic {
+			hints = append(hints, Hint{Cmd: "hap signatures search " + query + " --semantic",
+				Why: "search by meaning instead of exact words"})
+		}
+		PrintNextSteps(out, hints)
+		return nil
+	}
+	graduationN := graduationN(app)
+	for _, r := range results {
+		if *semantic {
+			fmt.Fprintf(out, "sem=%.2f\t", r.Score)
+		}
+		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%d/%d\tconf=%s\ttop=%q\t%s\n",
+			shortSignature(r.Signature), r.SituationType, orDash(r.AgentType), r.Mode,
+			r.ConsecutiveConfirmations, graduationN, frontend.ConfidenceLabel(r.Confidence),
+			r.TopAction, r.UpdatedAt.Format("01-02 15:04:05"))
+	}
+	fmt.Fprintf(out, "\n%d %s match(es) for %q\n", len(results), kind, query)
+	prefix := strings.TrimSuffix(shortSignature(results[0].Signature), "…")
+	hints := []Hint{{Cmd: "hap signatures show " + prefix, Why: "the original situation, plus recent decisions"}}
+	if !*semantic {
+		hints = append(hints, Hint{Cmd: "hap signatures search " + query + " --semantic",
+			Why: "the same query, ranked by meaning"})
+	}
+	hints = append(hints, Hint{Cmd: "hap signatures list", Why: "every learned rule, unfiltered"})
+	PrintNextSteps(out, hints)
 	return nil
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -262,7 +262,7 @@ func signaturesSearch(ctx context.Context, app *frontend.App, out io.Writer, arg
 	fs := flag.NewFlagSet("signatures search", flag.ContinueOnError)
 	semantic := fs.Bool("semantic", false, "embedding search: rank rules by meaning (needs the embedding model)")
 	limit := fs.Int("limit", frontend.DefaultSemanticSearchLimit, "semantic: max matches to return")
-	minScore := fs.Float64("min-score", frontend.DefaultSemanticSearchFloor, "semantic: minimum cosine score (0-1)")
+	minScore := fs.Float64("min-score", frontend.DefaultSemanticSearchFloor, "semantic: minimum cosine score in (0,1]; 0 uses the default")
 	situation := fs.String("type", "", "filter by situation type (idle|approval|choice|error)")
 	mode := fs.String("mode", "", "filter by mode (shadow|autonomous)")
 	agentType := fs.String("agent-type", "", "filter by agent type")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2005,3 +2005,91 @@ func TestConfigShowsEnvKeysNeverValues(t *testing.T) {
 		}
 	}
 }
+
+func TestSignaturesSearchKeyword(t *testing.T) {
+	app, st := testApp(t)
+	seedSignatures(t, st)
+
+	// A field substring (mode) matches the shadow rule only.
+	out, err := run(t, app, "signatures", "search", "shadow")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "approval:aaaa111…") {
+		t.Errorf("keyword search missing the shadow rule:\n%s", out)
+	}
+	if strings.Contains(out, "choice:cccc3333") {
+		t.Errorf("keyword search should not include the autonomous rule:\n%s", out)
+	}
+	if !strings.Contains(out, "1 keyword match(es)") {
+		t.Errorf("missing keyword match count:\n%s", out)
+	}
+
+	// No query is a usage error, not an all-rows dump.
+	if _, err := run(t, app, "signatures", "search"); err == nil {
+		t.Error("search with no query should error")
+	}
+
+	// A query matching nothing reports cleanly with a next-step hint.
+	out, err = run(t, app, "signatures", "search", "zzzznope")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "no rules match") {
+		t.Errorf("empty result should say so:\n%s", out)
+	}
+}
+
+// seedSearchableRule persists a learned state + its semantic identity row so
+// `signatures search --semantic` can both list and rank it.
+func seedSearchableRule(t *testing.T, st *store.Store, sig, model string, vec []float32) {
+	t.Helper()
+	ctx := context.Background()
+	if err := st.UpsertSignature(ctx, domain.SignatureState{
+		Signature: sig, SituationType: domain.SituationApproval, AgentType: "claude",
+		Mode: domain.ModeShadow, UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertSignatureEmbedding(ctx, domain.SignatureEmbedding{
+		Signature: sig, SituationType: domain.SituationApproval, AgentType: "claude",
+		Model: model, Dims: len(vec), Vector: vec, Salient: "permission:" + sig, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSignaturesSearchSemantic(t *testing.T) {
+	app, st := testApp(t)
+	modelPath := filepath.Join(t.TempDir(), "test-model.gguf")
+	if err := os.WriteFile(modelPath, []byte("gguf"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(app.ConfigPath,
+		[]byte(fmt.Sprintf("[embedding]\nmodel_path = %q\n", modelPath)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	app.NewEmbedder = func(config.Embedding) ports.EmbedderPort {
+		return &cliFakeEmbedder{id: "test-model.gguf"} // embeds every query as {1,0,0}
+	}
+	// Cosine vs {1,0,0}: hit=1.0 (ranked), miss=0.0 (below the 0.3 floor).
+	seedSearchableRule(t, st, "approval:hit", "test-model.gguf", []float32{1, 0, 0})
+	seedSearchableRule(t, st, "approval:miss", "test-model.gguf", []float32{0, 1, 0})
+
+	out, err := run(t, app, "signatures", "search", "approve the write", "--semantic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "approval:hit") {
+		t.Errorf("semantic search missing the aligned rule:\n%s", out)
+	}
+	if strings.Contains(out, "approval:miss") {
+		t.Errorf("semantic search should drop the orthogonal rule below the floor:\n%s", out)
+	}
+	if !strings.Contains(out, "sem=1.00") {
+		t.Errorf("semantic search should show the cosine score column:\n%s", out)
+	}
+	if !strings.Contains(out, "1 semantic match(es)") {
+		t.Errorf("missing semantic match count:\n%s", out)
+	}
+}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -461,7 +461,7 @@ func buildCommands() {
 				{Name: "--min-conf", Arg: "C", Default: "0", Desc: "list/search filter: minimum live confidence (0-1)"},
 				{Name: "--semantic", Desc: "search: rank rules by meaning (embeds the query with the model) instead of keyword substring"},
 				{Name: "--limit", Arg: "N", Default: "20", Desc: "search --semantic: max matches to return"},
-				{Name: "--min-score", Arg: "S", Default: "0.3", Desc: "search --semantic: minimum cosine score (0-1)"},
+				{Name: "--min-score", Arg: "S", Default: "0.3", Desc: "search --semantic: minimum cosine score in (0,1]; 0 uses the default"},
 				{Name: "--yes", Desc: "delete/reset: skip the interactive confirmation (required when stdin is not a terminal)"},
 				{Name: "--force", Desc: "reembed: re-run even when no model drift is detected"},
 			},

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -448,29 +448,36 @@ func buildCommands() {
 			Summary: "inspect and manage learned rules",
 			Usage: []string{
 				"hap signatures [list] [--type T] [--mode M] [--agent-type A] [--min-conf C]",
+				"hap signatures search <query> [--semantic] [--limit N] [--min-score S] [filters]",
 				"hap signatures show <sig-or-prefix>",
 				"hap signatures delete <sig-or-prefix> [--yes]",
 				"hap signatures reset <sig-or-prefix> [--yes]",
 				"hap signatures reembed [--force]",
 			},
 			Flags: []FlagDoc{
-				{Name: "--type", Arg: "T", Desc: "list filter: situation type (idle|approval|choice|error)"},
-				{Name: "--mode", Arg: "M", Desc: "list filter: shadow (learning only) or autonomous (acts on its own)"},
-				{Name: "--agent-type", Arg: "A", Desc: "list filter: agent type (claude, codex, …)"},
-				{Name: "--min-conf", Arg: "C", Default: "0", Desc: "list filter: minimum live confidence (0-1)"},
+				{Name: "--type", Arg: "T", Desc: "list/search filter: situation type (idle|approval|choice|error)"},
+				{Name: "--mode", Arg: "M", Desc: "list/search filter: shadow (learning only) or autonomous (acts on its own)"},
+				{Name: "--agent-type", Arg: "A", Desc: "list/search filter: agent type (claude, codex, …)"},
+				{Name: "--min-conf", Arg: "C", Default: "0", Desc: "list/search filter: minimum live confidence (0-1)"},
+				{Name: "--semantic", Desc: "search: rank rules by meaning (embeds the query with the model) instead of keyword substring"},
+				{Name: "--limit", Arg: "N", Default: "20", Desc: "search --semantic: max matches to return"},
+				{Name: "--min-score", Arg: "S", Default: "0.3", Desc: "search --semantic: minimum cosine score (0-1)"},
 				{Name: "--yes", Desc: "delete/reset: skip the interactive confirmation (required when stdin is not a terminal)"},
 				{Name: "--force", Desc: "reembed: re-run even when no model drift is detected"},
 			},
 			Details: "A signature is one learned situation. `list` shows: short signature, situation,\n" +
 				"agent type, mode, confirmation streak / graduation N, confidence, top action.\n" +
-				"`show` adds the original pane excerpt and recent decisions — pass any unique\n" +
-				"prefix. `delete` erases the rule and its decisions (audit rows are kept).\n" +
-				"`reset` keeps the history but returns the rule to shadow with a cleared streak\n" +
-				"and confidence, so it must re-earn graduation — prefer it over delete when a\n" +
-				"rule started answering wrongly. `reembed` re-computes stored embeddings after\n" +
-				"an embedding model change (via the running daemon when there is one).",
+				"`search` finds rules by keyword (substring over the rule's fields and its salient\n" +
+				"text); with `--semantic` it embeds the whole query and ranks rules by cosine\n" +
+				"similarity (needs the embedding model). `show` adds the original pane excerpt and\n" +
+				"recent decisions — pass any unique prefix. `delete` erases the rule and its\n" +
+				"decisions (audit rows are kept). `reset` keeps the history but returns the rule to\n" +
+				"shadow with a cleared streak and confidence, so it must re-earn graduation — prefer\n" +
+				"it over delete when a rule started answering wrongly. `reembed` re-computes stored\n" +
+				"embeddings after an embedding model change (via the running daemon when there is one).",
 			Examples: []string{
 				"hap signatures list --mode autonomous",
+				"hap signatures search \"approve the file write\" --semantic",
 				"hap signatures show a1b2c3",
 				"hap signatures reset a1b2c3 --yes",
 			},

--- a/internal/frontend/signaturesearch.go
+++ b/internal/frontend/signaturesearch.go
@@ -32,8 +32,9 @@ type SignatureSearchOpts struct {
 	// Limit caps how many semantic matches are returned (defaults to
 	// DefaultSemanticSearchLimit when <= 0). Ignored for keyword search.
 	Limit int
-	// MinScore drops semantic matches below this cosine floor (defaults to
-	// DefaultSemanticSearchFloor when <= 0). Ignored for keyword search.
+	// MinScore drops semantic matches below this cosine floor. A non-positive
+	// value falls back to DefaultSemanticSearchFloor (the zero value is a safe
+	// default, never "no floor"). Ignored for keyword search.
 	MinScore float64
 }
 
@@ -148,10 +149,12 @@ func (a *App) semanticSearch(ctx context.Context, query string, opts SignatureSe
 	if limit <= 0 {
 		limit = DefaultSemanticSearchLimit
 	}
-	// Only a NEGATIVE MinScore means "unset, use the default": an explicit 0 is
-	// a deliberate "no floor, show every ranked match" and must be honored.
+	// A non-positive MinScore means "unset": fall back to the default floor.
+	// Keeping the zero value safe (a real floor, not "return everything") is
+	// deliberate — a caller that forgets to set it must not flood the operator
+	// with near-zero-cosine noise.
 	floor := opts.MinScore
-	if floor < 0 {
+	if floor <= 0 {
 		floor = DefaultSemanticSearchFloor
 	}
 

--- a/internal/frontend/signaturesearch.go
+++ b/internal/frontend/signaturesearch.go
@@ -1,0 +1,206 @@
+package frontend
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/embedder"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+)
+
+// SignatureSearchResult is one learned rule that matched a search, enriched
+// exactly like a Rules-list row (SignatureRow) plus the masked salient text it
+// was minted from and — for a semantic search — the cosine similarity that
+// ranked it. Score is 0 for a keyword search.
+type SignatureSearchResult struct {
+	SignatureRow
+	Salient string
+	Score   float64
+}
+
+// SignatureSearchOpts selects the search mode and bounds the semantic result
+// set. The zero value is a keyword search with the default semantic bounds
+// (unused unless Semantic is set).
+type SignatureSearchOpts struct {
+	// Semantic switches from keyword substring matching to embedding cosine
+	// ranking (embeds the whole query with the configured model).
+	Semantic bool
+	// Limit caps how many semantic matches are returned (defaults to
+	// DefaultSemanticSearchLimit when <= 0). Ignored for keyword search.
+	Limit int
+	// MinScore drops semantic matches below this cosine floor (defaults to
+	// DefaultSemanticSearchFloor when <= 0). Ignored for keyword search.
+	MinScore float64
+}
+
+const (
+	// DefaultSemanticSearchLimit bounds an interactive semantic search: a
+	// recall-oriented top-N, not the whole ranked table.
+	DefaultSemanticSearchLimit = 20
+	// DefaultSemanticSearchFloor is a lenient cosine floor for interactive
+	// search — well below the daemon's auto-match similarity_threshold (~0.90),
+	// which is deliberately strict for acting alone. Search favours recall so an
+	// operator sees near-misses rather than an empty list.
+	DefaultSemanticSearchFloor = 0.3
+)
+
+// SearchSignatures finds learned rules by keyword (case-insensitive substring
+// over the rule's fields and its salient text) or, with opts.Semantic, by
+// embedding the query and ranking rules by cosine similarity against their
+// stored vectors.
+//
+// It reuses App.Signatures for the enriched rows and joins the salient
+// text/vectors from signature_embeddings by signature. The structured filter f
+// (situation/agent/mode/min-conf) composes with either search: it narrows the
+// candidate set first, then the query matches within it.
+//
+// Semantic search embeds the query with a standalone embedder (like
+// ReembedStandalone) — the daemon's control socket carries no reply channel, so
+// front-ends embed directly. It degrades cleanly: embedding disabled in config,
+// a missing model, or a build without the native embedder returns a clear error
+// and never a partial ranking; keyword search stays available regardless.
+func (a *App) SearchSignatures(ctx context.Context, query string,
+	opts SignatureSearchOpts, f domain.SignatureFilter) ([]SignatureSearchResult, error) {
+
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, fmt.Errorf("search needs a query")
+	}
+	rows, err := a.Signatures(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+	// Salient text and vectors live in signature_embeddings, keyed by signature;
+	// SignatureRow itself carries neither. Absent rows just miss the salient
+	// text (keyword) or are unrankable (semantic) — never a crash.
+	embs, err := a.Store.ListSignatureEmbeddings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	byMasked := make(map[string]domain.SignatureEmbedding, len(embs))
+	for _, e := range embs {
+		byMasked[e.Signature] = e
+	}
+	if opts.Semantic {
+		return a.semanticSearch(ctx, q, opts, rows, byMasked)
+	}
+	return keywordSearch(q, rows, byMasked), nil
+}
+
+// keywordSearch keeps rows whose query is a case-insensitive substring of any
+// searchable field (signature, situation, agent type, mode, top action) or the
+// salient text, preserving the newest-updated-first order from App.Signatures.
+func keywordSearch(query string, rows []SignatureRow,
+	byMasked map[string]domain.SignatureEmbedding) []SignatureSearchResult {
+
+	needle := strings.ToLower(query)
+	out := make([]SignatureSearchResult, 0, len(rows))
+	for _, r := range rows {
+		salient := byMasked[r.Signature].Salient
+		fields := []string{
+			r.Signature, string(r.SituationType),
+			r.AgentType, string(r.Mode), r.TopAction, salient,
+		}
+		if !anyContainsFold(fields, needle) {
+			continue
+		}
+		out = append(out, SignatureSearchResult{SignatureRow: r, Salient: salient})
+	}
+	return out
+}
+
+// semanticSearch embeds the query and ranks rows by cosine similarity against
+// their stored vectors. Vectors embedded by a different model (drift) or with a
+// mismatched dimensionality are skipped rather than scored against — a stale
+// vector is not comparable to a fresh query embedding.
+func (a *App) semanticSearch(ctx context.Context, query string, opts SignatureSearchOpts,
+	rows []SignatureRow, byMasked map[string]domain.SignatureEmbedding) ([]SignatureSearchResult, error) {
+
+	cfg, err := config.Load(a.ConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	if cfg.Embedding.Disabled {
+		return nil, fmt.Errorf("semantic search needs embedding, which is disabled in config — use a keyword search, or enable [embedding]")
+	}
+	var emb ports.EmbedderPort
+	if a.NewEmbedder != nil {
+		emb = a.NewEmbedder(cfg.Embedding)
+	} else {
+		emb = embedder.New(cfg.Embedding)
+	}
+	defer emb.Close()
+
+	qvec, err := emb.EmbedText(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("semantic search needs the embedding model, which is unavailable (%w) — use a keyword search", err)
+	}
+	if len(qvec) == 0 {
+		return nil, fmt.Errorf("semantic search needs the embedding model, which produced no vector (model missing, or built without the embedder) — use a keyword search")
+	}
+	modelID := emb.ModelID()
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = DefaultSemanticSearchLimit
+	}
+	floor := opts.MinScore
+	if floor <= 0 {
+		floor = DefaultSemanticSearchFloor
+	}
+
+	out := make([]SignatureSearchResult, 0, len(rows))
+	for _, r := range rows {
+		e, ok := byMasked[r.Signature]
+		// Only compare against a vector minted by the SAME model and dimension
+		// as this query embedding; a drifted or absent vector is not comparable.
+		if !ok || e.Model != modelID || len(e.Vector) != len(qvec) {
+			continue
+		}
+		score := cosineNormalized(qvec, e.Vector)
+		if score < floor {
+			continue
+		}
+		out = append(out, SignatureSearchResult{SignatureRow: r, Salient: e.Salient, Score: score})
+	}
+	// Highest cosine first; break ties on signature for a stable order.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].Signature < out[j].Signature
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// cosineNormalized returns the cosine similarity of two vectors. The embedder
+// L2-normalizes its output, so for stored vectors this is exactly their dot
+// product; the length guard keeps it total for any caller.
+func cosineNormalized(a, b []float32) float64 {
+	if len(a) != len(b) {
+		return 0
+	}
+	var dot float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+	}
+	return dot
+}
+
+// anyContainsFold reports whether needle (already lower-cased) is a substring
+// of any field, case-insensitively.
+func anyContainsFold(fields []string, needle string) bool {
+	for _, f := range fields {
+		if f != "" && strings.Contains(strings.ToLower(f), needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/frontend/signaturesearch.go
+++ b/internal/frontend/signaturesearch.go
@@ -148,8 +148,10 @@ func (a *App) semanticSearch(ctx context.Context, query string, opts SignatureSe
 	if limit <= 0 {
 		limit = DefaultSemanticSearchLimit
 	}
+	// Only a NEGATIVE MinScore means "unset, use the default": an explicit 0 is
+	// a deliberate "no floor, show every ranked match" and must be honored.
 	floor := opts.MinScore
-	if floor <= 0 {
+	if floor < 0 {
 		floor = DefaultSemanticSearchFloor
 	}
 

--- a/internal/frontend/signaturesearch_test.go
+++ b/internal/frontend/signaturesearch_test.go
@@ -114,13 +114,21 @@ func TestSearchSignaturesSemanticRanksByCosine(t *testing.T) {
 	// A row embedded by a different model must never be scored against a fresh
 	// query embedding — it is skipped, not ranked at 0.
 	seedSearchRule(t, st, "approval:stale", "claude", "old-model.gguf", "permission:stale", []float32{1, 0, 0})
+	// A row whose vector dimensionality does not match the query embedding is
+	// likewise skipped (same model id, wrong dims — an inconsistent store).
+	seedSearchRule(t, st, "approval:baddim", "claude", "test-model.gguf", "permission:baddim", []float32{1, 0})
 
 	got, err := app.SearchSignatures(ctx, "anything", frontend.SignatureSearchOpts{Semantic: true}, domain.SignatureFilter{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(got) != 2 {
-		t.Fatalf("semantic search = %d results, want 2 (far below floor, stale skipped): %+v", len(got), got)
+		t.Fatalf("semantic search = %d results, want 2 (far below floor, stale + baddim skipped): %+v", len(got), got)
+	}
+	for _, r := range got {
+		if r.Signature == "approval:baddim" || r.Signature == "approval:stale" {
+			t.Errorf("skipped row %s must not appear in results", r.Signature)
+		}
 	}
 	if got[0].Signature != "approval:exact" || got[1].Signature != "approval:near" {
 		t.Fatalf("ranking order = [%s %s], want [exact near]", got[0].Signature, got[1].Signature)

--- a/internal/frontend/signaturesearch_test.go
+++ b/internal/frontend/signaturesearch_test.go
@@ -1,0 +1,190 @@
+package frontend_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+)
+
+// searchEmbedder embeds every query as a fixed vector, so seeded rows at known
+// cosine distances rank deterministically. fail forces an embed error.
+type searchEmbedder struct {
+	id   string
+	vec  []float32
+	fail bool
+}
+
+func (e *searchEmbedder) EmbedText(context.Context, string) ([]float32, error) {
+	if e.fail {
+		return nil, errors.New("induced embed failure")
+	}
+	return e.vec, nil
+}
+func (e *searchEmbedder) ModelID() string { return e.id }
+func (e *searchEmbedder) Dims() int       { return len(e.vec) }
+func (e *searchEmbedder) Close() error    { return nil }
+
+// seedSearchRule persists both the learned state (so App.Signatures returns it)
+// and the semantic identity row (salient + vector) the search joins in.
+func seedSearchRule(t *testing.T, st interface {
+	UpsertSignature(context.Context, domain.SignatureState) error
+	UpsertSignatureEmbedding(context.Context, domain.SignatureEmbedding) error
+}, sig, agent, model, salient string, vec []float32) {
+	t.Helper()
+	ctx := context.Background()
+	if err := st.UpsertSignature(ctx, domain.SignatureState{
+		Signature: sig, SituationType: domain.SituationApproval, AgentType: agent,
+		Mode: domain.ModeShadow, UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertSignatureEmbedding(ctx, domain.SignatureEmbedding{
+		Signature: sig, SituationType: domain.SituationApproval, AgentType: agent,
+		Model: model, Dims: len(vec), Vector: vec, Salient: salient, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSearchSignaturesKeyword(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	seedSearchRule(t, st, "approval:aaaa1111", "claude", "m.gguf", "permission:write file config.toml", []float32{1, 0, 0})
+	seedSearchRule(t, st, "approval:bbbb2222", "codex", "m.gguf", "permission:run terraform apply", []float32{0, 1, 0})
+
+	// Substring over the salient text, case-insensitive.
+	got, err := app.SearchSignatures(ctx, "TERRAFORM", frontend.SignatureSearchOpts{}, domain.SignatureFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Signature != "approval:bbbb2222" {
+		t.Fatalf("terraform keyword search = %+v, want only bbbb2222", got)
+	}
+	if got[0].Salient != "permission:run terraform apply" {
+		t.Errorf("salient not attached: %q", got[0].Salient)
+	}
+	if got[0].Score != 0 {
+		t.Errorf("keyword result must carry no score, got %v", got[0].Score)
+	}
+
+	// Substring over an enriched field (agent type) also matches.
+	got, err = app.SearchSignatures(ctx, "codex", frontend.SignatureSearchOpts{}, domain.SignatureFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Signature != "approval:bbbb2222" {
+		t.Fatalf("agent-type keyword search = %+v, want bbbb2222", got)
+	}
+
+	// The structured filter composes with the query: agent-type claude drops
+	// the codex rule even though the query would match it.
+	got, err = app.SearchSignatures(ctx, "permission", frontend.SignatureSearchOpts{},
+		domain.SignatureFilter{AgentType: "claude"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Signature != "approval:aaaa1111" {
+		t.Fatalf("filtered keyword search = %+v, want only the claude rule", got)
+	}
+
+	// Empty query is an error, not an all-rows dump.
+	if _, err := app.SearchSignatures(ctx, "   ", frontend.SignatureSearchOpts{}, domain.SignatureFilter{}); err == nil {
+		t.Error("empty query should error")
+	}
+}
+
+func TestSearchSignaturesSemanticRanksByCosine(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	writeEmbeddingConfig(t, app)
+	app.NewEmbedder = func(config.Embedding) ports.EmbedderPort {
+		return &searchEmbedder{id: "test-model.gguf", vec: []float32{1, 0, 0}}
+	}
+	// Cosine vs the query {1,0,0}: exact=1.0, near=0.6, far=0.0 (below floor).
+	seedSearchRule(t, st, "approval:exact", "claude", "test-model.gguf", "permission:exact", []float32{1, 0, 0})
+	seedSearchRule(t, st, "approval:near", "claude", "test-model.gguf", "permission:near", []float32{0.6, 0.8, 0})
+	seedSearchRule(t, st, "approval:far", "claude", "test-model.gguf", "permission:far", []float32{0, 1, 0})
+	// A row embedded by a different model must never be scored against a fresh
+	// query embedding — it is skipped, not ranked at 0.
+	seedSearchRule(t, st, "approval:stale", "claude", "old-model.gguf", "permission:stale", []float32{1, 0, 0})
+
+	got, err := app.SearchSignatures(ctx, "anything", frontend.SignatureSearchOpts{Semantic: true}, domain.SignatureFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("semantic search = %d results, want 2 (far below floor, stale skipped): %+v", len(got), got)
+	}
+	if got[0].Signature != "approval:exact" || got[1].Signature != "approval:near" {
+		t.Fatalf("ranking order = [%s %s], want [exact near]", got[0].Signature, got[1].Signature)
+	}
+	if got[0].Score < got[1].Score {
+		t.Errorf("scores not descending: %v then %v", got[0].Score, got[1].Score)
+	}
+	if got[0].Score < 0.99 {
+		t.Errorf("exact match cosine = %v, want ~1.0", got[0].Score)
+	}
+}
+
+func TestSearchSignaturesSemanticLimitAndFloor(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	writeEmbeddingConfig(t, app)
+	app.NewEmbedder = func(config.Embedding) ports.EmbedderPort {
+		return &searchEmbedder{id: "test-model.gguf", vec: []float32{1, 0, 0}}
+	}
+	seedSearchRule(t, st, "approval:one", "claude", "test-model.gguf", "one", []float32{1, 0, 0})
+	seedSearchRule(t, st, "approval:two", "claude", "test-model.gguf", "two", []float32{0.9, 0.1, 0})
+	seedSearchRule(t, st, "approval:three", "claude", "test-model.gguf", "three", []float32{0.8, 0.2, 0})
+
+	// Limit caps the ranked set to the top match.
+	got, err := app.SearchSignatures(ctx, "q", frontend.SignatureSearchOpts{Semantic: true, Limit: 1}, domain.SignatureFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Signature != "approval:one" {
+		t.Fatalf("limit=1 = %+v, want only the top match", got)
+	}
+
+	// A floor above every score returns nothing (not an error).
+	got, err = app.SearchSignatures(ctx, "q", frontend.SignatureSearchOpts{Semantic: true, MinScore: 0.999999}, domain.SignatureFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Signature != "approval:one" {
+		t.Fatalf("high floor = %+v, want only the exact 1.0 match", got)
+	}
+}
+
+func TestSearchSignaturesSemanticDegradesCleanly(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	seedSearchRule(t, st, "approval:x", "claude", "m.gguf", "x", []float32{1, 0, 0})
+
+	// Embedding disabled → a clear error, never a partial ranking.
+	if err := os.WriteFile(app.ConfigPath, []byte("[embedding]\ndisabled = true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.SearchSignatures(ctx, "hello world", frontend.SignatureSearchOpts{Semantic: true}, domain.SignatureFilter{}); err == nil {
+		t.Error("semantic search with embedding disabled should error")
+	}
+
+	// Embed failure (model unavailable) → error, keyword unaffected.
+	writeEmbeddingConfig(t, app)
+	app.NewEmbedder = func(config.Embedding) ports.EmbedderPort {
+		return &searchEmbedder{id: "test-model.gguf", vec: []float32{1, 0, 0}, fail: true}
+	}
+	if _, err := app.SearchSignatures(ctx, "hello world", frontend.SignatureSearchOpts{Semantic: true}, domain.SignatureFilter{}); err == nil {
+		t.Error("semantic search with a failing embedder should error")
+	}
+	if got, err := app.SearchSignatures(ctx, "x", frontend.SignatureSearchOpts{}, domain.SignatureFilter{}); err != nil || len(got) != 1 {
+		t.Errorf("keyword search must still work: got %+v err %v", got, err)
+	}
+}

--- a/internal/tui/semantic_search_test.go
+++ b/internal/tui/semantic_search_test.go
@@ -1,0 +1,229 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// tuiSearchEmbedder embeds every query as {1,0,0} so seeded rows rank by their
+// stored vector's alignment with it.
+type tuiSearchEmbedder struct{}
+
+func (tuiSearchEmbedder) EmbedText(context.Context, string) ([]float32, error) {
+	return []float32{1, 0, 0}, nil
+}
+func (tuiSearchEmbedder) ModelID() string { return "test-model.gguf" }
+func (tuiSearchEmbedder) Dims() int       { return 3 }
+func (tuiSearchEmbedder) Close() error    { return nil }
+
+// semanticModel builds a Rules-tab Model backed by a real App+store so a
+// dispatched semantic search runs end to end against a fake embedder. It seeds
+// two rules: "approval:hit" aligned with the query (cosine 1.0) and
+// "approval:miss" orthogonal to it (cosine 0.0, below the floor).
+func semanticModel(t *testing.T) Model {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	ctx := context.Background()
+	modelPath := filepath.Join(dir, "test-model.gguf")
+	if err := os.WriteFile(modelPath, []byte("gguf"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath,
+		[]byte(fmt.Sprintf("[embedding]\nmodel_path = %q\n", modelPath)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rows := []struct {
+		sig string
+		vec []float32
+	}{
+		{"approval:hit", []float32{1, 0, 0}},
+		{"approval:miss", []float32{0, 1, 0}},
+	}
+	var sigRows []frontend.SignatureRow
+	for _, r := range rows {
+		if err := st.UpsertSignature(ctx, domain.SignatureState{
+			Signature: r.sig, SituationType: domain.SituationApproval, AgentType: "claude",
+			Mode: domain.ModeShadow, UpdatedAt: time.Now(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := st.UpsertSignatureEmbedding(ctx, domain.SignatureEmbedding{
+			Signature: r.sig, SituationType: domain.SituationApproval, AgentType: "claude",
+			Model: "test-model.gguf", Dims: len(r.vec), Vector: r.vec,
+			Salient: "permission:" + r.sig, CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		sigRows = append(sigRows, frontend.SignatureRow{
+			SignatureState: domain.SignatureState{
+				Signature: r.sig, SituationType: domain.SituationApproval,
+				AgentType: "claude", Mode: domain.ModeShadow,
+			},
+			TopAction: "1",
+		})
+	}
+	app := &frontend.App{
+		Store:      st,
+		ConfigPath: cfgPath,
+		NewEmbedder: func(config.Embedding) ports.EmbedderPort {
+			return tuiSearchEmbedder{}
+		},
+	}
+	m := Model{width: 120, height: 40, app: app, ctx: ctx, inflight: &sync.WaitGroup{}}
+	upd, _ := m.Update(refreshMsg{cfg: config.Default(), signatures: sigRows})
+	m = upd.(Model)
+	m.tab = tabSignatures
+	return m
+}
+
+// typeRunes appends each rune of s to the model one KeyMsg at a time.
+func typeRunes(t *testing.T, m Model, s string) Model {
+	t.Helper()
+	for _, r := range s {
+		upd, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = upd.(Model)
+	}
+	return m
+}
+
+func TestSemanticSearchHintVisibility(t *testing.T) {
+	m := semanticModel(t)
+	m = press(t, m, "/")
+
+	// One word: no semantic hint (a substring filter already covers it).
+	m = typeRunes(t, m, "apply")
+	if m.semanticHintVisible() {
+		t.Error("a single-word query must not show the semantic hint")
+	}
+	if strings.Contains(m.View(), "semantic search — embed") {
+		t.Errorf("single-word view should not advertise semantic search:\n%s", m.View())
+	}
+
+	// Two words: the hint appears.
+	m = typeRunes(t, m, " now")
+	if !m.semanticHintVisible() {
+		t.Fatal("a 2-word query on the Rules tab must show the semantic hint")
+	}
+	if !strings.Contains(m.View(), "enter: semantic search") {
+		t.Errorf("2-word view should advertise the enter key:\n%s", m.View())
+	}
+}
+
+func TestSemanticSearchHintOnlyOnRulesTab(t *testing.T) {
+	m := semanticModel(t)
+	m.tab = tabAudit
+	m = press(t, m, "/")
+	m = typeRunes(t, m, "two words")
+	if m.semanticHintVisible() {
+		t.Error("the semantic hint must not appear on non-Rules tabs")
+	}
+}
+
+func TestSemanticSearchEndToEnd(t *testing.T) {
+	m := semanticModel(t)
+	m = press(t, m, "/")
+	m = typeRunes(t, m, "approve the write")
+
+	// Enter over a 2+-word Rules query dispatches the semantic search command.
+	upd, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("Enter over a 2-word Rules query must dispatch a semantic search command")
+	}
+	if m.searching {
+		t.Error("dispatching semantic search should leave search-input mode")
+	}
+	// Run the command and feed its result back, as the runtime would.
+	msg := cmd()
+	sm, ok := msg.(semanticSearchMsg)
+	if !ok {
+		t.Fatalf("command produced %T, want semanticSearchMsg", msg)
+	}
+	if sm.err != nil {
+		t.Fatalf("semantic search errored: %v", sm.err)
+	}
+	upd, _ = m.Update(sm)
+	m = upd.(Model)
+
+	if !m.semanticActive() {
+		t.Fatal("a completed semantic search should be active for its query")
+	}
+	vis := m.visibleSignatures()
+	if len(vis) != 1 || vis[0].Signature != "approval:hit" {
+		t.Fatalf("visible = %+v, want only approval:hit (miss is below the floor)", vis)
+	}
+	view := m.View()
+	if !strings.Contains(view, "semantic: 1 match(es)") {
+		t.Errorf("view should show the semantic match count:\n%s", view)
+	}
+	if !strings.Contains(view, "SEM") || !strings.Contains(view, "1.00") {
+		t.Errorf("view should show the SEM score column:\n%s", view)
+	}
+	if strings.Contains(view, "approval:miss") {
+		t.Errorf("the below-floor rule must not appear:\n%s", view)
+	}
+}
+
+func TestSemanticSearchSingleWordEnterKeepsKeyword(t *testing.T) {
+	m := semanticModel(t)
+	m = press(t, m, "/")
+	m = typeRunes(t, m, "hit")
+
+	upd, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = upd.(Model)
+	if cmd != nil {
+		t.Error("a single-word Enter must not dispatch a semantic search")
+	}
+	if m.searching {
+		t.Error("Enter should leave search mode")
+	}
+	if m.semanticActive() {
+		t.Error("no semantic search should be active after a single-word Enter")
+	}
+	// The keyword filter still applies: "hit" matches only approval:hit.
+	vis := m.visibleSignatures()
+	if len(vis) != 1 || vis[0].Signature != "approval:hit" {
+		t.Fatalf("keyword filter after Enter = %+v, want only approval:hit", vis)
+	}
+}
+
+func TestSemanticSearchEditingRevertsToKeyword(t *testing.T) {
+	m := semanticModel(t)
+	// Prime an active semantic search for the exact query.
+	m.query[tabSignatures] = "approve the write"
+	m.sigSemantic = &semanticSigSearch{
+		query: "approve the write",
+		results: []frontend.SignatureSearchResult{
+			{SignatureRow: frontend.SignatureRow{SignatureState: domain.SignatureState{Signature: "approval:hit"}}, Score: 1},
+		},
+	}
+	if !m.semanticActive() {
+		t.Fatal("precondition: semantic search should be active for its query")
+	}
+	// Re-enter search and edit the query — the semantic view must fall away.
+	m = press(t, m, "/")
+	m = typeRunes(t, m, "X")
+	if m.semanticActive() {
+		t.Error("editing the query must drop back to live keyword filtering")
+	}
+}

--- a/internal/tui/semantic_search_test.go
+++ b/internal/tui/semantic_search_test.go
@@ -226,4 +226,14 @@ func TestSemanticSearchEditingRevertsToKeyword(t *testing.T) {
 	if m.semanticActive() {
 		t.Error("editing the query must drop back to live keyword filtering")
 	}
+	// And it must NOT resurrect if the operator later re-types the exact phrase
+	// as an ordinary keyword filter: the stale result set was torn down, so
+	// query-string equality alone can no longer reactivate it.
+	m.setQuery(tabSignatures, "approve the write")
+	if m.semanticActive() {
+		t.Error("re-typing a past semantic query as a keyword filter must not resurrect stale results")
+	}
+	if m.sigSemantic != nil {
+		t.Error("editing should have torn down the semantic result set")
+	}
 }

--- a/internal/tui/semantic_search_test.go
+++ b/internal/tui/semantic_search_test.go
@@ -184,6 +184,34 @@ func TestSemanticSearchEndToEnd(t *testing.T) {
 	}
 }
 
+func TestSemanticSearchFailedRerunClearsStaleResults(t *testing.T) {
+	m := semanticModel(t)
+	// An active semantic search for a query.
+	m.query[tabSignatures] = "approve the write"
+	m.sigSemantic = &semanticSigSearch{
+		query: "approve the write",
+		results: []frontend.SignatureSearchResult{
+			{SignatureRow: frontend.SignatureRow{SignatureState: domain.SignatureState{Signature: "approval:hit"}}, Score: 1},
+		},
+	}
+	if !m.semanticActive() {
+		t.Fatal("precondition: the prior search should be active")
+	}
+	// A rerun of the SAME query fails (e.g. the model was removed). The stale
+	// ranked rows must not survive alongside the error.
+	upd, _ := m.Update(semanticSearchMsg{query: "approve the write", err: fmt.Errorf("model unavailable")})
+	m = upd.(Model)
+	if m.sigSemantic != nil {
+		t.Error("a failed rerun must invalidate the prior semantic result set")
+	}
+	if m.semanticActive() {
+		t.Error("no semantic search should remain active after a failed rerun")
+	}
+	if m.status == nil || !m.status.err {
+		t.Error("the failure should surface as an error status")
+	}
+}
+
 func TestSemanticSearchSingleWordEnterKeepsKeyword(t *testing.T) {
 	m := semanticModel(t)
 	m = press(t, m, "/")

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -77,6 +77,15 @@ type sigDetailMsg struct {
 	err     error
 }
 
+// semanticSearchMsg carries the result of an embedding search on the Rules tab
+// (dispatched by semanticSearchCmd). query is echoed back so a result that
+// arrives after the operator edited the box is ignored by semanticActive.
+type semanticSearchMsg struct {
+	query   string
+	results []frontend.SignatureSearchResult
+	err     error
+}
+
 type actionResultMsg struct {
 	message string
 	err     error
@@ -483,9 +492,14 @@ type Model struct {
 
 	tab     tab
 	data    refreshMsg
-	items   []ruleItem     // Config tab rows, rebuilt on refresh
-	sigMode domain.Mode    // Rules tab display filter: "" = all
-	marked  map[int64]bool // Escalations tab multi-select (audit ids), space toggles
+	items   []ruleItem  // Config tab rows, rebuilt on refresh
+	sigMode domain.Mode // Rules tab display filter: "" = all
+	// sigSemantic holds the last semantic (embedding) search on the Rules tab.
+	// It is applied only while its query still equals the tab's live query
+	// (semanticActive) — so editing the query drops back to live keyword
+	// filtering with no explicit teardown. nil = never run / not applicable.
+	sigSemantic *semanticSigSearch
+	marked      map[int64]bool // Escalations tab multi-select (audit ids), space toggles
 	// taskMarks is the Tasks tab multi-select, keyed by taskMarkKey
 	// (group index + item number). Space toggles; d/x consume the set.
 	taskMarks map[string]bool
@@ -571,6 +585,62 @@ func (m Model) matchesQuery(t tab, fields ...string) bool {
 		}
 	}
 	return false
+}
+
+// semanticSigSearch is the result of one embedding search on the Rules tab: the
+// query it ran for (so an edited query invalidates it) and the ranked results.
+type semanticSigSearch struct {
+	query   string
+	results []frontend.SignatureSearchResult
+}
+
+// semanticHintVisible reports whether the "press enter for semantic search"
+// footer should show: only while typing a 2+-word query on the Rules tab, where
+// embedding the whole phrase is meaningfully different from a substring filter.
+func (m Model) semanticHintVisible() bool {
+	return m.searching && m.tab == tabSignatures && len(strings.Fields(m.query[tabSignatures])) >= 2
+}
+
+// semanticActive reports whether the Rules tab is currently showing a semantic
+// result set rather than live keyword filtering — true only while the stored
+// search's query still equals the tab's live query, so any edit silently drops
+// back to keyword filtering without tearing sigSemantic down.
+func (m Model) semanticActive() bool {
+	return m.sigSemantic != nil && m.tab == tabSignatures &&
+		m.sigSemantic.query == m.query[tabSignatures]
+}
+
+// sigSemanticScores maps signature → cosine score for the active semantic
+// search, or nil when none is active (renderSignatures uses it to add the SEM
+// column).
+func (m Model) sigSemanticScores() map[string]float64 {
+	if !m.semanticActive() {
+		return nil
+	}
+	scores := make(map[string]float64, len(m.sigSemantic.results))
+	for _, r := range m.sigSemantic.results {
+		scores[r.Signature] = r.Score
+	}
+	return scores
+}
+
+// semanticSearchCmd embeds the query and ranks the learned rules by meaning,
+// off the update loop (the model loads the embedding model — see App.
+// SearchSignatures). The inflight Add mirrors do(): Run's drain never races the
+// counter from zero.
+func (m Model) semanticSearchCmd(query string) tea.Cmd {
+	app, ctx, wg := m.app, m.ctx, m.inflight
+	if wg != nil {
+		wg.Add(1)
+	}
+	return func() tea.Msg {
+		if wg != nil {
+			defer wg.Done()
+		}
+		results, err := app.SearchSignatures(ctx, query,
+			frontend.SignatureSearchOpts{Semantic: true}, domain.SignatureFilter{})
+		return semanticSearchMsg{query: query, results: results, err: err}
+	}
 }
 
 // visibleAgents applies the Agents tab search filter.
@@ -753,6 +823,28 @@ func (m Model) filterAudit(t tab, rows []domain.AuditRecord) []domain.AuditRecor
 // visibleSignatures applies the display-side mode filter (f key) composed
 // with the Rules tab search query (CR-017).
 func (m Model) visibleSignatures() []frontend.SignatureRow {
+	// Semantic search replaces keyword filtering: show the ranked matches in
+	// score order, re-mapped onto the latest refresh so confidence/mode/LAST
+	// stay live (a signature that vanished since the search is dropped). The
+	// mode filter (f) still composes on top.
+	if m.semanticActive() {
+		byID := make(map[string]frontend.SignatureRow, len(m.data.signatures))
+		for _, r := range m.data.signatures {
+			byID[r.Signature] = r
+		}
+		var out []frontend.SignatureRow
+		for _, res := range m.sigSemantic.results {
+			r, ok := byID[res.Signature]
+			if !ok {
+				continue
+			}
+			if m.sigMode != "" && r.Mode != m.sigMode {
+				continue
+			}
+			out = append(out, r)
+		}
+		return out
+	}
 	if m.sigMode == "" && m.query[tabSignatures] == "" {
 		return m.data.signatures
 	}
@@ -1066,6 +1158,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.detail = d
 		return m, nil
+	case semanticSearchMsg:
+		if msg.err != nil {
+			m.message = ""
+			m.status = &statusNote{text: msg.err.Error(), err: true, at: time.Now()}
+			m.clampListViewport()
+			return m, nil
+		}
+		m.sigSemantic = &semanticSigSearch{query: msg.query, results: msg.results}
+		// A fresh ranking: start at the top match, not wherever the keyword
+		// cursor sat.
+		m.cursors[tabSignatures] = 0
+		m.offsets[tabSignatures] = 0
+		m.message = fmt.Sprintf("semantic: %d match(es) for %q", len(msg.results), msg.query)
+		m.clampListViewport()
+		return m, nil
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 	}
@@ -1294,6 +1401,15 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case tea.KeyCtrlC:
 			return m, tea.Quit
 		case tea.KeyEsc, tea.KeyEnter:
+			// On the Rules tab, Enter over a 2+-word query runs a semantic
+			// (embedding) search instead of just committing the keyword filter.
+			if msg.Type == tea.KeyEnter && m.semanticHintVisible() {
+				q := m.query[tabSignatures]
+				m.searching = false
+				m.message = "running semantic search…"
+				m.clampListViewport()
+				return m, m.semanticSearchCmd(q)
+			}
 			// Leaving search hands ←/→ back to tab navigation.
 			m.searching = false
 		default:
@@ -2822,6 +2938,9 @@ func (m Model) listPageSize() int {
 	if m.searching || (m.tab.isList() && m.query[m.tab] != "") {
 		chrome++
 	}
+	if m.semanticHintVisible() {
+		chrome++ // the extra "enter: semantic search" hint line under the box
+	}
 	if m.tab == tabSignatures && m.sigMode != "" {
 		chrome++
 	}
@@ -4107,6 +4226,13 @@ func (m Model) View() string {
 	// listPageSize so the body never overflows the pane).
 	if m.searching {
 		fmt.Fprintf(&b, "%s%s\n", st.section.Render("search> "), m.queryEdit().withCaret())
+		if m.semanticHintVisible() {
+			fmt.Fprintf(&b, "%s\n", st.help.Render(
+				"enter: semantic search — embed this query to rank rules by meaning"))
+		}
+	} else if m.semanticActive() {
+		fmt.Fprintf(&b, "%s\n", st.help.Render(
+			fmt.Sprintf("semantic: %q — / to edit, backspace to clear", m.query[tabSignatures])))
 	} else if m.tab.isList() && m.query[m.tab] != "" {
 		fmt.Fprintf(&b, "%s\n", st.help.Render(
 			fmt.Sprintf("filter: %q — / to edit, backspace to clear", m.query[m.tab])))
@@ -4319,7 +4445,14 @@ func (m Model) renderSignatures(b *strings.Builder) {
 	// to fit "5h 59m ago" and the ≥ 6h timestamp fallback; "-" until first use.
 	const rulesRowFmt = "%-*s %-12s %-10s %5s %-11s %7s  %s"
 	actWidth, _ := m.budget(sigW+52, false)
-	header := fmt.Sprintf(rulesRowFmt, sigW,
+	// A semantic search adds a leading SEM (cosine) column; keyword search and
+	// the plain list omit it entirely.
+	scores := m.sigSemanticScores()
+	semHeader := ""
+	if scores != nil {
+		semHeader = fmt.Sprintf("%-6s", "SEM")
+	}
+	header := semHeader + fmt.Sprintf(rulesRowFmt, sigW,
 		"SIGNATURE", "LAST", "TYPE", "CONF", "MODE", "CONFIRM", "TOP ACTION")
 	fmt.Fprintln(b, st.section.Render(header))
 	start, end := m.window(len(sigs))
@@ -4329,7 +4462,11 @@ func (m Model) renderSignatures(b *strings.Builder) {
 		if r.LastAudit != nil {
 			lastUsed = r.LastAudit.CreatedAt
 		}
-		line := fmt.Sprintf(rulesRowFmt,
+		semCol := ""
+		if scores != nil {
+			semCol = fmt.Sprintf("%-6s", fmt.Sprintf("%.2f", scores[r.Signature]))
+		}
+		line := semCol + fmt.Sprintf(rulesRowFmt,
 			sigW, r.Signature, humanizeWhen(lastUsed, m.renderNow()), orDash(r.AgentType),
 			frontend.ConfidenceLabel(r.Confidence), r.Mode,
 			fmt.Sprintf("%d/%d", r.ConsecutiveConfirmations, gradN),

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -638,7 +638,8 @@ func (m Model) semanticSearchCmd(query string) tea.Cmd {
 			defer wg.Done()
 		}
 		results, err := app.SearchSignatures(ctx, query,
-			frontend.SignatureSearchOpts{Semantic: true}, domain.SignatureFilter{})
+			frontend.SignatureSearchOpts{Semantic: true, MinScore: frontend.DefaultSemanticSearchFloor},
+			domain.SignatureFilter{})
 		return semanticSearchMsg{query: query, results: results, err: err}
 	}
 }
@@ -1159,6 +1160,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.detail = d
 		return m, nil
 	case semanticSearchMsg:
+		// The operator edited (or cleared) the query while the embed was in
+		// flight: this result is for a query they moved on from, so drop it
+		// rather than jump the cursor and announce matches for stale input.
+		if msg.query != m.query[tabSignatures] {
+			return m, nil
+		}
 		if msg.err != nil {
 			m.message = ""
 			m.status = &statusNote{text: msg.err.Error(), err: true, at: time.Now()}
@@ -1417,7 +1424,15 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// editing keys. Every key is swallowed here (this branch always
 			// returns), so ← moves the caret instead of switching tabs out
 			// from under a half-typed query.
+			before := m.query[m.tab]
 			m.setQueryEdit(applyTextKey(m.queryEdit(), msg, false))
+			// Editing the Rules query abandons any semantic result set: it must
+			// be re-run, or a later keyword query that happens to re-type the
+			// old phrase would otherwise resurrect the stale ranking. Guarded on
+			// a real text change so caret-only moves keep the results visible.
+			if m.tab == tabSignatures && m.query[m.tab] != before {
+				m.sigSemantic = nil
+			}
 		}
 		m.clampListViewport() // CR-016
 		return m, nil
@@ -1462,6 +1477,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// search mode too; a no-op otherwise.
 		if m.tab.isList() && m.query[m.tab] != "" {
 			m.setQuery(m.tab, "")
+			// Clearing the query also abandons the semantic result set (see the
+			// search-input edit branch) so re-typing can't resurrect it.
+			if m.tab == tabSignatures {
+				m.sigSemantic = nil
+			}
 			m.clampListViewport()
 		}
 	case "p":

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1167,6 +1167,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if msg.err != nil {
+			// A failed rerun must not keep rendering a PRIOR search's ranked
+			// rows: with the same query, semanticActive() would still be true
+			// (it only checks the query/pointer pair), so the stale matches +
+			// SEM scores would show alongside the error. Invalidate them.
+			m.sigSemantic = nil
 			m.message = ""
 			m.status = &statusNote{text: msg.err.Error(), err: true, at: time.Now()}
 			m.clampListViewport()

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -637,9 +637,9 @@ func (m Model) semanticSearchCmd(query string) tea.Cmd {
 		if wg != nil {
 			defer wg.Done()
 		}
+		// Zero Limit/MinScore fall back to the recall-oriented defaults.
 		results, err := app.SearchSignatures(ctx, query,
-			frontend.SignatureSearchOpts{Semantic: true, MinScore: frontend.DefaultSemanticSearchFloor},
-			domain.SignatureFilter{})
+			frontend.SignatureSearchOpts{Semantic: true}, domain.SignatureFilter{})
 		return semanticSearchMsg{query: query, results: results, err: err}
 	}
 }


### PR DESCRIPTION
## What

Adds **search** for learned rules/signatures in both surfaces, with a new **semantic (embedding)** mode alongside keyword search.

- **CLI** — new `hap signatures search <query>`:
  - keyword by default (case-insensitive substring over the rule's fields + its salient text)
  - `--semantic` embeds the whole query and ranks rules by cosine similarity
  - `--limit` / `--min-score` bound the semantic set; the existing `--type` / `--mode` / `--agent-type` / `--min-conf` filters compose with either mode
  - semantic results show a `sem=` score column
- **TUI (Rules tab)** — `/` keeps the live keyword filter; typing a **2+-word** query surfaces a footer hint to press **Enter** for a semantic search. Results re-rank the list with a `SEM` cosine column and a match-count message; editing the query returns to live keyword filtering.

## How

`App.SearchSignatures` (new, `internal/frontend/signaturesearch.go`) reuses the enriched rows from `App.Signatures` and joins the salient text/vectors from `signature_embeddings`. Semantic mode builds a **standalone** embedder (mirroring `ReembedStandalone` — the control socket carries no reply channel, so front-ends embed directly) and ranks by cosine via a plain linear scan (vectors are L2-normalized, so cosine is a dot product) — no daemon and no `vectors` tag required, only the embedding model.

Recall-oriented by design: top-N above a lenient floor (0.3), scores shown. Degrades cleanly — drifted / dimension-mismatched vectors are skipped, and a disabled/missing model returns a clear error (never a partial ranking); keyword search is unaffected.

## Tests

New unit tests in `internal/frontend`, `internal/cli`, and `internal/tui` covering keyword substring + filter composition, cosine ranking/floor/limit, model-drift & dimension-mismatch skips, clean degradation, the TUI 2-word hint, end-to-end dispatch, single-word/edit fallbacks, and stale-result teardown. Full changed-package suite green (403 tests); `gofmt`, `go vet`, and `golangci-lint` clean with `-tags "vectors,cpu"`.

## Notes

- Semantic search loads the embedding model per call (acceptable for an explicit on-demand action; mirrors `ReembedStandalone`).
- Reviewed via the code-review subagent; findings addressed. One review suggestion (letting `--min-score 0` mean "no floor") was intentionally declined — it would make the zero value a footgun; `0`/unset uses the default floor instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)