### PR TITLE
#1 fix: keep a task's nested detail with its own item on delete and append

### DIFF
--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -295,6 +295,23 @@ func foldItemAt(lines []string, i int, itemText string) string {
 	return itemText + "\n" + strings.Join(nested, "\n")
 }
 
+// detailBlockEnd is the exclusive end line of the checklist item at lines[i]
+// together with its detail: the item's own line plus every nested continuation
+// line beneath it. `lines[i:detailBlockEnd(lines, i)]` is exactly the run that
+// belongs to that item.
+//
+// It exists so the two mutators that MOVE lines (DeleteChecklistItem and
+// AppendChecklistItem) share one definition of "where does this item end". Both
+// used to answer it with `LineNo + 1`, which is why both handed one item's
+// detail to another.
+//
+// The conversion from nestedContinuationLines' LENGTH to a line span is exact
+// because that helper appends every line it scans — interior blanks included —
+// and only trims from the tail; see the contiguity note on its doc.
+func detailBlockEnd(lines []string, i int) int {
+	return i + 1 + len(nestedContinuationLines(lines, i))
+}
+
 // nestedContinuationLines collects the lines that belong to the checklist item
 // at lines[i] as its folded detail: the run of following lines indented deeper
 // than the item, kept verbatim. Interior blank lines are preserved but trailing
