### PR TITLE
#1 feat: disable a specific builtin never-auto rule instead of all seeds

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -850,13 +850,40 @@ func escalations(ctx context.Context, app *frontend.App, out io.Writer, args []s
 	// pending one — so a caller can copy a line verbatim instead of translating
 	// a placeholder.
 	id := esc[0].ID
-	PrintNextSteps(out, []Hint{
+	hints := []Hint{
 		{Cmd: fmt.Sprintf("hap confirm %d --send", id), Why: "the suggestion is right — accept and deliver it"},
 		{Cmd: fmt.Sprintf("hap resolve %d --action TEXT --send", id), Why: "it is wrong — record and send the right answer (@noop = no reply needed)"},
 		{Cmd: fmt.Sprintf("hap dismiss %d", id), Why: "drop it; nothing sent or learned"},
 		{Cmd: "hap escalations prune 120", Why: "dismiss everything older than 2 hours"},
-	})
+	}
+	// When a pending escalation was forced by a builtin (seed) never-auto rule
+	// that keeps tripping on this repo's benign wording, point at the exact
+	// command to silence just that one rule. Resolved from the escalation's own
+	// rationale — the newest such row wins, so the id shown matches what a
+	// reader is most likely looking at.
+	if seedID, ok := firstSeedRuleEscalation(esc); ok {
+		hints = append(hints, Hint{
+			Cmd: fmt.Sprintf("hap rules disable-seed %d", seedID),
+			Why: "a builtin safety rule blocked this — silence it if it is too aggressive for this repo",
+		})
+	}
+	PrintNextSteps(out, hints)
 	return nil
+}
+
+// firstSeedRuleEscalation returns the seed-rule index behind the newest pending
+// escalation raised by a builtin never-auto/heuristic hit, if any. Only a
+// builtin never-auto/heuristic hit renders "pattern <seed> matched" into a
+// rationale (via NeverAutoHit.Diagnostic), so the mapping is self-selecting: an
+// operator pattern or any non-safety escalation resolves to false, and the
+// disable-seed hint never appears where it would not apply.
+func firstSeedRuleEscalation(esc []domain.AuditRecord) (int, bool) {
+	for _, e := range esc {
+		if idx, ok := domain.SeedRuleIndexForRationale(e.Rationale); ok {
+			return idx, true
+		}
+	}
+	return 0, false
 }
 
 // escalationsPrune dismisses pending escalations older than the given age
