### PR TITLE
#1 feat: reorder a task within its checklist from the TUI and CLI

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"golang.org/x/term"
 
@@ -1490,7 +1491,7 @@ func taskHints(agent, path string, listing bool) []Hint {
 
 // taskOp runs one checklist operation against an already-resolved target.
 func taskOp(ctx context.Context, app *frontend.App, out io.Writer, agent, path string, args []string) error {
-	usage := "usage: task [<agent> | --path <file>] list [--status all|pending|done] | get <n> | add <text> | start <n> | done <n> | undone <n> | update <n> <text> | remove <n> | send <n> [--yes]\n<n> is a task id from the list (e.g. 3.4), or #<position>\nsee: hap help task"
+	usage := "usage: task [<agent> | --path <file>] list [--status all|pending|done] | get <n> | add <text> | start <n> | done <n> | undone <n> | update <n> <text> | remove <n> | move <n> <position|up|down> | send <n> [--yes]\n<n> is a task id from the list (e.g. 3.4), or #<position>\nsee: hap help task"
 	if agent == "" && path == "" {
 		return fmt.Errorf("%s", usage)
 	}
@@ -1567,6 +1568,8 @@ func taskOp(ctx context.Context, app *frontend.App, out io.Writer, agent, path s
 		fmt.Fprintf(out, "removed task #%d\n", idx)
 		printTaskList(out, items, "all")
 		return nil
+	case "move", "mv", "reorder":
+		return taskMove(app, out, agent, path, rest)
 	case "send":
 		return taskSend(ctx, app, out, agent, path, rest)
 	}
@@ -1772,6 +1775,94 @@ func taskStart(app *frontend.App, out io.Writer, agent, path string, rest []stri
 	fmt.Fprintf(out, "task #%d marked in-progress\n", idx)
 	printTaskList(out, items, "all")
 	return nil
+}
+
+// taskMove reorders one item. The SOURCE is a task reference (an id like 3.4,
+// or '#3' for a position), matching every other `hap task` op; the DESTINATION
+// is always a POSITION, because that is the only thing that is unambiguous
+// here: after the move the item's own id is unchanged, so naming the target by
+// id would ask "put 5 where 2 is" and leave "which 2 — before or after the
+// shift?" open. `up`/`down` are the one-step forms the TUI's keys drive.
+func taskMove(app *frontend.App, out io.Writer, agent, path string, args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("usage: task %s move <n> <position|up|down> (see: hap help task)",
+			taskTargetLabel(agent, path))
+	}
+	it, err := taskItemArg(app, agent, path, args[:1])
+	if err != nil {
+		return err
+	}
+	idx := it.Index
+	to, relative, err := moveDestination(args[1], idx)
+	if err != nil {
+		return err
+	}
+	// A relative step off either end is a normal thing to ask for — it is what
+	// a repeated `move X up` does when it reaches the top — so it is reported
+	// as "already there" rather than the bare "no task #0" the position
+	// validator would raise for a number the caller never typed. n == 0 means
+	// the count could not be read, and is deliberately NOT treated as "past the
+	// end": that would swallow the read error behind a success message. Falling
+	// through lets MoveTask report the real problem.
+	if n := countTasks(app, agent, path); relative && (to < 1 || (n > 0 && to > n)) {
+		edge := "top"
+		if to > idx {
+			edge = "bottom"
+		}
+		fmt.Fprintf(out, "task #%d is already at the %s of this list\n", idx, edge)
+		return nil
+	}
+	if to == idx {
+		// Short-circuit before the mutation: taskfile.Mutate writes
+		// unconditionally, so calling through would rewrite the file (new
+		// mtime, new inode) purely to report that nothing changed.
+		fmt.Fprintf(out, "task #%d is already at position #%d\n", idx, to)
+		return nil
+	}
+	items, err := app.MoveTask(agent, path, idx, to, it.Text)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "moved task #%d to position #%d\n", idx, to)
+	printTaskList(out, items, "all")
+	return nil
+}
+
+// countTasks reports how many checklist items the target file holds, for the
+// relative-move edge check, or 0 when it cannot be read — which the caller
+// treats as "unknown", not "empty".
+func countTasks(app *frontend.App, agent, path string) int {
+	items, err := app.ListTasks(agent, path)
+	if err != nil {
+		return 0
+	}
+	return len(items)
+}
+
+// moveDestination resolves a move target to a 1-based position, reporting
+// whether it was RELATIVE ("up"/"down", one step from idx) — the caller treats
+// a relative step off the end as "already there" rather than an error, since
+// walking a task to the top with repeated `up` naturally ends there. An
+// absolute position is never clamped: a destination the caller actually typed
+// is rejected by name if no such task exists.
+func moveDestination(arg string, idx int) (to int, relative bool, err error) {
+	switch strings.ToLower(strings.TrimSpace(arg)) {
+	case "up":
+		return idx - 1, true, nil
+	case "down":
+		return idx + 1, true, nil
+	}
+	digits := strings.TrimPrefix(strings.TrimSpace(arg), "#")
+	// Digits only: strconv.Atoi also accepts a sign, and "+2" reading as
+	// position 2 would quietly answer a relative-looking request absolutely.
+	if digits == "" || strings.TrimFunc(digits, unicode.IsDigit) != "" {
+		return 0, false, fmt.Errorf("invalid destination %q — pass a position (e.g. 2 or '#2'), or up/down", arg)
+	}
+	n, err := strconv.Atoi(digits)
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid destination %q — pass a position (e.g. 2 or '#2'), or up/down", arg)
+	}
+	return n, false, nil
 }
 
 func taskList(app *frontend.App, out io.Writer, agent, path string, args []string) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1211,6 +1211,15 @@ func writeTaskFile(t *testing.T, content string) string {
 	return p
 }
 