@@ -302,6 +319,13 @@ func foldItemAt(lines []string, i int, itemText string) string {
 // below the item, or at the next checklist item at any indent — a nested "[ ]"
 // checkbox is its own task (ParseChecklist counts it), so it is a boundary, not
 // folded detail.
+//
+// CONTIGUITY (load-bearing): the result is always exactly
+// lines[i+1 : i+1+len(result)]. Every scanned line is appended — interior blanks
+// included — and only the tail is trimmed, so a caller may convert the result's
+// LENGTH into a line span. detailBlockEnd does exactly that, and the delete and
+// append mutators depend on it. Skipping a line instead of appending it (for
+// blanks, say) would silently make them move the wrong number of lines.
 func nestedContinuationLines(lines []string, i int) []string {
 	base := indentWidth(lines[i])
 	var out []string
@@ -751,8 +775,28 @@ func DecodeTaskNewlines(s string) string {
 	return strings.ReplaceAll(s, `\n`, "\n")
 }
 
-// DeleteChecklistItem removes item index's line entirely, leaving every other
-// line untouched.
+// DeleteChecklistItem removes item index — its own line AND the nested
+// continuation lines that are its detail (the same block FoldTaskContent
+// delivers with it) — leaving every other line untouched.
+//
+// Deleting the detail with the item is a CORRECTNESS requirement, not tidiness.
+// Those lines are identified purely by being indented deeper than the item
+// above them, so removing only the item's own line REPARENTS them onto the
+// PRECEDING item: the next fold hands that item the deleted task's acceptance
+// criteria, and the agent is delivered detail for work nobody asked for.
+// (Deleting the first item instead strands them at the top of the file, owned
+// by nothing.) Reparenting is never the right answer for the same reason —
+// the detail describes the task being removed.
+//
+// Trailing blank lines are NOT consumed: nestedContinuationLines trims them, so
+// the run ends at the last non-blank detail line and the blank separator
+// between items survives the delete.
+//
+// The removed run NEVER crosses another checklist item's line — a nested "[ ]"
+// bounds the block rather than joining it — so every other item keeps its
+// number and a nested sub-task survives its parent. The TUI's multi-delete
+// depends on that: it deletes bottom-up by descending index, which is only
+// sufficient because a delete cannot renumber the targets still queued above it.
 func DeleteChecklistItem(content string, index int) (string, error) {
 	lines := strings.Split(content, "\n")
 	count := 0
@@ -762,7 +806,8 @@ func DeleteChecklistItem(content string, index int) (string, error) {
 		}
 		count++
 		if count == index {
-			lines = append(lines[:i], lines[i+1:]...)
+			// The item's line plus its detail block, as one contiguous run.
+			lines = append(lines[:i], lines[detailBlockEnd(lines, i):]...)
 			return strings.Join(lines, "\n"), nil
 		}
 	}
@@ -771,11 +816,18 @@ func DeleteChecklistItem(content string, index int) (string, error) {
 
 // AppendChecklistItem adds a new unchecked item with the given text and
 // returns the updated content plus the new item's 1-based number. The item is
-// inserted just after the last existing checklist item and takes the FIRST
-// item's indent+bullet — usually the list's top-level style — so appending
-// never accidentally nests the new task under a preceding sub-item. With no
-// existing items it is appended at end of file with a default "- " bullet. The
-// text must be a non-empty single line.
+// inserted after the last existing checklist item AND ITS NESTED DETAIL, and
+// takes the FIRST item's indent+bullet — usually the list's top-level style —
+// so appending never accidentally nests the new task under a preceding
+// sub-item. With no existing items it is appended at end of file with a default
+// "- " bullet. The text must be a non-empty single line.
+//
+// Inserting after the whole block, not just the last item's own line, is a
+// CORRECTNESS requirement — the mirror of DeleteChecklistItem's. Detail lines
+// are identified only by being indented deeper than the item above them, so
+// splitting the last item from its detail hands that detail to the NEW task:
+// the appended task is delivered with instructions written for its predecessor,
+// which is left bare.
 func AppendChecklistItem(content, text string) (string, int, error) {
 	text, err := validateTaskText(text)
 	if err != nil {
@@ -792,7 +844,34 @@ func AppendChecklistItem(content, text string) (string, int, error) {
 	}
 	newLine := items[0].Prefix + "[ ] " + text
 	lines := strings.Split(content, "\n")
-	insertAt := items[len(items)-1].LineNo + 1
+	lastLine := items[len(items)-1].LineNo
+	// Two conditions must BOTH hold at the insertion point, so take whichever
+	// is further down the file:
+	//
+	//  1. past the last item's own detail block — otherwise the new task is
+	//     wedged between that item and its detail, and steals it;
+	//  2. past anything that would nest under the NEW line — otherwise the new
+	//     task adopts it. This is not implied by (1): when the last ITEM is a
+	//     nested sub-task, its block ends at its own indent, but a following
+	//     note written at the PARENT's depth is still deeper than the new
+	//     top-level line and would fold into it.
+	//
+	// Neither condition alone is enough, hence the max rather than a single
+	// rule: (2) alone would strand the last item's detail whenever items[0] is
+	// indented deeper than the last item.
+	insertAt := detailBlockEnd(lines, lastLine)
+	newIndent := indentWidth(newLine)
+	for j := insertAt; j < len(lines); j++ {
+		if strings.TrimSpace(lines[j]) != "" && indentWidth(lines[j]) <= newIndent {
+			break
+		}
+		insertAt = j + 1
+	}
+	// Give back the trailing blanks either scan consumed, so a blank separator
+	// (or the file's final newline) stays below the new item rather than above it.
+	for insertAt > lastLine+1 && strings.TrimSpace(lines[insertAt-1]) == "" {
+		insertAt--
+	}
 	lines = append(lines[:insertAt], append([]string{newLine}, lines[insertAt:]...)...)
 	return strings.Join(lines, "\n"), newIndex, nil
 }

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -614,6 +614,139 @@ func TestDeleteChecklistItem(t *testing.T) {
 	}
 }
 
+// TestDeleteChecklistItemTakesItsNestedDetail pins that a delete removes the
+// item's detail block with it. Nested lines are identified only by being
+// indented deeper than the item above them, so leaving them behind REPARENTS
+// them onto the preceding item — see TestDeleteChecklistItemNeverReparentsDetail
+// for the delivery consequence.
+func TestDeleteChecklistItemTakesItsNestedDetail(t *testing.T) {
+	cases := []struct {
+		name, content string
+		index         int
+		want          string
+	}{
+		{
+			name: "middle item with detail",
+			content: "- [ ] a\n  - a detail\n" +
+				"- [ ] b\n  - b detail\n    - b deeper\n" +
+				"- [ ] c\n  - c detail\n",
+			index: 2,
+			want:  "- [ ] a\n  - a detail\n- [ ] c\n  - c detail\n",
+		},
+		{
+			// The last item's detail runs to EOF — nothing terminates it but
+			// the end of the file, the case an "until the next item" scan misses.
+			name:    "last item with detail",
+			content: "- [ ] a\n  - a detail\n- [ ] b\n  - b detail\n    - b deeper\n",
+			index:   2,
+			want:    "- [ ] a\n  - a detail\n",
+		},
+		{
+			// A following item at the SAME depth is a boundary, not detail:
+			// deleting #1 must not touch #2's line.
+			name:    "following item at the same depth",
+			content: "- [ ] a\n  - a detail\n- [ ] b\n",
+			index:   1,
+			want:    "- [ ] b\n",
+		},
+		{
+			// A nested checkbox is its own task (ParseChecklist counts it), so
+			// it bounds the block: deleting #1 leaves #2 and its own detail.
+			name:    "nested checkbox is a task, not detail",
+			content: "- [ ] a\n  - a detail\n  - [ ] a.1\n    - a.1 detail\n",
+			index:   1,
+			want:    "  - [ ] a.1\n    - a.1 detail\n",
+		},
+		{
+			// Interior blanks belong to the block; the trailing blank does not,
+			// so it is left in place — here at the top of the file, since the
+			// deleted item was first. A later tidy-up of that leading blank
+			// would be a change, not a regression.
+			name:    "interior blank kept, trailing blank left in place",
+			content: "- [ ] a\n  - one\n\n  - two\n\n- [ ] b\n",
+			index:   1,
+			want:    "\n- [ ] b\n",
+		},
+		{
+			name:    "flat item is unaffected",
+			content: "intro\n- [ ] a\n- [ ] b\n",
+			index:   1,
+			want:    "intro\n- [ ] b\n",
+		},
+		// The block ends at EOF with no terminating newline — the shape that
+		// pushes the computed end to exactly len(lines), where an off-by-one
+		// would panic rather than misbehave quietly.
+		{
+			name:    "last item with detail, no trailing newline",
+			content: "- [ ] a\n- [ ] b\n  - d",
+			index:   2,
+			// No terminating newline in, none out: the delete removes lines,
+			// it does not normalize how the file ends.
+			want: "- [ ] a",
+		},
+		{
+			name:    "only item with detail, no trailing newline",
+			content: "- [ ] a\n  - d",
+			index:   1,
+			want:    "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DeleteChecklistItem(tc.content, tc.index)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Errorf("DeleteChecklistItem:\ngot  %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDeleteChecklistItemNeverReparentsDetail is the delivery-level invariant:
+// after removing a task, no surviving task may fold in a line that belonged to
+// the deleted one. Orphaned sub-bullets stay indented deeper than the PRECEDING
+// item, so the pre-fix delete handed task #1 the removed task's detail and the
+// agent was delivered instructions for work nobody asked for.
+func TestDeleteChecklistItemNeverReparentsDetail(t *testing.T) {
+	content := "- [ ] 1. build the widget\n" +
+		"  - wire the API\n" +
+		"- [ ] 2. ship it\n" +
+		"  - tag the release\n" +
+		"  - announce it\n"
+	out, err := DeleteChecklistItem(content, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, leaked := range []string{"tag the release", "announce it"} {
+		if strings.Contains(out, leaked) {
+			t.Errorf("deleted task's detail %q survived:\n%s", leaked, out)
+		}
+	}
+	// The survivor keeps its OWN detail and gains nothing.
+	if got, want := FoldTaskContent(out, "1. build the widget"),
+		"1. build the widget\n  - wire the API"; got != want {
+		t.Errorf("survivor folds to %q, want %q", got, want)
+	}
+	// Deleting the FIRST item strands nothing at the top of the file either.
+	out, err = DeleteChecklistItem(content, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "wire the API") {
+		t.Errorf("first item's detail was stranded at the top of the file:\n%s", out)
+	}
+	if got, want := FoldTaskContent(out, "2. ship it"),
+		"2. ship it\n  - tag the release\n  - announce it"; got != want {
+		t.Errorf("remaining task folds to %q, want %q", got, want)
+	}
+	// Every surviving line still parses into exactly the tasks that remain.
+	if items := ParseChecklist(out); len(items) != 1 || items[0].Text != "2. ship it" {
+		t.Errorf("expected exactly the one surviving task, got %+v", items)
+	}
+}
+
 func TestAppendChecklistItem(t *testing.T) {
 	cases := []struct {
 		name, content, text, want string
@@ -626,6 +759,32 @@ func TestAppendChecklistItem(t *testing.T) {
 		{"empty file", "", "first", "- [ ] first\n", 1},
 		{"non-checklist file", "just notes\n", "first", "just notes\n- [ ] first\n", 1},
 		{"trailing prose after list", "- [ ] a\nnotes\n", "b", "- [ ] a\n- [ ] b\nnotes\n", 2},
+		// The new item goes after the last item's DETAIL BLOCK, not after its
+		// own line — inserting between an item and its detail hands that detail
+		// to the new task (see TestAppendChecklistItemNeverStealsDetail).
+		{"after the last item's nested detail", "- [ ] a\n  - wire it\n  - test it\n", "b",
+			"- [ ] a\n  - wire it\n  - test it\n- [ ] b\n", 2},
+		{"deeper nesting is still detail", "- [ ] a\n  - criteria:\n    - it renders\n", "b",
+			"- [ ] a\n  - criteria:\n    - it renders\n- [ ] b\n", 2},
+		// A nested checkbox is its own task, so it is the last ITEM and the
+		// append follows ITS detail, not the outer item's.
+		{"nested checkbox is the last item", "- [ ] a\n  - [ ] a.1\n    - sub detail\n", "b",
+			"- [ ] a\n  - [ ] a.1\n    - sub detail\n- [ ] b\n", 3},
+		// A trailing blank separator stays at the end of the file.
+		{"trailing blank after detail", "- [ ] a\n  - wire it\n\n", "b",
+			"- [ ] a\n  - wire it\n- [ ] b\n\n", 2},
+		// The last ITEM is a nested sub-task, so its own block ends at its own
+		// indent — but the following note sits at the PARENT's depth, which is
+		// still deeper than the new top-level line and would fold into it. The
+		// insert must clear it too, which spanning only the last item's block
+		// does not do.
+		{"note below a nested last item is not adopted",
+			"- [ ] a\n  - [ ] a.1\n  - Note: coordinate with ops\n", "b",
+			"- [ ] a\n  - [ ] a.1\n  - Note: coordinate with ops\n- [ ] b\n", 3},
+		// Mirror of the delete boundary case: the block runs to EOF with no
+		// terminating newline, putting the insert index at exactly len(lines).
+		{"detail to EOF, no trailing newline", "- [ ] a\n  - d", "b",
+			"- [ ] a\n  - d\n- [ ] b", 2},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -650,6 +809,47 @@ func TestAppendChecklistItem(t *testing.T) {
 		if _, _, err := AppendChecklistItem("- [ ] a", bad); err == nil {
 			t.Errorf("AppendChecklistItem must reject embedded newline in %q", bad)
 		}
+	}
+}
+
+// TestAppendChecklistItemNeverStealsDetail is the delivery-level mirror of
+// TestDeleteChecklistItemNeverReparentsDetail: appending must not split the
+// last task from its detail. Inserting after the last item's own line put the
+// new task ABOVE that detail, so the fold handed the appended task the previous
+// task's instructions and left the previous task bare.
+func TestAppendChecklistItemNeverStealsDetail(t *testing.T) {
+	content := "- [ ] 1. build the widget\n  - wire the API\n  - test it\n"
+	out, idx, err := AppendChecklistItem(content, "2. ship it")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx != 2 {
+		t.Errorf("new item index = %d, want 2", idx)
+	}
+	// The appended task owns nothing it did not bring.
+	if got := FoldTaskContent(out, "2. ship it"); got != "2. ship it" {
+		t.Errorf("appended task folds to %q, want the bare title", got)
+	}
+	// The previous task keeps every one of its detail lines.
+	if got, want := FoldTaskContent(out, "1. build the widget"),
+		"1. build the widget\n  - wire the API\n  - test it"; got != want {
+		t.Errorf("previous task folds to %q, want %q", got, want)
+	}
+
+	// Spanning only the last ITEM's block is not enough. Here the last item is
+	// a nested sub-task whose block ends at its own indent, but the note below
+	// it sits at the parent's depth — still deeper than the new top-level line,
+	// so it would fold into the appended task.
+	nested := "- [ ] 1. build the widget\n  - [ ] 1.1 test it\n  - Note: coordinate with ops\n"
+	out, _, err = AppendChecklistItem(nested, "2. ship it")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := FoldTaskContent(out, "2. ship it"); got != "2. ship it" {
+		t.Errorf("appended task adopted a line it did not bring: %q", got)
+	}
+	if !strings.Contains(out, "  - Note: coordinate with ops\n- [ ] 2. ship it") {
+		t.Errorf("the note must stay above the appended task:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Problem

A checklist task's **detail** — the acceptance criteria, dependencies and notes indented under its `- [ ]` title — is identified *only* by relative indentation. Nothing links a detail line to its owning item. `FoldTaskContent` folds that block into the prompt delivered to the agent (#238).

So the two mutators that move lines both handed one task's detail to another. Both confirmed by repro.

### `hap task remove` reparented detail onto the neighbour

```
- [ ] 1. build the widget          delete #2  →   - [ ] 1. build the widget
  - wire the API                                    - wire the API
- [ ] 2. ship it                                    - tag the release   ← orphan, now
  - tag the release                                                        indented under #1
```

`FoldTaskContent` then delivered task #1 with `- tag the release` — **instructions for work that had just been deleted**. Deleting the *first* item instead stranded its block at the top of the file, owned by nothing.

### `hap task add` stole the previous task's detail — worse

It inserted at `lastItem.LineNo + 1`, i.e. *between* the last item and its detail:

```
- [ ] 1. build the widget          add "ship it"  →   - [ ] 1. build the widget   ← left bare
  - wire the API                                      - [ ] 2. ship it
  - test it                                             - wire the API            ← inherited
                                                        - test it
```

The appended task was delivered its predecessor's entire instructions, and the predecessor lost them.

## Fix

Both now span the item's whole block through a shared `detailBlockEnd(lines, i)` — one definition of "where does this item end", replacing the `LineNo + 1` that both got wrong.

**Delete removes the detail with the item.** Reparenting is never the right answer: the detail describes the task being removed, so attaching it to a neighbour is silently wrong in exactly the way the bug already is.

**Append takes the max of two conditions** — past the last item's block, *and* past anything that would nest under the new line. Neither alone is sufficient:

- Block-span alone fails when the last **item** is a nested sub-task. Its block ends at its own indent, but a note at the *parent's* depth is still deeper than a new top-level line and gets adopted:
  ```
  - [ ] 1. Build the widget
    - [ ] 1.1 test it          ← last ITEM; its block ends here
    - Note: coordinate with ops ← outside it, but deeper than "- [ ] 2. new"
  ```
- New-indent alone fails when `items[0]` is indented deeper than the last item — it stops short and strands the last item's detail.

## Invariants documented, because they are now load-bearing

- **`nestedContinuationLines` contiguity.** Its result is always exactly `lines[i+1 : i+1+len(result)]` — every scanned line is appended, interior blanks included, and only the tail is trimmed. Both mutators convert that *length* into a *line span*. A future `continue`-without-append on blanks would silently move the wrong number of lines with nothing in the helper's own suite failing. Stated on the helper and referenced from `detailBlockEnd`.
- **The removed run never crosses another checklist item's line** (a nested `[ ]` bounds the block rather than joining it). The TUI's multi-delete deletes bottom-up by descending index, which is only sufficient because a delete cannot renumber the targets still queued above it. Stated on `DeleteChecklistItem`.
- Trailing blanks are not consumed, so a blank separator (or the file's final newline) survives both operations.

## Tests

`TestDeleteChecklistItemTakesItsNestedDetail` — middle item with detail, **last item**, **following item at the same depth** (the three cases requested), plus deeper nesting, a nested `[ ]` checkbox as a boundary, interior-vs-trailing blanks, a flat item, and two `end == len(lines)` cases (files ending without a newline — the indices the fix newly pushes to the slice limit).

`TestAppendChecklistItem` gains mirrors of each, including the nested-last-item case and the no-trailing-newline boundary.

Two delivery-level invariant tests state the property rather than the mechanics:
- `TestDeleteChecklistItemNeverReparentsDetail` — after a delete, no surviving task folds in a line belonging to the deleted one, from either end of the list
- `TestAppendChecklistItemNeverStealsDetail` — the appended task folds in nothing it did not bring, and its predecessor keeps every line

Full suite green (24 packages), `internal/domain` clean under `-race`, `gofmt`/`go vet`/`golangci-lint --build-tags "vectors,cpu"` clean.

## Deliberately out of scope

**`ensureGeneratedTaskFile` silently erases all hand-authored detail.** It rebuilds the file via `RenderGeneratedTaskList`, which takes only item *texts*, so task generation refilling a source destroys every nested line:

```
- [ ] 1. build the widget       →   # Tasks for agent-x
  - wire the API
  - Acceptance: it renders          - [ ] 1. build the widget
                                    - [ ] 2. ship it
```

Verified. This is outright **data loss**, not misdelivery, but fixing it means threading detail through `mergeGeneratedTasks` and the renderer — a taskgen change, not line surgery. Worth its own issue.

Two smaller open questions, both product calls:
- Should the delete confirmations quote the detail count (`delete task #3 (+4 detail lines)?`)? The operator never sees those lines in the list. Cheapest once #242's `ChecklistItem.Detail` lands.
- Deleting a parent leaves its nested `[ ]` sub-tasks behind as indent-orphans — pinned as deliberate here rather than changed.