@@ -1166,12 +1193,17 @@ func rules(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 		if cfg.Safety.DisableNeverAutoSeedPatterns {
 			fmt.Fprintln(out, "# shipped never-auto rules disabled by safety.disable_never_auto_seed_patterns=true")
 		} else {
-			fmt.Fprintln(out, "# shipped never-auto rules")
-			for _, p := range domain.SeedNeverAutoPatterns {
-				fmt.Fprintf(out, "seed strict\t%s\n", p)
+			fmt.Fprintln(out, "# shipped never-auto rules (silence one: hap rules disable-seed <id>)")
+			disabled := make(map[string]bool, len(cfg.Safety.DisabledSeedPatterns))
+			for _, p := range cfg.Safety.DisabledSeedPatterns {
+				disabled[p] = true
 			}
-			for _, r := range domain.SeedHeuristicNeverAutoRules {
-				fmt.Fprintf(out, "seed heuristic\t%s\n", r.Pattern)
+			for i, r := range domain.SeedNeverAutoRules() {
+				state := ""
+				if disabled[r.Pattern] {
+					state = " [disabled]"
+				}
+				fmt.Fprintf(out, "seed #%d\t%s%s\t%s\n", i, r.Kind, state, r.Pattern)
 			}
 		}
 		for i, p := range cfg.Safety.NeverAutoPatterns {
@@ -1187,6 +1219,7 @@ func rules(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 		PrintNextSteps(out, []Hint{
 			{Cmd: "hap rules add <regex>", Why: "force a matching situation to always ask a human"},
 			{Cmd: "hap rules remove <index>", Why: "drop one of the operator patterns listed above"},
+			{Cmd: "hap rules disable-seed <id>", Why: "silence one builtin (seed #) rule that is too aggressive here"},
 		})
 		return nil
 	}
@@ -1198,6 +1231,10 @@ func rules(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 		fmt.Fprintf(out, "never-auto pattern added: %s\n", args[1])
 		PrintNextSteps(out, rulesEditedHints())
 		return nil
+	case args[0] == "disable-seed" && len(args) == 2:
+		return rulesSeedToggle(ctx, app, out, args[1], true)
+	case args[0] == "enable-seed" && len(args) == 2:
+		return rulesSeedToggle(ctx, app, out, args[1], false)
 	case args[0] == "remove" && len(args) == 2:
 		idx, err := strconv.Atoi(args[1])
 		if err != nil {
@@ -1218,7 +1255,36 @@ func rules(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 		PrintNextSteps(out, rulesEditedHints())
 		return nil
 	}
-	return fmt.Errorf("usage: rules [list|add <regex>|remove <index>] (see: hap help rules)")
+	return fmt.Errorf("usage: rules [list|add <regex>|remove <index>|disable-seed <id>|enable-seed <id>] (see: hap help rules)")
+}
+
+// rulesSeedToggle disables (or re-enables) one shipped seed never-auto rule by
+// its `rules list` index. The resolved pattern is passed to the App as the
+// stale-listing guard, and the rule is stored by pattern so the setting is
+// stable across a seed-list reordering.
+func rulesSeedToggle(ctx context.Context, app *frontend.App, out io.Writer, idxArg string, disable bool) error {
+	idx, err := strconv.Atoi(idxArg)
+	if err != nil {
+		return fmt.Errorf("invalid seed rule index %q (see: rules list)", idxArg)
+	}
+	seeds := domain.SeedNeverAutoRules()
+	if idx < 0 || idx >= len(seeds) {
+		return fmt.Errorf("no seed rule #%d (see: rules list)", idx)
+	}
+	pattern := seeds[idx].Pattern
+	if disable {
+		if err := app.DisableSeedRule(ctx, idx, pattern); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "seed rule #%d disabled: %s\n", idx, pattern)
+	} else {
+		if err := app.EnableSeedRule(ctx, idx, pattern); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "seed rule #%d re-enabled: %s\n", idx, pattern)
+	}
+	PrintNextSteps(out, rulesEditedHints())
+	return nil
 }
 
 // rulesEditedHints are the follow-ups after a never-auto pattern changed: the

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -856,34 +856,19 @@ func escalations(ctx context.Context, app *frontend.App, out io.Writer, args []s
 		{Cmd: fmt.Sprintf("hap dismiss %d", id), Why: "drop it; nothing sent or learned"},
 		{Cmd: "hap escalations prune 120", Why: "dismiss everything older than 2 hours"},
 	}
-	// When a pending escalation was forced by a builtin (seed) never-auto rule
-	// that keeps tripping on this repo's benign wording, point at the exact
-	// command to silence just that one rule. Resolved from the escalation's own
-	// rationale — the newest such row wins, so the id shown matches what a
-	// reader is most likely looking at.
-	if seedID, ok := firstSeedRuleEscalation(esc); ok {
+	// When the escalation whose id the footer carries was forced by a builtin
+	// (seed) never-auto rule tripping on this repo's benign wording, point at the
+	// exact command to silence just that one rule. Gated on esc[0] — the SAME row
+	// as the confirm/dismiss ids above — so the hint always refers to the
+	// escalation being acted on, never an unrelated older row in a mixed queue.
+	if rule, ok := domain.SeedRuleForRationale(esc[0].Rationale); ok {
 		hints = append(hints, Hint{
-			Cmd: fmt.Sprintf("hap rules disable-seed %d", seedID),
-			Why: "a builtin safety rule blocked this — silence it if it is too aggressive for this repo",
+			Cmd: fmt.Sprintf("hap rules disable-seed %s", domain.SeedRuleID(rule.Pattern)),
+			Why: fmt.Sprintf("a builtin safety rule blocked escalation #%d — silence it if it is too aggressive for this repo", id),
 		})
 	}
 	PrintNextSteps(out, hints)
 	return nil
-}
-
-// firstSeedRuleEscalation returns the seed-rule index behind the newest pending
-// escalation raised by a builtin never-auto/heuristic hit, if any. Only a
-// builtin never-auto/heuristic hit renders "pattern <seed> matched" into a
-// rationale (via NeverAutoHit.Diagnostic), so the mapping is self-selecting: an
-// operator pattern or any non-safety escalation resolves to false, and the
-// disable-seed hint never appears where it would not apply.
-func firstSeedRuleEscalation(esc []domain.AuditRecord) (int, bool) {
-	for _, e := range esc {
-		if idx, ok := domain.SeedRuleIndexForRationale(e.Rationale); ok {
-			return idx, true
-		}
-	}
-	return 0, false
 }
 
 // escalationsPrune dismisses pending escalations older than the given age
@@ -1198,12 +1183,12 @@ func rules(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 			for _, p := range cfg.Safety.DisabledSeedPatterns {
 				disabled[p] = true
 			}
-			for i, r := range domain.SeedNeverAutoRules() {
+			for _, r := range domain.SeedNeverAutoRules() {
 				state := ""
 				if disabled[r.Pattern] {
 					state = " [disabled]"
 				}
-				fmt.Fprintf(out, "seed #%d\t%s%s\t%s\n", i, r.Kind, state, r.Pattern)
+				fmt.Fprintf(out, "seed %s\t%s%s\t%s\n", domain.SeedRuleID(r.Pattern), r.Kind, state, r.Pattern)
 			}
 		}
 		for i, p := range cfg.Safety.NeverAutoPatterns {
@@ -1219,7 +1204,7 @@ func rules(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 		PrintNextSteps(out, []Hint{
 			{Cmd: "hap rules add <regex>", Why: "force a matching situation to always ask a human"},
 			{Cmd: "hap rules remove <index>", Why: "drop one of the operator patterns listed above"},
-			{Cmd: "hap rules disable-seed <id>", Why: "silence one builtin (seed #) rule that is too aggressive here"},
+			{Cmd: "hap rules disable-seed <id>", Why: "silence one builtin (seed <id>) rule that is too aggressive here"},
 		})
 		return nil
 	}
@@ -1259,29 +1244,25 @@ func rules(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 }
 
 // rulesSeedToggle disables (or re-enables) one shipped seed never-auto rule by
-// its `rules list` index. The resolved pattern is passed to the App as the
-// stale-listing guard, and the rule is stored by pattern so the setting is
-// stable across a seed-list reordering.
-func rulesSeedToggle(ctx context.Context, app *frontend.App, out io.Writer, idxArg string, disable bool) error {
-	idx, err := strconv.Atoi(idxArg)
-	if err != nil {
-		return fmt.Errorf("invalid seed rule index %q (see: rules list)", idxArg)
+// its durable domain.SeedRuleID (as listed by `rules list`). Resolving the id
+// to its pattern rejects an unknown or stale id — one whose pattern no longer
+// ships — instead of acting on whatever rule happens to sit at a position, and
+// the rule is stored by pattern so the setting is stable across a reorder.
+func rulesSeedToggle(ctx context.Context, app *frontend.App, out io.Writer, id string, disable bool) error {
+	rule, ok := domain.SeedRuleByID(id)
+	if !ok {
+		return fmt.Errorf("no seed rule %q (see: rules list)", id)
 	}
-	seeds := domain.SeedNeverAutoRules()
-	if idx < 0 || idx >= len(seeds) {
-		return fmt.Errorf("no seed rule #%d (see: rules list)", idx)
-	}
-	pattern := seeds[idx].Pattern
 	if disable {
-		if err := app.DisableSeedRule(ctx, idx, pattern); err != nil {
+		if err := app.DisableSeedRule(ctx, rule.Pattern); err != nil {
 			return err
 		}
-		fmt.Fprintf(out, "seed rule #%d disabled: %s\n", idx, pattern)
+		fmt.Fprintf(out, "seed rule %s disabled: %s\n", id, rule.Pattern)
 	} else {
-		if err := app.EnableSeedRule(ctx, idx, pattern); err != nil {
+		if err := app.EnableSeedRule(ctx, rule.Pattern); err != nil {
 			return err
 		}
-		fmt.Fprintf(out, "seed rule #%d re-enabled: %s\n", idx, pattern)
+		fmt.Fprintf(out, "seed rule %s re-enabled: %s\n", id, rule.Pattern)
 	}
 	PrintNextSteps(out, rulesEditedHints())
 	return nil

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -860,6 +860,96 @@ func TestEscalationsAndAuditShowMatchedRule(t *testing.T) {
 	}
 }
 
+func TestRulesListNumbersAndDisablesSeedRules(t *testing.T) {
+	app, _ := testApp(t)
+
+	out, err := run(t, app, "rules", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "seed #0\t") {
+		t.Errorf("rules list should number seed rules, got:\n%s", out)
+	}
+	if strings.Contains(out, "[disabled]") {
+		t.Errorf("no seed rule should be disabled initially, got:\n%s", out)
+	}
+
+	// Disable seed #0 and confirm it is marked disabled on the next list.
+	if _, err := run(t, app, "rules", "disable-seed", "0"); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ := app.Config()
+	if len(cfg.Safety.DisabledSeedPatterns) != 1 {
+		t.Fatalf("disable-seed must persist one entry, got %v", cfg.Safety.DisabledSeedPatterns)
+	}
+	out, _ = run(t, app, "rules", "list")
+	if !strings.Contains(out, "seed #0\tstrict [disabled]") {
+		t.Errorf("disabled seed rule must be marked, got:\n%s", out)
+	}
+
+	// Re-enable clears the mark.
+	if _, err := run(t, app, "rules", "enable-seed", "0"); err != nil {
+		t.Fatal(err)
+	}
+	out, _ = run(t, app, "rules", "list")
+	if strings.Contains(out, "[disabled]") {
+		t.Errorf("re-enabled seed rule must not be marked, got:\n%s", out)
+	}
+
+	// Bad indexes are rejected.
+	for _, bad := range []string{"-1", "99999", "abc"} {
+		if _, err := run(t, app, "rules", "disable-seed", bad); err == nil {
+			t.Errorf("disable-seed %q must error", bad)
+		}
+	}
+}
+
+func TestEscalationsHintsDisableSeedForBuiltinRule(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+
+	// Produce a real seed-rule diagnostic (the escalation rationale a builtin
+	// heuristic hit would carry) and store an escalation with it.
+	list, errs := domain.NewNeverAutoList(true, nil, nil, nil)
+	if len(errs) > 0 {
+		t.Fatalf("matcher: %v", errs)
+	}
+	hit, ok := list.SuspectedIrreversible("claude", "This action cannot be undone")
+	if !ok {
+		t.Fatal("expected a builtin heuristic to fire")
+	}
+	wantIdx, ok := domain.SeedRuleIndexForRationale(hit.Diagnostic())
+	if !ok {
+		t.Fatal("seed rationale must resolve to an index")
+	}
+	st.AppendAudit(ctx, domain.AuditRecord{Signature: "approval:seedhit0001",
+		Trigger: "purge?", SituationType: domain.SituationApproval, Action: "escalated",
+		Rationale: hit.Diagnostic(), Status: "escalated", CreatedAt: time.Now()})
+
+	out, err := run(t, app, "escalations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, fmt.Sprintf("hap rules disable-seed %d", wantIdx)) {
+		t.Errorf("a builtin-rule escalation should hint disable-seed %d, got:\n%s", wantIdx, out)
+	}
+}
+
+func TestEscalationsOmitsDisableSeedForNonSeedEscalation(t *testing.T) {
+	app, st := testApp(t)
+	st.AppendAudit(context.Background(), domain.AuditRecord{Signature: "error:plainrow01",
+		Trigger: "boom", SituationType: domain.SituationError, Action: "escalated",
+		Rationale: "contradictory history", Status: "escalated", CreatedAt: time.Now()})
+
+	out, err := run(t, app, "escalations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "disable-seed") {
+		t.Errorf("a non-seed escalation must not hint disable-seed, got:\n%s", out)
+	}
+}
+
 // cliFakeEmbedder backs the standalone reembed path in CLI tests.
 type cliFakeEmbedder struct{ id string }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -860,56 +860,10 @@ func TestEscalationsAndAuditShowMatchedRule(t *testing.T) {
 	}
 }
 
-func TestRulesListNumbersAndDisablesSeedRules(t *testing.T) {
-	app, _ := testApp(t)
-
-	out, err := run(t, app, "rules", "list")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out, "seed #0\t") {
-		t.Errorf("rules list should number seed rules, got:\n%s", out)
-	}
-	if strings.Contains(out, "[disabled]") {
-		t.Errorf("no seed rule should be disabled initially, got:\n%s", out)
-	}
-
-	// Disable seed #0 and confirm it is marked disabled on the next list.
-	if _, err := run(t, app, "rules", "disable-seed", "0"); err != nil {
-		t.Fatal(err)
-	}
-	cfg, _ := app.Config()
-	if len(cfg.Safety.DisabledSeedPatterns) != 1 {
-		t.Fatalf("disable-seed must persist one entry, got %v", cfg.Safety.DisabledSeedPatterns)
-	}
-	out, _ = run(t, app, "rules", "list")
-	if !strings.Contains(out, "seed #0\tstrict [disabled]") {
-		t.Errorf("disabled seed rule must be marked, got:\n%s", out)
-	}
-
-	// Re-enable clears the mark.
-	if _, err := run(t, app, "rules", "enable-seed", "0"); err != nil {
-		t.Fatal(err)
-	}
-	out, _ = run(t, app, "rules", "list")
-	if strings.Contains(out, "[disabled]") {
-		t.Errorf("re-enabled seed rule must not be marked, got:\n%s", out)
-	}
-
-	// Bad indexes are rejected.
-	for _, bad := range []string{"-1", "99999", "abc"} {
-		if _, err := run(t, app, "rules", "disable-seed", bad); err == nil {
-			t.Errorf("disable-seed %q must error", bad)
-		}
-	}
-}
-
-func TestEscalationsHintsDisableSeedForBuiltinRule(t *testing.T) {
-	app, st := testApp(t)
-	ctx := context.Background()
-
-	// Produce a real seed-rule diagnostic (the escalation rationale a builtin
-	// heuristic hit would carry) and store an escalation with it.
+// seedHeuristicDiagnostic returns a real builtin-heuristic hit's rationale plus
+// the durable id and pattern of the seed rule that produced it.
+func seedHeuristicDiagnostic(t *testing.T) (rationale, id, pattern string) {
+	t.Helper()
 	list, errs := domain.NewNeverAutoList(true, nil, nil, nil)
 	if len(errs) > 0 {
 		t.Fatalf("matcher: %v", errs)
@@ -918,20 +872,74 @@ func TestEscalationsHintsDisableSeedForBuiltinRule(t *testing.T) {
 	if !ok {
 		t.Fatal("expected a builtin heuristic to fire")
 	}
-	wantIdx, ok := domain.SeedRuleIndexForRationale(hit.Diagnostic())
+	rule, ok := domain.SeedRuleForRationale(hit.Diagnostic())
 	if !ok {
-		t.Fatal("seed rationale must resolve to an index")
+		t.Fatal("seed rationale must resolve to a rule")
 	}
-	st.AppendAudit(ctx, domain.AuditRecord{Signature: "approval:seedhit0001",
+	return hit.Diagnostic(), domain.SeedRuleID(rule.Pattern), rule.Pattern
+}
+
+func TestRulesListShowsSeedIDsAndDisables(t *testing.T) {
+	app, _ := testApp(t)
+
+	id := domain.SeedRuleID(domain.SeedNeverAutoRules()[0].Pattern)
+
+	out, err := run(t, app, "rules", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "seed "+id+"\t") {
+		t.Errorf("rules list should tag seed rules with their id, got:\n%s", out)
+	}
+	if strings.Contains(out, "[disabled]") {
+		t.Errorf("no seed rule should be disabled initially, got:\n%s", out)
+	}
+
+	// Disable by id and confirm it is marked disabled on the next list.
+	if _, err := run(t, app, "rules", "disable-seed", id); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ := app.Config()
+	if len(cfg.Safety.DisabledSeedPatterns) != 1 {
+		t.Fatalf("disable-seed must persist one entry, got %v", cfg.Safety.DisabledSeedPatterns)
+	}
+	out, _ = run(t, app, "rules", "list")
+	if !strings.Contains(out, "seed "+id+"\tstrict [disabled]") {
+		t.Errorf("disabled seed rule must be marked, got:\n%s", out)
+	}
+
+	// Re-enable clears the mark.
+	if _, err := run(t, app, "rules", "enable-seed", id); err != nil {
+		t.Fatal(err)
+	}
+	out, _ = run(t, app, "rules", "list")
+	if strings.Contains(out, "[disabled]") {
+		t.Errorf("re-enabled seed rule must not be marked, got:\n%s", out)
+	}
+
+	// Unknown / malformed ids are rejected (a stale id whose pattern no longer
+	// ships must never disable a positional neighbor).
+	for _, bad := range []string{"deadbeef", "0", ""} {
+		if _, err := run(t, app, "rules", "disable-seed", bad); err == nil {
+			t.Errorf("disable-seed %q must error", bad)
+		}
+	}
+}
+
+func TestEscalationsHintsDisableSeedForBuiltinRule(t *testing.T) {
+	app, st := testApp(t)
+	rationale, wantID, _ := seedHeuristicDiagnostic(t)
+
+	st.AppendAudit(context.Background(), domain.AuditRecord{Signature: "approval:seedhit0001",
 		Trigger: "purge?", SituationType: domain.SituationApproval, Action: "escalated",
-		Rationale: hit.Diagnostic(), Status: "escalated", CreatedAt: time.Now()})
+		Rationale: rationale, Status: "escalated", CreatedAt: time.Now()})
 
 	out, err := run(t, app, "escalations")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, fmt.Sprintf("hap rules disable-seed %d", wantIdx)) {
-		t.Errorf("a builtin-rule escalation should hint disable-seed %d, got:\n%s", wantIdx, out)
+	if !strings.Contains(out, "hap rules disable-seed "+wantID) {
+		t.Errorf("a builtin-rule escalation should hint disable-seed %s, got:\n%s", wantID, out)
 	}
 }
 
@@ -947,6 +955,42 @@ func TestEscalationsOmitsDisableSeedForNonSeedEscalation(t *testing.T) {
 	}
 	if strings.Contains(out, "disable-seed") {
 		t.Errorf("a non-seed escalation must not hint disable-seed, got:\n%s", out)
+	}
+}
+
+// TestEscalationsDisableSeedHintTracksNewestRow is the regression for review
+// comment #3: the footer's confirm/dismiss ids refer to the newest row, so the
+// disable-seed hint must be gated on THAT row. A seed-caused escalation sitting
+// under a newer non-seed one must not leak a hint that would reference the wrong
+// escalation; when the newest row IS seed-caused, the hint appears.
+func TestEscalationsDisableSeedHintTracksNewestRow(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	rationale, wantID, _ := seedHeuristicDiagnostic(t)
+
+	// Older row is the seed-caused one; a newer non-seed row sits on top.
+	st.AppendAudit(ctx, domain.AuditRecord{Signature: "approval:oldseed0001",
+		Trigger: "purge?", SituationType: domain.SituationApproval, Action: "escalated",
+		Rationale: rationale, Status: "escalated", CreatedAt: time.Now().Add(-10 * time.Minute)})
+	st.AppendAudit(ctx, domain.AuditRecord{Signature: "error:newplain001",
+		Trigger: "boom", SituationType: domain.SituationError, Action: "escalated",
+		Rationale: "contradictory history", Status: "escalated", CreatedAt: time.Now()})
+
+	out, err := run(t, app, "escalations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "disable-seed") {
+		t.Errorf("seed row under a newer non-seed row must not surface a disconnected hint, got:\n%s", out)
+	}
+
+	// Now make the NEWEST row the seed-caused one: the hint appears and names it.
+	st.AppendAudit(ctx, domain.AuditRecord{Signature: "approval:newseed0001",
+		Trigger: "purge?", SituationType: domain.SituationApproval, Action: "escalated",
+		Rationale: rationale, Status: "escalated", CreatedAt: time.Now().Add(time.Minute)})
+	out, _ = run(t, app, "escalations")
+	if !strings.Contains(out, "hap rules disable-seed "+wantID) {
+		t.Errorf("a seed-caused newest row should surface the hint, got:\n%s", out)
 	}
 }
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -531,20 +531,32 @@ func buildCommands() {
 				"hap rules [list]",
 				"hap rules add <regex>",
 				"hap rules remove <index>",
+				"hap rules disable-seed <id>",
+				"hap rules enable-seed <id>",
 			},
-			Details: "`list` prints the shipped seed rules first (strict and heuristic), then your\n" +
-				"operator patterns with the index `remove` takes. A situation matching any rule is\n" +
-				"always escalated to a human, whatever the learned confidence says — this is a\n" +
-				"safety control, not a preference. Patterns are Go regular expressions matched\n" +
-				"against the situation's content.",
+			Details: "`list` prints the shipped seed rules first, each with a `seed #<id>` (strict or\n" +
+				"heuristic), then your operator patterns with the index `remove` takes. A situation\n" +
+				"matching any rule is always escalated to a human, whatever the learned confidence\n" +
+				"says — this is a safety control, not a preference. Patterns are Go regular\n" +
+				"expressions matched against the situation's content.\n\n" +
+				"When a builtin seed rule is too aggressive for a repo (e.g. a heuristic firing on a\n" +
+				"legitimate word like \"unrecoverable\"), take its `seed #<id>` from `rules list` and\n" +
+				"run `disable-seed <id>` to silence just that one rule while keeping the rest of the\n" +
+				"safety net; `enable-seed <id>` restores it. Note a seed rule is a single regex: one\n" +
+				"heuristic can cover several phrasings, so disabling it silences every phrase in that\n" +
+				"rule's pattern, not only the word you saw. The rule is recorded by its pattern, so\n" +
+				"the setting survives upgrades. To drop every seed rule at once instead, set\n" +
+				"safety.disable_never_auto_seed_patterns=true.",
 			Examples: []string{
 				"hap rules list",
 				"hap rules add '(?i)force[- ]push'",
 				"hap rules remove 0",
+				"hap rules disable-seed <id from rules list>",
 			},
 			Next: []Hint{
-				{Cmd: "hap rules list", Why: "every rule, with the index `remove` takes"},
+				{Cmd: "hap rules list", Why: "every rule, with the index `remove`/`disable-seed` take"},
 				{Cmd: "hap rules add <regex>", Why: "force a situation to always ask a human"},
+				{Cmd: "hap rules disable-seed <id>", Why: "silence a builtin rule that keeps over-escalating"},
 			},
 			// list and add/remove want opposite follow-ups, so the handler picks.
 			SelfHints: true,

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -534,18 +534,20 @@ func buildCommands() {
 				"hap rules disable-seed <id>",
 				"hap rules enable-seed <id>",
 			},
-			Details: "`list` prints the shipped seed rules first, each with a `seed #<id>` (strict or\n" +
-				"heuristic), then your operator patterns with the index `remove` takes. A situation\n" +
-				"matching any rule is always escalated to a human, whatever the learned confidence\n" +
-				"says — this is a safety control, not a preference. Patterns are Go regular\n" +
-				"expressions matched against the situation's content.\n\n" +
+			Details: "`list` prints the shipped seed rules first, each with a stable `seed <id>` (a\n" +
+				"short hash of the pattern, strict or heuristic), then your operator patterns with\n" +
+				"the index `remove` takes. A situation matching any rule is always escalated to a\n" +
+				"human, whatever the learned confidence says — this is a safety control, not a\n" +
+				"preference. Patterns are Go regular expressions matched against the situation's\n" +
+				"content.\n\n" +
 				"When a builtin seed rule is too aggressive for a repo (e.g. a heuristic firing on a\n" +
-				"legitimate word like \"unrecoverable\"), take its `seed #<id>` from `rules list` and\n" +
+				"legitimate word like \"unrecoverable\"), take its `seed <id>` from `rules list` and\n" +
 				"run `disable-seed <id>` to silence just that one rule while keeping the rest of the\n" +
-				"safety net; `enable-seed <id>` restores it. Note a seed rule is a single regex: one\n" +
-				"heuristic can cover several phrasings, so disabling it silences every phrase in that\n" +
-				"rule's pattern, not only the word you saw. The rule is recorded by its pattern, so\n" +
-				"the setting survives upgrades. To drop every seed rule at once instead, set\n" +
+				"safety net; `enable-seed <id>` restores it. The id is derived from the pattern, so\n" +
+				"it names the same rule across upgrades (or is rejected if that pattern no longer\n" +
+				"ships). Note a seed rule is a single regex: one heuristic can cover several\n" +
+				"phrasings, so disabling it silences every phrase in that rule's pattern, not only\n" +
+				"the word you saw. To drop every seed rule at once instead, set\n" +
 				"safety.disable_never_auto_seed_patterns=true.",
 			Examples: []string{
 				"hap rules list",
@@ -554,7 +556,7 @@ func buildCommands() {
 				"hap rules disable-seed <id from rules list>",
 			},
 			Next: []Hint{
-				{Cmd: "hap rules list", Why: "every rule, with the index `remove`/`disable-seed` take"},
+				{Cmd: "hap rules list", Why: "every rule, with the index `remove` and the id `disable-seed` take"},
 				{Cmd: "hap rules add <regex>", Why: "force a situation to always ask a human"},
 				{Cmd: "hap rules disable-seed <id>", Why: "silence a builtin rule that keeps over-escalating"},
 			},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,14 @@ type Safety struct {
 	// DisableNeverAutoSeedPatterns disables the shipped seed never-auto
 	// patterns (not recommended).
 	DisableNeverAutoSeedPatterns bool `toml:"disable_never_auto_seed_patterns"`
+	// DisabledSeedPatterns lists shipped seed never-auto patterns (strict or
+	// heuristic) the operator has disabled individually, keyed by the exact
+	// pattern string so the setting survives seed-list reordering across
+	// versions. Distinct from DisableNeverAutoSeedPatterns, which drops every
+	// seed rule at once: this silences only the named rules and keeps the rest
+	// of the safety net. An entry that matches no current seed pattern (a rule
+	// dropped by a later release) is simply ignored.
+	DisabledSeedPatterns []string `toml:"disabled_seed_patterns"`
 	// DeprecatedDisableSeed is the pre-rename key for
 	// DisableNeverAutoSeedPatterns. Load migrates it only when the canonical
 	// key is absent, then clears it so Save emits only the new key.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -339,6 +339,27 @@ func TestSaveRoundTrip(t *testing.T) {
 	}
 }
 
+// TestDisabledSeedPatternsRoundTrip pins that per-rule seed disables survive
+// Save/Load — the setting that lets an operator silence one over-aggressive
+// builtin rule must persist across daemon restarts.
+func TestDisabledSeedPatternsRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	cfg := Default()
+	cfg.Safety.DisabledSeedPatterns = []string{`(?i)\bunrecoverabl[ey]\b`, `(?i)\bDROP\s+TABLE\b`}
+	if err := Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Safety.DisabledSeedPatterns) != 2 ||
+		got.Safety.DisabledSeedPatterns[0] != `(?i)\bunrecoverabl[ey]\b` ||
+		got.Safety.DisabledSeedPatterns[1] != `(?i)\bDROP\s+TABLE\b` {
+		t.Errorf("disabled_seed_patterns round trip mismatch: %+v", got.Safety.DisabledSeedPatterns)
+	}
+}
+
 // TestEmbeddingTimeoutKeysRoundTrip pins the TOML surface an operator edits to
 // rescue a large model: the three tunables must parse from a hand-written file
 // and survive Save/Load, and an omitted key must stay 0 (the "use the built-in

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -502,7 +502,7 @@ func (d *Daemon) reloadWith(forceEmbedder bool) error {
 	}
 	d.mu.Unlock()
 	allow, errs := domain.NewNeverAutoList(!cfg.Safety.DisableNeverAutoSeedPatterns,
-		cfg.Safety.NeverAutoPatterns, neverAutoRules(cfg.Safety))
+		cfg.Safety.DisabledSeedPatterns, cfg.Safety.NeverAutoPatterns, neverAutoRules(cfg.Safety))
 	for _, e := range errs {
 		slog.Warn("never-auto pattern rejected", "error", e)
 	}

--- a/internal/daemon/safety_config_test.go
+++ b/internal/daemon/safety_config_test.go
@@ -67,6 +67,7 @@ agents = ['codex']
 
 	matcher, errs := domain.NewNeverAutoList(
 		!cfg.Safety.DisableNeverAutoSeedPatterns,
+		cfg.Safety.DisabledSeedPatterns,
 		cfg.Safety.NeverAutoPatterns,
 		neverAutoRules(cfg.Safety),
 	)

--- a/internal/domain/safety.go
+++ b/internal/domain/safety.go
@@ -135,6 +135,38 @@ func SeedNeverAutoRuleCount() int {
 	return len(SeedNeverAutoPatterns) + len(SeedHeuristicNeverAutoRules)
 }
 
+// SeedNeverAutoRules returns every shipped seed rule — strict patterns first,
+// then heuristic rules — with Kind and Source filled in. The order is stable
+// for a given build, so a caller may address a rule by its index in this slice
+// (that index is only a display convenience; the durable key for disabling a
+// rule is its Pattern string, which survives reordering across versions).
+func SeedNeverAutoRules() []NeverAutoRule {
+	rules := make([]NeverAutoRule, 0, SeedNeverAutoRuleCount())
+	for _, p := range SeedNeverAutoPatterns {
+		rules = append(rules, NeverAutoRule{Pattern: p, Kind: NeverAutoStrict, Source: NeverAutoSeed})
+	}
+	for _, r := range SeedHeuristicNeverAutoRules {
+		r.Kind = NeverAutoHeuristic
+		r.Source = NeverAutoSeed
+		rules = append(rules, r)
+	}
+	return rules
+}
+
+// SeedRuleIndexForRationale maps an escalation rationale back to the seed rule
+// that produced it, returning that rule's index in SeedNeverAutoRules. It keys
+// off the stable Diagnostic() rendering ("pattern <P> matched …"), so it fires
+// only for a seed never-auto/heuristic hit and never for an operator pattern or
+// an unrelated escalation reason. The bool is false when no seed rule matches.
+func SeedRuleIndexForRationale(rationale string) (int, bool) {
+	for i, r := range SeedNeverAutoRules() {
+		if strings.Contains(rationale, "pattern "+r.Pattern+" matched") {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
 // compiledNeverAutoRule is one unified rule ready for matching.
 type compiledNeverAutoRule struct {
 	rule NeverAutoRule
@@ -150,16 +182,29 @@ type NeverAutoList struct {
 // NewNeverAutoList compiles strict and heuristic rules into one matcher while
 // preserving each rule's source, kind, and agent-type scope.
 // Invalid operator patterns are reported, not silently dropped.
-func NewNeverAutoList(seedEnabled bool, extraPatterns []string, extraRules []NeverAutoRule) (*NeverAutoList, []error) {
+//
+// disabledSeeds names individual seed patterns (strict or heuristic) the
+// operator has switched off; each is skipped while every other seed rule stays
+// active. Operator rules are never filtered by it. Passing nil (or the whole
+// set disabled via seedEnabled=false) keeps the previous behavior.
+func NewNeverAutoList(seedEnabled bool, disabledSeeds, extraPatterns []string, extraRules []NeverAutoRule) (*NeverAutoList, []error) {
 	var errs []error
 	a := &NeverAutoList{}
-	addRules := func(rules []NeverAutoRule, defaultKind NeverAutoRuleKind, defaultSource NeverAutoRuleSource) {
+	disabled := make(map[string]bool, len(disabledSeeds))
+	for _, p := range disabledSeeds {
+		disabled[p] = true
+	}
+	addRules := func(rules []NeverAutoRule, defaultKind NeverAutoRuleKind, defaultSource NeverAutoRuleSource, seed bool) {
 		for _, rule := range rules {
 			if rule.Kind == "" {
 				rule.Kind = defaultKind
 			}
 			if rule.Source == "" {
 				rule.Source = defaultSource
+			}
+			// Only seed rules honor the operator's per-rule disable list.
+			if seed && disabled[rule.Pattern] {
+				continue
 			}
 			re, err := regexp.Compile(rule.Pattern)
 			if err != nil {
@@ -174,15 +219,15 @@ func NewNeverAutoList(seedEnabled bool, extraPatterns []string, extraRules []Nev
 		for _, pattern := range SeedNeverAutoPatterns {
 			seedRules = append(seedRules, NeverAutoRule{Pattern: pattern})
 		}
-		addRules(seedRules, NeverAutoStrict, NeverAutoSeed)
-		addRules(SeedHeuristicNeverAutoRules, NeverAutoHeuristic, NeverAutoSeed)
+		addRules(seedRules, NeverAutoStrict, NeverAutoSeed, true)
+		addRules(SeedHeuristicNeverAutoRules, NeverAutoHeuristic, NeverAutoSeed, true)
 	}
 	operatorRules := make([]NeverAutoRule, 0, len(extraPatterns)+len(extraRules))
 	for _, pattern := range extraPatterns {
 		operatorRules = append(operatorRules, NeverAutoRule{Pattern: pattern})
 	}
 	operatorRules = append(operatorRules, extraRules...)
-	addRules(operatorRules, NeverAutoStrict, NeverAutoOperator)
+	addRules(operatorRules, NeverAutoStrict, NeverAutoOperator, false)
 	return a, errs
 }
 

--- a/internal/domain/safety.go
+++ b/internal/domain/safety.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"regexp"
 	"strings"
@@ -136,10 +137,9 @@ func SeedNeverAutoRuleCount() int {
 }
 
 // SeedNeverAutoRules returns every shipped seed rule — strict patterns first,
-// then heuristic rules — with Kind and Source filled in. The order is stable
-// for a given build, so a caller may address a rule by its index in this slice
-// (that index is only a display convenience; the durable key for disabling a
-// rule is its Pattern string, which survives reordering across versions).
+// then heuristic rules — with Kind and Source filled in. Rules are addressed by
+// their content-derived SeedRuleID, not by position, so callers never depend on
+// this ordering surviving a version upgrade.
 func SeedNeverAutoRules() []NeverAutoRule {
 	rules := make([]NeverAutoRule, 0, SeedNeverAutoRuleCount())
 	for _, p := range SeedNeverAutoPatterns {
@@ -153,18 +153,65 @@ func SeedNeverAutoRules() []NeverAutoRule {
 	return rules
 }
 
-// SeedRuleIndexForRationale maps an escalation rationale back to the seed rule
-// that produced it, returning that rule's index in SeedNeverAutoRules. It keys
-// off the stable Diagnostic() rendering ("pattern <P> matched …"), so it fires
-// only for a seed never-auto/heuristic hit and never for an operator pattern or
-// an unrelated escalation reason. The bool is false when no seed rule matches.
-func SeedRuleIndexForRationale(rationale string) (int, bool) {
-	for i, r := range SeedNeverAutoRules() {
-		if strings.Contains(rationale, "pattern "+r.Pattern+" matched") {
-			return i, true
+// SeedRuleID is a short, stable identifier for a seed rule, derived from its
+// pattern text. Because it is a content hash — not a list position — an id an
+// operator copied from `rules list` still names the SAME rule after a seed-list
+// reorder or version upgrade (or names nothing, if that pattern was dropped);
+// it can never silently point at a different rule. This is the durable key the
+// disable/enable commands and the escalation hint use.
+func SeedRuleID(pattern string) string {
+	sum := sha256.Sum256([]byte(pattern))
+	return fmt.Sprintf("%x", sum[:4]) // 8 hex chars — collision-safe for ~90 rules
+}
+
+// SeedRuleByID resolves a SeedRuleID back to its shipped rule. The bool is
+// false for an unknown id (e.g. a stale id whose pattern no longer ships),
+// which the callers surface as a "no such seed rule" error rather than acting
+// on the wrong one.
+func SeedRuleByID(id string) (NeverAutoRule, bool) {
+	for _, r := range SeedNeverAutoRules() {
+		if SeedRuleID(r.Pattern) == id {
+			return r, true
 		}
 	}
-	return 0, false
+	return NeverAutoRule{}, false
+}
+
+// IsSeedPattern reports whether pattern is the exact text of a shipped seed
+// rule. It guards the disable/enable path so only a real seed rule can be
+// recorded in safety.disabled_seed_patterns.
+func IsSeedPattern(pattern string) bool {
+	for _, r := range SeedNeverAutoRules() {
+		if r.Pattern == pattern {
+			return true
+		}
+	}
+	return false
+}
+
+// SeedRuleForRationale maps an escalation rationale back to the seed rule that
+// produced it. It requires the stable Diagnostic() rendering
+// ("pattern <P> matched …") AND, immediately after that hit's excerpt, the
+// seed-source marker "(source=seed ": an operator rule whose pattern text
+// happens to equal a seed's — or a hit taken once that seed is disabled —
+// renders "(source=operator " and must NOT resolve to a builtin, or the hint
+// would name an unrelated (or already-inactive) rule. Anchoring the source
+// check to the position after this rule's own match keeps a crafted excerpt
+// elsewhere in the rationale from spoofing it. The bool is false when no seed
+// rule matches.
+func SeedRuleForRationale(rationale string) (NeverAutoRule, bool) {
+	seedSource := "(source=" + string(NeverAutoSeed) + " "
+	for _, r := range SeedNeverAutoRules() {
+		marker := "pattern " + r.Pattern + " matched"
+		i := strings.Index(rationale, marker)
+		if i < 0 {
+			continue
+		}
+		if strings.Contains(rationale[i+len(marker):], seedSource) {
+			return r, true
+		}
+	}
+	return NeverAutoRule{}, false
 }
 
 // compiledNeverAutoRule is one unified rule ready for matching.

--- a/internal/domain/safety_test.go
+++ b/internal/domain/safety_test.go
@@ -10,7 +10,7 @@ import (
 
 func newSeedNeverAuto(t *testing.T) *NeverAutoList {
 	t.Helper()
-	a, errs := NewNeverAutoList(true, nil, nil)
+	a, errs := NewNeverAutoList(true, nil, nil, nil)
 	if len(errs) > 0 {
 		t.Fatalf("seed allowlist failed to compile: %v", errs)
 	}
@@ -71,7 +71,7 @@ func TestNeverAutoDoesNotMatchBenignPrompts(t *testing.T) {
 }
 
 func TestOperatorPatternsExtendSeed(t *testing.T) {
-	a, errs := NewNeverAutoList(true, []string{`(?i)restart\s+the\s+payment\s+service`}, nil)
+	a, errs := NewNeverAutoList(true, nil, []string{`(?i)restart\s+the\s+payment\s+service`}, nil)
 	if len(errs) > 0 {
 		t.Fatalf("compile: %v", errs)
 	}
@@ -90,7 +90,7 @@ func TestOperatorPatternsExtendSeed(t *testing.T) {
 }
 
 func TestDisableSeedRemovesStrictAndHeuristicRules(t *testing.T) {
-	a, errs := NewNeverAutoList(false, []string{`operator-only`}, nil)
+	a, errs := NewNeverAutoList(false, nil, []string{`operator-only`}, nil)
 	if len(errs) > 0 {
 		t.Fatalf("compile: %v", errs)
 	}
@@ -116,11 +116,11 @@ func TestNeverAutoStrictAndHeuristicRegressionMatrix(t *testing.T) {
 	operatorRules := []NeverAutoRule{{
 		Pattern: scopedPattern, AgentTypes: []string{"codex"},
 	}}
-	enabled, errs := NewNeverAutoList(true, []string{operatorPattern}, operatorRules)
+	enabled, errs := NewNeverAutoList(true, nil, []string{operatorPattern}, operatorRules)
 	if len(errs) > 0 {
 		t.Fatalf("compile enabled matcher: %v", errs)
 	}
-	disabled, errs := NewNeverAutoList(false, []string{operatorPattern}, operatorRules)
+	disabled, errs := NewNeverAutoList(false, nil, []string{operatorPattern}, operatorRules)
 	if len(errs) > 0 {
 		t.Fatalf("compile disabled matcher: %v", errs)
 	}
@@ -226,7 +226,7 @@ func TestNeverAutoStrictAndHeuristicRegressionMatrix(t *testing.T) {
 
 func TestUnifiedNeverAutoRulesPreserveMetadataAndScope(t *testing.T) {
 	scopedPattern := `(?i)compact\s+the\s+conversation`
-	a, errs := NewNeverAutoList(true, []string{`operator-global`}, []NeverAutoRule{{
+	a, errs := NewNeverAutoList(true, nil, []string{`operator-global`}, []NeverAutoRule{{
 		Pattern: scopedPattern, AgentTypes: []string{"codex", "agy"},
 	}})
 	if len(errs) > 0 {
@@ -259,7 +259,7 @@ func TestUnifiedNeverAutoRulesPreserveMetadataAndScope(t *testing.T) {
 }
 
 func TestInvalidOperatorPatternReported(t *testing.T) {
-	_, errs := NewNeverAutoList(true, []string{`([unclosed`}, nil)
+	_, errs := NewNeverAutoList(true, nil, []string{`([unclosed`}, nil)
 	if len(errs) == 0 {
 		t.Error("invalid pattern must be reported")
 	}
@@ -360,7 +360,7 @@ func TestSuspectedIrreversibleIgnoresDistantNarration(t *testing.T) {
 func TestEmptyMatchableIndicatorStillFires(t *testing.T) {
 	// A misconfigured operator pattern that can match the empty string must
 	// fire (noisy-safe), not silently disable itself.
-	a, errs := NewNeverAutoList(false, nil, []NeverAutoRule{{
+	a, errs := NewNeverAutoList(false, nil, nil, []NeverAutoRule{{
 		Pattern: `(?i)(drop prod)?`, Kind: NeverAutoHeuristic, Source: NeverAutoOperator,
 	}})
 	if len(errs) > 0 {
@@ -376,7 +376,7 @@ func TestAgentScopedIndicators(t *testing.T) {
 		{Pattern: `(?i)compact\s+the\s+conversation`, AgentTypes: []string{"codex", "agy"}, Kind: NeverAutoHeuristic},
 		{Pattern: `(?i)squash\s+the\s+timeline`, AgentTypes: []string{"*"}, Kind: NeverAutoHeuristic},
 	}
-	a, errs := NewNeverAutoList(false, nil, rules)
+	a, errs := NewNeverAutoList(false, nil, nil, rules)
 	if len(errs) > 0 {
 		t.Fatalf("compile: %v", errs)
 	}
@@ -394,7 +394,7 @@ func TestAgentScopedIndicators(t *testing.T) {
 
 	// Sloppy scope entries fail noisy, not silently dead: a padded "*" is
 	// still a wildcard and a blank entry is treated as one.
-	padded, errs := NewNeverAutoList(false, nil, []NeverAutoRule{
+	padded, errs := NewNeverAutoList(false, nil, nil, []NeverAutoRule{
 		{Pattern: `(?i)compact\s+the\s+conversation`, AgentTypes: []string{" * "}, Kind: NeverAutoHeuristic},
 		{Pattern: `(?i)squash\s+the\s+timeline`, AgentTypes: []string{""}, Kind: NeverAutoHeuristic},
 	})
@@ -599,5 +599,121 @@ func TestCheckRateExemptsIdleHandoutFromConsecutiveCeiling(t *testing.T) {
 	paused := PauseAgent(AgentRate{WindowStart: now})
 	if ok, _ := CheckRate(paused, now, lim, true); ok {
 		t.Error("a paused agent must stay blocked even for an idle hand-out")
+	}
+}
+
+// heuristicSeedPattern is the shipped "no-undo language" heuristic (the one
+// that fires on "unrecoverable"/"irreversible"). Located by content so the
+// test does not hard-code a slice index that could drift.
+func heuristicSeedPattern(t *testing.T) string {
+	t.Helper()
+	for _, r := range SeedHeuristicNeverAutoRules {
+		if strings.Contains(r.Pattern, "unrecoverabl") {
+			return r.Pattern
+		}
+	}
+	t.Fatal("no-undo heuristic seed rule not found")
+	return ""
+}
+
+// strictSeedPattern locates a shipped strict seed pattern by a substring of its
+// regex, keeping tests independent of the seed list's ordering.
+func strictSeedPattern(t *testing.T, substr string) string {
+	t.Helper()
+	for _, p := range SeedNeverAutoPatterns {
+		if strings.Contains(p, substr) {
+			return p
+		}
+	}
+	t.Fatalf("no strict seed pattern containing %q", substr)
+	return ""
+}
+
+func TestDisableSpecificSeedSkipsOnlyThatRule(t *testing.T) {
+	target := heuristicSeedPattern(t)
+	a, errs := NewNeverAutoList(true, []string{target}, nil, nil)
+	if len(errs) > 0 {
+		t.Fatalf("compile: %v", errs)
+	}
+	// The disabled heuristic no longer fires on its own wording...
+	if _, ok := a.SuspectedIrreversible("claude", "This status is unrecoverable"); ok {
+		t.Error("disabled heuristic seed rule must not fire")
+	}
+	// ...but a different heuristic still does (credential revocation)...
+	if _, ok := a.SuspectedIrreversible("claude", "Revoke the API tokens for this account"); !ok {
+		t.Error("an unrelated heuristic seed rule must still fire")
+	}
+	// ...and strict seed rules are untouched.
+	if _, ok := a.Match("claude", "DROP TABLE users"); !ok {
+		t.Error("strict seed rules must stay active when only a heuristic is disabled")
+	}
+	// The disabled rule is gone from the rule set; siblings remain.
+	for _, rule := range a.Rules() {
+		if rule.Pattern == target {
+			t.Fatalf("disabled seed rule still present: %+v", rule)
+		}
+	}
+}
+
+func TestDisableSpecificSeedStrictRule(t *testing.T) {
+	target := strictSeedPattern(t, "DROP")
+	a, errs := NewNeverAutoList(true, []string{target}, nil, nil)
+	if len(errs) > 0 {
+		t.Fatalf("compile: %v", errs)
+	}
+	if _, ok := a.Match("claude", "DROP TABLE users"); ok {
+		t.Error("disabled strict seed rule must not fire")
+	}
+	// A different strict seed rule still fires.
+	if _, ok := a.Match("claude", "TRUNCATE TABLE logs"); !ok {
+		t.Error("an unrelated strict seed rule must still fire")
+	}
+}
+
+func TestSeedNeverAutoRulesOrderAndCount(t *testing.T) {
+	rules := SeedNeverAutoRules()
+	if len(rules) != SeedNeverAutoRuleCount() {
+		t.Fatalf("SeedNeverAutoRules len=%d want %d", len(rules), SeedNeverAutoRuleCount())
+	}
+	strictN := len(SeedNeverAutoPatterns)
+	for i, r := range rules {
+		if r.Source != NeverAutoSeed {
+			t.Errorf("rule #%d source=%q want seed", i, r.Source)
+		}
+		wantKind := NeverAutoStrict
+		if i >= strictN {
+			wantKind = NeverAutoHeuristic
+		}
+		if r.Kind != wantKind {
+			t.Errorf("rule #%d kind=%q want %q", i, r.Kind, wantKind)
+		}
+	}
+}
+
+func TestSeedRuleIndexForRationale(t *testing.T) {
+	a := newSeedNeverAuto(t)
+	hit, ok := a.SuspectedIrreversible("claude", "This action cannot be undone")
+	if !ok {
+		t.Fatal("expected the no-undo heuristic to fire")
+	}
+	idx, ok := SeedRuleIndexForRationale(hit.Diagnostic())
+	if !ok {
+		t.Fatalf("rationale from a seed hit must resolve: %q", hit.Diagnostic())
+	}
+	if got := SeedNeverAutoRules()[idx].Pattern; got != hit.Pattern {
+		t.Errorf("resolved seed #%d pattern=%q want %q", idx, got, hit.Pattern)
+	}
+	// An operator-pattern rationale must not resolve to a seed rule.
+	op, errs := NewNeverAutoList(false, nil, []string{`(?i)operator-only-phrase`}, nil)
+	if len(errs) > 0 {
+		t.Fatalf("compile: %v", errs)
+	}
+	opHit, _ := op.Match("claude", "operator-only-phrase here")
+	if _, ok := SeedRuleIndexForRationale(opHit.Diagnostic()); ok {
+		t.Error("an operator-pattern rationale must not resolve to a seed rule")
+	}
+	// An unrelated rationale must not resolve.
+	if _, ok := SeedRuleIndexForRationale("contradictory history"); ok {
+		t.Error("an unrelated rationale must not resolve to a seed rule")
 	}
 }

--- a/internal/domain/safety_test.go
+++ b/internal/domain/safety_test.go
@@ -690,18 +690,18 @@ func TestSeedNeverAutoRulesOrderAndCount(t *testing.T) {
 	}
 }
 
-func TestSeedRuleIndexForRationale(t *testing.T) {
+func TestSeedRuleForRationale(t *testing.T) {
 	a := newSeedNeverAuto(t)
 	hit, ok := a.SuspectedIrreversible("claude", "This action cannot be undone")
 	if !ok {
 		t.Fatal("expected the no-undo heuristic to fire")
 	}
-	idx, ok := SeedRuleIndexForRationale(hit.Diagnostic())
+	rule, ok := SeedRuleForRationale(hit.Diagnostic())
 	if !ok {
 		t.Fatalf("rationale from a seed hit must resolve: %q", hit.Diagnostic())
 	}
-	if got := SeedNeverAutoRules()[idx].Pattern; got != hit.Pattern {
-		t.Errorf("resolved seed #%d pattern=%q want %q", idx, got, hit.Pattern)
+	if rule.Pattern != hit.Pattern {
+		t.Errorf("resolved pattern=%q want %q", rule.Pattern, hit.Pattern)
 	}
 	// An operator-pattern rationale must not resolve to a seed rule.
 	op, errs := NewNeverAutoList(false, nil, []string{`(?i)operator-only-phrase`}, nil)
@@ -709,11 +709,67 @@ func TestSeedRuleIndexForRationale(t *testing.T) {
 		t.Fatalf("compile: %v", errs)
 	}
 	opHit, _ := op.Match("claude", "operator-only-phrase here")
-	if _, ok := SeedRuleIndexForRationale(opHit.Diagnostic()); ok {
+	if _, ok := SeedRuleForRationale(opHit.Diagnostic()); ok {
 		t.Error("an operator-pattern rationale must not resolve to a seed rule")
 	}
 	// An unrelated rationale must not resolve.
-	if _, ok := SeedRuleIndexForRationale("contradictory history"); ok {
+	if _, ok := SeedRuleForRationale("contradictory history"); ok {
 		t.Error("an unrelated rationale must not resolve to a seed rule")
+	}
+}
+
+// TestSeedRuleForRationaleRejectsOperatorDuplicateOfSeed is the regression for
+// review comment #2: an operator rule whose pattern text is byte-identical to a
+// shipped seed rule renders "source=operator" in its diagnostic, and the source
+// check must keep it from resolving to a builtin — otherwise the CLI would tell
+// the operator to disable a seed while their own rule is the one firing.
+func TestSeedRuleForRationaleRejectsOperatorDuplicateOfSeed(t *testing.T) {
+	seedPattern := strictSeedPattern(t, "DROP")
+	// Seeds disabled so ONLY the operator copy of the pattern is active.
+	a, errs := NewNeverAutoList(false, nil, []string{seedPattern}, nil)
+	if len(errs) > 0 {
+		t.Fatalf("compile: %v", errs)
+	}
+	hit, ok := a.Match("claude", "DROP TABLE users")
+	if !ok {
+		t.Fatal("operator copy of the seed pattern must still fire")
+	}
+	if hit.Source != NeverAutoOperator {
+		t.Fatalf("expected operator source, got %q", hit.Source)
+	}
+	if _, ok := SeedRuleForRationale(hit.Diagnostic()); ok {
+		t.Error("an operator rule duplicating a seed pattern must not resolve to the seed")
+	}
+}
+
+// TestSeedRuleIDIsDurableAcrossOrdering is the regression for review comment #1:
+// the disable/enable id is a content hash, so it round-trips to the same rule
+// regardless of position, and an unknown id resolves to nothing rather than to
+// whatever rule sits at some index.
+func TestSeedRuleIDIsDurableAcrossOrdering(t *testing.T) {
+	seeds := SeedNeverAutoRules()
+	seen := make(map[string]bool, len(seeds))
+	for _, r := range seeds {
+		id := SeedRuleID(r.Pattern)
+		if seen[id] {
+			t.Fatalf("seed rule id collision at %q", id)
+		}
+		seen[id] = true
+		got, ok := SeedRuleByID(id)
+		if !ok || got.Pattern != r.Pattern {
+			t.Errorf("id %q must resolve back to its own pattern, got ok=%v pattern=%q", id, ok, got.Pattern)
+		}
+	}
+	// An id whose pattern does not ship (e.g. copied from an older version) is
+	// rejected, never silently mapped onto a positional neighbor.
+	if _, ok := SeedRuleByID("deadbeef"); ok {
+		t.Error("an unknown seed id must not resolve")
+	}
+	// IsSeedPattern gates the disable path.
+	if !IsSeedPattern(seeds[0].Pattern) {
+		t.Error("a shipped pattern must be recognized as a seed pattern")
+	}
+	if IsSeedPattern("(?i)operator-only") {
+		t.Error("an operator pattern must not be recognized as a seed pattern")
 	}
 }

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -2365,9 +2365,9 @@ func JoinCommand(argv []string) string {
 // listed by `rules list` / the TUI). expected is the pattern text the caller
 // believes is at that index: removal is refused on mismatch, so a listing
 // gone stale (another front-end edited in between) can never silently delete
-// the wrong never-auto pattern. Seed patterns cannot be removed here;
-// disabling the seed requires the explicit
-// safety.disable_never_auto_seed_patterns TOML edit.
+// the wrong never-auto pattern. Seed patterns are not deleted here — they are
+// shipped constants; disable one individually with DisableSeedRule, or drop
+// them all with safety.disable_never_auto_seed_patterns.
 func (a *App) RemoveNeverAutoPattern(ctx context.Context, index int, expected string) error {
 	return a.UpdateConfig(ctx, func(cfg *config.Config) error {
 		if index < 0 || index >= len(cfg.Safety.NeverAutoPatterns) {
@@ -2380,6 +2380,80 @@ func (a *App) RemoveNeverAutoPattern(ctx context.Context, index int, expected st
 			cfg.Safety.NeverAutoPatterns[:index], cfg.Safety.NeverAutoPatterns[index+1:]...)
 		return nil
 	})
+}
+
+// SeedRuleDisabled reports whether a shipped seed pattern has been disabled
+// individually via safety.disabled_seed_patterns, for list rendering.
+func (a *App) SeedRuleDisabled(pattern string) bool {
+	cfg, err := a.Config()
+	if err != nil {
+		return false
+	}
+	for _, p := range cfg.Safety.DisabledSeedPatterns {
+		if p == pattern {
+			return true
+		}
+	}
+	return false
+}
+
+// DisableSeedRule silences one shipped seed never-auto rule (strict or
+// heuristic) permanently, keeping every other seed rule active. index is the
+// rule's position in domain.SeedNeverAutoRules (as listed by `rules list`) and
+// expected is the pattern text the caller saw there: the edit is refused on
+// mismatch so a stale listing can never disable the wrong rule. The rule is
+// recorded by its pattern string (not its index), so the setting survives a
+// seed-list reordering across versions. Disabling an already-disabled rule is a
+// no-op.
+func (a *App) DisableSeedRule(ctx context.Context, index int, expected string) error {
+	return a.UpdateConfig(ctx, func(cfg *config.Config) error {
+		pattern, err := seedPatternAt(index, expected)
+		if err != nil {
+			return err
+		}
+		for _, p := range cfg.Safety.DisabledSeedPatterns {
+			if p == pattern {
+				return nil // already disabled
+			}
+		}
+		cfg.Safety.DisabledSeedPatterns = append(cfg.Safety.DisabledSeedPatterns, pattern)
+		return nil
+	})
+}
+
+// EnableSeedRule re-enables a seed rule previously disabled with
+// DisableSeedRule. index/expected identify the rule the same way. Re-enabling a
+// rule that is not disabled is a no-op.
+func (a *App) EnableSeedRule(ctx context.Context, index int, expected string) error {
+	return a.UpdateConfig(ctx, func(cfg *config.Config) error {
+		pattern, err := seedPatternAt(index, expected)
+		if err != nil {
+			return err
+		}
+		kept := cfg.Safety.DisabledSeedPatterns[:0]
+		for _, p := range cfg.Safety.DisabledSeedPatterns {
+			if p != pattern {
+				kept = append(kept, p)
+			}
+		}
+		cfg.Safety.DisabledSeedPatterns = kept
+		return nil
+	})
+}
+
+// seedPatternAt resolves a seed-rule index to its pattern, refusing the edit if
+// the index is out of range or the pattern at that position no longer matches
+// what the caller listed (the same stale-listing guard RemoveNeverAutoPattern
+// uses).
+func seedPatternAt(index int, expected string) (string, error) {
+	seeds := domain.SeedNeverAutoRules()
+	if index < 0 || index >= len(seeds) {
+		return "", fmt.Errorf("no seed rule #%d", index)
+	}
+	if got := seeds[index].Pattern; got != expected {
+		return "", fmt.Errorf("seed rule #%d changed since it was listed (now %q); re-list and retry", index, got)
+	}
+	return seeds[index].Pattern, nil
 }
 
 // RemoveTaskSource deletes a task source by index. expected is the entry the
@@ -2477,7 +2551,7 @@ func (a *App) SetThreshold(ctx context.Context, situation string, value float64)
 
 // AddNeverAutoPattern appends a never-auto pattern (FR-016) and reloads.
 func (a *App) AddNeverAutoPattern(ctx context.Context, pattern string) error {
-	if _, errs := domain.NewNeverAutoList(false, []string{pattern}, nil); len(errs) > 0 {
+	if _, errs := domain.NewNeverAutoList(false, nil, []string{pattern}, nil); len(errs) > 0 {
 		return fmt.Errorf("invalid pattern: %v", errs[0])
 	}
 	return a.UpdateConfig(ctx, func(cfg *config.Config) error {

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -2398,19 +2398,17 @@ func (a *App) SeedRuleDisabled(pattern string) bool {
 }
 
 // DisableSeedRule silences one shipped seed never-auto rule (strict or
-// heuristic) permanently, keeping every other seed rule active. index is the
-// rule's position in domain.SeedNeverAutoRules (as listed by `rules list`) and
-// expected is the pattern text the caller saw there: the edit is refused on
-// mismatch so a stale listing can never disable the wrong rule. The rule is
-// recorded by its pattern string (not its index), so the setting survives a
-// seed-list reordering across versions. Disabling an already-disabled rule is a
-// no-op.
-func (a *App) DisableSeedRule(ctx context.Context, index int, expected string) error {
+// heuristic) permanently, keeping every other seed rule active. The rule is
+// named by its exact pattern (resolved from a durable domain.SeedRuleID by the
+// caller); a pattern that is not a shipped seed rule is refused, so a stale or
+// bogus identifier can never write an arbitrary string into the disable list.
+// The pattern is what gets recorded, so the setting survives a seed-list
+// reordering across versions. Disabling an already-disabled rule is a no-op.
+func (a *App) DisableSeedRule(ctx context.Context, pattern string) error {
+	if !domain.IsSeedPattern(pattern) {
+		return fmt.Errorf("%q is not a shipped seed rule", pattern)
+	}
 	return a.UpdateConfig(ctx, func(cfg *config.Config) error {
-		pattern, err := seedPatternAt(index, expected)
-		if err != nil {
-			return err
-		}
 		for _, p := range cfg.Safety.DisabledSeedPatterns {
 			if p == pattern {
 				return nil // already disabled
@@ -2422,14 +2420,10 @@ func (a *App) DisableSeedRule(ctx context.Context, index int, expected string) e
 }
 
 // EnableSeedRule re-enables a seed rule previously disabled with
-// DisableSeedRule. index/expected identify the rule the same way. Re-enabling a
-// rule that is not disabled is a no-op.
-func (a *App) EnableSeedRule(ctx context.Context, index int, expected string) error {
+// DisableSeedRule, named by the same exact pattern. Re-enabling a rule that is
+// not disabled is a no-op.
+func (a *App) EnableSeedRule(ctx context.Context, pattern string) error {
 	return a.UpdateConfig(ctx, func(cfg *config.Config) error {
-		pattern, err := seedPatternAt(index, expected)
-		if err != nil {
-			return err
-		}
 		kept := cfg.Safety.DisabledSeedPatterns[:0]
 		for _, p := range cfg.Safety.DisabledSeedPatterns {
 			if p != pattern {
@@ -2439,21 +2433,6 @@ func (a *App) EnableSeedRule(ctx context.Context, index int, expected string) er
 		cfg.Safety.DisabledSeedPatterns = kept
 		return nil
 	})
-}
-
-// seedPatternAt resolves a seed-rule index to its pattern, refusing the edit if
-// the index is out of range or the pattern at that position no longer matches
-// what the caller listed (the same stale-listing guard RemoveNeverAutoPattern
-// uses).
-func seedPatternAt(index int, expected string) (string, error) {
-	seeds := domain.SeedNeverAutoRules()
-	if index < 0 || index >= len(seeds) {
-		return "", fmt.Errorf("no seed rule #%d", index)
-	}
-	if got := seeds[index].Pattern; got != expected {
-		return "", fmt.Errorf("seed rule #%d changed since it was listed (now %q); re-list and retry", index, got)
-	}
-	return seeds[index].Pattern, nil
 }
 
 // RemoveTaskSource deletes a task source by index. expected is the entry the

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -2078,27 +2078,26 @@ func TestDisableAndEnableSeedRule(t *testing.T) {
 	// Pick the no-undo heuristic — the one that over-fires on words like
 	// "unrecoverable" — by locating it in the shipped seed list.
 	seeds := domain.SeedNeverAutoRules()
-	idx := -1
-	for i, r := range seeds {
+	pattern := ""
+	for _, r := range seeds {
 		if strings.Contains(r.Pattern, "unrecoverabl") {
-			idx = i
+			pattern = r.Pattern
 			break
 		}
 	}
-	if idx < 0 {
+	if pattern == "" {
 		t.Fatal("no-undo heuristic seed rule not found")
 	}
-	pattern := seeds[idx].Pattern
 
 	if !seedMatcherFires(t, app, "This action cannot be undone") {
 		t.Fatal("heuristic must fire before it is disabled")
 	}
 
-	if err := app.DisableSeedRule(ctx, idx, pattern); err != nil {
+	if err := app.DisableSeedRule(ctx, pattern); err != nil {
 		t.Fatal(err)
 	}
 	// Disabling again is a no-op, not a duplicate.
-	if err := app.DisableSeedRule(ctx, idx, pattern); err != nil {
+	if err := app.DisableSeedRule(ctx, pattern); err != nil {
 		t.Fatal(err)
 	}
 	cfg, _ := app.Config()
@@ -2113,15 +2112,13 @@ func TestDisableAndEnableSeedRule(t *testing.T) {
 		t.Error("disabling one seed rule must not disable the others")
 	}
 
-	// A stale expectation must refuse to change the wrong rule.
-	if err := app.DisableSeedRule(ctx, idx, "not-the-pattern"); err == nil {
-		t.Error("mismatched expected pattern must refuse")
-	}
-	if err := app.EnableSeedRule(ctx, 99999, pattern); err == nil {
-		t.Error("out-of-range seed index must error")
+	// A pattern that is not a shipped seed rule must be refused, so a bogus id
+	// can never write an arbitrary string into the disable list.
+	if err := app.DisableSeedRule(ctx, "not-a-seed-pattern"); err == nil {
+		t.Error("a non-seed pattern must be refused")
 	}
 
-	if err := app.EnableSeedRule(ctx, idx, pattern); err != nil {
+	if err := app.EnableSeedRule(ctx, pattern); err != nil {
 		t.Fatal(err)
 	}
 	cfg, _ = app.Config()
@@ -2761,12 +2758,12 @@ func TestCLIParityWithSharedLayer(t *testing.T) {
 	if out := run("kill-history"); !strings.Contains(out, "active") {
 		t.Errorf("kill history output: %q", out)
 	}
-	if out := run("rules", "list"); !strings.Contains(out, "seed #0\tstrict") || !strings.Contains(out, "\theuristic\t") {
+	if out := run("rules", "list"); !strings.Contains(out, "\tstrict\t") || !strings.Contains(out, "\theuristic\t") {
 		t.Errorf("rules output: %q", out)
 	}
 	run("config", "set", "safety.disable_never_auto_seed_patterns", "true")
 	if out := run("rules", "list"); !strings.Contains(out, "shipped never-auto rules disabled") ||
-		strings.Contains(out, "seed #0\tstrict") || strings.Contains(out, "\theuristic\t") {
+		strings.Contains(out, "\tstrict\t") || strings.Contains(out, "\theuristic\t") {
 		t.Errorf("disabled rules output: %q", out)
 	}
 

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -2051,6 +2051,88 @@ func TestAddNeverAutoPatternValidates(t *testing.T) {
 	}
 }
 
+// seedMatcherFires rebuilds the never-auto matcher the daemon would build from
+// the app's current config and reports whether content still trips a rule.
+func seedMatcherFires(t *testing.T, app *frontend.App, content string) bool {
+	t.Helper()
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, errs := domain.NewNeverAutoList(!cfg.Safety.DisableNeverAutoSeedPatterns,
+		cfg.Safety.DisabledSeedPatterns, cfg.Safety.NeverAutoPatterns, nil)
+	if len(errs) > 0 {
+		t.Fatalf("matcher compile: %v", errs)
+	}
+	_, matched := list.Match("claude", content)
+	if !matched {
+		_, matched = list.SuspectedIrreversible("claude", content)
+	}
+	return matched
+}
+
+func TestDisableAndEnableSeedRule(t *testing.T) {
+	app, _ := testApp(t)
+	ctx := context.Background()
+
+	// Pick the no-undo heuristic — the one that over-fires on words like
+	// "unrecoverable" — by locating it in the shipped seed list.
+	seeds := domain.SeedNeverAutoRules()
+	idx := -1
+	for i, r := range seeds {
+		if strings.Contains(r.Pattern, "unrecoverabl") {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatal("no-undo heuristic seed rule not found")
+	}
+	pattern := seeds[idx].Pattern
+
+	if !seedMatcherFires(t, app, "This action cannot be undone") {
+		t.Fatal("heuristic must fire before it is disabled")
+	}
+
+	if err := app.DisableSeedRule(ctx, idx, pattern); err != nil {
+		t.Fatal(err)
+	}
+	// Disabling again is a no-op, not a duplicate.
+	if err := app.DisableSeedRule(ctx, idx, pattern); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ := app.Config()
+	if len(cfg.Safety.DisabledSeedPatterns) != 1 || cfg.Safety.DisabledSeedPatterns[0] != pattern {
+		t.Fatalf("disabled set wrong: %v", cfg.Safety.DisabledSeedPatterns)
+	}
+	if seedMatcherFires(t, app, "This action cannot be undone") {
+		t.Error("disabled heuristic must not fire")
+	}
+	// Sibling rules stay active.
+	if !seedMatcherFires(t, app, "DROP TABLE users") {
+		t.Error("disabling one seed rule must not disable the others")
+	}
+
+	// A stale expectation must refuse to change the wrong rule.
+	if err := app.DisableSeedRule(ctx, idx, "not-the-pattern"); err == nil {
+		t.Error("mismatched expected pattern must refuse")
+	}
+	if err := app.EnableSeedRule(ctx, 99999, pattern); err == nil {
+		t.Error("out-of-range seed index must error")
+	}
+
+	if err := app.EnableSeedRule(ctx, idx, pattern); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ = app.Config()
+	if len(cfg.Safety.DisabledSeedPatterns) != 0 {
+		t.Errorf("re-enable must clear the disabled entry: %v", cfg.Safety.DisabledSeedPatterns)
+	}
+	if !seedMatcherFires(t, app, "This action cannot be undone") {
+		t.Error("re-enabled heuristic must fire again")
+	}
+}
+
 func TestSetFieldValidatesAndPersists(t *testing.T) {
 	app, _ := testApp(t)
 	ctx := context.Background()
@@ -2679,12 +2761,12 @@ func TestCLIParityWithSharedLayer(t *testing.T) {
 	if out := run("kill-history"); !strings.Contains(out, "active") {
 		t.Errorf("kill history output: %q", out)
 	}
-	if out := run("rules", "list"); !strings.Contains(out, "seed strict") || !strings.Contains(out, "seed heuristic") {
+	if out := run("rules", "list"); !strings.Contains(out, "seed #0\tstrict") || !strings.Contains(out, "\theuristic\t") {
 		t.Errorf("rules output: %q", out)
 	}
 	run("config", "set", "safety.disable_never_auto_seed_patterns", "true")
 	if out := run("rules", "list"); !strings.Contains(out, "shipped never-auto rules disabled") ||
-		strings.Contains(out, "seed strict") || strings.Contains(out, "seed heuristic") {
+		strings.Contains(out, "seed #0\tstrict") || strings.Contains(out, "\theuristic\t") {
 		t.Errorf("disabled rules output: %q", out)
 	}
 


### PR DESCRIPTION
## Problem

A blocked action that trips a shipped (**seed**) never-auto rule always escalates. The only way to silence a builtin rule was the all-or-nothing `safety.disable_never_auto_seed_patterns`, which drops **every** shipped rule. That's too coarse for a repo where a heuristic over-fires on legitimate wording — e.g. the suspected-irreversible heuristic firing on `unrecoverable` when it's a valid data-model status:

```
[suspected_irreversible] pattern (?i)\birreversibl[ey]\b|\bunrecoverabl[ey]\b|... matched "unrecoverable" (source=seed kind=heuristic)
```

## What this adds

Per-rule disabling of a single builtin seed rule, keeping the rest of the safety net:

- **config** — `safety.disabled_seed_patterns`, keyed by the exact pattern string so the setting survives seed-list reordering across versions.
- **domain** — `NewNeverAutoList` skips disabled seed patterns (operator rules are never filtered); new `SeedNeverAutoRules()` and `SeedRuleIndexForRationale()` helpers.
- **frontend** — `DisableSeedRule` / `EnableSeedRule` with an index + `expected` stale-listing guard (mirrors `RemoveNeverAutoPattern`); `SeedRuleDisabled` for rendering.
- **cli** — `hap rules list` numbers seed rules (`seed #<id>`) and marks disabled ones; new `hap rules disable-seed <id>` / `enable-seed <id>`; the `hap escalations` footer suggests the exact `disable-seed <id>` command when a builtin seed rule caused the escalation.

The escalation → rule mapping keys off the stable `Diagnostic()` rendering, so it's self-selecting (operator patterns and non-safety escalations never resolve) and needs **no store/schema change**.

## Safety

The disable only ever removes the one intended seed rule — operator rules and other seeds are untouched. Invariant tests cover single-rule isolation, the self-selecting escalation mapping (operator/unrelated rationales don't resolve), the stale-listing guard, and idempotent disable/enable.

## Testing

- New unit tests in `internal/domain`, `internal/config`, `internal/frontend`, `internal/cli`.
- Full tagged suite green: `go test -tags "vectors cpu" ./internal/{domain,config,frontend,cli,daemon}/ -count=1`.
- `gofmt`, `go vet`, and `golangci-lint` (vectors,cpu) clean.

Usage:
```sh
hap rules list                 # seed rules now numbered; disabled ones marked
hap rules disable-seed <id>    # silence one over-aggressive builtin rule
hap rules enable-seed <id>     # restore it
```