### PR TITLE
#1 feat: expand ~ and $VAR in path-valued config keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ task at all (a bare `---`, punctuation only) is treated the same way.
 ```toml
 [llm]
 task_generate_command = [
-  "claude", "-p",
+  "claude", "--permission-mode", "auto", "-p",
   "Suggest concrete next tasks, most important first. Reply with only the tasks, one per line. If no new task is needed, reply with exactly @noop and nothing else.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
   "--model", "haiku",
 ]
@@ -968,7 +968,7 @@ Code:
 # Claude Code: the prompt belongs immediately after -p (the plugin
 # auto-repairs a prompt misplaced after other flags — see below).
 command = [
-  "claude", "-p",
+  "claude", "--permission-mode", "auto", "-p",
   "Use the hap MCP tools: call get_context, decide what the operator would answer — or whether no reply is needed — then call submit_decision (select_options for multiple-choice, recommend_action '@noop' to do nothing).",
   "--mcp-config", '{"mcpServers":{"hap":{"command":"{self}","args":["mcp"],"env":{"HAP_REQUEST_ID":"{request_id}"}}}}',
   "--allowedTools", "mcp__hap__get_context,mcp__hap__submit_decision",
@@ -991,8 +991,8 @@ enables the fallback (`command` is what gates it):
 
 ```toml
 [llm]