+func readTaskFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
 func TestTaskListStatusFilterPreservesNumbers(t *testing.T) {
 	app, _ := testApp(t)
 	path := writeTaskFile(t, "- [ ] one\n- [x] two\n- [ ] three\n")
@@ -1300,6 +1309,117 @@ func TestTaskListMarksNestedDetailAndGetPrintsIt(t *testing.T) {
 	}
 	if strings.Contains(out, "wire the API") {
 		t.Errorf("get on a flat task must print no detail, got:\n%s", out)
+	}
+}
+
+// TestTaskMove covers `hap task move`: the reorder itself, that a task's nested
+// detail travels with it, and that the two kinds of out-of-range destination
+// are reported differently — a relative step off the end is "already there",
+// a typed position that names no task is an error.
+func TestTaskMove(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] alpha\n  - a detail\n  - Acceptance: works\n- [ ] beta\n  - b detail\n- [ ] gamma\n")
+
+	out, err := run(t, app, "task", "--path", path, "move", "#3", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "moved task #3 to position #1") {
+		t.Errorf("move should report the new position, got:\n%s", out)
+	}
+	// The detail blocks followed their own tasks, so each remains foldable.
+	data := readTaskFile(t, path)
+	if want := "- [ ] gamma\n- [ ] alpha\n  - a detail\n  - Acceptance: works\n- [ ] beta\n  - b detail\n"; data != want {
+		t.Errorf("file after move:\ngot  %q\nwant %q", data, want)
+	}
+
+	// Relative steps, including off each end.
+	if out, err = run(t, app, "task", "--path", path, "move", "#1", "up"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "already at the top") {
+		t.Errorf("up at the top should say so, got:\n%s", out)
+	}
+	if out, err = run(t, app, "task", "--path", path, "move", "#3", "down"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "already at the bottom") {
+		t.Errorf("down at the bottom should say so, got:\n%s", out)
+	}
+	// Neither no-op touched the file.
+	if got := readTaskFile(t, path); got != data {
+		t.Errorf("an edge no-op must not rewrite the file:\ngot  %q\nwant %q", got, data)
+	}
+
+	// A position the caller actually typed is validated, never clamped.
+	if _, err := run(t, app, "task", "--path", path, "move", "#1", "99"); err == nil {
+		t.Error("an out-of-range typed position must error")
+	}
+	for _, bad := range []string{"sideways", "+2", "", "2.5"} {
+		if _, err := run(t, app, "task", "--path", path, "move", "#1", bad); err == nil {
+			t.Errorf("destination %q must be rejected", bad)
+		}
+	}
+	if _, err := run(t, app, "task", "--path", path, "move", "#1"); err == nil {
+		t.Error("a missing destination must error")
+	}
+	// The alias resolves to the same op.
+	if _, err := run(t, app, "task", "--path", path, "mv", "#1", "2"); err != nil {
+		t.Errorf("mv alias should work: %v", err)
+	}
+	// The no-op position reports without rewriting the file — taskfile.Mutate
+	// writes unconditionally, so calling through would churn mtime for nothing.
+	before := readTaskFile(t, path)
+	out, err = run(t, app, "task", "--path", path, "move", "#2", "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "already at position #2") {
+		t.Errorf("a same-position move should say so, got:\n%s", out)
+	}
+	if got := readTaskFile(t, path); got != before {
+		t.Error("a same-position move must not rewrite the file")
+	}
+}
+
+// TestTaskMoveByDeclaredID pins the documented headline usage: when a checklist
+// numbers its own tasks, the SOURCE is addressed by that id (not its position)
+// while the destination stays a position.
+func TestTaskMoveByDeclaredID(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] 1.1 first\n- [ ] 1.2 second\n  - detail\n- [ ] 1.3 third\n")
+
+	out, err := run(t, app, "task", "--path", path, "move", "1.3", "up")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "moved task #3 to position #2") {
+		t.Errorf("an id source should resolve to its position, got:\n%s", out)
+	}
+	if want := "- [ ] 1.1 first\n- [ ] 1.3 third\n- [ ] 1.2 second\n  - detail\n"; readTaskFile(t, path) != want {
+		t.Errorf("file:\ngot  %q\nwant %q", readTaskFile(t, path), want)
+	}
+	// An id that names no task is refused before anything is written.
+	if _, err := run(t, app, "task", "--path", path, "move", "9.9", "1"); err == nil {
+		t.Error("an unknown id must error")
+	}
+}
+
+// TestTaskMoveRefusesNestingRewrite pins that the CLI surfaces the domain's
+// siblings-only refusals rather than silently restructuring the file.
+func TestTaskMoveRefusesNestingRewrite(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] a\n  - [ ] a1\n- [ ] b\n")
+	before := readTaskFile(t, path)
+
+	if _, err := run(t, app, "task", "--path", path, "move", "#1", "3"); err == nil {
+		t.Error("moving a task with nested sub-tasks must error")
+	}
+	if _, err := run(t, app, "task", "--path", path, "move", "#3", "2"); err == nil {
+		t.Error("moving across nesting depths must error")
+	}
+	if got := readTaskFile(t, path); got != before {
+		t.Errorf("a refused move must not rewrite the file:\ngot  %q\nwant %q", got, before)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1416,10 +1416,21 @@ func TestTaskMoveRefusesNestingRewrite(t *testing.T) {
 		t.Error("moving a task with nested sub-tasks must error")
 	}
 	if _, err := run(t, app, "task", "--path", path, "move", "#3", "2"); err == nil {
-		t.Error("moving across nesting depths must error")
+		t.Error("moving into another item's nesting must error")
 	}
 	if got := readTaskFile(t, path); got != before {
 		t.Errorf("a refused move must not rewrite the file:\ngot  %q\nwant %q", got, before)
+	}
+
+	// Equal indentation is not siblinghood: two sub-tasks under different
+	// parents look alike but swapping them reparents one of them.
+	cousins := writeTaskFile(t, "- [ ] parent A\n  - [ ] a\n- [ ] parent B\n  - [ ] b\n")
+	cousinsBefore := readTaskFile(t, cousins)
+	if _, err := run(t, app, "task", "--path", cousins, "move", "#2", "4"); err == nil {
+		t.Error("moving a sub-task under a different parent must error")
+	}
+	if got := readTaskFile(t, cousins); got != cousinsBefore {
+		t.Errorf("a refused move must not rewrite the file:\ngot  %q\nwant %q", got, cousinsBefore)
 	}
 }
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -614,6 +614,7 @@ func buildCommands() {
 				"hap task [<agent> | --path <file>] undone <n>",
 				"hap task [<agent> | --path <file>] update <n> <text>",
 				"hap task [<agent> | --path <file>] remove <n>",
+				"hap task [<agent> | --path <file>] move <n> <position|up|down>",
 				"hap task <agent> send <n> [--yes]",
 			},
 			Flags: []FlagDoc{
@@ -624,10 +625,15 @@ func buildCommands() {
 			Details: "<n> is a task REFERENCE, not always a position: when the list numbers its own\n" +
 				"tasks, use that id (e.g. `done 3.4`); '#3' always means the 3rd item in the file\n" +
 				"(quote it — a bare #3 is a shell comment). Every mutating op reprints the list.\n" +
-				"Aliases: ls, show, create, wip, check, uncheck/reopen, edit, rm/delete.\n" +
+				"Aliases: ls, show, create, wip, check, uncheck/reopen, edit, rm/delete, mv/reorder.\n" +
 				"Marks: [ ] pending, [-] in progress, [x] done.\n" +
 				"`list` marks a task carrying nested sub-items with `(+N detail lines)`; `get`\n" +
 				"prints them — they are folded into the prompt the agent receives.\n" +
+				"`move` reorders one task: the SOURCE is a reference like any other op, but the\n" +
+				"DESTINATION is always a position (or up/down for one step), since a task keeps\n" +
+				"its own id when it moves. A task's nested DETAIL lines travel with it; nested\n" +
+				"sub-TASKS are items of their own, so a task that has them cannot be moved, and\n" +
+				"a task can only be reordered among its siblings.\n" +
 				"`send` hands a pending item to a live, cleanly idle agent NOW and marks it [-];\n" +
 				"idleness is re-checked at delivery, and a failed send returns the item to [ ].\n" +
 				"Normally you do not need `send`: the daemon hands out the next task by itself.",
@@ -637,6 +643,8 @@ func buildCommands() {
 				"hap task vivid-falcon start 3.4",
 				"hap task vivid-falcon done 3.4",
 				"hap task --path ./docs/tasks.md add \"write the migration test\"",
+				"hap task vivid-falcon move 5 1",
+				"hap task vivid-falcon move 3.4 up",
 			},
 			Next: []Hint{
 				{Cmd: "hap task <agent> list", Why: "the items, with their numbers"},

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -297,6 +297,26 @@ func FoldedTaskText(itemText string, detail []string) string {
 	return itemText + "\n" + strings.Join(detail, "\n")
 }
 
+// hasNestedSubTasks reports whether the checklist item at lines[i] has checklist
+// items nested under it. Those are NOT part of its detail block — a nested "[ ]"
+// bounds the block — so a move that carried only the block would leave them
+// behind. MoveChecklistItem declines rather than orphan them.
+func hasNestedSubTasks(lines []string, i int) bool {
+	base := indentWidth(lines[i])
+	for j := i + 1; j < len(lines); j++ {
+		if strings.TrimSpace(lines[j]) == "" {
+			continue
+		}
+		if indentWidth(lines[j]) <= base {
+			return false
+		}
+		if checklistItemRE.MatchString(lines[j]) {
+			return true
+		}
+	}
+	return false
+}
+
 // detailBlockEnd is the exclusive end line of the checklist item at lines[i]
 // together with its detail: the item's own line plus every nested continuation
 // line beneath it. `lines[i:detailBlockEnd(lines, i)]` is exactly the run that
@@ -835,6 +855,83 @@ func DeleteChecklistItem(content string, index int) (string, error) {
 		}
 	}
 	return "", outOfRangeErr(index, count)
+}
+
+// MoveChecklistItem moves the item at 1-based position `from` to 1-based
+// position `to`, carrying its nested detail with it, and returns the updated
+// content. Positions are the same numbering ParseChecklist and the `hap task`
+// CLI expose: after the move the item IS item `to`, and the items it displaced
+// shift by one. Moving an item to its own position is a no-op that returns the
+// content byte-for-byte unchanged.
+//
+// The item travels as its whole block (detailBlockEnd), for the reason
+// DeleteChecklistItem does: detail lines belong to their item only by being
+// indented deeper than it, so moving the title alone would leave the detail
+// behind to be folded into — and delivered with — whatever task ends up above
+// it, while the moved task arrives bare. Reordering is exactly the operation
+// that would otherwise scramble every task's instructions at once.
+//
+// Reordering is SIBLINGS-ONLY, and the two refusals below are why. A nested
+// "[ ]" is its own item, not detail, so it is neither carried along nor stepped
+// over — without these guards, moving a parent would strand its sub-tasks at
+// the old position (orphaned under whatever precedes it) and moving any item to
+// a position inside another's nesting would silently adopt that nesting. Both
+// rewrite the tree the operator wrote, which is worse than declining:
+//
+//   - an item with nested sub-tasks cannot move (its children would not follow);
+//   - source and destination must sit at the same indent depth.
+//
+// Everything a flat list can express — the shape hap writes and the shape
+// nearly every checklist has — is unaffected.
+//
+// The block is re-inserted VERBATIM; indentation and bullet style are the
+// operator's. Both positions must name an existing item; neither is clamped, so
+// a caller that computed a target off the end gets an error instead of a silent
+// no-op. Blank separators do NOT travel with the item: they sit between items
+// rather than belonging to one, so a move can leave a blank where the item was
+// and none where it landed. That is cosmetic and deliberate — carrying them
+// trades one spacing artifact for another (see TestMoveChecklistItemBlankLines).
+func MoveChecklistItem(content string, from, to int) (string, error) {
+	items := ParseChecklist(content)
+	if from < 1 || from > len(items) {
+		return "", outOfRangeErr(from, len(items))
+	}
+	if to < 1 || to > len(items) {
+		return "", outOfRangeErr(to, len(items))
+	}
+	if from == to {
+		return content, nil
+	}
+	lines := strings.Split(content, "\n")
+	if hasNestedSubTasks(lines, items[from-1].LineNo) {
+		return "", fmt.Errorf("task #%d has nested sub-tasks, which would be left behind — move or unnest them first", from)
+	}
+	if a, b := indentWidth(items[from-1].Prefix), indentWidth(items[to-1].Prefix); a != b {
+		return "", fmt.Errorf("task #%d and position #%d are at different nesting depths — a task can only be reordered among its siblings", from, to)
+	}
+	start := items[from-1].LineNo
+	end := detailBlockEnd(lines, start)
+	block := append([]string(nil), lines[start:end]...)
+
+	// Cut first, then locate the target in what REMAINS: the destination is a
+	// position in the final list, and removing the block renumbers everything
+	// after it.
+	rest := append(append([]string(nil), lines[:start]...), lines[end:]...)
+	restItems := ParseChecklist(strings.Join(rest, "\n"))
+
+	// Moving DOWN, the items between `from` and `to` each shift up by one, so
+	// the destination lands after the item now sitting at to-1. Moving UP, the
+	// destination is simply before the item now at `to` — unshifted, since every
+	// item before `from` kept its number.
+	var at int
+	if to > from {
+		anchor := restItems[to-2].LineNo
+		at = detailBlockEnd(rest, anchor)
+	} else {
+		at = restItems[to-1].LineNo
+	}
+	out := append(append(append([]string(nil), rest[:at]...), block...), rest[at:]...)
+	return strings.Join(out, "\n"), nil
 }
 
 // AppendChecklistItem adds a new unchecked item with the given text and

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -297,6 +297,23 @@ func FoldedTaskText(itemText string, detail []string) string {
 	return itemText + "\n" + strings.Join(detail, "\n")
 }
 
+// checklistParent returns the LineNo of the item that items[k] is nested under
+// — the nearest preceding item indented strictly less — or -1 when it is
+// top-level. Two items are siblings exactly when this agrees for both.
+//
+// Depth alone does not answer that question: "  - [ ] a" under "parent A" and
+// "  - [ ] b" under "parent B" are equally indented but are not siblings, and
+// swapping them would move one under the other's parent.
+func checklistParent(items []ChecklistItem, k int) int {
+	depth := indentWidth(items[k].Prefix)
+	for i := k - 1; i >= 0; i-- {
+		if indentWidth(items[i].Prefix) < depth {
+			return items[i].LineNo
+		}
+	}
+	return -1
+}
+
 // hasNestedSubTasks reports whether the checklist item at lines[i] has checklist
 // items nested under it. Those are NOT part of its detail block — a nested "[ ]"
 // bounds the block — so a move that carried only the block would leave them
@@ -879,7 +896,10 @@ func DeleteChecklistItem(content string, index int) (string, error) {
 // rewrite the tree the operator wrote, which is worse than declining:
 //
 //   - an item with nested sub-tasks cannot move (its children would not follow);
-//   - source and destination must sit at the same indent depth.
+//   - source and destination must be SIBLINGS — same parent, not merely the
+//     same indent depth. Equal depth is not siblinghood: two sub-tasks under
+//     different parents are equally indented, and swapping them would move one
+//     under the other's parent.
 //
 // Everything a flat list can express — the shape hap writes and the shape
 // nearly every checklist has — is unaffected.
@@ -906,8 +926,12 @@ func MoveChecklistItem(content string, from, to int) (string, error) {
 	if hasNestedSubTasks(lines, items[from-1].LineNo) {
 		return "", fmt.Errorf("task #%d has nested sub-tasks, which would be left behind — move or unnest them first", from)
 	}
-	if a, b := indentWidth(items[from-1].Prefix), indentWidth(items[to-1].Prefix); a != b {
-		return "", fmt.Errorf("task #%d and position #%d are at different nesting depths — a task can only be reordered among its siblings", from, to)
+	// Same PARENT, not merely the same depth. Equal indentation is not
+	// siblinghood: two sub-tasks under different parents sit at the same depth,
+	// so a depth-only check would let one be moved under the other's parent —
+	// the reparenting this refusal exists to prevent.
+	if a, b := checklistParent(items, from-1), checklistParent(items, to-1); a != b {
+		return "", fmt.Errorf("task #%d and position #%d are under different parents — a task can only be reordered among its siblings", from, to)
 	}
 	start := items[from-1].LineNo
 	end := detailBlockEnd(lines, start)

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -740,6 +740,169 @@ func TestDeleteChecklistItemTakesItsNestedDetail(t *testing.T) {
 	}
 }
 
+func TestMoveChecklistItem(t *testing.T) {
+	// Every item carries detail, so a move that dropped or stranded a block
+	// shows up as a wrong ordering AND a wrong fold.
+	const three = "- [ ] alpha\n  - a detail\n- [ ] beta\n  - b detail\n- [ ] gamma\n  - g detail\n"
+	cases := []struct {
+		name     string
+		content  string
+		from, to int
+		want     string
+	}{
+		{"up to the top", three, 3, 1,
+			"- [ ] gamma\n  - g detail\n- [ ] alpha\n  - a detail\n- [ ] beta\n  - b detail\n"},
+		{"down to the bottom", three, 1, 3,
+			"- [ ] beta\n  - b detail\n- [ ] gamma\n  - g detail\n- [ ] alpha\n  - a detail\n"},
+		{"up one", three, 2, 1,
+			"- [ ] beta\n  - b detail\n- [ ] alpha\n  - a detail\n- [ ] gamma\n  - g detail\n"},
+		{"down one", three, 1, 2,
+			"- [ ] beta\n  - b detail\n- [ ] alpha\n  - a detail\n- [ ] gamma\n  - g detail\n"},
+		{"middle stays put", three, 2, 2, three},
+		{"flat list", "- [ ] a\n- [ ] b\n- [ ] c\n", 1, 3, "- [ ] b\n- [ ] c\n- [ ] a\n"},
+		{"prose and headers are not items and stay put",
+			"# Plan\n- [ ] a\nnotes\n- [ ] b\n", 2, 1,
+			"# Plan\n- [ ] b\n- [ ] a\nnotes\n"},
+		{"deeper nesting travels whole",
+			"- [ ] a\n  - criteria:\n    - it renders\n- [ ] b\n", 2, 1,
+			"- [ ] b\n- [ ] a\n  - criteria:\n    - it renders\n"},
+		{"marks are preserved verbatim",
+			"- [x] done\n- [-] wip\n- [ ] todo\n", 3, 1,
+			"- [ ] todo\n- [x] done\n- [-] wip\n"},
+		{"no trailing newline", "- [ ] a\n  - d\n- [ ] b", 2, 1,
+			"- [ ] b\n- [ ] a\n  - d"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := MoveChecklistItem(tc.content, tc.from, tc.to)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Errorf("MoveChecklistItem(%d→%d):\ngot  %q\nwant %q", tc.from, tc.to, got, tc.want)
+			}
+		})
+	}
+
+	// Both positions must name a real item — a caller that computed a target off
+	// the end gets an error, never a silent clamp that reorders something else.
+	for _, bad := range [][2]int{{0, 1}, {1, 0}, {4, 1}, {1, 4}, {-1, 2}} {
+		if _, err := MoveChecklistItem(three, bad[0], bad[1]); err == nil {
+			t.Errorf("MoveChecklistItem(%d→%d) must error", bad[0], bad[1])
+		}
+	}
+	if _, err := MoveChecklistItem("no items here\n", 1, 1); err == nil {
+		t.Error("a file with no checklist items must error")
+	}
+}
+
+// TestMoveChecklistItemRefusesToRewriteNesting pins the siblings-only rule. A
+// nested "[ ]" is its own item, not detail, so it neither travels with a parent
+// nor is stepped over — without these refusals a move would strand a parent's
+// sub-tasks at the old position or adopt someone else's nesting at the new one.
+func TestMoveChecklistItemRefusesToRewriteNesting(t *testing.T) {
+	// Moving a parent would leave a1 orphaned under whatever precedes it.
+	parent := "- [ ] a\n  - [ ] a1\n- [ ] b\n"
+	if _, err := MoveChecklistItem(parent, 1, 3); err == nil {
+		t.Error("moving a task with nested sub-tasks must be refused")
+	} else if !strings.Contains(err.Error(), "nested sub-tasks") {
+		t.Errorf("the refusal should name the reason, got %v", err)
+	}
+	// Its own detail is still fine to carry — only sub-TASKS block the move.
+	ok := "- [ ] a\n  - just detail\n- [ ] b\n"
+	if _, err := MoveChecklistItem(ok, 1, 2); err != nil {
+		t.Errorf("plain detail must not block a move: %v", err)
+	}
+
+	// Landing inside another item's nesting would adopt it.
+	nested := "- [ ] a\n  - [ ] a1\n    - a1 detail\n- [ ] b\n"
+	if _, err := MoveChecklistItem(nested, 3, 2); err == nil {
+		t.Error("moving to a different nesting depth must be refused")
+	} else if !strings.Contains(err.Error(), "nesting depths") {
+		t.Errorf("the refusal should name the reason, got %v", err)
+	}
+	// Refusals never touch the content.
+	for _, c := range []string{parent, nested} {
+		if got, _ := MoveChecklistItem(c, 1, 3); got != "" {
+			t.Errorf("a refused move must return no content, got %q", got)
+		}
+	}
+	// Siblings at the SAME depth still reorder normally.
+	sibs := "- [ ] a\n  - [ ] a1\n  - [ ] a2\n"
+	got, err := MoveChecklistItem(sibs, 3, 2)
+	if err != nil {
+		t.Fatalf("sub-tasks at the same depth must reorder: %v", err)
+	}
+	if want := "- [ ] a\n  - [ ] a2\n  - [ ] a1\n"; got != want {
+		t.Errorf("sibling reorder:\ngot  %q\nwant %q", got, want)
+	}
+}
+
+// TestMoveChecklistItemBlankLines documents what a move does to blank
+// separators: they sit BETWEEN items rather than belonging to one, so a move
+// can leave a blank behind and land the item tight against its new neighbour.
+// Cosmetic and deliberate — carrying them just trades one artifact for another
+// (the blank would then follow the item to the end of the file). Pinned so the
+// behavior is a decision rather than a surprise.
+func TestMoveChecklistItemBlankLines(t *testing.T) {
+	got, err := MoveChecklistItem("- [ ] a\n  - d1\n\n- [ ] b\n", 1, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "\n- [ ] b\n- [ ] a\n  - d1\n"; got != want {
+		t.Errorf("blank handling changed:\ngot  %q\nwant %q", got, want)
+	}
+	// Whatever the spacing, no line is ever lost or duplicated.
+	for _, c := range []string{"- [ ] a\n\n- [ ] b\n", "- [ ] a\n  - d\n\n\n- [ ] b\n"} {
+		out, err := MoveChecklistItem(c, 1, 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if a, b := len(strings.Split(c, "\n")), len(strings.Split(out, "\n")); a != b {
+			t.Errorf("move changed the line count for %q: %d → %d", c, a, b)
+		}
+	}
+}
+
+// TestMoveChecklistItemKeepsEveryTasksDetail is the delivery-level invariant:
+// reordering must not change what any task is delivered. It is the operation
+// that would otherwise scramble every task's instructions at once — the moved
+// task arriving bare while its detail is folded into whatever ends up above it.
+func TestMoveChecklistItemKeepsEveryTasksDetail(t *testing.T) {
+	content := "- [ ] alpha\n  - wire the API\n  - Acceptance:\n    - it renders\n" +
+		"- [ ] beta\n  - tag the release\n" +
+		"- [ ] gamma\n  - announce it\n"
+	want := map[string]string{
+		"alpha": "alpha\n  - wire the API\n  - Acceptance:\n    - it renders",
+		"beta":  "beta\n  - tag the release",
+		"gamma": "gamma\n  - announce it",
+	}
+	// Every ordered pair, so no direction or distance is left unchecked.
+	for from := 1; from <= 3; from++ {
+		for to := 1; to <= 3; to++ {
+			out, err := MoveChecklistItem(content, from, to)
+			if err != nil {
+				t.Fatalf("move %d→%d: %v", from, to, err)
+			}
+			items := ParseChecklist(out)
+			if len(items) != 3 {
+				t.Fatalf("move %d→%d lost an item: %+v", from, to, items)
+			}
+			for _, it := range items {
+				if got := FoldTaskContent(out, it.Text); got != want[it.Text] {
+					t.Errorf("move %d→%d: %q folds to %q, want %q",
+						from, to, it.Text, got, want[it.Text])
+				}
+			}
+			// The moved task really is at its requested position.
+			if got := items[to-1].Text; got != ParseChecklist(content)[from-1].Text {
+				t.Errorf("move %d→%d: position %d holds %q, want the moved task",
+					from, to, to, got)
+			}
+		}
+	}
+}
+
 // TestDeleteChecklistItemNeverReparentsDetail is the delivery-level invariant:
 // after removing a task, no surviving task may fold in a line that belonged to
 // the deleted one. Orphaned sub-bullets stay indented deeper than the PRECEDING

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -818,8 +818,32 @@ func TestMoveChecklistItemRefusesToRewriteNesting(t *testing.T) {
 	nested := "- [ ] a\n  - [ ] a1\n    - a1 detail\n- [ ] b\n"
 	if _, err := MoveChecklistItem(nested, 3, 2); err == nil {
 		t.Error("moving to a different nesting depth must be refused")
-	} else if !strings.Contains(err.Error(), "nesting depths") {
+	} else if !strings.Contains(err.Error(), "different parents") {
 		t.Errorf("the refusal should name the reason, got %v", err)
+	}
+
+	// EQUAL DEPTH IS NOT SIBLINGHOOD. Two sub-tasks under different parents are
+	// indented identically, so a depth-only check would let one be moved under
+	// the other's parent — leaving the first parent childless. This is the case
+	// that makes the guard compare parents rather than indentation.
+	cousins := "- [ ] parent A\n  - [ ] a\n- [ ] parent B\n  - [ ] b\n"
+	if _, err := MoveChecklistItem(cousins, 2, 4); err == nil {
+		t.Error("moving a sub-task under a different parent must be refused")
+	} else if !strings.Contains(err.Error(), "different parents") {
+		t.Errorf("the refusal should name the reason, got %v", err)
+	}
+	// The same shape one level deeper, to pin that the parent lookup is not
+	// special-cased to top level.
+	deep := "- [ ] root\n  - [ ] A\n    - [ ] a\n  - [ ] B\n    - [ ] b\n"
+	if _, err := MoveChecklistItem(deep, 3, 5); err == nil {
+		t.Error("nested cousins must be refused too")
+	}
+	// But true siblings under a shared parent still reorder.
+	twins := "- [ ] root\n  - [ ] A\n    - [ ] a1\n    - [ ] a2\n"
+	if got, err := MoveChecklistItem(twins, 4, 3); err != nil {
+		t.Errorf("siblings under a shared parent must reorder: %v", err)
+	} else if want := "- [ ] root\n  - [ ] A\n    - [ ] a2\n    - [ ] a1\n"; got != want {
+		t.Errorf("sibling reorder:\ngot  %q\nwant %q", got, want)
 	}
 	// Refusals never touch the content.
 	for _, c := range []string{parent, nested} {

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -3165,6 +3165,23 @@ func (a *App) DeleteTask(agent, path string, index int, expectText ...string) ([
 	}))
 }
 
+// MoveTask reorders an item to 1-based position `to`, carrying its nested
+// detail, and returns the renumbered list. An optional expectText aborts
+// (inside the file lock) if the item's text no longer matches — see
+// expectTaskText. That guard is what makes a reorder safe to drive from a
+// stale view: the TUI computes `to` from the row positions it last rendered,
+// so if the file changed underneath, the move is refused rather than applied
+// to whatever now sits at that index.
+func (a *App) MoveTask(agent, path string, index, to int, expectText ...string) ([]domain.ChecklistItem, error) {
+	p, err := a.taskFilePath(agent, path)
+	if err != nil {
+		return nil, err
+	}
+	return mutateTaskFile(p, guardedMutation(index, expectText, func(content string) (string, error) {
+		return domain.MoveChecklistItem(content, index, to)
+	}))
+}
+
 // SignatureRow is a learned signature enriched for display: the persisted
 // state plus the confidence, dominant action, and decision count recomputed
 // from history.

--- a/internal/tui/tasks_test.go
+++ b/internal/tui/tasks_test.go
@@ -271,6 +271,24 @@ func runAction(t *testing.T, m Model, cmd tea.Cmd) (Model, actionResultMsg) {
 	return upd.(Model), res
 }
 
+// syncModel replays the refresh the Bubble Tea runtime performs after every
+// action result (Update returns m.refresh(), whose refreshMsg reloads m.data).
+// runAction deliberately drops that command, so a test that presses a SECOND
+// key against the same model would otherwise act on a stale snapshot — and the
+// expected-text guard would correctly refuse it.
+func syncModel(t *testing.T, m Model) Model {
+	t.Helper()
+	upd, _ := m.Update(refreshData(m.ctx, m.app))
+	out := upd.(Model)
+	// A refresh can legitimately move the tab (a new escalation pulls focus).
+	// Assert rather than silently restore, so a caller never keeps pressing
+	// Tasks keys against a model that has navigated away.
+	if out.tab != tabTasks {
+		t.Fatalf("refresh switched away from the Tasks tab (now %v)", out.tab)
+	}
+	return out
+}
+
 func readTasks(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(path)
@@ -762,6 +780,137 @@ func TestTaskRowDetailMarkerSurvivesNarrowPane(t *testing.T) {
 	}
 }
 
+// TestTasksReorderKeys covers K/J on the Tasks tab: the file is reordered, the
+// cursor FOLLOWS the moved task rather than staying on the row index, and the
+// two ends refuse instead of silently rewriting the file.
+func TestTasksReorderKeys(t *testing.T) {
+	m, _, path := taskAppModel(t) // "- [ ] alpha\n- [x] beta\n- [-] gamma\n"
+	m = press(t, m, "down")       // row 1 = item #1 (alpha)
+	if r := m.selectedTaskRow(); r == nil || r.item != 1 {
+		t.Fatalf("precondition: cursor should be on item #1, got %+v", r)
+	}
+
+	// J moves the task down; the cursor tracks it onto row 2.
+	upd, cmd := m.Update(pressKeyMsg("J"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("J on an item row should run a move")
+	}
+	if got := m.cursors[tabTasks]; got != 2 {
+		t.Errorf("cursor should follow the moved task to row 2, got %d", got)
+	}
+	m, res := runAction(t, m, cmd)
+	if res.err != nil {
+		t.Fatal(res.err)
+	}
+	if got, want := readTasks(t, path), "- [x] beta\n- [ ] alpha\n- [-] gamma\n"; got != want {
+		t.Errorf("after J:\ngot  %q\nwant %q", got, want)
+	}
+	m = syncModel(t, m) // the runtime's post-action refresh
+
+	// K moves it back up, cursor following again. The cursor is still on row 2,
+	// which the refreshed data now shows as the task that was just moved.
+	if r := m.selectedTaskRow(); r == nil || r.itemText != "alpha" {
+		t.Fatalf("cursor should still be on the moved task, got %+v", r)
+	}
+	upd, cmd = m.Update(pressKeyMsg("K"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("K on an item row should run a move")
+	}
+	if got := m.cursors[tabTasks]; got != 1 {
+		t.Errorf("cursor should follow the moved task back to row 1, got %d", got)
+	}
+	if m, res = runAction(t, m, cmd); res.err != nil {
+		t.Fatal(res.err)
+	}
+	if got, want := readTasks(t, path), "- [ ] alpha\n- [x] beta\n- [-] gamma\n"; got != want {
+		t.Errorf("after K:\ngot  %q\nwant %q", got, want)
+	}
+	m = syncModel(t, m)
+
+	// At the top, K refuses — no command, no rewrite.
+	before := readTasks(t, path)
+	upd, cmd = m.Update(pressKeyMsg("K"))
+	m = upd.(Model)
+	if cmd != nil {
+		t.Error("K on the first task must not run a move")
+	}
+	if !strings.Contains(m.message, "already at the top") {
+		t.Errorf("K at the top should explain itself, got %q", m.message)
+	}
+	if got := readTasks(t, path); got != before {
+		t.Errorf("a refused move must not rewrite the file:\ngot  %q\nwant %q", got, before)
+	}
+
+	// Same at the bottom.
+	m = press(t, m, "down", "down") // row 3 = item #3
+	upd, cmd = m.Update(pressKeyMsg("J"))
+	m = upd.(Model)
+	if cmd != nil {
+		t.Error("J on the last task must not run a move")
+	}
+	if !strings.Contains(m.message, "already at the bottom") {
+		t.Errorf("J at the bottom should explain itself, got %q", m.message)
+	}
+
+	// On a group header there is no task to move.
+	m = press(t, m, "up", "up", "up")
+	upd, cmd = m.Update(pressKeyMsg("J"))
+	m = upd.(Model)
+	if cmd != nil || !strings.Contains(m.message, "move the cursor onto a task") {
+		t.Errorf("J on a header should only hint, got cmd=%v message=%q", cmd != nil, m.message)
+	}
+}
+
+// TestTasksReorderClearsMarks pins that a reorder drops the multi-select.
+// m.taskMarks are keyed POSITIONALLY, so renumbering the list would leave every
+// surviving mark pointing at a different task — the same reason the delete path
+// consumes them.
+func TestTasksReorderClearsMarks(t *testing.T) {
+	m, _, _ := taskAppModel(t)
+	m = press(t, m, "down", " ") // mark item #1; space also advances the cursor
+	if len(m.taskMarks) != 1 {
+		t.Fatalf("precondition: one mark expected, got %v", m.taskMarks)
+	}
+	upd, cmd := m.Update(pressKeyMsg("J"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("J should run a move")
+	}
+	if len(m.taskMarks) != 0 {
+		t.Errorf("a reorder renumbers items, so marks must be cleared, got %v", m.taskMarks)
+	}
+}
+
+// TestTasksReorderShiftArrowAliases pins the non-vim spelling of the same keys.
+func TestTasksReorderShiftArrowAliases(t *testing.T) {
+	// Start file: "- [ ] alpha\n- [x] beta\n- [-] gamma\n".
+	for _, tc := range []struct {
+		key, want string
+		downs     int // cursor presses to reach the task being moved
+	}{
+		{"shift+down", "- [x] beta\n- [ ] alpha\n- [-] gamma\n", 1}, // item #1 down
+		{"shift+up", "- [ ] alpha\n- [-] gamma\n- [x] beta\n", 3},   // item #3 up
+	} {
+		m, _, path := taskAppModel(t)
+		for i := 0; i < tc.downs; i++ {
+			m = press(t, m, "down")
+		}
+		upd, cmd := m.Update(pressKeyMsg(tc.key))
+		m = upd.(Model)
+		if cmd == nil {
+			t.Fatalf("%s should run a move", tc.key)
+		}
+		if _, res := runAction(t, m, cmd); res.err != nil {
+			t.Fatal(res.err)
+		}
+		if got := readTasks(t, path); got != tc.want {
+			t.Errorf("%s:\ngot  %q\nwant %q", tc.key, got, tc.want)
+		}
+	}
+}
+
 // mustParse reads a checklist file the way the frontend does, so a test row
 // carries the same Detail the real Tasks tab renders from.
 func mustParse(t *testing.T, path string) []domain.ChecklistItem {
@@ -771,6 +920,14 @@ func mustParse(t *testing.T, path string) []domain.ChecklistItem {
 		t.Fatal(err)
 	}
 	return domain.ParseChecklist(string(b))
+}
+
+// TestTasksHelpAdvertisesReorder keeps the footer honest about the new keys.
+func TestTasksHelpAdvertisesReorder(t *testing.T) {
+	m := taskModel(t)
+	if view := m.View(); !strings.Contains(view, "K/J: move up/down") {
+		t.Errorf("Tasks footer should advertise the reorder keys:\n%s", view)
+	}
 }
 
 func TestTaskDetailEditAction(t *testing.T) {
@@ -1449,5 +1606,93 @@ func TestTasksTabUnescapesDisplayedIDs(t *testing.T) {
 	// The row keeps the raw text: it is what matches the line in the file.
 	if got := m.taskRows()[1].itemText; got != `8\.1 commit to a new branch` {
 		t.Errorf("itemText = %q, want the raw file text", got)
+	}
+}
+
+// TestTasksReorderRefusesUnderSearchFilter pins the filter guard. A filter
+// hides rows while `move` works in FILE positions, so a step would jump the
+// task over invisible items — and because a moved task often keeps its filtered
+// row while its file position changes, the cursor nudge would land on a
+// different task and the next keypress would move the wrong one.
+func TestTasksReorderRefusesUnderSearchFilter(t *testing.T) {
+	m, _, path := taskAppModel(t)
+	before := readTasks(t, path)
+	m = press(t, m, "down")
+	m.query[tabTasks] = "alpha"
+	upd, cmd := m.Update(pressKeyMsg("J"))
+	m = upd.(Model)
+	if cmd != nil {
+		t.Error("a reorder must not run while the Tasks filter is active")
+	}
+	if !strings.Contains(m.message, "clear the search filter") {
+		t.Errorf("the refusal should say why, got %q", m.message)
+	}
+	if got := readTasks(t, path); got != before {
+		t.Errorf("a refused reorder must not rewrite the file:\ngot  %q\nwant %q", got, before)
+	}
+	// Clearing the filter re-enables it.
+	m.query[tabTasks] = ""
+	if _, cmd = m.Update(pressKeyMsg("J")); cmd == nil {
+		t.Error("clearing the filter should re-enable reordering")
+	}
+}
+
+// TestTasksReorderCursorNudgeWithTwoGroups pins the arithmetic in the case it
+// is least obviously right: with a second task source above it, the rows the
+// cursor indexes include another group's header and items. It still holds
+// because a group's items are a contiguous run of rows and the end guard stops
+// a move from crossing its own header — so ±1 item is always ±1 row.
+func TestTasksReorderCursorNudgeWithTwoGroups(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.md")
+	second := filepath.Join(dir, "second.md")
+	if err := os.WriteFile(first, []byte("- [ ] one-a\n- [ ] one-b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, []byte("- [ ] two-a\n- [ ] two-b\n- [ ] two-c\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	app := &frontend.App{Store: st, Herdr: &captureHerdr{},
+		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+	ctx := context.Background()
+	if err := app.AddTaskSource(ctx, "a1", "", first, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(ctx, "a2", "", second, ""); err != nil {
+		t.Fatal(err)
+	}
+	m := New(ctx, app)
+	m.width, m.height = 100, 30
+	upd, _ := m.Update(refreshData(ctx, app))
+	m = upd.(Model)
+	m.tab = tabTasks
+
+	// Rows: 0 header, 1 one-a, 2 one-b, 3 header, 4 two-a, 5 two-b, 6 two-c.
+	m.cursors[tabTasks] = 4
+	if r := m.selectedTaskRow(); r == nil || r.itemText != "two-a" || r.group != 1 {
+		t.Fatalf("precondition: cursor should be on the second group's first item, got %+v", r)
+	}
+	upd, cmd := m.Update(pressKeyMsg("J"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("J should run a move")
+	}
+	if got := m.cursors[tabTasks]; got != 5 {
+		t.Errorf("cursor should follow the moved task to row 5, got %d", got)
+	}
+	if _, res := runAction(t, m, cmd); res.err != nil {
+		t.Fatal(res.err)
+	}
+	if got, want := readTasks(t, second), "- [ ] two-b\n- [ ] two-a\n- [ ] two-c\n"; got != want {
+		t.Errorf("second group:\ngot  %q\nwant %q", got, want)
+	}
+	// The other group's file is untouched.
+	if got, want := readTasks(t, first), "- [ ] one-a\n- [ ] one-b\n"; got != want {
+		t.Errorf("first group must be untouched:\ngot  %q\nwant %q", got, want)
 	}
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1638,6 +1638,17 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case tabTasks:
 			return m.toggleTaskMarkSelected()
 		}
+	// Reorder: the shifted forms of the j/k cursor keys, so "move the selection"
+	// and "move the task" share a mnemonic. shift+arrow is bound to the same
+	// handlers for anyone who does not read j/k as movement.
+	case "K", "shift+up":
+		if m.tab == tabTasks {
+			return m.moveSelectedTask(-1)
+		}
+	case "J", "shift+down":
+		if m.tab == tabTasks {
+			return m.moveSelectedTask(1)
+		}
 	case "x", "delete":
 		switch m.tab {
 		case tabAgents:
@@ -2625,6 +2636,84 @@ func (m Model) taskGroupAgent(group int) *domain.AgentTransition {
 		}
 	}
 	return nil
+}
+
+// moveSelectedTask reorders the task under the cursor by delta positions
+// (-1 = up, +1 = down) within its own source file, carrying its nested detail.
+//
+// Three things have to be handled that no other Tasks action needs:
+//
+//   - m.taskMarks are keyed POSITIONALLY (taskMarkKey(group, item)), so a
+//     reorder renumbers items out from under them and every surviving mark
+//     would silently retarget a different task. They are cleared, exactly as
+//     the delete path does for the same reason.
+//   - the cursor is a row index, not an item identity, and a reorder leaves the
+//     row COUNT unchanged — so clampListViewport does nothing and the cursor
+//     would end up on whichever task swapped into place. It is nudged by delta
+//     so that once the refresh lands it is on the task that moved, not on the
+//     one that took its row.
+//   - a search filter hides rows while positions count every task, so the move
+//     is refused outright (see below).
+//
+// The nudge anticipates the async refresh rather than replacing it: m.data is
+// only reloaded when the actionResultMsg round-trip completes, so a second
+// press inside that window still reads stale rows and the expected-text guard
+// refuses it. The file is never at risk; the operator just has to press again.
+// One move per refresh is the honest cadence here.
+func (m Model) moveSelectedTask(delta int) (tea.Model, tea.Cmd) {
+	r := m.selectedTaskRow()
+	if r == nil || r.item == 0 {
+		m.message = "K/J reorders checklist items — move the cursor onto a task"
+		return m, nil
+	}
+	if r.group >= len(m.data.tasks) {
+		m.message = "this task source is no longer loaded — refreshing"
+		return m, nil
+	}
+	// A search filter hides rows, and positions are FILE positions — so one step
+	// would jump the task over items the operator cannot see, and the cursor
+	// could not follow it: a moved task often keeps its filtered row while its
+	// file position changes, so the nudge below would land on a different task
+	// and the next keypress would move THAT one. Refuse rather than reorder
+	// against a view that does not show what is happening.
+	if m.query[tabTasks] != "" {
+		m.message = "clear the search filter to reorder — positions count hidden tasks too"
+		return m, nil
+	}
+	to := r.item + delta
+	// Refuse at the ends rather than clamping: a clamp would rewrite the file
+	// with identical content and report success, so holding the key at the top
+	// of the list would look like it was still doing something.
+	if n := len(m.data.tasks[r.group].Items); to < 1 || to > n {
+		m.message = fmt.Sprintf("task #%d is already at the %s of this list", r.item, edgeName(delta))
+		return m, nil
+	}
+	app, path, from, text := m.app, canonicalTaskPath(r.path), r.item, r.itemText
+	m.taskMarks = nil
+	if delta > 0 && m.cursors[m.tab] < m.rowCount()-1 {
+		m.cursors[m.tab]++
+	} else if delta < 0 && m.cursors[m.tab] > 0 {
+		m.cursors[m.tab]--
+	}
+	m.scrollCursorIntoView()
+	m.beginAction()
+	return m, m.do(fmt.Sprintf("task #%d moved to position #%d", from, to),
+		func(c context.Context) error {
+			// The snapshotted text is the staleness guard: the row positions
+			// this move was computed from are the ones last rendered, so if the
+			// file changed underneath, refuse rather than reorder whatever now
+			// sits at that index.
+			_, err := app.MoveTask("", path, from, to, text)
+			return err
+		})
+}
+
+// edgeName names the end of the list a move ran into, for the refusal message.
+func edgeName(delta int) string {
+	if delta < 0 {
+		return "top"
+	}
+	return "bottom"
 }
 
 // sendSelectedTask delivers the pending task under the cursor to the live
@@ -4431,7 +4520,7 @@ func (m Model) helpLine() string {
 	case tabAgents:
 		return "v: details  x: disable  e: enable  n: rename agent  f: focus in herdr  t: see tasks  /: search  " + common
 	case tabTasks:
-		return "enter/y: send to agent  v: details  a: add  e: edit  d: done/undone  x: delete (source on a header)  space: mark  f: focus in herdr  /: search  " + common
+		return "enter/y: send to agent  v: details  a: add  e: edit  d: done/undone  K/J: move up/down  x: delete (source on a header)  space: mark  f: focus in herdr  /: search  " + common
 	case tabEscalations:
 		return "enter: confirm+send  y: confirm only (marked)  c: correct (+send?)  l: retry LLM  f: focus in herdr  t: see rule  space: mark  x: delete  X: prune old  v: details  /: search  " + common
 	case tabAudit:


### PR DESCRIPTION
> **Stacked on #243** — base that branch, not `main`. The reorder must carry a task's detail block, which is `detailBlockEnd` from #243; a reorder that moved only the title line would reintroduce that bug in its worst form. Retarget to `main` once #243 merges.

## What

The Tasks tab could add, edit, complete and delete a task but not **move** one, so fixing the order of a hand-authored plan meant editing the file behind hap's back.

| Layer | Added |
|---|---|
| domain | `MoveChecklistItem(content, from, to)` |
| frontend | `App.MoveTask(agent, path, index, to, expectText...)` |
| CLI | `hap task <agent> move <n> <position\|up\|down>` (aliases `mv`, `reorder`) |
| TUI | `K`/`J` and `shift+up`/`shift+down` on the Tasks tab, plus footer hint |

The CLI verb is not optional — `hap help tui` states that everything the TUI does is available as a CLI verb, which is what scripts and agents use.

Verified live in a running TUI: repeated `J` walks a task down and the cursor follows it, each detail block travelling with its own task.

## Detail travels with the task

`MoveChecklistItem` moves the item's whole block via `detailBlockEnd`, exactly as delete and append do since #243. Moving only the title would strand the detail to be folded into whatever ends up above it while the moved task arrives bare — reordering is precisely the operation that would otherwise scramble *every* task's instructions at once, rather than one.

`TestMoveChecklistItemKeepsEveryTasksDetail` walks all nine ordered pairs of a three-task list and asserts every task still folds to exactly its own content.

## Reordering is siblings-only, and that is deliberate

A nested `- [ ]` is its own **item**, not detail, so `detailBlockEnd` stops at it — meaning it neither travels with a parent nor is stepped over. Without a guard:

```
- [ ] a          move a (1→2)      - [ ] a1     ← orphaned, no parent
  - [ ] a1            →            - [ ] a
- [ ] b                            - [ ] b

- [ ] a          move b (3→2)      - [ ] a
  - [ ] a1            →            - [ ] b
    - a1 detail                      - [ ] a1   ← adopted by b
- [ ] b                              - a1 detail
```

Positions are right and no line is lost, but the tree the operator wrote gets rewritten. Both cases are now refused by name:

- an item with nested sub-tasks cannot move (its children would not follow);
- source and destination must sit at the same indent depth.

Subtree moves were considered and rejected: they make `to` ambiguous (does the destination position count the moved children?). Flat lists — what hap writes, and what nearly every checklist is — are unaffected, and siblings at the same depth reorder normally.

## TUI specifics

Three things this action needs that no other Tasks action does:

- **`m.taskMarks` are keyed positionally** (`taskMarkKey(group, item)`), so a reorder renumbers items under them and every surviving mark would silently retarget a different task. Cleared, as the delete path does.
- **The cursor is a row index, not an item identity**, and a reorder leaves the row *count* unchanged — so `clampListViewport` does nothing and the cursor would land on whichever task swapped into place. It is nudged by delta so it follows the moved task.
- **Refused while a search filter is active.** Positions count hidden tasks, so a step would jump the task over items the operator cannot see; worse, a moved task often keeps its filtered row while its file position changes, so the nudge would land on a different task and the next keypress would move *that* one.

Both ends **refuse rather than clamp**: a clamp would rewrite the file with identical content and report success, so holding the key at the top would look like it was still working. Same for `move 2 2` on the CLI, which short-circuits before the mutation (`taskfile.Mutate` writes unconditionally).

The cursor nudge anticipates the async refresh rather than replacing it — a second press inside that window still reads stale rows and is refused by the expected-text guard. The file is never at risk; one move per refresh is the honest cadence, and the comment says so.

## Tests

- domain: both directions and distances, all nine ordered pairs with fold assertions, marks preserved, prose/headers untouched, no trailing newline, both error classes, the nesting refusals (and that siblings at the same depth still work), and blank-line behaviour pinned with a line-count invariant
- CLI: the reorder, detail travelling, relative vs absolute destinations, both edge no-ops leaving the file untouched, invalid destinations (`sideways`, `+2`, `""`, `2.5`), the alias, id-addressed sources (`move 1.3 up`), and the nesting refusals
- TUI: `K`/`J` with the cursor following, both edges refusing without a write, header rows, marks cleared, shift-arrow aliases, footer hint, the filter refusal, and the cursor nudge with **two** task-source groups

Full suite green (24 packages), `internal/domain` clean under `-race`, `gofmt`/`go vet`/`golangci-lint --build-tags "vectors,cpu"` clean.

## Known, documented behaviour

Blank separators do **not** travel with a moved item — they sit between items rather than belonging to one, so a move can leave a blank where the item was and land it tight against its new neighbour. Carrying them just trades one spacing artifact for another (the blank would follow the item to the end of the file). Pinned by `TestMoveChecklistItemBlankLines` so it is a decision, not a surprise.
