### PR TITLE
#1 feat: show a task's folded nested detail in every listing and confirm

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1448,8 +1448,9 @@ func task(ctx context.Context, app *frontend.App, out io.Writer, args []string) 
 	// op-specific output above already said what changed. `list` gets the
 	// shorter set: it has just printed domain.TaskManagementHints, which
 	// already covers start/done and how <n> is addressed.
-	// `list` has just printed domain.TaskManagementHints, and `get`/`show` print
-	// a single line a script may capture: both get the short footer.
+	// `list` has just printed domain.TaskManagementHints, and `get`/`show` lead
+	// with a single line a script may capture (its nested detail lines follow):
+	// both get the short footer.
 	listing := len(rest) > 0 && (rest[0] == "list" || rest[0] == "ls" ||
 		rest[0] == "get" || rest[0] == "show")
 	PrintNextSteps(out, taskHints(agent, path, listing))
@@ -1508,6 +1509,15 @@ func taskOp(ctx context.Context, app *frontend.App, out io.Writer, agent, path s
 			return err
 		}
 		fmt.Fprintln(out, formatTask(it))
+		// `get` is the detail view, so it prints the task WHOLE — the nested
+		// sub-items (acceptance criteria, dependencies, notes) that ride along
+		// to the agent in the delivered prompt. `list` only marks that they
+		// exist; this is where you read them. Stored literal `\n` sequences
+		// become real breaks, as the delivery path and the TUI overlay both
+		// render them — otherwise the three would disagree about one task.
+		for _, line := range it.Detail {
+			fmt.Fprintln(out, domain.DecodeTaskNewlines(line))
+		}
 		return nil
 	case "add", "create":
 		text := strings.TrimSpace(strings.Join(rest, " "))