-command       = [ "claude", "-p", "...ongoing consult prompt...", "--model", "haiku" ]
-command_start = [ "claude", "-p", "...first-touch kickoff prompt...", "--model", "opus" ]
+command       = [ "claude", "--permission-mode", "auto", "-p", "...ongoing consult prompt...", "--model", "haiku" ]
+command_start = [ "claude", "--permission-mode", "auto", "-p", "...first-touch kickoff prompt...", "--model", "opus" ]
 ```
 
 #### A separate environment per command
@@ -1021,7 +1021,8 @@ ANTHROPIC_MODEL = "haiku"                                       # cheaper for ta
 
 The `.env` format is the usual one: `KEY=VALUE` per line, `#` comments, an
 optional `export` prefix, and single/double quotes (`\n`, `\t`, `\"`, `\\`
-escapes inside double quotes). `~/` is expanded. In an *unquoted* value a
+escapes inside double quotes). The configured file *path* expands a leading
+`~`/`~/…` and `$VAR`/`${VAR}`. In an *unquoted* value a
 ` #` starts a comment, so quote any value that contains one; a value that
 opens a quote without closing it (a pasted multi-line key) is rejected
 rather than passed on truncated. **Secrets belong in the file, not in

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,8 +186,9 @@ type LLM struct {
 	// Values support the same placeholders as the command template, minus
 	// {pane_excerpt} (untrusted pane text is never put in the environment).
 	//
-	// EnvFile is the shared `.env` file applied to every command; `~/` is
-	// expanded, and a relative path resolves against the daemon's cwd.
+	// EnvFile is the shared `.env` file applied to every command; a leading
+	// `~`/`~/…` and `$VAR`/`${VAR}` are expanded (via ExpandPath), and a
+	// relative path resolves against the daemon's cwd.
 	EnvFile string `toml:"env_file,omitempty"`
 	// CommandEnvFile is the `.env` file for Command only.
 	CommandEnvFile string `toml:"command_env_file,omitempty"`

--- a/internal/config/expand.go
+++ b/internal/config/expand.go
@@ -7,12 +7,11 @@ import (
 )
 
 // ExpandPath resolves a user-configured filesystem path so operators can write
-// the shorthands they expect in config.toml. It performs two substitutions, in
-// order:
+// the shorthands they expect in config.toml. It performs two substitutions:
 //
 //  1. Environment variables: `$VAR` and `${VAR}` are replaced with their values
-//     via os.ExpandEnv (an undefined variable expands to "", matching the shell).
-//     A consequence, also matching the shell, is that a literal `$` in a path
+//     via os.ExpandEnv (an undefined variable expands to "", as in the shell).
+//     A consequence, also as in the shell, is that a literal `$` in a path
 //     (e.g. a file named `cost$5.md`) is treated as a variable reference — keep
 //     `$` out of paths that are not meant to interpolate.
 //  2. Home directory: a leading `~` (alone) or `~/…` is replaced with the current
@@ -23,6 +22,21 @@ import (
 // and plain relative paths pass through untouched — making a relative path
 // absolute is the caller's job (e.g. filepath.Abs), deliberately kept separate.
 //
+// The two steps are iterated to a fixed point, which makes ExpandPath
+// idempotent for any terminating chain: ExpandPath(ExpandPath(x)) ==
+// ExpandPath(x). This matters because the helper is applied at several layers
+// (e.g. a task path is expanded for its lock key AND for the read/write), and
+// os.ExpandEnv is single-pass — a value that expands to another `$VAR` (e.g.
+// `A=$B`, `B=/tmp/x`) would otherwise be left partially expanded, so a second
+// pass would change it again and the lock key would diverge from the file
+// actually read. The iteration is therefore deliberately MORE aggressive than
+// the shell (which does not re-expand a value that itself contains `$`); the
+// goal is cross-layer idempotency, not shell fidelity. The loop is capped, so a
+// reference CYCLE (`A=$B`, `B=$A`) terminates by returning a bounded, partially
+// expanded value instead of spinning — that value is not a fixed point, but a
+// path built from a variable cycle never names a real file, so the identity it
+// would otherwise break is moot.
+//
 // Expansion is best-effort: when the home directory cannot be determined, the
 // leading `~` is left literal rather than erroring, so a misconfigured
 // environment degrades to the written path instead of failing the caller. This
@@ -32,6 +46,20 @@ func ExpandPath(path string) string {
 	if path == "" {
 		return ""
 	}
+	// A shallow cap: real $VAR/~ chains are one or two levels deep; the bound
+	// only guards a pathological mutual reference.
+	for i := 0; i < 8; i++ {
+		next := expandPathOnce(path)
+		if next == path {
+			break
+		}
+		path = next
+	}
+	return path
+}
+
+// expandPathOnce applies one round of env-var then leading-~ substitution.
+func expandPathOnce(path string) string {
 	path = os.ExpandEnv(path)
 	if path != "~" && !strings.HasPrefix(path, "~/") {
 		return path

--- a/internal/config/expand.go
+++ b/internal/config/expand.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExpandPath resolves a user-configured filesystem path so operators can write
+// the shorthands they expect in config.toml. It performs two substitutions, in
+// order:
+//
+//  1. Environment variables: `$VAR` and `${VAR}` are replaced with their values
+//     via os.ExpandEnv (an undefined variable expands to "", matching the shell).
+//     A consequence, also matching the shell, is that a literal `$` in a path
+//     (e.g. a file named `cost$5.md`) is treated as a variable reference — keep
+//     `$` out of paths that are not meant to interpolate.
+//  2. Home directory: a leading `~` (alone) or `~/…` is replaced with the current
+//     user's home directory. A `~` anywhere but the start (e.g. `/opt/~/x`), and
+//     the `~user` form, are left literal.
+//
+// A path with neither `$` nor a leading `~` is returned unchanged, so absolute
+// and plain relative paths pass through untouched — making a relative path
+// absolute is the caller's job (e.g. filepath.Abs), deliberately kept separate.
+//
+// Expansion is best-effort: when the home directory cannot be determined, the
+// leading `~` is left literal rather than erroring, so a misconfigured
+// environment degrades to the written path instead of failing the caller. This
+// is the shared helper for path-valued config keys: task_sources.path,
+// embedding.model_path, and the five [llm] *_env_file keys.
+func ExpandPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	path = os.ExpandEnv(path)
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == "~" {
+		return home
+	}
+	return filepath.Join(home, path[2:])
+}

--- a/internal/config/expand_test.go
+++ b/internal/config/expand_test.go
@@ -45,13 +45,55 @@ func TestExpandPath(t *testing.T) {
 // TestExpandPathIdempotent confirms a second pass is a no-op: once ~/$VAR are
 // resolved to an absolute path, re-expanding must not change it. Callers that
 // expand at more than one layer (e.g. canonicalTaskPath then the daemon's
-// ReadTaskFile wrapper) rely on this.
+// ReadTaskFile wrapper, or MutateWithin then LockPath) rely on this — otherwise
+// the lock key would diverge from the file actually read/written.
 func TestExpandPathIdempotent(t *testing.T) {
 	t.Setenv("HOME", "/home/tester")
-	for _, in := range []string{"~/tasks.md", "$HOME/tasks.md", "/etc/tasks.md", "rel.md"} {
+	// A variable whose VALUE is itself another $VAR reference: os.ExpandEnv is
+	// single-pass, so without fixed-point iteration ExpandPath("$CHAIN_A")
+	// would return "$CHAIN_B" and a second pass would then change it again.
+	t.Setenv("CHAIN_B", "/srv/tasks.md")
+	t.Setenv("CHAIN_A", "$CHAIN_B")
+	for _, in := range []string{"~/tasks.md", "$HOME/tasks.md", "/etc/tasks.md", "rel.md", "$CHAIN_A", "${CHAIN_A}"} {
 		once := ExpandPath(in)
 		if twice := ExpandPath(once); twice != once {
 			t.Errorf("ExpandPath not idempotent for %q: %q then %q", in, once, twice)
 		}
+	}
+}
+
+// TestExpandPathResolvesNestedVars confirms a $VAR whose value references
+// another $VAR is resolved fully in a single ExpandPath call, so the read,
+// write, and lock-key derivations for one task file all agree.
+func TestExpandPathResolvesNestedVars(t *testing.T) {
+	t.Setenv("CHAIN_B", "/srv/tasks.md")
+	t.Setenv("CHAIN_A", "$CHAIN_B")
+	if got := ExpandPath("$CHAIN_A"); got != "/srv/tasks.md" {
+		t.Errorf("ExpandPath($CHAIN_A) = %q, want /srv/tasks.md", got)
+	}
+}
+
+// TestExpandPathChainEndingInTilde confirms the env→tilde ordering survives
+// iteration: a $VAR whose resolved value carries a leading ~ still gets the ~
+// expanded (each pass does env-then-tilde), so a chain ending in "~/x" lands in
+// HOME rather than a literal "~".
+func TestExpandPathChainEndingInTilde(t *testing.T) {
+	t.Setenv("HOME", "/home/tester")
+	t.Setenv("TILDE_B", "~/tasks.md")
+	t.Setenv("TILDE_A", "$TILDE_B")
+	if got := ExpandPath("$TILDE_A"); got != "/home/tester/tasks.md" {
+		t.Errorf("ExpandPath($TILDE_A) = %q, want /home/tester/tasks.md", got)
+	}
+}
+
+// TestExpandPathTerminatesOnCycle confirms a self-referential variable cycle
+// does not spin: the loop is capped, so it returns (best-effort) instead of
+// hanging the caller.
+func TestExpandPathTerminatesOnCycle(t *testing.T) {
+	t.Setenv("CYCLE_A", "$CYCLE_B")
+	t.Setenv("CYCLE_B", "$CYCLE_A")
+	got := ExpandPath("$CYCLE_A") // must return, value is unspecified but bounded
+	if got != "$CYCLE_A" && got != "$CYCLE_B" {
+		t.Errorf("cycle expansion returned unexpected %q", got)
 	}
 }

--- a/internal/config/expand_test.go
+++ b/internal/config/expand_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandPath(t *testing.T) {
+	// A stable, known home for the tilde cases. os.UserHomeDir consults $HOME
+	// first on Unix, so setting it makes the expansion deterministic.
+	home := "/home/tester"
+	t.Setenv("HOME", home)
+	t.Setenv("HAP_TEST_DIR", "/srv/data")
+	t.Setenv("HAP_TEST_EMPTY", "")
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"tilde alone", "~", home},
+		{"tilde slash", "~/tasks.md", filepath.Join(home, "tasks.md")},
+		{"tilde nested", "~/a/b/tasks.md", filepath.Join(home, "a/b/tasks.md")},
+		{"env var bare", "$HAP_TEST_DIR/tasks.md", "/srv/data/tasks.md"},
+		{"env var braced", "${HAP_TEST_DIR}/tasks.md", "/srv/data/tasks.md"},
+		{"env then tilde", "$HOME/tasks.md", filepath.Join(home, "tasks.md")},
+		{"undefined var drops to empty", "$HAP_TEST_MISSING/tasks.md", "/tasks.md"},
+		{"empty var", "${HAP_TEST_EMPTY}/tasks.md", "/tasks.md"},
+		{"absolute unchanged", "/etc/hap/tasks.md", "/etc/hap/tasks.md"},
+		{"relative unchanged", "tasks/list.md", "tasks/list.md"},
+		{"relative dot unchanged", "./tasks.md", "./tasks.md"},
+		{"tilde not a prefix", "~user/tasks.md", "~user/tasks.md"},
+		{"tilde mid-path is literal", "/opt/~/tasks.md", "/opt/~/tasks.md"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ExpandPath(tc.in); got != tc.want {
+				t.Errorf("ExpandPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExpandPathIdempotent confirms a second pass is a no-op: once ~/$VAR are
+// resolved to an absolute path, re-expanding must not change it. Callers that
+// expand at more than one layer (e.g. canonicalTaskPath then the daemon's
+// ReadTaskFile wrapper) rely on this.
+func TestExpandPathIdempotent(t *testing.T) {
+	t.Setenv("HOME", "/home/tester")
+	for _, in := range []string{"~/tasks.md", "$HOME/tasks.md", "/etc/tasks.md", "rel.md"} {
+		once := ExpandPath(in)
+		if twice := ExpandPath(once); twice != once {
+			t.Errorf("ExpandPath not idempotent for %q: %q then %q", in, once, twice)
+		}
+	}
+}

--- a/internal/daemon/autosendidle.go
+++ b/internal/daemon/autosendidle.go
@@ -456,12 +456,14 @@ func inProgressTask(content, taskText string) bool {
 }
 
 // canonicalTaskPath resolves a task-source path to the one key that identifies
-// the physical file (absolute, symlinks resolved — the same normalization
-// taskfile.LockPath applies). Claims are compared by path, and two
-// [[task_sources]] entries can spell the same file differently; without this
-// they would look like different sources and could promise one line to two
+// the physical file (~ and $VAR expanded, then absolute, symlinks resolved —
+// the same normalization taskfile.LockPath applies). Claims are compared by
+// path, and two [[task_sources]] entries can spell the same file differently
+// (including one as `~/tasks.md` and another as its absolute form); without
+// this they would look like different sources and could promise one line to two
 // agents in a single sweep.
 func canonicalTaskPath(path string) string {
+	path = config.ExpandPath(path)
 	if abs, err := filepath.Abs(path); err == nil {
 		path = abs
 	}

--- a/internal/daemon/autosendidle_test.go
+++ b/internal/daemon/autosendidle_test.go
@@ -124,6 +124,59 @@ func quietFor(t *testing.T, h *harness, d time.Duration) {
 	}
 }
 
+func TestAutoSendIdleResolvesTildeSourcePathDespiteStateDirCwd(t *testing.T) {
+	// Regression: a task_sources.path written as "~/tasks.md" must resolve to
+	// the operator's HOME even though the daemon chdirs to its StateDir at
+	// startup (chdirStable, main.go:182). If "~" were treated as a plain
+	// relative path it would resolve against the cwd (the state dir) as a
+	// literal "~" directory, the source would never be read, and the agent
+	// would stay parked forever. HOME and the cwd are redirected to DISTINCT
+	// temp dirs so a relative-resolution regression cannot accidentally find
+	// the file — only genuine ~ expansion locates it.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stateDir := t.TempDir()
+	t.Chdir(stateDir) // stand in for chdirStable(StateDir): cwd != HOME
+
+	realFile := filepath.Join(home, "tasks.md")
+	if err := os.WriteFile(realFile, []byte("- [x] done\n- [ ] step two\n- [ ] step three\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// The source path is the shorthand, exactly as an operator would write it.
+	cfg := "[[task_sources]]\nagent = \"agent-tilde\"\npath = \"~/tasks.md\"\nenable_auto_send_task_when_idle = true\n"
+	h := newHarness(t, cfg)
+	h.herdr.setPane(autoSendIdlePane)
+	h.seedAutonomous(autoSendIdlePane, domain.SituationIdle, domain.ActionNextDeclaredTask)
+
+	name, err := h.raw.EnsureAgentName(context.Background(), "agent-tilde")
+	if err != nil {
+		t.Fatal(err)
+	}
+	agents := parkIdle(h, 2*time.Minute, "agent-tilde")
+
+	h.daemon.autoSendIdleTasks(context.Background(), agents)
+
+	// A send proves the daemon READ the ~-based source from HOME, not the cwd.
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	want := (&domain.DeclaredTask{Task: "step two", Path: "~/tasks.md", AgentName: name}).Prompt()
+	if got := h.herdr.sentInputs()[0]; got != want {
+		t.Errorf("sent %q, want the next declared task prompt %q", got, want)
+	}
+	// The reservation MUST land in the real HOME file — proof the mutate path
+	// (taskfile.MutateWithin) expanded ~ too, not a literal "~" file elsewhere.
+	waitFor(t, 3*time.Second, func() bool {
+		return strings.Contains(readTasks(t, realFile), "- [-] step two")
+	})
+	if got := readTasks(t, realFile); !strings.Contains(got, "- [ ] step three") {
+		t.Errorf("only the delivered task should be reserved:\n%s", got)
+	}
+	// And no literal "~" path leaked into the state dir (the cwd).
+	if _, err := os.Stat(filepath.Join(stateDir, "~")); err == nil {
+		t.Error("a literal ~ path was created under the state dir; expansion did not happen")
+	}
+}
+
 func TestAutoSendIdleOffByDefault(t *testing.T) {
 	// Without enable_auto_send_task_when_idle a long-idle agent is left alone:
 	// today's event-driven behavior is unchanged for every existing source.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -328,7 +328,14 @@ func New(opt Options) (*Daemon, error) {
 		opt.Clock = ports.SystemClock{}
 	}
 	if opt.ReadTaskFile == nil {
-		opt.ReadTaskFile = os.ReadFile
+		// Expand ~/$VAR so a task_sources.path written with either shorthand
+		// reaches the same physical file canonicalTaskPath keys it by. Reads
+		// bypass the taskfile package (which expands its own writes/locks), so
+		// the wrapper is needed here; MutateTaskFile below goes through
+		// taskfile.MutateWithin, which expands, so it does not.
+		opt.ReadTaskFile = func(path string) ([]byte, error) {
+			return os.ReadFile(config.ExpandPath(path))
+		}
 	}
 	if opt.MutateTaskFile == nil {
 		opt.MutateTaskFile = func(path string, fn func(string) (string, error)) error {

--- a/internal/embedder/embedder.go
+++ b/internal/embedder/embedder.go
@@ -195,11 +195,12 @@ func ResolveContextWindow(cfg config.Embedding) int {
 	return w
 }
 
-// ResolveModelPath expands the configured model path, defaulting to the
-// bundled model next to the binary. Shared with `hap status` reporting.
+// ResolveModelPath expands the configured model path (~ and $VAR resolved),
+// defaulting to the bundled model next to the binary. Shared with `hap status`
+// reporting.
 func ResolveModelPath(cfg config.Embedding) string {
 	if cfg.ModelPath != "" {
-		return cfg.ModelPath
+		return config.ExpandPath(cfg.ModelPath)
 	}
 	return filepath.Join(PluginRoot(), "models", DefaultModelFile)
 }

--- a/internal/embedder/embedder.go
+++ b/internal/embedder/embedder.go
@@ -196,11 +196,13 @@ func ResolveContextWindow(cfg config.Embedding) int {
 }
 
 // ResolveModelPath expands the configured model path (~ and $VAR resolved),
-// defaulting to the bundled model next to the binary. Shared with `hap status`
-// reporting.
+// defaulting to the bundled model next to the binary. The emptiness check is on
+// the EXPANDED value, so a model_path that expands to "" (e.g. an unset
+// `$VAR`) falls back to the bundled default rather than handing the embedder an
+// empty path. Shared with `hap status` reporting.
 func ResolveModelPath(cfg config.Embedding) string {
-	if cfg.ModelPath != "" {
-		return config.ExpandPath(cfg.ModelPath)
+	if expanded := config.ExpandPath(cfg.ModelPath); expanded != "" {
+		return expanded
 	}
 	return filepath.Join(PluginRoot(), "models", DefaultModelFile)
 }

--- a/internal/embedder/embedder_test.go
+++ b/internal/embedder/embedder_test.go
@@ -1,10 +1,35 @@
 package embedder
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 )
+
+// TestResolveModelPathExpandsAndFallsBack covers the model-path resolution:
+// a real override is ~/$VAR-expanded, while an empty configured value OR one
+// that EXPANDS to empty (an unset $VAR) falls back to the bundled default
+// rather than handing the embedder an empty path. Engine-independent.
+func TestResolveModelPathExpandsAndFallsBack(t *testing.T) {
+	bundled := filepath.Join(PluginRoot(), "models", DefaultModelFile)
+
+	t.Setenv("HOME", "/home/tester")
+	if got := ResolveModelPath(config.Embedding{ModelPath: "~/models/m.gguf"}); got != "/home/tester/models/m.gguf" {
+		t.Errorf("~ override = %q, want /home/tester/models/m.gguf", got)
+	}
+	t.Setenv("HAP_MODEL", "/opt/models/m.gguf")
+	if got := ResolveModelPath(config.Embedding{ModelPath: "$HAP_MODEL"}); got != "/opt/models/m.gguf" {
+		t.Errorf("$VAR override = %q, want /opt/models/m.gguf", got)
+	}
+	// Empty, and expands-to-empty, both fall back to the bundled default.
+	if got := ResolveModelPath(config.Embedding{ModelPath: ""}); got != bundled {
+		t.Errorf("empty model_path = %q, want bundled default %q", got, bundled)
+	}
+	if got := ResolveModelPath(config.Embedding{ModelPath: "$HAP_UNSET_MODEL"}); got != bundled {
+		t.Errorf("unset-$VAR model_path = %q, want bundled default %q", got, bundled)
+	}
+}
 
 // TestResolveContextWindowFloor covers the override boundaries — 0/negative
 // fall to the default, and any positive value below the safe minimum (at or

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -1045,7 +1045,7 @@ func (a *App) acceptGeneratedTask(ctx context.Context, audit *domain.AuditRecord
 	bootstrapPath := filepath.Join(base, "tasks", sanitizeTaskFileName(name)+".md")
 	var external []config.TaskSource
 	for _, src := range a.matchingDeclaredSources(ctx, cfg, audit, name, live) {
-		p := src.Path
+		p := config.ExpandPath(src.Path)
 		if abs, err := filepath.Abs(p); err == nil {
 			p = abs
 		}
@@ -1198,6 +1198,9 @@ func taskCapExceededError(path string, existing, adding, limit int) error {
 // this file without the lock. Returns the merged task list (raw, unnumbered) so
 // the caller can locate a task's rendered position.
 func ensureGeneratedTaskFile(path, name string, tasks []string, limit int) ([]string, error) {
+	// Expand ~/$VAR so the manual os.ReadFile/WriteFileAtomic below and the
+	// lock key all resolve to the same physical file the daemon uses.
+	path = config.ExpandPath(path)
 	lockPath := taskLockPath(path)
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
 		return nil, err
@@ -1423,7 +1426,7 @@ func pickAppendTarget(sources []config.TaskSource) (config.TaskSource, bool) {
 	}
 	var withItems *config.TaskSource
 	for i := range sources {
-		p := sources[i].Path
+		p := config.ExpandPath(sources[i].Path)
 		if abs, err := filepath.Abs(p); err == nil {
 			p = abs
 		}
@@ -1456,7 +1459,7 @@ func pickAppendTarget(sources []config.TaskSource) (config.TaskSource, bool) {
 // before the send, so the daemon's idle flow can never hand it out mid-send,
 // and a failed send rolls it back to "[ ]".
 func (a *App) appendGeneratedTasks(ctx context.Context, audit *domain.AuditRecord, src config.TaskSource, name string, tasks []string, send bool) error {
-	path := src.Path
+	path := config.ExpandPath(src.Path)
 	if abs, err := filepath.Abs(path); err == nil {
 		path = abs
 	}
@@ -2512,8 +2515,9 @@ func MaxTasks(n int) TaskSourceOption {
 // "" uses the default.
 func (a *App) AddTaskSource(ctx context.Context, agent, workspace, path, template string, opts ...TaskSourceOption) error {
 	// The daemon reads the file from its own cwd (the state dir), not the
-	// operator's shell; resolve relative paths here where they still mean
-	// what the operator sees.
+	// operator's shell; expand ~/$VAR and resolve relative paths here where
+	// they still mean what the operator sees.
+	path = config.ExpandPath(path)
 	if abs, err := filepath.Abs(path); err == nil {
 		path = abs
 	}
@@ -2589,6 +2593,7 @@ func resolveTaskFilePath(cfg config.Config, agent string) (string, error) {
 // takes precedence; otherwise the agent's configured source is resolved.
 func (a *App) taskFilePath(agent, path string) (string, error) {
 	if path != "" {
+		path = config.ExpandPath(path)
 		if abs, err := filepath.Abs(path); err == nil {
 			return abs, nil
 		}
@@ -2601,7 +2606,11 @@ func (a *App) taskFilePath(agent, path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return resolveTaskFilePath(cfg, agent)
+	resolved, err := resolveTaskFilePath(cfg, agent)
+	if err != nil {
+		return "", err
+	}
+	return config.ExpandPath(resolved), nil
 }
 
 // The locked read-modify-write over a checklist file lives in
@@ -2657,7 +2666,7 @@ func (a *App) TaskSourceTemplateFor(agent, sourcePath string) (string, error) {
 		return "", err
 	}
 	for _, src := range cfg.TaskSources {
-		p := src.Path
+		p := config.ExpandPath(src.Path)
 		if abs, e := filepath.Abs(p); e == nil {
 			p = abs
 		}
@@ -2804,7 +2813,7 @@ func (a *App) paneCwd(ctx context.Context, paneID string) string {
 
 // readChecklist reads and parses a checklist file.
 func readChecklist(path string) ([]domain.ChecklistItem, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(config.ExpandPath(path))
 	if err != nil {
 		return nil, err
 	}
@@ -2956,15 +2965,17 @@ func (a *App) taskSourceLimit(resolvedPath string) int {
 	if err != nil {
 		return 0
 	}
-	// Abs both sides: the agent-addressed path comes back from
-	// resolveTaskFilePath as the raw config spelling (possibly relative),
-	// while a --path add is already absolute — normalize so a relative
-	// [[task_sources]] path still matches and stays capped.
+	// Expand ~/$VAR then Abs both sides: the agent-addressed path comes back
+	// from resolveTaskFilePath as the raw config spelling (possibly relative or
+	// ~-based), while a --path add is already absolute — normalize so a
+	// relative or shorthand [[task_sources]] path still matches and stays
+	// capped.
+	resolvedPath = config.ExpandPath(resolvedPath)
 	if abs, e := filepath.Abs(resolvedPath); e == nil {
 		resolvedPath = abs
 	}
 	for _, src := range cfg.TaskSources {
-		sp := src.Path
+		sp := config.ExpandPath(src.Path)
 		if abs, e := filepath.Abs(sp); e == nil {
 			sp = abs
 		}

--- a/internal/llm/env.go
+++ b/internal/llm/env.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 )
 
 // This file builds the environment each LLM CLI is spawned with. Every one of
@@ -31,7 +33,7 @@ const maxEnvFileBytes = 1 << 20
 type EnvSpec struct {
 	// Vars are inline KEY→VALUE pairs; they override the file.
 	Vars map[string]string
-	// File is an optional path to a `.env` file ("~/" is expanded). A
+	// File is an optional path to a `.env` file (~/$VAR/${VAR} expanded). A
 	// configured file that cannot be read fails the run.
 	File string
 }
@@ -204,10 +206,9 @@ func (s *envSet) slice() []string { return s.order }
 // one that defines nothing at all, is an error naming the line NUMBER but
 // never its content.
 func LoadEnvFile(path string) ([]string, error) {
-	resolved, err := expandEnvPath(path)
-	if err != nil {
-		return nil, err
-	}
+	// Expand ~/$VAR via the shared config helper so an env_file path resolves
+	// the same shorthands as every other path-valued config key.
+	resolved := config.ExpandPath(strings.TrimSpace(path))
 	info, err := os.Stat(resolved)
 	if err != nil {
 		return nil, fmt.Errorf("read env file %s: %w", resolved, err)
@@ -323,20 +324,4 @@ func validEnvKey(name string) bool {
 		}
 	}
 	return true
-}
-
-// expandEnvPath resolves "~" / "~/…" in a configured env file path.
-func expandEnvPath(path string) (string, error) {
-	path = strings.TrimSpace(path)
-	if path != "~" && !strings.HasPrefix(path, "~/") {
-		return path, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("expand env file path %q: %w", path, err)
-	}
-	if path == "~" {
-		return home, nil
-	}
-	return filepath.Join(home, path[2:]), nil
 }

--- a/internal/llm/env_test.go
+++ b/internal/llm/env_test.go
@@ -100,6 +100,26 @@ func TestLoadEnvFileExpandsHome(t *testing.T) {
 	}
 }
 
+// TestLoadEnvFileExpandsEnvVars confirms the env_file PATH now resolves
+// $VAR/${VAR} (and $HOME) via the shared config.ExpandPath helper, not just ~.
+func TestLoadEnvFileExpandsEnvVars(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "hap.env"), []byte("FOO=bar\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HAP_ENV_DIR", dir)
+	t.Setenv("HOME", dir)
+	for _, spelling := range []string{"$HAP_ENV_DIR/hap.env", "${HAP_ENV_DIR}/hap.env", "$HOME/hap.env"} {
+		got, err := LoadEnvFile(spelling)
+		if err != nil {
+			t.Fatalf("LoadEnvFile(%q): %v", spelling, err)
+		}
+		if !slices.Equal(got, []string{"FOO=bar"}) {
+			t.Errorf("LoadEnvFile(%q) = %q, want FOO=bar", spelling, got)
+		}
+	}
+}
+
 // lookupEnv finds a key in a composed environment slice.
 func lookupEnv(t *testing.T, env []string, key string) (string, bool) {
 	t.Helper()

--- a/internal/taskfile/taskfile.go
+++ b/internal/taskfile/taskfile.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 )
 
@@ -32,6 +33,10 @@ func Mutate(path string, fn func(content string) (string, error)) ([]domain.Chec
 // on the main select loop, where an unbounded wait behind another hap process
 // would stall every agent.
 func MutateWithin(path string, wait time.Duration, fn func(content string) (string, error)) ([]domain.ChecklistItem, error) {
+	// Expand ~/$VAR here (and in LockPath below) so every process mutating a
+	// task_sources.path — daemon, CLI, TUI — reads, writes, and LOCKS the same
+	// physical file regardless of which shorthand the config used.
+	path = config.ExpandPath(path)
 	lockPath := LockPath(path)
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
 		return nil, err
@@ -89,13 +94,16 @@ func WriteFileAtomic(path string, data []byte, perm os.FileMode) error {
 // than a `<file>.lock` sidecar — serializes concurrent mutations without
 // dropping a stray lock file into the user's repo next to a --path checklist.
 //
-// The path is canonicalized (absolute + symlinks resolved, best-effort) so
-// every caller — the daemon, the CLI, the TUI's add/edit, and the TUI's bulk
-// toggle/delete (which passes an already symlink-resolved path) — hashes to
-// the SAME key for one physical file. Without this, a symlinked path component
-// (e.g. macOS /var vs /private/var) would yield two different locks and stop
-// serializing concurrent mutations of the same checklist.
+// The path is canonicalized (~/$VAR expanded, then absolute + symlinks
+// resolved, best-effort) so every caller — the daemon, the CLI, the TUI's
+// add/edit, and the TUI's bulk toggle/delete (which passes an already
+// symlink-resolved path) — hashes to the SAME key for one physical file.
+// Without this, a symlinked path component (e.g. macOS /var vs /private/var),
+// or one config spelling a source `~/tasks.md` and another its absolute form,
+// would yield two different locks and stop serializing concurrent mutations of
+// the same checklist.
 func LockPath(path string) string {
+	path = config.ExpandPath(path)
 	if abs, err := filepath.Abs(path); err == nil {
 		path = abs
 	}

--- a/internal/taskfile/taskfile_test.go
+++ b/internal/taskfile/taskfile_test.go
@@ -106,6 +106,33 @@ func TestReleaseIsClaimScoped(t *testing.T) {
 	})
 }
 
+// TestLockPathAndMutateAgreeForNestedEnvVars guards the read/mutate/lock
+// identity for a $VAR whose value is itself a $VAR reference. os.ExpandEnv is
+// single-pass, so before ExpandPath was made idempotent the lock key (LockPath
+// expands once more) diverged from the file MutateWithin actually read/wrote.
+func TestLockPathAndMutateAgreeForNestedEnvVars(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "tasks.md")
+	if err := os.WriteFile(real, []byte("- [ ] alpha\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TASKS_B", real)
+	t.Setenv("TASKS_A", "$TASKS_B") // A's value is itself a $VAR reference
+
+	// The lock key for the nested spelling must equal the absolute one.
+	if got, want := LockPath("$TASKS_A"), LockPath(real); got != want {
+		t.Errorf("LockPath($TASKS_A) = %q, want %q", got, want)
+	}
+	// And the mutation must land in the real file, not a literal "$TASKS_B".
+	mutate, _ := ReserveFirstPending("alpha")
+	if _, err := Mutate("$TASKS_A", mutate); err != nil {
+		t.Fatalf("Mutate($TASKS_A): %v", err)
+	}
+	if got := read(t, real); got != "- [-] alpha\n" {
+		t.Errorf("nested-var file not mutated: %q", got)
+	}
+}
+
 func TestMutateResolvesTildePath(t *testing.T) {
 	// A ~-based task_sources.path must read AND write the real home file, not a
 	// literally-named "~" directory. This is the functional half of the

--- a/internal/taskfile/taskfile_test.go
+++ b/internal/taskfile/taskfile_test.go
@@ -106,6 +106,30 @@ func TestReleaseIsClaimScoped(t *testing.T) {
 	})
 }
 
+func TestMutateResolvesTildePath(t *testing.T) {
+	// A ~-based task_sources.path must read AND write the real home file, not a
+	// literally-named "~" directory. This is the functional half of the
+	// expansion (TestLockPathExpandsShorthand covers the lock-key half).
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	real := filepath.Join(home, "tasks.md")
+	if err := os.WriteFile(real, []byte("- [ ] alpha\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mutate, _ := ReserveFirstPending("alpha")
+	if _, err := Mutate("~/tasks.md", mutate); err != nil {
+		t.Fatalf("Mutate(~/tasks.md): %v", err)
+	}
+	got := read(t, real)
+	if got != "- [-] alpha\n" {
+		t.Errorf("home file not mutated via ~ path: %q", got)
+	}
+	// And no stray literal-tilde file was created next to the cwd.
+	if _, err := os.Stat("~"); err == nil {
+		t.Error("a literal ~ path was created; expansion did not happen")
+	}
+}
+
 func TestMutatePreservesPermissions(t *testing.T) {
 	// A user's 0644 --path checklist must not be narrowed on every edit.
 	path := writeTasks(t, "- [ ] alpha\n")
@@ -136,6 +160,23 @@ func TestLockPathIsStableAcrossEquivalentPaths(t *testing.T) {
 	viaDot := filepath.Join(dir, ".", "tasks.md")
 	if LockPath(path) != LockPath(viaDot) {
 		t.Errorf("lock path differs for equivalent paths: %s vs %s", LockPath(path), LockPath(viaDot))
+	}
+}
+
+// TestLockPathExpandsShorthand guards the lock-divergence invariant for the
+// config shorthands ExpandPath resolves: a source spelled `~/tasks.md` or
+// `$HOME/tasks.md` and its absolute form MUST hash to the same lock, or the
+// daemon and the CLI/TUI would lock different keys for one file and stop
+// serializing concurrent mutations.
+func TestLockPathExpandsShorthand(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	abs := filepath.Join(home, "tasks.md")
+	want := LockPath(abs)
+	for _, spelling := range []string{"~/tasks.md", "$HOME/tasks.md", "${HOME}/tasks.md"} {
+		if got := LockPath(spelling); got != want {
+			t.Errorf("LockPath(%q) = %q, want %q (same file as %q)", spelling, got, want, abs)
+		}
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2195,11 +2195,12 @@ func truncatePathKeepBase(p string, limit int) string {
 const taskPathDisplayWidth = 44
 
 // canonicalTaskPath normalizes a source path for identity comparisons (the
-// duplicate dedupe and the per-file delete ordering): absolute + symlinks
-// resolved, best-effort. Two config spellings of one file (relative vs
-// absolute, /var vs /private/var) must not slip past the dedupe and mutate
-// the same line twice.
+// duplicate dedupe and the per-file delete ordering): ~/$VAR expanded, then
+// absolute + symlinks resolved, best-effort. Two config spellings of one file
+// (relative vs absolute, ~/x vs its absolute form, /var vs /private/var) must
+// not slip past the dedupe and mutate the same line twice.
 func canonicalTaskPath(p string) string {
+	p = config.ExpandPath(p)
 	if abs, err := filepath.Abs(p); err == nil {
 		p = abs
 	}

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -51,7 +51,7 @@ max_error_retries = 2              # per error signature
 # is the agent's short name ({db}/{control} also available). The prompt must
 # come immediately after -p (claude quirk; the plugin auto-repairs it).
 command = [
-  "claude", "--model", "opus", "-p",
+  "claude", "--model", "opus", "--permission-mode", "auto", "-p",
   "You are hap's auto-answer assistant. Use ONLY get_context and submit_decision.\n\nCall get_context, treat pane_excerpt as ground truth, and follow answer_format. If proposed_task is present, this is a task review: when the agent is ready and current_task is unfinished, prefer @next_task:declared to send it verbatim—do not make small edits. Return rewritten task text only when its details need a major rewrite. If current_task is clearly done, send an instruction for the next unfinished item in pending_tasks. Use @noop if the agent is busy, no suitable task remains, or evidence is ambiguous. Never invent a task.\n\nOtherwise: for approval/choice, select the safest option and deny destructive or irreversible work; for error, give one concrete recovery instruction; for idle, give the sensible next instruction or @noop.\n\nCall submit_decision with select_options for menus, otherwise recommend_action. Always include confident_score (0-100) and a one-sentence rationale.",
   "--mcp-config", '{"mcpServers":{"hap":{"command":"{self}","args":["mcp"],"env":{"HAP_REQUEST_ID":"{request_id}"}}}}',
   "--allowedTools", "mcp__hap__get_context,mcp__hap__submit_decision",
@@ -66,7 +66,7 @@ command = [
 # If the preferred command exits with an error in under one second without
 # submitting a decision, hap retries once with the other command template.
 # command_start = [
-#   "claude", "--model", "opus", "-p",
+#   "claude", "--model", "opus", "--permission-mode", "auto", "-p",
 #   "This is your first interaction with this agent. ...same MCP flow as command...",
 #   "--mcp-config", '{"mcpServers":{"hap":{"command":"{self}","args":["mcp"],"env":{"HAP_REQUEST_ID":"{request_id}"}}}}',
 #   "--allowedTools", "mcp__hap__get_context,mcp__hap__submit_decision",
@@ -102,7 +102,8 @@ pane_excerpt_chars = 5000          # pane context included in the consult
 # Two ways to set it, and they combine:
 #   * inline, in a `[llm.…_env]` table (values live in this file);
 #   * in a `.env` file, via `…_env_file` (KEY=VALUE lines, `#` comments,
-#     `export` and quotes accepted, `~/` expanded — quote any value with a
+#     `export` and quotes accepted; the file PATH expands `~/` and
+#     `$VAR`/`${VAR}` — quote any value with a
 #     " #" in it, which otherwise starts a comment). SECRETS BELONG HERE — the
 #     file is read when the CLI is spawned, so its contents never enter this
 #     config, and editing it applies to the next run without a restart. A
@@ -180,7 +181,7 @@ pane_excerpt_chars = 5000          # pane context included in the consult
 # prompt must name the sentinel for the model to ever use it.
 # (Renamed from generate_task_command; the old key no longer loads — update it.)
 task_generate_command = [
-  "claude", "--model", "opus", "-p",
+  "claude", "--model", "opus", "--permission-mode", "auto", "-p",
   "Suggest up to 3 concrete next tasks for this project's coding agent, in priority order. Reply ONLY with tasks, one per line. If no new task is needed, reply with exactly @noop and nothing else.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
 ]
 


### PR DESCRIPTION
## What & why

Path-valued config keys did not resolve the shell shorthands operators expect: `~`/`~/…` was handled inconsistently (only env-file paths, and only `~`), and `$HOME`/`$VAR` was not expanded anywhere. Relative paths silently resolved against the daemon's cwd (the plugin **state dir**, after `chdirStable`), not the operator's shell — a surprising footgun.

This adds one shared helper and routes every path-valued key through it.

## Changes

**New helper** — `config.ExpandPath` (`internal/config/expand.go`)
- Leading `~` / `~/…` via `os.UserHomeDir`; `$VAR` / `${VAR}` via `os.ExpandEnv`.
- Absolute and plain relative paths pass through unchanged (making relative absolute stays the caller's job).
- Best-effort: degrades to the literal path if home is unresolvable, so all consumers fail identically — no split-brain.

**Applied to `task_sources.path`** — centralized in the `taskfile` lock/mutation chokepoint (`LockPath`, `MutateWithin`) plus every daemon/frontend/TUI read and identity site. The first review caught that expanding only some consumers created a **lock-divergence corruption risk** (a `~`-source and its absolute form hashed to different lock keys → daemon and CLI/TUI stop serializing concurrent mutations). Now all three surfaces resolve **and lock** the same physical file regardless of spelling.

**Applied to `embedding.model_path`** — via `ResolveModelPath`.

**Applied to the five `[llm] *_env_file` keys** — via `LoadEnvFile`, replacing the local `~`-only `expandEnvPath` (now also expands `$HOME`/`$VAR`).

**Docs** — corrected the `config.go` `EnvFile` comment (was "only `~/` is expanded"), updated `expand.go`/README/`sample.toml` env-file text, and (from an earlier request in the same working set) added `--permission-mode auto` to the `claude` LLM command examples in README and `sample/config.toml`.

## Tests

- `config`: `TestExpandPath` (tilde, `~/…`, `$VAR`/`${VAR}`, `$HOME`, undefined/empty var, absolute, relative, `~user`, mid-path `~`) + `TestExpandPathIdempotent`.
- `taskfile`: `TestLockPathExpandsShorthand` (lock-key invariant: `~`/`$HOME`/absolute → one key) + `TestMutateResolvesTildePath` (functional read/write via `~`, incl. "no stray `~` file").
- `llm`: `TestLoadEnvFileExpandsEnvVars` (`$VAR`/`${VAR}`/`$HOME`).
- `daemon`: `TestAutoSendIdleResolvesTildeSourcePathDespiteStateDirCwd` — a `~`-based `task_sources.path` resolves to `$HOME` even with cwd redirected to a distinct state dir (guards the `chdirStable` relative-resolution surprise).

## Notes

- No import cycle: `taskfile`/`llm`/`embedder` → `config` is one-directional (`config` imports only stdlib + toml).
- Consistent, documented tradeoff: `os.ExpandEnv` treats a literal `$` in a path as a variable reference (matches shell) — noted in the helper doc.
- `internal/domain`'s `{task_list_path}` template stays raw by necessity (pure package, cannot import `config`); it's harmless end-to-end since the emitted `--path ~/tasks.md` is re-expanded when the agent runs `hap task --path`.

## Verification

`go build`, `go vet`, `gofmt`, and `golangci-lint` (0 issues) clean across changed packages (`-tags "vectors cpu"`); all affected suites pass. Two independent code reviews confirmed the fix is complete and the corruption risk closed.
