### PR TITLE
#1 feat: fold a task's nested sub-items into its delivered content

### DIFF
--- a/internal/daemon/autosendidle_test.go
+++ b/internal/daemon/autosendidle_test.go
@@ -228,6 +228,53 @@ func TestAutoSendIdleSendsNextPendingTaskAndReservesIt(t *testing.T) {
 	}
 }
 
+func TestAutoSendIdleFoldsNestedTaskDetailButReservesByIdentity(t *testing.T) {
+	// A hand-authored task carries its detail as nested sub-bullets. The
+	// delivered prompt must fold those in (title + nested lines), while the
+	// RESERVATION still keys off the single-line title identity — so the item is
+	// marked [-] correctly and the next task is untouched.
+	content := "- [ ] 1. Build the widget\n" +
+		"  - Wire the API\n" +
+		"  - Acceptance: it renders\n" +
+		"- [ ] 2. Later task\n"
+	h, taskFile := autoSendFixture(t, "agent-fold", content, true)
+	name, err := h.raw.EnsureAgentName(context.Background(), "agent-fold")
+	if err != nil {
+		t.Fatal(err)
+	}
+	agents := parkIdle(h, 2*time.Minute, "agent-fold")
+
+	h.daemon.autoSendIdleTasks(context.Background(), agents)
+
+	waitFor(t, 3*time.Second, func() bool { return len(h.herdr.sentInputs()) == 1 })
+	want := (&domain.DeclaredTask{
+		Task:      "1. Build the widget",
+		Content:   domain.FoldTaskContent(content, "1. Build the widget"),
+		Path:      taskFile,
+		AgentName: name,
+	}).Prompt()
+	got := h.herdr.sentInputs()[0]
+	if got != want {
+		t.Errorf("sent %q, want the folded declared-task prompt %q", got, want)
+	}
+	// The nested detail actually rode along.
+	if !strings.Contains(got, "- Wire the API") || !strings.Contains(got, "- Acceptance: it renders") {
+		t.Errorf("delivered prompt is missing folded nested detail:\n%s", got)
+	}
+	// Reservation marked the single-line title [-], leaving nested lines and the
+	// next task untouched.
+	waitFor(t, 3*time.Second, func() bool {
+		return strings.Contains(readTasks(t, taskFile), "- [-] 1. Build the widget")
+	})
+	after := readTasks(t, taskFile)
+	if !strings.Contains(after, "  - Wire the API") {
+		t.Errorf("nested detail must be preserved in the file, got:\n%s", after)
+	}
+	if !strings.Contains(after, "- [ ] 2. Later task") {
+		t.Errorf("only the delivered task should be reserved, got:\n%s", after)
+	}
+}
+
 func TestAutoSendIdleDoesNotClimbConsecutiveRunawayCounter(t *testing.T) {
 	// Regression: the runaway-loop guard (FR-019) counts every autonomous send
 	// toward ConsecutiveAuto, which only a human check-in resets. An idle agent

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4398,6 +4398,15 @@ func (d *Daemon) declaredTask(ctx context.Context, cfg config.Config, tr domain.
 	return &domain.DeclaredTask{
 		Task: task, Path: m.src.Path, Template: m.src.NextTaskTemplate,
 		AgentName: agentName, Cwd: cwd,
+		// Fold the task's nested sub-items into the delivered content while
+		// Task stays the single-line reservation identity. A flat file (no
+		// nesting) folds to the title unchanged, so this is a no-op there.
+		// Deliberately fail-safe: the outbound-text safety scans (never-auto,
+		// suspected-irreversible) run over declared.Prompt(), so they now inspect
+		// the whole folded body — a destructive phrase in a task's nested notes
+		// escalates the hand-out instead of auto-sending it, which is the safe
+		// direction (more review, never less).
+		Content: domain.FoldTaskContent(string(m.data), task),
 		// A source opts out of the pre-send LLM review with llm_review=false
 		// (nil = the default, on).
 		LLMReview: m.src.EnableLLMReview == nil || *m.src.EnableLLMReview,

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -98,7 +98,16 @@ const MarkInProgress = "-"
 // task content plus the source it came from, so the outbound prompt can be
 // rendered from the source's template.
 type DeclaredTask struct {
-	Task      string // next unchecked item, or NoTaskContent when complete
+	Task string // next unchecked item, or NoTaskContent when complete
+	// Content is the FULL delivery text substituted for {next_task_content}:
+	// the task's title line plus every nested sub-item folded in
+	// (FoldTaskContent), so a hand-authored task's acceptance criteria,
+	// dependencies and notes ride along with the one-line title. Empty falls
+	// back to Task, so a caller that does not fold keeps the historical
+	// one-line behavior. Task ALWAYS stays the single physical line that is the
+	// task's reservation identity — the checklist item's own text — so folding
+	// never perturbs reservation, hand-out ledger rows, or the freshness check.
+	Content   string
 	Path      string // task-source file path
 	Template  string // operator template; "" uses DefaultNextTaskTemplate
 	AgentName string // agent short name, for {agent_name}
@@ -136,6 +145,12 @@ func TemplateOrDefault(template string) string {
 // one-line-per-item storage encoding (see EncodeTaskNewlines).
 func (t DeclaredTask) Prompt() string {
 	tpl := TemplateOrDefault(t.Template)
+	// Deliver the folded content (title + nested sub-items) when it was
+	// resolved; fall back to the one-line identity otherwise.
+	body := t.Task
+	if t.Content != "" {
+		body = t.Content
+	}
 	return strings.NewReplacer(
 		// The quoted form comes first: NewReplacer matches in argument order,
 		// so the shorter {task_list_path} would otherwise consume its prefix
@@ -144,8 +159,10 @@ func (t DeclaredTask) Prompt() string {
 		// The task reaches the agent with its id unescaped: the agent reads the
 		// id here and types it back at `hap task done`, so showing it "8\.1"
 		// invites a reference nobody typed intentionally. The FILE keeps the
-		// operator's escape — only the outbound copy is normalized.
-		"{next_task_content}", DecodeTaskNewlines(DisplayTaskText(t.Task)),
+		// operator's escape — only the outbound copy is normalized. DisplayTaskText
+		// unescapes only the leading id on the first line; nested lines pass
+		// through verbatim.
+		"{next_task_content}", DecodeTaskNewlines(DisplayTaskText(body)),
 		"{task_list_path}", t.Path,
 		"{agent_name}", t.AgentName,
 		"{cwd}", t.Cwd,
@@ -216,6 +233,110 @@ func PendingDeclaredTasks(content string) []string {
 		}
 	}
 	return pending
+}
+
+// FoldTaskContent returns the delivery content of the first PENDING checklist
+// item whose text equals taskText: the item's own text, then every nested
+// continuation line beneath it — the more-indented, non-item lines that carry
+// the task's detail (implementation notes, acceptance criteria, dependencies)
+// — appended verbatim and separated by newlines. When no such item matches, or
+// it has no nested lines, taskText is returned unchanged.
+//
+// This folds a hand-authored task's sub-bullets into the one-line title so they
+// reach the agent together, WITHOUT touching the file or the task's identity:
+// callers set the result on DeclaredTask.Content (for the outbound prompt),
+// while DeclaredTask.Task — the single physical line — stays the reservation
+// identity everywhere. Matching the first PENDING ("[ ]") item aligns with
+// NextDeclaredTask and ReserveFirstPending, so the daemon folds exactly the item
+// it is about to reserve even when an earlier item (done, or a duplicate title)
+// shares the text. A caller that reserves a specific POSITION (the frontend's
+// manual send) must use FoldTaskContentAt instead, which is unambiguous.
+func FoldTaskContent(content, taskText string) string {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		m := checklistItemRE.FindStringSubmatch(line)
+		if m == nil || m[2] != " " || strings.TrimSpace(m[3]) != taskText {
+			continue
+		}
+		return foldItemAt(lines, i, taskText)
+	}
+	return taskText
+}
+
+// FoldTaskContentAt folds the checklist item at the given 1-based index — the
+// same numbering ParseChecklist and the `hap task` CLI expose — so a caller that
+// reserved a SPECIFIC position delivers that exact item's nested detail, even
+// when another item shares its title. Returns "" when index names no item,
+// letting the caller fall back to the plain task text.
+func FoldTaskContentAt(content string, index int) string {
+	lines := strings.Split(content, "\n")
+	count := 0
+	for i, line := range lines {
+		m := checklistItemRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		count++
+		if count == index {
+			return foldItemAt(lines, i, strings.TrimSpace(m[3]))
+		}
+	}
+	return ""
+}
+
+// foldItemAt returns itemText followed by the nested continuation lines of the
+// checklist item at lines[i] (verbatim, newline-joined), or itemText alone when
+// it has none.
+func foldItemAt(lines []string, i int, itemText string) string {
+	nested := nestedContinuationLines(lines, i)
+	if len(nested) == 0 {
+		return itemText
+	}
+	return itemText + "\n" + strings.Join(nested, "\n")
+}
+
+// nestedContinuationLines collects the lines that belong to the checklist item
+// at lines[i] as its folded detail: the run of following lines indented deeper
+// than the item, kept verbatim. Interior blank lines are preserved but trailing
+// ones trimmed. Collection stops at the first non-blank line indented at or
+// below the item, or at the next checklist item at any indent — a nested "[ ]"
+// checkbox is its own task (ParseChecklist counts it), so it is a boundary, not
+// folded detail.
+func nestedContinuationLines(lines []string, i int) []string {
+	base := indentWidth(lines[i])
+	var out []string
+	for j := i + 1; j < len(lines); j++ {
+		line := lines[j]
+		if strings.TrimSpace(line) == "" {
+			out = append(out, line) // interior blank; trimmed below if trailing
+			continue
+		}
+		if indentWidth(line) <= base || checklistItemRE.MatchString(line) {
+			break
+		}
+		out = append(out, line)
+	}
+	for len(out) > 0 && strings.TrimSpace(out[len(out)-1]) == "" {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// indentWidth is the number of leading space/tab runes on a line — the depth
+// used to decide whether a line nests under a checklist item. Tabs and spaces
+// each count as one unit; hand-authored checklists indent with spaces. Mixing
+// tabs and spaces between a parent and its children is unsupported — a child
+// that measures shallower than its parent is simply not folded (title-only
+// delivery), the safe fallback.
+func indentWidth(s string) int {
+	n := 0
+	for _, r := range s {
+		if r != ' ' && r != '\t' {
+			break
+		}
+		n++
+	}
+	return n
 }
 
 // InProgressDeclaredTasks returns every checklist item marked "[-]" from an

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -1203,3 +1203,137 @@ func TestDeclaredTaskPromptUnescapesID(t *testing.T) {
 		t.Errorf("Prompt() = %q, want %q", got, want)
 	}
 }
+
+func TestFoldTaskContent(t *testing.T) {
+	cases := []struct {
+		name     string
+		content  string
+		taskText string
+		want     string
+	}{
+		{
+			// A flat file (no nested lines) folds to the title unchanged, so a
+			// generated/one-line checklist is untouched.
+			name:     "flat task returns itself",
+			content:  "- [ ] 1. Do the thing\n- [ ] 2. Do the other",
+			taskText: "1. Do the thing",
+			want:     "1. Do the thing",
+		},
+		{
+			// Nested sub-bullets fold in verbatim (indentation preserved); the
+			// next top-level task and any header are boundaries.
+			name: "nested sub-items fold in, next task is a boundary",
+			content: "## Milestone\n\n" +
+				"- [ ] 1\\. Extend the model\n" +
+				"  - In `x.ts`, add a kind\n" +
+				"  - Acceptance Criteria:\n" +
+				"    - it has the kind\n" +
+				"  - _Complexity: Medium_\n\n" +
+				"## Milestone 2\n\n" +
+				"- [ ] 2\\. Classify text",
+			taskText: "1\\. Extend the model",
+			want: "1\\. Extend the model\n" +
+				"  - In `x.ts`, add a kind\n" +
+				"  - Acceptance Criteria:\n" +
+				"    - it has the kind\n" +
+				"  - _Complexity: Medium_",
+		},
+		{
+			// A nested checkbox is its own task (ParseChecklist counts it), so it
+			// bounds the fold rather than being folded as detail.
+			name: "nested checkbox is a boundary",
+			content: "- [ ] 1. parent\n" +
+				"  - a note\n" +
+				"  - [ ] sub task\n" +
+				"  - unreachable note",
+			taskText: "1. parent",
+			want:     "1. parent\n  - a note",
+		},
+		{
+			// A blank line between nested lines is kept; the trailing blank
+			// before the boundary is trimmed.
+			name: "interior blank kept, trailing blank trimmed",
+			content: "- [ ] 1. t\n" +
+				"  - first\n\n" +
+				"  - second\n\n" +
+				"- [ ] 2. u",
+			taskText: "1. t",
+			want:     "1. t\n  - first\n\n  - second",
+		},
+		{
+			// No matching item → the text is returned unchanged.
+			name:     "no match returns input",
+			content:  "- [ ] 1. something else",
+			taskText: "1. missing",
+			want:     "1. missing",
+		},
+		{
+			// The FIRST matching item is folded (mirrors ReserveFirstPending).
+			name: "first match wins",
+			content: "- [ ] 1. dup\n  - first block\n" +
+				"- [ ] 1. dup\n  - second block",
+			taskText: "1. dup",
+			want:     "1. dup\n  - first block",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FoldTaskContent(tc.content, tc.taskText); got != tc.want {
+				t.Errorf("FoldTaskContent =\n%q\nwant\n%q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFoldTaskContentSkipsDoneDuplicate(t *testing.T) {
+	// FoldTaskContent targets the first PENDING item with the text, aligning
+	// with NextDeclaredTask/ReserveFirstPending — so an earlier DONE item that
+	// shares the title (and carries stale detail) is not folded.
+	content := "- [x] 1. build it\n  - stale done detail\n" +
+		"- [ ] 1. build it\n  - the real detail"
+	want := "1. build it\n  - the real detail"
+	if got := FoldTaskContent(content, "1. build it"); got != want {
+		t.Errorf("FoldTaskContent =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestFoldTaskContentAt(t *testing.T) {
+	// Index-based folding disambiguates duplicate titles for the position-based
+	// (frontend manual send) path: item #2 and #4 share a title but carry
+	// different detail, and each index folds its own.
+	content := "- [ ] 1. first\n  - one\n" +
+		"- [ ] 2. dup\n  - detail A\n" +
+		"- [ ] 3. third\n  - three\n" +
+		"- [ ] 4. dup\n  - detail B\n"
+	cases := map[int]string{
+		1: "1. first\n  - one",
+		2: "2. dup\n  - detail A",
+		4: "4. dup\n  - detail B",
+		9: "", // out of range → caller falls back to the plain text
+	}
+	for idx, want := range cases {
+		if got := FoldTaskContentAt(content, idx); got != want {
+			t.Errorf("FoldTaskContentAt(_, %d) =\n%q\nwant\n%q", idx, got, want)
+		}
+	}
+}
+
+func TestDeclaredTaskPromptFoldsContent(t *testing.T) {
+	// When Content is set, Prompt delivers it (with the leading id unescaped)
+	// instead of the one-line Task identity; nested lines pass through verbatim.
+	task := DeclaredTask{
+		Task:     "1\\. Extend the model",
+		Content:  "1\\. Extend the model\n  - In `x.ts`, add a kind\n  - _Complexity: Medium_",
+		Path:     "/p/t.md",
+		Template: "{next_task_content}",
+	}
+	want := "1. Extend the model\n  - In `x.ts`, add a kind\n  - _Complexity: Medium_"
+	if got := task.Prompt(); got != want {
+		t.Errorf("Prompt() =\n%q\nwant\n%q", got, want)
+	}
+	// Empty Content falls back to the one-line Task (backward compatible).
+	fallback := DeclaredTask{Task: "1. do it", Path: "/p", Template: "{next_task_content}"}
+	if got, want := fallback.Prompt(), "1. do it"; got != want {
+		t.Errorf("empty Content must fall back to Task: got %q, want %q", got, want)
+	}
+}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -2735,25 +2735,29 @@ func (a *App) SendTaskToAgent(ctx context.Context, paneID, agentType, agentName,
 	if strings.Contains(domain.TemplateOrDefault(template), "{cwd}") {
 		cwd = a.paneCwd(ctx, paneID)
 	}
-	if _, err := mutateTaskFile(sourcePath, reserveTask(index, taskText)); err != nil {
+	// Reserve the item AND fold its nested sub-items from the SAME locked
+	// snapshot, so the delivered detail always describes the item just marked
+	// [-] — even under a concurrent edit. Fold by the RESERVED index (the exact
+	// position reserveTask verified by text), never a separate post-reserve read:
+	// an insert/delete/reorder between reserve and that read could make the index
+	// point at a different item and send the wrong detail. taskText stays the
+	// reservation identity regardless.
+	folded := ""
+	if _, err := mutateTaskFile(sourcePath, func(content string) (string, error) {
+		out, rerr := reserveTask(index, taskText)(content)
+		if rerr != nil {
+			return out, rerr
+		}
+		folded = domain.FoldTaskContentAt(content, index)
+		return out, nil
+	}); err != nil {
 		// Name the phase: reserveTask's own refusals are self-describing, but
 		// a lock/read/write failure would otherwise surface as a bare os
 		// error in a flow whose first question is "did it send?".
 		return fmt.Errorf("reserving task #%d (nothing was sent): %w", index, err)
 	}
-	// Fold the task's nested sub-items into the delivered content, matching the
-	// daemon's idle-time send. Fold by the RESERVED index (not by text): this
-	// path reserves a specific position, so a duplicate title must not fold a
-	// different item's detail. Best-effort — an unreadable file falls back to the
-	// one-line title (Content stays ""); reserving marked only the checkbox, so
-	// the nested lines are intact for this read. taskText remains the reservation
-	// identity regardless.
-	content := ""
-	if data, rerr := os.ReadFile(config.ExpandPath(sourcePath)); rerr == nil {
-		content = domain.FoldTaskContentAt(string(data), index)
-	}
 	prompt := domain.DeclaredTask{
-		Task: taskText, Content: content, Path: sourcePath, Template: template, AgentName: agentName, Cwd: cwd,
+		Task: taskText, Content: folded, Path: sourcePath, Template: template, AgentName: agentName, Cwd: cwd,
 	}.Prompt()
 	if err := ports.SendToAgent(ctx, a.Herdr, paneID, agentType, prompt); err != nil {
 		if _, rbErr := mutateTaskFile(sourcePath, releaseTask(index, taskText)); rbErr != nil {

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -2741,8 +2741,19 @@ func (a *App) SendTaskToAgent(ctx context.Context, paneID, agentType, agentName,
 		// error in a flow whose first question is "did it send?".
 		return fmt.Errorf("reserving task #%d (nothing was sent): %w", index, err)
 	}
+	// Fold the task's nested sub-items into the delivered content, matching the
+	// daemon's idle-time send. Fold by the RESERVED index (not by text): this
+	// path reserves a specific position, so a duplicate title must not fold a
+	// different item's detail. Best-effort — an unreadable file falls back to the
+	// one-line title (Content stays ""); reserving marked only the checkbox, so
+	// the nested lines are intact for this read. taskText remains the reservation
+	// identity regardless.
+	content := ""
+	if data, rerr := os.ReadFile(config.ExpandPath(sourcePath)); rerr == nil {
+		content = domain.FoldTaskContentAt(string(data), index)
+	}
 	prompt := domain.DeclaredTask{
-		Task: taskText, Path: sourcePath, Template: template, AgentName: agentName, Cwd: cwd,
+		Task: taskText, Content: content, Path: sourcePath, Template: template, AgentName: agentName, Cwd: cwd,
 	}.Prompt()
 	if err := ports.SendToAgent(ctx, a.Herdr, paneID, agentType, prompt); err != nil {
 		if _, rbErr := mutateTaskFile(sourcePath, releaseTask(index, taskText)); rbErr != nil {

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -3880,6 +3880,47 @@ func TestSendTaskToAgent(t *testing.T) {
 	}
 }
 
+func TestSendTaskToAgentFoldsNestedDetail(t *testing.T) {
+	// A manual send folds the RESERVED item's nested sub-items into the
+	// delivered prompt (from the same locked snapshot as the reservation), while
+	// the item is marked [-] by its single-line identity.
+	app, _ := testApp(t)
+	h := &sendCaptureHerdr{agents: idleAt("w1:p2")}
+	app.Herdr = h
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "tasks.md")
+	content := "- [ ] 1. Build the widget\n" +
+		"  - Wire the API\n" +
+		"  - Acceptance: it renders\n" +
+		"- [ ] 2. Later task\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.SendTaskToAgent(ctx, "w1:p2", "claude", "brave-otter", path, "", 1, "1. Build the widget"); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.sent) != 1 {
+		t.Fatalf("expected one delivery, got %v", h.sent)
+	}
+	for _, want := range []string{"1. Build the widget", "- Wire the API", "- Acceptance: it renders"} {
+		if !strings.Contains(h.sent[0], want) {
+			t.Errorf("delivered prompt missing folded detail %q:\n%s", want, h.sent[0])
+		}
+	}
+	// The second task's detail must NOT leak into task 1's delivery.
+	if strings.Contains(h.sent[0], "Later task") {
+		t.Errorf("a sibling task leaked into the folded content:\n%s", h.sent[0])
+	}
+	// Reserved by single-line identity; nested lines and the next task untouched.
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), "- [-] 1. Build the widget") {
+		t.Errorf("task should be marked in progress, got:\n%s", data)
+	}
+	if !strings.Contains(string(data), "  - Wire the API") || !strings.Contains(string(data), "- [ ] 2. Later task") {
+		t.Errorf("nested detail and next task must be preserved, got:\n%s", data)
+	}
+}
+
 // TestSendTaskToAgentRechecksIdle pins the guard against the window between
 // the caller's status read and delivery: the operator's confirmation (or a
 // --yes script) can be seconds stale, and a task must never land in a working


### PR DESCRIPTION
## What

A declared task source's checklist item is one physical line, so only the **title** reached the agent. A hand-authored task's nested detail — implementation notes, acceptance criteria, dependencies, complexity — written as indented sub-bullets under a `- [ ]` line was silently **dropped** at delivery.

This folds those nested sub-items into the content the agent receives, kept as real multi-line text (not `\n`-encoded), read from the file as-is. Milestone headers and sibling tasks are excluded.

Example — task 1 is now delivered as:

```
1. Extend the shared model and pin the real contracts
  - In `shared/generate/chat-decision.ts`, add an `mcq` kind ...
  - Confirm the exact interview MCQ-answer part type/schema ...
  - Acceptance Criteria:
    - `PendingCard` has an `mcq` kind; ...
  - _Dependencies: none_
  - _Requirements: Shared:AR-001, Shared:AR-004_
  - _Complexity: Medium_
```

## How

**Identity stays single-line; only the delivered content folds.** `DeclaredTask.Task` remains the one physical line used for reservation, the hand-out ledger (`task_reservations.task_text`), and the freshness check. A new `DeclaredTask.Content` carries the folded text; `Prompt()` renders it for `{next_task_content}` when set (else `Task`).

- `domain.FoldTaskContent(content, taskText)` — folds the **first pending** item with that title, aligning with `NextDeclaredTask`/`ReserveFirstPending` (daemon idle hand-out). Skips an earlier done/duplicate.
- `domain.FoldTaskContentAt(content, index)` — folds a **specific position** (frontend manual `hap task send`), which reserves by index, so duplicate titles fold the right item.
- Wired in `daemon.declaredTask` (auto hand-out) and `frontend.SendTaskToAgent` (manual send). Flat files (generated one-line tasks) fold to the title unchanged — a no-op.

The reservation guard (`declared.Prompt() == dec.Input`) stays consistent because `dec.Input` is built from the same struct via `Decide → in.DeclaredTask.Prompt()`.

## Safety

The outbound-text safety scans (never-auto, suspected-irreversible) run over `declared.Prompt()`, so they now inspect the **whole folded body**: a destructive phrase in a task's nested notes escalates the hand-out instead of auto-sending it — the fail-safe direction (more review, never less).

## Tests

- `TestFoldTaskContent` (boundaries: header, next task, nested checkbox, interior/trailing blanks, first-match, no-match, flat backward-compat).
- `TestFoldTaskContentSkipsDoneDuplicate`, `TestFoldTaskContentAt` (duplicate-title disambiguation, out-of-range).
- `TestDeclaredTaskPromptFoldsContent` (Prompt prefers Content; empty falls back to Task).
- `TestAutoSendIdleFoldsNestedTaskDetailButReservesByIdentity` (folded prompt delivered **and** item reserved `[-]` by single-line identity, next task untouched).

Full `internal/domain`, `internal/daemon`, `internal/frontend` suites pass (`vectors cpu`); `go vet`, `gofmt`, `golangci-lint` clean. Code-reviewed; the two should-fix findings (index-based fold for the manual-send path; documenting the widened safety scan) are addressed here.