@@ -1639,7 +1649,12 @@ func taskSend(ctx context.Context, app *frontend.App, out io.Writer, agent, path
 		if stdin == os.Stdin && !stdinIsTTY() {
 			return fmt.Errorf("confirmation needs a terminal; rerun as: task %s send %d --yes", agent, idx)
 		}
-		fmt.Fprintf(out, "send task #%d (%s) to %s? [y/N] ", idx, oneLineText(domain.DisplayTaskText(it.Text), 60), agent)
+		// The marker rides along: what gets delivered is the FOLDED task, so a
+		// prompt showing only the title would take a "y" for something larger
+		// than it displayed. This is the one moment the operator authorizes the
+		// send, so it is the last place the count may be omitted.
+		fmt.Fprintf(out, "send task #%d (%s%s) to %s? [y/N] ", idx,
+			oneLineText(domain.DisplayTaskText(it.Text), 60), detailMarker(it), agent)
 		answer := ""
 		if _, err := fmt.Fscanln(stdin, &answer); err != nil {
 			answer = "" // EOF or a bare newline both read as the default No
@@ -1799,6 +1814,22 @@ func formatTask(it domain.ChecklistItem) string {
 	return fmt.Sprintf("#%d\t[%s]\t%s", it.Index, it.Mark, domain.DisplayTaskText(it.Text))
 }
 
+// detailMarker labels an item that carries nested sub-items, so a one-line
+// listing never reads as if the title were the whole task. The count is what
+// `get` prints in full and what the delivered prompt folds in; a flat item gets
+// nothing. Only the LISTING appends it — `get` prints the lines themselves, so
+// announcing them there would be noise.
+func detailMarker(it domain.ChecklistItem) string {
+	n := len(it.Detail)
+	if n == 0 {
+		return ""
+	}
+	if n == 1 {
+		return " (+1 detail line)"
+	}
+	return fmt.Sprintf(" (+%d detail lines)", n)
+}
+
 // printTaskList prints items matching the status filter, numbered by absolute
 // file position (the number never depends on the filter), then a count summary.
 func printTaskList(out io.Writer, items []domain.ChecklistItem, status string) {
@@ -1818,7 +1849,7 @@ func printTaskList(out io.Writer, items []domain.ChecklistItem, status string) {
 		if status == "done" && !it.Done {
 			continue
 		}
-		fmt.Fprintln(out, formatTask(it))
+		fmt.Fprintln(out, formatTask(it)+detailMarker(it))
 		shown++
 	}
 	if shown == 0 {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1246,6 +1246,63 @@ func TestTaskListStatusFilterPreservesNumbers(t *testing.T) {
 	}
 }
 
+// TestTaskListMarksNestedDetailAndGetPrintsIt pins the display half of task
+// folding: a task's nested sub-items ride along to the agent in the delivered
+// prompt, so a listing that showed only the title read as if the title WERE the
+// whole task. `list` now counts them and `get` prints them.
+func TestTaskListMarksNestedDetailAndGetPrintsIt(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] build the widget\n"+
+		"  - wire the API\n"+
+		"  - Acceptance Criteria:\n"+
+		"    - it renders\n"+
+		"- [ ] flat task\n")
+
+	out, err := run(t, app, "task", "--path", path, "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "#1\t[ ]\tbuild the widget (+3 detail lines)") {
+		t.Errorf("list must mark the nested detail, got:\n%s", out)
+	}
+	// A flat task gets no marker — the count would be a lie and the noise
+	// would train operators to ignore it.
+	if !strings.Contains(out, "#2\t[ ]\tflat task\n") {
+		t.Errorf("a flat task must carry no detail marker, got:\n%s", out)
+	}
+	// The list stays one row per task: the detail is counted, never inlined.
+	if strings.Contains(out, "wire the API") {
+		t.Errorf("list must not inline the detail lines, got:\n%s", out)
+	}
+
+	out, err = run(t, app, "task", "--path", path, "get", "#1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"build the widget", "  - wire the API",
+		"  - Acceptance Criteria:", "    - it renders"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("get must print the nested detail line %q, got:\n%s", want, out)
+		}
+	}
+	// get prints the lines, so it must not also announce them, and it must not
+	// bleed the sibling task in.
+	if strings.Contains(out, "detail lines)") {
+		t.Errorf("get prints the detail, so it must not also count it:\n%s", out)
+	}
+	if strings.Contains(out, "flat task") {
+		t.Errorf("get #1 leaked the sibling task:\n%s", out)
+	}
+
+	out, err = run(t, app, "task", "--path", path, "get", "#2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "wire the API") {
+		t.Errorf("get on a flat task must print no detail, got:\n%s", out)
+	}
+}
+
 // TestTaskInProgressMarkerFaithful pins that an in-progress "[-]" item (what
 // this codebase's generated-task flow writes for the active task) renders as
 // "[-]", not "[x]", and is treated as not-pending by the filters.

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -626,6 +626,8 @@ func buildCommands() {
 				"(quote it — a bare #3 is a shell comment). Every mutating op reprints the list.\n" +
 				"Aliases: ls, show, create, wip, check, uncheck/reopen, edit, rm/delete.\n" +
 				"Marks: [ ] pending, [-] in progress, [x] done.\n" +
+				"`list` marks a task carrying nested sub-items with `(+N detail lines)`; `get`\n" +
+				"prints them — they are folded into the prompt the agent receives.\n" +
 				"`send` hands a pending item to a live, cleanly idle agent NOW and marks it [-];\n" +
 				"idleness is re-checked at delivery, and a failed send returns the item to [ ].\n" +
 				"Normally you do not need `send`: the daemon hands out the next task by itself.",

--- a/internal/cli/task_send_test.go
+++ b/internal/cli/task_send_test.go
@@ -119,6 +119,41 @@ func TestTaskSendConfirmation(t *testing.T) {
 	}
 }
 
