### PR TITLE
#1 feat: surface generated-task ignored prose as escalation rationale

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2558,12 +2558,15 @@ func (d *Daemon) handleTaskGenOutcome(ctx context.Context, res taskGenOutcome) {
 	// StripNoopGeneratedLines).
 	task, declined := domain.StripNoopGeneratedLines(res.task)
 
-	// Parse only to VALIDATE. Output that yields no task (a bare horizontal
-	// rule, a punctuation-only reply) would otherwise become a confirmable
-	// escalation that can ONLY fail when the operator acts on it — the confirm
-	// path runs this same parse and refuses. Deciding it here keeps the two
-	// verdicts ("is there a task" / "can this be confirmed") from disagreeing.
-	if len(domain.NormalizeGeneratedTasks(task)) == 0 {
+	// Parse to VALIDATE and to recover the ignored prose. Output that yields no
+	// task (a bare horizontal rule, a punctuation-only reply) would otherwise
+	// become a confirmable escalation that can ONLY fail when the operator acts
+	// on it — the confirm path runs this same parse and refuses. Deciding it
+	// here keeps the two verdicts ("is there a task" / "can this be confirmed")
+	// from disagreeing. In list mode the rationale is the non-list prose the
+	// model wrote around the list, surfaced on the success escalation below.
+	tasks, rationale := domain.NormalizeGeneratedTasksWithRationale(task)
+	if len(tasks) == 0 {
 		// Nothing but sentinels: the model's explicit decline. Park the
 		// situation by suggesting the human-readable noop (never the raw
 		// sentinel), matching the exhausted-source escalation in domain.Decide
@@ -2599,6 +2602,9 @@ func (d *Daemon) handleTaskGenOutcome(ctx context.Context, res taskGenOutcome) {
 	// — while the suggestion carries the generated task for the confirm path.
 	d.escalate(ctx, s, res.sig, domain.Decision{
 		Action: domain.ActionEscalate, Reason: res.reason,
+		// Rationale is the model's non-list prose in list mode (empty in plain
+		// mode); escalate() renders it after the "[reason]" tag.
+		Rationale:  rationale,
 		Suggestion: domain.SuggestTaskPrefix + task,
 	}, res.tr, now)
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2630,6 +2630,60 @@ func TestIdleGeneratesTaskSuggestionEscalation(t *testing.T) {
 	}
 }
 
+func TestIdleTaskGenListModeCapturesRationale(t *testing.T) {
+	// When the model wraps a bullet list in prose, the list items become the
+	// confirmable tasks (RAW, in the suggestion) and the ignored non-list prose
+	// is surfaced as the escalation's rationale — escalate() renders it after
+	// the "[reason]" tag.
+	raw := "Because the auth suite is red, here is the plan:\n" +
+		"- Fix the flaky auth test\n" +
+		"- Add a retry guard"
+	h, _ := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+		return raw, nil
+	})
+	h.herdr.setPane("Task is complete.\n")
+
+	ctx := context.Background()
+	h.push("agent-20", "idle")
+	var esc []domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	// The suggestion still carries the RAW text (the confirm path normalizes).
+	if want := domain.SuggestTaskPrefix + raw; esc[0].Suggestion != want {
+		t.Errorf("suggestion = %q, want %q", esc[0].Suggestion, want)
+	}
+	// The ignored prose lands in the rationale.
+	if !strings.Contains(esc[0].Rationale, "Because the auth suite is red, here is the plan:") {
+		t.Errorf("rationale should carry the ignored prose, got %q", esc[0].Rationale)
+	}
+	// The bullet text must NOT leak into the rationale (it is a task, not prose).
+	if strings.Contains(esc[0].Rationale, "Fix the flaky auth test") {
+		t.Errorf("rationale must not include list items, got %q", esc[0].Rationale)
+	}
+}
+
+func TestIdleTaskGenPlainModeHasNoRationaleProse(t *testing.T) {
+	// A plain (no-list) generation ignores nothing, so the success escalation
+	// carries only the bare "[reason]" tag — no extra prose grafted on.
+	h, _ := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+		return "Investigate the flaky auth test and add a retry guard", nil
+	})
+	h.herdr.setPane("Task is complete.\n")
+
+	ctx := context.Background()
+	h.push("agent-20", "idle")
+	var esc []domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	if want := "[" + string(domain.ReasonNoTaskSource) + "]"; esc[0].Rationale != want {
+		t.Errorf("plain-mode rationale = %q, want the bare tag %q", esc[0].Rationale, want)
+	}
+}
+
 func TestIdleTaskGenNoopParksInsteadOfPersisting(t *testing.T) {
 	// The model's explicit decline must NOT be written into a checklist as a
 	// literal "@noop" task, and must NOT masquerade as a broken CLI: it

--- a/internal/domain/taskgen.go
+++ b/internal/domain/taskgen.go
@@ -126,18 +126,39 @@ func stripInlineEmphasis(s string) string {
 	return masked
 }
 
+// maxGeneratedRationale caps the rationale text NormalizeGeneratedTasksWithRationale
+// returns for the ignored non-list prose. The raw model output can be up to
+// maxTaskGenOutput (16KB); a rationale line on an escalation has a small budget
+// (see the daemon's escalate()), so anything longer is truncated with an
+// ellipsis. Measured in runes so a multibyte tail is never split.
+const maxGeneratedRationale = 500
+
 // NormalizeGeneratedTasks parses a generate-task CLI's raw stdout into a clean
-// list of task strings. The model may return one task or several, plain or as
-// a Markdown list. The parser picks a mode from the content: if ANY line
-// carries a real list/checkbox marker, the whole block is treated as a list
+// list of task strings. See NormalizeGeneratedTasksWithRationale for the parse
+// rules; this drops the rationale for callers that only need the tasks.
+func NormalizeGeneratedTasks(raw string) []string {
+	tasks, _ := NormalizeGeneratedTasksWithRationale(raw)
+	return tasks
+}
+
+// NormalizeGeneratedTasksWithRationale parses a generate-task CLI's raw stdout
+// into a clean list of task strings and, in list mode, the ignored non-list
+// prose joined as rationale text. The model may return one task or several,
+// plain or as a Markdown list. The parser picks a mode from the content: if ANY
+// line carries a real list/checkbox marker, the whole block is treated as a list
 // and ONLY marked lines become tasks — so a lead-in sentence ("Here are the
 // tasks:") preceding a bullet list is dropped rather than written as an item.
 // If no line carries a marker, it falls back to plain mode, where each
 // non-empty line is a task (a single- or multi-line plain response). Each task
 // is reduced to its bare text with Markdown inline emphasis (bold/italic/code)
-// stripped, and lines without a letter or digit are dropped. Returns nil when
-// nothing usable remains.
-func NormalizeGeneratedTasks(raw string) []string {
+// stripped, and lines without a letter or digit are dropped. Returns nil tasks
+// when nothing usable remains.
+//
+// The rationale is collected ONLY in list mode: it is the dropped, unmarked,
+// non-fence, non-blank prose (the model's reasoning around the list), collapsed
+// to a single line and capped at maxGeneratedRationale runes. In plain mode
+// nothing is ignored, so rationale is "".
+func NormalizeGeneratedTasksWithRationale(raw string) (tasks []string, rationale string) {
 	lines := strings.Split(raw, "\n")
 
 	// List mode iff some non-fence line has a real marker AND a real task body
@@ -156,16 +177,20 @@ func NormalizeGeneratedTasks(raw string) []string {
 		}
 	}
 
-	var tasks []string
+	var ignored []string
 	for _, line := range lines {
 		if isFenceLine(line) {
 			continue
 		}
 		var t string
 		if listMode {
-			// Only marked lines are tasks; unmarked prose is skipped.
+			// Only marked lines are tasks; unmarked prose is skipped — but
+			// captured as rationale so the model's reasoning is not lost.
 			m := listItemRE.FindStringSubmatch(line)
 			if m == nil {
+				if p := strings.TrimSpace(line); p != "" {
+					ignored = append(ignored, p)
+				}
 				continue
 			}
 			t = strings.TrimSpace(m[1])
@@ -182,7 +207,10 @@ func NormalizeGeneratedTasks(raw string) []string {
 			tasks = append(tasks, t)
 		}
 	}
-	return tasks
+	// excerpt (safety.go) collapses whitespace to a single line and caps the
+	// rune count with an ellipsis — a rationale is a compact one-liner rendered
+	// in the escalation's Rationale column, so multi-line prose folds to one row.
+	return tasks, excerpt(strings.Join(ignored, "\n"), maxGeneratedRationale)
 }
 
 // StripNoopGeneratedLines removes the noop sentinel from a generate-task CLI's

--- a/internal/domain/taskgen_test.go
+++ b/internal/domain/taskgen_test.go
@@ -225,6 +225,110 @@ func TestNormalizeGeneratedTasksRealSample(t *testing.T) {
 	}
 }
 
+// TestNormalizeGeneratedTasksWithRationale: in list mode the dropped non-list
+// prose is returned as rationale (the model's reasoning around the list); in
+// plain mode nothing is ignored, so the rationale is empty. The tasks returned
+// must match what NormalizeGeneratedTasks yields for the same input.
+func TestNormalizeGeneratedTasksWithRationale(t *testing.T) {
+	tests := []struct {
+		name          string
+		raw           string
+		wantTasks     []string
+		wantRationale string
+	}{
+		{
+			// Plain mode: every non-empty line is a task, nothing is ignored.
+			"plain mode has no rationale",
+			"Investigate the flaky auth test",
+			[]string{"Investigate the flaky auth test"},
+			"",
+		},
+		{
+			// Multi-line plain response is still all tasks, no rationale.
+			"multi-line plain mode has no rationale",
+			"First task\nSecond task",
+			[]string{"First task", "Second task"},
+			"",
+		},
+		{
+			// List mode: the lead-in sentence is dropped from tasks and becomes
+			// the rationale.
+			"intro line before bullets is rationale",
+			"Here are the tasks:\n- First real task\n- Second real task",
+			[]string{"First real task", "Second real task"},
+			"Here are the tasks:",
+		},
+		{
+			// Prose interleaved with bullets is captured in reading order and
+			// collapsed to a single line (excerpt folds whitespace).
+			"prose around bullets is single-line rationale",
+			"Because the suite is red:\n- Fix the parser\nthen, once green:\n- Add validation",
+			[]string{"Fix the parser", "Add validation"},
+			"Because the suite is red: then, once green:",
+		},
+		{
+			// Fence lines and empty/bullet-only markers are list artifacts, not
+			// reasoning, so they are excluded from the rationale.
+			"fences and empty markers excluded from rationale",
+			"Rationale here\n```\n- Real task\n```\n- \n[ ] ",
+			[]string{"Real task"},
+			"Rationale here",
+		},
+		{
+			// No prose around the list → empty rationale even in list mode.
+			"pure list has empty rationale",
+			"- Only task one\n- Only task two",
+			[]string{"Only task one", "Only task two"},
+			"",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTasks, gotRationale := NormalizeGeneratedTasksWithRationale(tc.raw)
+			if len(gotTasks) != len(tc.wantTasks) {
+				t.Fatalf("tasks = %v, want %v", gotTasks, tc.wantTasks)
+			}
+			for i := range gotTasks {
+				if gotTasks[i] != tc.wantTasks[i] {
+					t.Errorf("task[%d] = %q, want %q", i, gotTasks[i], tc.wantTasks[i])
+				}
+			}
+			if gotRationale != tc.wantRationale {
+				t.Errorf("rationale = %q, want %q", gotRationale, tc.wantRationale)
+			}
+			// The thin wrapper must return exactly the same tasks.
+			wrap := NormalizeGeneratedTasks(tc.raw)
+			if len(wrap) != len(gotTasks) {
+				t.Fatalf("NormalizeGeneratedTasks tasks = %v, want %v", wrap, gotTasks)
+			}
+			for i := range wrap {
+				if wrap[i] != gotTasks[i] {
+					t.Errorf("wrapper task[%d] = %q, want %q", i, wrap[i], gotTasks[i])
+				}
+			}
+		})
+	}
+}
+
+// TestNormalizeGeneratedTasksRationaleCapped: a huge block of ignored prose is
+// truncated to maxGeneratedRationale runes with a trailing ellipsis, so an
+// escalation rationale line stays bounded no matter how much the model wrote.
+func TestNormalizeGeneratedTasksRationaleCapped(t *testing.T) {
+	prose := strings.Repeat("x", maxGeneratedRationale+50)
+	raw := prose + "\n- Do the one real task"
+	tasks, rationale := NormalizeGeneratedTasksWithRationale(raw)
+	if len(tasks) != 1 || tasks[0] != "Do the one real task" {
+		t.Fatalf("tasks = %v, want the single bullet item", tasks)
+	}
+	runes := []rune(rationale)
+	if len(runes) != maxGeneratedRationale+1 { // capped runes + one ellipsis rune
+		t.Fatalf("rationale rune count = %d, want %d", len(runes), maxGeneratedRationale+1)
+	}
+	if runes[len(runes)-1] != '…' {
+		t.Errorf("truncated rationale must end with an ellipsis, got %q", rationale)
+	}
+}
+
 func TestRenderGeneratedTaskList(t *testing.T) {
 	// Every task renders pending "[ ]" — "[-]" is written only at delivery
 	// time (issue #156: pre-marking the first item stranded it whenever no

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -179,16 +179,22 @@ pane_excerpt_chars = 5000          # pane context included in the consult
 # still counts as work, so ask for the sentinel alone. An EMPTY reply is not a
 # decline (it looks like a crashed CLI) and stays a retryable failure. The
 # prompt must name the sentinel for the model to ever use it.
+#
+# Task-list parsing: if the reply contains a markdown list (any "-"/"+"/"*" or
+# "1."/"2)" item, or a "[ ]" checkbox), ONLY the list items become tasks and
+# every other line is kept as the suggestion's rationale (capped, shown on the
+# escalation). Without any list marker, each non-empty line is a task instead —
+# so asking for a markdown list is the reliable way to separate tasks from notes.
 # (Renamed from generate_task_command; the old key no longer loads — update it.)
 task_generate_command = [
   "claude", "--model", "opus", "--permission-mode", "auto", "-p",
-  "Suggest up to 3 concrete next tasks for this project's coding agent, in priority order. Reply ONLY with tasks, one per line. If no new task is needed, reply with exactly @noop and nothing else.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
+  "Suggest up to 3 concrete next tasks for this project's coding agent, in priority order. Return the tasks as a markdown list — one \"- \" bullet or \"1.\" numbered item per task; any surrounding text is ignored as tasks and kept as rationale. If no new task is needed, reply with exactly @noop and nothing else.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
 ]
 
 # ── Idle task suggestion — OpenAI Codex (commented; swap in to use codex) ──
 # task_generate_command = [
 #   "codex", "--model", "gpt-5.6-sol", "exec", "--skip-git-repo-check",
-#   "Suggest up to 3 concrete next tasks for this project's coding agent, in priority order. Reply ONLY with tasks, one per line. If no new task is needed, reply with exactly @noop and nothing else.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
+#   "Suggest up to 3 concrete next tasks for this project's coding agent, in priority order. Return the tasks as a markdown list — one \"- \" bullet or \"1.\" numbered item per task; any surrounding text is ignored as tasks and kept as rationale. If no new task is needed, reply with exactly @noop and nothing else.\n\nAgent: {agent_name}\nCwd: {cwd}\n\nScreen:\n{pane_excerpt}",
 # ]
 
 # task_generate_command_start runs INSTEAD on the agent's first task generation


### PR DESCRIPTION
## What

The `[llm] task generate` parser already switches to **list mode** when the model returns a markdown list (`-`, `+`, `*`, `1.`, `2)`, checkboxes) and keeps only the marked lines as tasks, dropping the surrounding prose. Those dropped lines were simply discarded.

This change captures that ignored prose (the model's reasoning around the list) and surfaces it as the **rationale** on the generate-task success escalation, so the operator sees *why* the tasks were suggested when confirming/dismissing.

## How

- **`internal/domain/taskgen.go`** — new `NormalizeGeneratedTasksWithRationale(raw) (tasks, rationale)`. `NormalizeGeneratedTasks` is now a thin wrapper over it, so every existing caller (frontend confirm path, daemon validation) is unchanged. In list mode the dropped, unmarked, non-fence, non-blank lines are collected, collapsed to a single line via the existing `excerpt()` helper, and capped at `maxGeneratedRationale = 500` runes. Plain mode ignores nothing, so rationale is `""`.
- **`internal/daemon/daemon.go`** — `handleTaskGenOutcome` calls the combined function (reusing it for the existing "no usable task" validation) and sets `Rationale` on the success escalation. The **raw** text still goes into `Suggestion`, preserving the confirm path's single re-normalization (the parser is intentionally not idempotent).

## Safety

No retryability impact: `escalate()` keeps the `[reason]` prefix that `IsRetryableLLMEscalation` matches on, and the success reasons (`no_task_source` / `task_source_exhausted`) are not in the retryable set.

## Tests

- `TestNormalizeGeneratedTasksWithRationale` — plain→empty, intro line, interleaved prose, fences/empty markers excluded, wrapper parity.
- `TestNormalizeGeneratedTasksRationaleCapped` — rune-safe truncation with `…`.
- `TestIdleTaskGenListModeCapturesRationale` / `TestIdleTaskGenPlainModeHasNoRationaleProse` — escalation carries the prose in list mode; bare `[no_task_source]` tag in plain mode.

Full `internal/domain` and `internal/daemon` suites pass (`vectors cpu`); `go vet`, `gofmt`, and `golangci-lint` clean.