+// TestTaskSendConfirmationCountsNestedDetail pins that the y/N prompt names the
+// nested sub-items that will be delivered with the task. The send folds them
+// into the outbound prompt, so a confirmation showing only the title would take
+// a "y" for more than it displayed.
+func TestTaskSendConfirmationCountsNestedDetail(t *testing.T) {
+	app, h, path := sendTestApp(t, "idle")
+	if err := os.WriteFile(path, []byte("- [ ] alpha\n  - wire it\n  - test it\n- [ ] flat\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := stdin
+	t.Cleanup(func() { stdin = old })
+
+	stdin = strings.NewReader("n\n")
+	out, err := runSend(t, app, "w1:p1", "send", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "(alpha (+2 detail lines)) to w1:p1? [y/N]") {
+		t.Errorf("confirmation must count the detail that rides along, got %q", out)
+	}
+	// A flat task's prompt stays clean — a "(+0)" would be noise that trains
+	// operators to stop reading the marker.
+	stdin = strings.NewReader("n\n")
+	out, err = runSend(t, app, "w1:p1", "send", "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "(flat) to w1:p1? [y/N]") {
+		t.Errorf("a flat task needs no marker, got %q", out)
+	}
+	if len(h.sent) != 0 {
+		t.Errorf("both sends were declined, got %v", h.sent)
+	}
+}
+
 func TestOneLineTextRuneSafe(t *testing.T) {
 	got := oneLineText(strings.Repeat("계획", 40), 10)
 	if r := []rune(got); len(r) != 10 || !strings.HasSuffix(got, "…") {

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -258,7 +258,7 @@ func FoldTaskContent(content, taskText string) string {
 		if m == nil || m[2] != " " || strings.TrimSpace(m[3]) != taskText {
 			continue
 		}
-		return foldItemAt(lines, i, taskText)
+		return FoldedTaskText(taskText, nestedContinuationLines(lines, i))
 	}
 	return taskText
 }
@@ -278,21 +278,23 @@ func FoldTaskContentAt(content string, index int) string {
 		}
 		count++
 		if count == index {
-			return foldItemAt(lines, i, strings.TrimSpace(m[3]))
+			return FoldedTaskText(strings.TrimSpace(m[3]), nestedContinuationLines(lines, i))
 		}
 	}
 	return ""
 }
 
-// foldItemAt returns itemText followed by the nested continuation lines of the
-// checklist item at lines[i] (verbatim, newline-joined), or itemText alone when
-// it has none.
-func foldItemAt(lines []string, i int, itemText string) string {
-	nested := nestedContinuationLines(lines, i)
-	if len(nested) == 0 {
+// FoldedTaskText joins an item's own text with its nested detail lines
+// (verbatim, newline-separated), or returns itemText alone when there is no
+// detail. It is the single renderer of the folded body, so what the delivery
+// path sends and what a listing or detail view SHOWS can never drift apart —
+// the reason the display paths take ChecklistItem.Detail rather than re-deriving
+// the fold themselves.
+func FoldedTaskText(itemText string, detail []string) string {
+	if len(detail) == 0 {
 		return itemText
 	}
-	return itemText + "\n" + strings.Join(nested, "\n")
+	return itemText + "\n" + strings.Join(detail, "\n")
 }
 
 // nestedContinuationLines collects the lines that belong to the checklist item
@@ -318,6 +320,12 @@ func nestedContinuationLines(lines []string, i int) []string {
 	}
 	for len(out) > 0 && strings.TrimSpace(out[len(out)-1]) == "" {
 		out = out[:len(out)-1]
+	}
+	// Normalize an all-blank run back to nil: this is stored on every parsed
+	// item, and "no detail" must be one value, not nil-or-empty depending on
+	// whether blank lines happened to follow the item.
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }
@@ -384,14 +392,25 @@ type ChecklistItem struct {
 	Mark string
 	Done bool
 	Text string
+	// Detail is the item's nested continuation lines, verbatim and in file
+	// order — the sub-bullets, acceptance criteria, dependencies and notes an
+	// operator writes UNDER a "- [ ]" title. It is exactly what the delivery
+	// path folds into the outbound prompt (FoldTaskContent), carried on the
+	// parsed item so a listing or detail view can show the task the agent will
+	// actually receive instead of re-deriving the fold. Nil for a flat item.
+	//
+	// Text stays the single physical line — the reservation identity — so
+	// nothing that keys off an item's text is affected by this field.
+	Detail []string
 }
 
 // ParseChecklist returns every checklist item in content, in file order,
 // numbered from 1. Non-item lines (headers, prose, blanks) are skipped for
 // numbering and left untouched by the mutation helpers below.
 func ParseChecklist(content string) []ChecklistItem {
+	lines := strings.Split(content, "\n")
 	var items []ChecklistItem
-	for lineNo, line := range strings.Split(content, "\n") {
+	for lineNo, line := range lines {
 		m := checklistItemRE.FindStringSubmatch(line)
 		if m == nil {
 			continue
@@ -403,6 +422,10 @@ func ParseChecklist(content string) []ChecklistItem {
 			Mark:   m[2],
 			Done:   m[2] != " ",
 			Text:   strings.TrimSpace(m[3]),
+			// The same lines FoldTaskContent delivers, resolved here once so
+			// every reader (TUI rows and detail overlay, `hap task list`/`get`)
+			// shows the folded task without re-parsing the file.
+			Detail: nestedContinuationLines(lines, lineNo),
 		})
 	}
 	return items

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -449,9 +450,44 @@ func TestParseChecklist(t *testing.T) {
 		t.Fatalf("ParseChecklist returned %d items, want %d: %+v", len(items), len(want), items)
 	}
 	for i := range want {
-		if items[i] != want[i] {
+		if !reflect.DeepEqual(items[i], want[i]) {
 			t.Errorf("item %d = %+v, want %+v", i, items[i], want[i])
 		}
+	}
+}
+
+// TestParseChecklistCarriesNestedDetail pins that a parsed item carries the
+// SAME nested lines the delivery path folds in — the listing and detail views
+// read Detail, so a drift here would put different text on screen than the
+// agent receives.
+func TestParseChecklistCarriesNestedDetail(t *testing.T) {
+	content := "- [ ] 1. Build the widget\n" +
+		"  - Wire the API\n" +
+		"  - Acceptance Criteria:\n" +
+		"    - it renders\n" +
+		"  - _Complexity: Medium_\n" +
+		"- [ ] 2. Flat task\n"
+	items := ParseChecklist(content)
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2", len(items))
+	}
+	wantDetail := []string{"  - Wire the API", "  - Acceptance Criteria:",
+		"    - it renders", "  - _Complexity: Medium_"}
+	if !reflect.DeepEqual(items[0].Detail, wantDetail) {
+		t.Errorf("Detail = %q, want %q", items[0].Detail, wantDetail)
+	}
+	if items[1].Detail != nil {
+		t.Errorf("a flat item must carry no detail, got %q", items[1].Detail)
+	}
+	// The folded rendering is byte-identical to what the send path delivers —
+	// the invariant that lets a display path render from Detail instead of
+	// re-folding the file.
+	if got, want := FoldedTaskText(items[0].Text, items[0].Detail),
+		FoldTaskContent(content, items[0].Text); got != want {
+		t.Errorf("FoldedTaskText = %q, want the delivered fold %q", got, want)
+	}
+	if got := FoldedTaskText(items[1].Text, items[1].Detail); got != items[1].Text {
+		t.Errorf("flat item folds to %q, want %q", got, items[1].Text)
 	}
 }
 

--- a/internal/tui/tasks_test.go
+++ b/internal/tui/tasks_test.go
@@ -665,6 +665,114 @@ func TestTaskDetailViewOpensAndCloses(t *testing.T) {
 	}
 }
 
+// TestTaskRowCountsNestedDetailAndDetailShowsIt pins the display half of task
+// folding: a task's nested sub-items ride along to the agent in the delivered
+// prompt, so a row showing only the title read as if the title WERE the whole
+// task. The row now counts them and "v" shows them in full.
+func TestTaskRowCountsNestedDetailAndDetailShowsIt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.md")
+	if err := os.WriteFile(path, []byte("- [ ] build the widget\n"+
+		"  - wire the API\n"+
+		"  - Acceptance Criteria:\n"+
+		"    - it renders\n"+
+		"- [ ] flat task\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Default()
+	cfg.TaskSources = []config.TaskSource{{Agent: "brave-otter", Path: path}}
+	m := Model{width: 100, height: 30}
+	upd, _ := m.Update(refreshMsg{
+		cfg:   cfg,
+		tasks: []frontend.TaskGroup{{Source: cfg.TaskSources[0], Index: 0, Items: mustParse(t, path)}},
+	})
+	m = upd.(Model)
+	m.tab = tabTasks
+
+	view := m.View()
+	if !strings.Contains(view, "build the widget (+3)") {
+		t.Errorf("row must count the nested detail:\n%s", view)
+	}
+	// A flat task gets no marker, and the list stays one row per task.
+	if strings.Contains(view, "flat task (+") {
+		t.Errorf("a flat task must carry no detail marker:\n%s", view)
+	}
+	if strings.Contains(view, "wire the API") {
+		t.Errorf("rows must not inline the detail lines:\n%s", view)
+	}
+
+	m = press(t, m, "down", "v")
+	if m.detail == nil || m.detail.task == nil {
+		t.Fatal("v on an item row should open the task detail")
+	}
+	view = m.View()
+	for _, want := range []string{"build the widget", "wire the API",
+		"Acceptance Criteria:", "it renders"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("task detail missing folded line %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "flat task") {
+		t.Errorf("the detail overlay leaked the sibling task:\n%s", view)
+	}
+}
+
+// TestTaskRowDetailMarkerSurvivesNarrowPane pins the width arithmetic behind
+// the marker: it is budgeted OUT of the title's allowance, so a narrow pane
+// truncates the title and keeps the count rather than dropping the count and
+// leaving a row that reads as the whole task. Rows must also stay one screen
+// line — the accounting listPageSize depends on.
+func TestTaskRowDetailMarkerSurvivesNarrowPane(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.md")
+	if err := os.WriteFile(path, []byte(
+		"- [ ] a deliberately long task title that will not fit a narrow pane\n"+
+			"  - wire the API\n"+
+			"  - Acceptance Criteria:\n"+
+			"    - it renders\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Default()
+	cfg.TaskSources = []config.TaskSource{{Agent: "brave-otter", Path: path}}
+	for _, w := range []int{40, 60, 80, 92, 120} {
+		m := Model{width: w, height: 30}
+		upd, _ := m.Update(refreshMsg{
+			cfg:   cfg,
+			tasks: []frontend.TaskGroup{{Source: cfg.TaskSources[0], Index: 0, Items: mustParse(t, path)}},
+		})
+		m = upd.(Model)
+		m.tab = tabTasks
+		rows := m.taskRows()
+		var item *taskRow
+		for i := range rows {
+			if rows[i].item == 1 {
+				item = &rows[i]
+			}
+		}
+		if item == nil {
+			t.Fatalf("width %d: no item row", w)
+		}
+		if !strings.Contains(item.text, "(+3)") {
+			t.Errorf("width %d: the detail count must survive truncation, got %q", w, item.text)
+		}
+		if got := runewidth.StringWidth(item.text); got > m.contentWidth() {
+			t.Errorf("width %d: row is %d cells, exceeds contentWidth %d — it would wrap: %q",
+				w, got, m.contentWidth(), item.text)
+		}
+	}
+}
+
+// mustParse reads a checklist file the way the frontend does, so a test row
+// carries the same Detail the real Tasks tab renders from.
+func mustParse(t *testing.T, path string) []domain.ChecklistItem {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return domain.ParseChecklist(string(b))
+}
+
 func TestTaskDetailEditAction(t *testing.T) {
 	m, _, _ := taskAppModel(t)
 	m = press(t, m, "down", "v")
@@ -989,6 +1097,26 @@ func TestTaskDetailShowsDecodedNewlines(t *testing.T) {
 	if !strings.Contains(view, "write the parser") || !strings.Contains(view, "start with the lexer") ||
 		strings.Contains(view, `parser\nstart`) {
 		t.Errorf("detail should decode stored \\n into real lines:\n%s", view)
+	}
+}
+
+// TestTasksSendConfirmCountsNestedDetail pins that the send confirmation names
+// the nested sub-items that will be delivered with the task — the send folds
+// them into the outbound prompt, so a label naming only the item number would
+// take a "y" for more than it showed.
+func TestTasksSendConfirmCountsNestedDetail(t *testing.T) {
+	m, _, _ := sendTaskModel(t)
+	// Give item #1 the nested detail the file's fold would produce.
+	m.data.tasks[0].Items[0].Detail = []string{"  - wire it", "  - test it"}
+	upd, _ := m.Update(pressKeyMsg("down"))
+	m = upd.(Model)
+	upd, _ = m.Update(pressKeyMsg("enter"))
+	m = upd.(Model)
+	if m.confirm == nil {
+		t.Fatal("enter on an item row should confirm the send")
+	}
+	if !strings.Contains(m.confirm.label, "send task #1 (+2) to") {
+		t.Errorf("confirm label must count the detail that rides along, got %q", m.confirm.label)
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -677,6 +677,29 @@ type taskRow struct {
 	item       int    // 1-based checklist item number; 0 = not an item row
 	path       string // the group's checklist file
 	itemText   string // the item's raw (untruncated) text; "" for non-item rows
+	// itemDetail is the item's nested sub-items (acceptance criteria,
+	// dependencies, notes) — the lines the delivered prompt folds in. The row
+	// only COUNTS them (a row is one screen line); the detail overlay prints
+	// them, so "v" shows the task as the agent will actually receive it.
+	itemDetail []string
+}
+
+// taskDetailMarker labels a row whose task carries nested sub-items, so a
+// one-line listing never reads as if the title were the whole task. The count
+// is what "v" (the detail overlay) shows in full and what the delivered prompt
+// folds in; a flat item gets nothing.
+func taskDetailMarker(it domain.ChecklistItem) string {
+	return detailCount(it.Detail)
+}
+
+// detailCount renders the nested-sub-item count as a compact " (+N)" suffix,
+// or "" for a flat task. Shared by the row marker and the send confirmation so
+// the number an operator authorizes is the number they were shown.
+func detailCount(detail []string) string {
+	if len(detail) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (+%d)", len(detail))
 }
 
 // taskMarkKey identifies a checklist item for multi-select. Keyed by group
@@ -751,8 +774,15 @@ func (m Model) taskRows() []taskRow {
 				// takes. itemText below stays RAW — it identifies the line in the
 				// file for edit/send, and must match it byte for byte.
 				shown := domain.DisplayTaskText(it.Text)
+				// A task's nested sub-items ride along to the agent but cannot
+				// fit a one-line row, so the row carries a count and "v" opens
+				// the full text. The marker is budgeted OUT of the title's width
+				// rather than appended after truncation, so it survives a narrow
+				// pane — a row that dropped it would read as the whole task.
+				marker := taskDetailMarker(it)
+				body := max(20, m.contentWidth()-12) - runewidth.StringWidth(marker)
 				rows = append(rows, taskRow{
-					text:       fmt.Sprintf("%s#%d [%s] %s", markCh, it.Index, it.Mark, oneLine(shown, max(20, m.contentWidth()-12))),
+					text:       fmt.Sprintf("%s#%d [%s] %s%s", markCh, it.Index, it.Mark, oneLine(shown, body), marker),
 					fields:     append([]string{fmt.Sprintf("#%d", it.Index), shown, it.Mark}, hfields...),
 					done:       it.Done,
 					inProgress: it.Mark == domain.MarkInProgress,
@@ -760,6 +790,7 @@ func (m Model) taskRows() []taskRow {
 					item:       it.Index,
 					path:       g.Source.Path,
 					itemText:   it.Text,
+					itemDetail: it.Detail,
 				})
 			}
 		}
@@ -2646,8 +2677,10 @@ func (m Model) sendTaskRow(r taskRow) (tea.Model, tea.Cmd) {
 		func(c context.Context) error {
 			return app.SendTaskToAgent(c, paneID, agentType, name, path, template, item, text)
 		})
+	// The count rides along: what gets delivered is the FOLDED task, so a label
+	// naming only the item number would take a "y" for more than it showed.
 	m.confirm = &confirmation{
-		label:     fmt.Sprintf("send task #%d to %s?", item, name),
+		label:     fmt.Sprintf("send task #%d%s to %s?", item, detailCount(r.itemDetail), name),
 		onConfirm: func() tea.Cmd { return send },
 	}
 	return m, nil
@@ -2670,7 +2703,13 @@ func (m Model) taskDetailLines(r taskRow, width int) []string {
 	// Stored literal `\n` sequences render as real line breaks here — the
 	// detail shows the task as the agent will receive it. The id is unescaped
 	// like the list row, so both show the id `hap task done` takes.
-	lines = m.detailField(lines, w, "Text", domain.DecodeTaskNewlines(domain.DisplayTaskText(r.itemText)))
+	//
+	// The item's nested sub-items are folded in exactly as the delivery path
+	// folds them (domain.FoldedTaskText over the SAME lines), so this overlay
+	// is the operator's answer to "what will actually be sent?" — the list row
+	// only counts them.
+	text := domain.FoldedTaskText(domain.DisplayTaskText(r.itemText), r.itemDetail)
+	lines = m.detailField(lines, w, "Text", domain.DecodeTaskNewlines(text))
 	lines = m.detailField(lines, w, "Source file", r.path)
 	if r.group < len(m.data.tasks) {
 		src := m.data.tasks[r.group].Source


### PR DESCRIPTION
## Problem

#238 folded a checklist task's nested sub-items (acceptance criteria, dependencies, notes indented under a `- [ ]` title) into the **delivered** prompt. But **no display path ever showed them** — `hap task list`, `hap task get`, the TUI task rows and the TUI detail overlay all rendered the single title line.

The result reads as a folding bug even though the fold and the delivery are both correct: every surface an operator looks at claims the title is the whole task.

Verified against a real 8-task checklist: `FoldTaskContent`/`FoldTaskContentAt` fold correctly (including escaped `1\.` ids, `Acceptance Criteria:` sub-trees, and stopping cleanly at the next `- [ ]`), the daemon auto-send path delivers the whole block, and a real Claude Code pane receives it as one message. Only the display lied.

## Change

`domain.ChecklistItem` gains `Detail []string`, populated by `ParseChecklist` from the same lines the fold delivers (via the existing `nestedContinuationLines`). A new exported `domain.FoldedTaskText(itemText, detail)` is the **single renderer** both delivery and display route through, so what is shown and what is sent cannot drift apart.

### Surfaces

| Surface | Before | After |
|---|---|---|
| `hap task list` | `#1 [ ] 1. Extend the shared model…` | `… (+9 detail lines)` |
| `hap task get <n>` | title only | title **+ every nested line** |
| TUI task row | title only | `… (+9)` |
| TUI detail overlay (`v`) | title only | full folded task |
| CLI send confirm | `send task #1 (alpha) to w1:p1? [y/N]` | `send task #1 (alpha (+2 detail lines)) to w1:p1? [y/N]` |
| TUI send confirm | `send task #1 to brave-otter?` | `send task #1 (+2) to brave-otter?` |

**The two send confirmations are the load-bearing ones.** They are where the operator *authorizes* delivery of the folded body, so a title-only prompt took a `y` for more than it displayed.

## Delivered text is byte-identical

`FoldedTaskText`'s body is the verbatim body of the removed unexported `foldItemAt`, and both fold call sites pass exactly the arguments `foldItemAt` previously computed internally. `len(detail) == 0` covers nil and empty alike, so the new nil-normalization in `nestedContinuationLines` is invisible to it.

`ChecklistItem.Text` is untouched — it remains the single physical line that is the task's reservation identity — so reservation, the hand-out ledger rows (`task_reservations`), and the send-gated freshness check all behave exactly as before. **No agent receives different text as a result of this PR.**

The TUI applies `DisplayTaskText` to the title *before* folding while delivery folds *first*; these are equivalent because `taskLabelRE` is `^`-anchored and non-multiline, so it can only ever match inside the first line.

## Invariants kept

- **A list row stays ONE screen line** — the window/`listPageSize` accounting depends on it. The detail is *counted*, never inlined.
- **The count is budgeted OUT of the title's width**, not appended after truncation, so a narrow pane truncates the title and keeps the count. A row that dropped the marker would again read as the whole task. Pinned by a width sweep (40/60/80/92/120) asserting the marker survives *and* no row exceeds `contentWidth()`.
- `ParseChecklist` stays linear: `nestedContinuationLines` breaks at the first checklist item, so per-item scan regions are pairwise disjoint.
- `ChecklistItem` becomes non-comparable (`[]string` field). Verified no non-test code compares it with `==`, uses it as a map key, or passes it to `slices.Contains`/`Equal`; it is never JSON-serialized. Same check done for `taskRow`.

## Tests

- `TestParseChecklistCarriesNestedDetail` — parsed `Detail` matches the delivered fold byte-for-byte (the invariant that lets display render from `Detail` instead of re-folding)
- `TestTaskListMarksNestedDetailAndGetPrintsIt` — list counts and does not inline; `get` prints the lines and does not leak siblings
- `TestTaskSendConfirmationCountsNestedDetail` — CLI y/N prompt carries the count; a flat task stays clean
- `TestTaskRowCountsNestedDetailAndDetailShowsIt` — TUI row counts, overlay shows the folded task
- `TestTaskRowDetailMarkerSurvivesNarrowPane` — width sweep, no wrapped rows
- `TestTasksSendConfirmCountsNestedDetail` — TUI confirm label carries the count

Full suite green (20 packages), `gofmt`/`go vet`/`golangci-lint --build-tags "vectors,cpu"` clean. Verified live in the running TUI and CLI against a real checklist.

## Also fixed (review findings)

- `hap task get` decodes stored literal `\n`, matching what delivery and the TUI overlay already did — the three surfaces no longer disagree about one task
- `(+1 detail line)` singular
- `hap help task` documents the marker
- Removed `ChecklistItem.FoldedText()` — exported API with no production caller; `FoldedTaskText` covers every real use
- Corrected a stale comment claiming `get` prints a single line

## Out of scope — filed separately

`domain.DeleteChecklistItem` removes only the item's own line, so `hap task remove` orphans its nested lines. Because they stay indented deeper than the *preceding* item, they fold into and are delivered with the **wrong task**. Pre-existing, but making detail visible makes it reachable by an operator acting on what they just saw.
