### PR TITLE
#1 feat: reorder a task together with its nested sub-tasks

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1729,16 +1729,38 @@ func taskTargetLabel(agent, path string) string {
 // would otherwise shift positions under the resolved index and rewrite the
 // wrong line.
 func taskItemArg(app *frontend.App, agent, path string, args []string) (domain.ChecklistItem, error) {
-	if len(args) == 0 {
-		return domain.ChecklistItem{}, domain.ErrTaskRefRequired
-	}
-	// Reject a syntactically impossible reference before reading anything:
-	// resolution needs the checklist, so without this `done xyz` on a missing
-	// file reports the file error instead of the typo that caused it.
-	if !domain.TaskRefSyntaxOK(args[0]) {
-		return domain.ChecklistItem{}, fmt.Errorf("invalid task number %q — pass a task id from the list (e.g. 3.4) or a position (e.g. '#3')", args[0])
+	if err := checkTaskRefArg(args); err != nil {
+		return domain.ChecklistItem{}, err
 	}
 	return app.ResolveTaskRef(agent, path, args[0])
+}
+
+// taskItemArgIn is taskItemArg against an ALREADY-READ list, for a caller that
+// needs the list too. Resolving from the same snapshot the rest of the command
+// reasons about is the point: two reads can straddle a concurrent edit, and
+// then the index one half resolved names a different task in the other's list.
+func taskItemArgIn(tasks []domain.ChecklistItem, args []string) (domain.ChecklistItem, error) {
+	if err := checkTaskRefArg(args); err != nil {
+		return domain.ChecklistItem{}, err
+	}
+	index, err := domain.ResolveTaskRef(tasks, args[0])
+	if err != nil {
+		return domain.ChecklistItem{}, err
+	}
+	return tasks[index-1], nil
+}
+
+// checkTaskRefArg rejects a missing or syntactically impossible reference. Both
+// resolvers call it BEFORE anything reads the checklist, so `done xyz` on a
+// missing file reports the typo that caused it rather than the file error.
+func checkTaskRefArg(args []string) error {
+	if len(args) == 0 {
+		return domain.ErrTaskRefRequired
+	}
+	if !domain.TaskRefSyntaxOK(args[0]) {
+		return fmt.Errorf("invalid task number %q — pass a task id from the list (e.g. 3.4) or a position (e.g. '#3')", args[0])
+	}
+	return nil
 }
 
 func taskToggle(app *frontend.App, out io.Writer, agent, path string, rest []string, done bool) error {
@@ -1783,19 +1805,46 @@ func taskStart(app *frontend.App, out io.Writer, agent, path string, rest []stri
 // here: after the move the item's own id is unchanged, so naming the target by
 // id would ask "put 5 where 2 is" and leave "which 2 — before or after the
 // shift?" open. `up`/`down` are the one-step forms the TUI's keys drive.
+//
+// ONE read of the checklist decides everything (taskMoveIn). Resolving the
+// reference and then RE-READING for the destination let a concurrent edit
+// answer the two halves from different files: the index one read resolved can
+// name a different task in the other's list, so the sibling step, the
+// off-the-end check and the reported position could all describe a checklist
+// the caller never named. The write itself was never at risk — expectText
+// refuses inside the lock — but a command that reports one thing and does
+// another is not one an operator can reason about.
 func taskMove(app *frontend.App, out io.Writer, agent, path string, args []string) error {
 	if len(args) < 2 {
 		return fmt.Errorf("usage: task %s move <n> <position|up|down> (see: hap help task)",
 			taskTargetLabel(agent, path))
 	}
-	it, err := taskItemArg(app, agent, path, args[:1])
+	// Before the read, so a typo is reported as a typo even when the file
+	// cannot be read — the ordering taskItemArg guarantees for every other op.
+	if err := checkTaskRefArg(args[:1]); err != nil {
+		return err
+	}
+	tasks, err := app.ListTasks(agent, path)
+	if err != nil {
+		return err
+	}
+	return taskMoveIn(app, out, agent, path, args, tasks)
+}
+
+// taskMoveIn is taskMove decided entirely from the `tasks` snapshot: which item
+// the reference names, which sibling a relative step lands on, whether that
+// step ran off the end, and which position to report. Taking the snapshot as a
+// parameter is what makes that single-snapshot property structural — there is
+// no second list for the two halves to disagree about, and a test can hand it
+// one deliberately at odds with the file on disk.
+func taskMoveIn(app *frontend.App, out io.Writer, agent, path string, args []string, tasks []domain.ChecklistItem) error {
+	it, err := taskItemArgIn(tasks, args[:1])
 	if err != nil {
 		return err
 	}
 	idx := it.Index
-	// The item list resolves a relative step: "down" is one SIBLING, not one
-	// position, since the position after a parent is its own first child.
-	tasks := listTasksOrNil(app, agent, path)
+	// "down" is one SIBLING, not one position, since the position after a
+	// parent is its own first child.
 	to, relative, err := moveDestination(args[1], idx, tasks)
 	if err != nil {
 		return err
@@ -1804,11 +1853,8 @@ func taskMove(app *frontend.App, out io.Writer, agent, path string, args []strin
 	// a repeated `move X up` does when it reaches the top, and equally what it
 	// does for a task that has no sibling on that side — so it is reported as
 	// "already there" rather than the bare "no task #0" the position validator
-	// would raise for a number the caller never typed. A nil list means it could
-	// not be read, and is deliberately NOT treated as "past the end": that would
-	// swallow the read error behind a success message. Falling through lets
-	// MoveTask report the real problem.
-	if n := len(tasks); relative && (to < 1 || (n > 0 && to > n)) {
+	// would raise for a number the caller never typed.
+	if n := len(tasks); relative && (to < 1 || to > n) {
 		edge := "top"
 		if to > idx {
 			edge = "bottom"
@@ -1837,27 +1883,15 @@ func taskMove(app *frontend.App, out io.Writer, agent, path string, args []strin
 }
 
 // moveLanding is the position domain.MoveChecklistItem leaves the item at,
-// derived from the PRE-move item list. Moving up it is the destination itself;
-// moving down it is the destination shifted back by however much more of the
-// list the source subtree occupied than the destination's does. With no item
-// list to measure (a read that failed) the destination is the honest guess.
+// derived from the SAME pre-move snapshot the move was decided from. Moving up
+// it is the destination itself; moving down it is the destination shifted back
+// by however much more of the list the source subtree occupied than the
+// destination's does.
 func moveLanding(tasks []domain.ChecklistItem, from, to int) int {
-	if tasks == nil || to < from {
+	if to < from {
 		return to
 	}
 	return to + domain.SubtreeSize(tasks, to) - domain.SubtreeSize(tasks, from)
-}
-
-// listTasksOrNil reads the target file's checklist items for the relative-move
-// step and its edge check, or nil when it cannot be read — which the caller
-// treats as "unknown", not "empty", so a read failure surfaces from the move
-// itself instead of as a bogus "already at the top".
-func listTasksOrNil(app *frontend.App, agent, path string) []domain.ChecklistItem {
-	items, err := app.ListTasks(agent, path)
-	if err != nil {
-		return nil
-	}
-	return items
 }
 
 // moveDestination resolves a move target to a 1-based position, reporting
@@ -1875,19 +1909,13 @@ func listTasksOrNil(app *frontend.App, agent, path string) []domain.ChecklistIte
 // direction (0 going up, past the last item going down), so the caller's
 // edge check reports the side the operator actually asked for.
 //
-// A nil `tasks` means the list could not be read; the plain ±1 step is kept so
-// that failure surfaces from the move itself rather than as a bogus edge report.
+// `tasks` is the caller's single snapshot — the same one the reference was
+// resolved against, so `idx` always names the item the step is computed for.
 func moveDestination(arg string, idx int, tasks []domain.ChecklistItem) (to int, relative bool, err error) {
 	switch strings.ToLower(strings.TrimSpace(arg)) {
 	case "up":
-		if tasks == nil {
-			return idx - 1, true, nil
-		}
 		return domain.SiblingPosition(tasks, idx, -1), true, nil
 	case "down":
-		if tasks == nil {
-			return idx + 1, true, nil
-		}
 		if p := domain.SiblingPosition(tasks, idx, 1); p > 0 {
 			return p, true, nil
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1793,23 +1793,27 @@ func taskMove(app *frontend.App, out io.Writer, agent, path string, args []strin
 		return err
 	}
 	idx := it.Index
-	to, relative, err := moveDestination(args[1], idx)
+	// The item list resolves a relative step: "down" is one SIBLING, not one
+	// position, since the position after a parent is its own first child.
+	tasks := listTasksOrNil(app, agent, path)
+	to, relative, err := moveDestination(args[1], idx, tasks)
 	if err != nil {
 		return err
 	}
 	// A relative step off either end is a normal thing to ask for — it is what
-	// a repeated `move X up` does when it reaches the top — so it is reported
-	// as "already there" rather than the bare "no task #0" the position
-	// validator would raise for a number the caller never typed. n == 0 means
-	// the count could not be read, and is deliberately NOT treated as "past the
-	// end": that would swallow the read error behind a success message. Falling
-	// through lets MoveTask report the real problem.
-	if n := countTasks(app, agent, path); relative && (to < 1 || (n > 0 && to > n)) {
+	// a repeated `move X up` does when it reaches the top, and equally what it
+	// does for a task that has no sibling on that side — so it is reported as
+	// "already there" rather than the bare "no task #0" the position validator
+	// would raise for a number the caller never typed. A nil list means it could
+	// not be read, and is deliberately NOT treated as "past the end": that would
+	// swallow the read error behind a success message. Falling through lets
+	// MoveTask report the real problem.
+	if n := len(tasks); relative && (to < 1 || (n > 0 && to > n)) {
 		edge := "top"
 		if to > idx {
 			edge = "bottom"
 		}
-		fmt.Fprintf(out, "task #%d is already at the %s of this list\n", idx, edge)
+		fmt.Fprintf(out, "task #%d is already at the %s of its siblings\n", idx, edge)
 		return nil
 	}
 	if to == idx {
@@ -1823,20 +1827,37 @@ func taskMove(app *frontend.App, out io.Writer, agent, path string, args []strin
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "moved task #%d to position #%d\n", idx, to)
+	// Report where the task LANDED, not the destination that was asked for.
+	// Moving down, the source subtree vacates the positions above the
+	// destination, so the item usually ends up earlier than `to` — printing `to`
+	// would contradict the list printed on the very next line.
+	fmt.Fprintf(out, "moved task #%d to position #%d\n", idx, moveLanding(tasks, idx, to))
 	printTaskList(out, items, "all")
 	return nil
 }
 
-// countTasks reports how many checklist items the target file holds, for the
-// relative-move edge check, or 0 when it cannot be read — which the caller
-// treats as "unknown", not "empty".
-func countTasks(app *frontend.App, agent, path string) int {
+// moveLanding is the position domain.MoveChecklistItem leaves the item at,
+// derived from the PRE-move item list. Moving up it is the destination itself;
+// moving down it is the destination shifted back by however much more of the
+// list the source subtree occupied than the destination's does. With no item
+// list to measure (a read that failed) the destination is the honest guess.
+func moveLanding(tasks []domain.ChecklistItem, from, to int) int {
+	if tasks == nil || to < from {
+		return to
+	}
+	return to + domain.SubtreeSize(tasks, to) - domain.SubtreeSize(tasks, from)
+}
+
+// listTasksOrNil reads the target file's checklist items for the relative-move
+// step and its edge check, or nil when it cannot be read — which the caller
+// treats as "unknown", not "empty", so a read failure surfaces from the move
+// itself instead of as a bogus "already at the top".
+func listTasksOrNil(app *frontend.App, agent, path string) []domain.ChecklistItem {
 	items, err := app.ListTasks(agent, path)
 	if err != nil {
-		return 0
+		return nil
 	}
-	return len(items)
+	return items
 }
 
 // moveDestination resolves a move target to a 1-based position, reporting
@@ -1845,12 +1866,32 @@ func countTasks(app *frontend.App, agent, path string) int {
 // walking a task to the top with repeated `up` naturally ends there. An
 // absolute position is never clamped: a destination the caller actually typed
 // is rejected by name if no such task exists.
-func moveDestination(arg string, idx int) (to int, relative bool, err error) {
+//
+// A relative step moves one SIBLING, which `tasks` is needed to find: the
+// position after a parent is its own first child, and swapping a parent with
+// its child is re-parenting, which MoveChecklistItem refuses. Stepping by
+// position would make `move X down` fail on every nested list. When the item
+// has no sibling that way the result is deliberately off the end in THAT
+// direction (0 going up, past the last item going down), so the caller's
+// edge check reports the side the operator actually asked for.
+//
+// A nil `tasks` means the list could not be read; the plain ±1 step is kept so
+// that failure surfaces from the move itself rather than as a bogus edge report.
+func moveDestination(arg string, idx int, tasks []domain.ChecklistItem) (to int, relative bool, err error) {
 	switch strings.ToLower(strings.TrimSpace(arg)) {
 	case "up":
-		return idx - 1, true, nil
+		if tasks == nil {
+			return idx - 1, true, nil
+		}
+		return domain.SiblingPosition(tasks, idx, -1), true, nil
 	case "down":
-		return idx + 1, true, nil
+		if tasks == nil {
+			return idx + 1, true, nil
+		}
+		if p := domain.SiblingPosition(tasks, idx, 1); p > 0 {
+			return p, true, nil
+		}
+		return len(tasks) + 1, true, nil
 	}
 	digits := strings.TrimPrefix(strings.TrimSpace(arg), "#")
 	// Digits only: strconv.Atoi also accepts a sign, and "+2" reading as

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1405,6 +1405,49 @@ func TestTaskMoveByDeclaredID(t *testing.T) {
 	}
 }
 
+// TestTaskMoveCarriesSubtree: `move` reorders a parent together with its
+// sub-tasks instead of refusing, and `down` steps one SIBLING — the position
+// below a parent is its own first child, which the mutator would refuse as
+// re-parenting.
+func TestTaskMoveCarriesSubtree(t *testing.T) {
+	app, _ := testApp(t)
+	path := writeTaskFile(t, "- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n")
+
+	out, err := run(t, app, "task", "--path", path, "move", "#1", "down")
+	if err != nil {
+		t.Fatalf("moving a parent with sub-tasks must work: %v", err)
+	}
+	want := "- [ ] b\n- [ ] a\n  - [ ] a1\n  - [ ] a2\n"
+	if got := readTaskFile(t, path); got != want {
+		t.Errorf("after move down:\ngot  %q\nwant %q", got, want)
+	}
+	// The message must name where the task LANDED (#2), not the destination it
+	// stepped to (#4) — the list printed right below it says #2.
+	if !strings.Contains(out, "moved task #1 to position #2") {
+		t.Errorf("the move should report its landing position, got %q", out)
+	}
+	// And back up, so `up` steps a sibling too.
+	if _, err := run(t, app, "task", "--path", path, "move", "#2", "up"); err != nil {
+		t.Fatalf("moving the parent back must work: %v", err)
+	}
+	want = "- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n"
+	if got := readTaskFile(t, path); got != want {
+		t.Errorf("after move up:\ngot  %q\nwant %q", got, want)
+	}
+	// A sub-task with no sibling below it is "already at the bottom", not an
+	// error and not a step into the next parent.
+	out, err = run(t, app, "task", "--path", path, "move", "#3", "down")
+	if err != nil {
+		t.Fatalf("a step with no sibling must not error: %v", err)
+	}
+	if !strings.Contains(out, "already at the bottom") {
+		t.Errorf("a sub-task with no next sibling should say so, got %q", out)
+	}
+	if got := readTaskFile(t, path); got != want {
+		t.Errorf("an edge step must not rewrite the file:\ngot  %q\nwant %q", got, want)
+	}
+}
+
 // TestTaskMoveRefusesNestingRewrite pins that the CLI surfaces the domain's
 // siblings-only refusals rather than silently restructuring the file.
 func TestTaskMoveRefusesNestingRewrite(t *testing.T) {
@@ -1412,8 +1455,8 @@ func TestTaskMoveRefusesNestingRewrite(t *testing.T) {
 	path := writeTaskFile(t, "- [ ] a\n  - [ ] a1\n- [ ] b\n")
 	before := readTaskFile(t, path)
 
-	if _, err := run(t, app, "task", "--path", path, "move", "#1", "3"); err == nil {
-		t.Error("moving a task with nested sub-tasks must error")
+	if _, err := run(t, app, "task", "--path", path, "move", "#2", "3"); err == nil {
+		t.Error("moving a sub-task out from under its parent must error")
 	}
 	if _, err := run(t, app, "task", "--path", path, "move", "#3", "2"); err == nil {
 		t.Error("moving into another item's nesting must error")

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -631,9 +631,11 @@ func buildCommands() {
 				"prints them — they are folded into the prompt the agent receives.\n" +
 				"`move` reorders one task: the SOURCE is a reference like any other op, but the\n" +
 				"DESTINATION is always a position (or up/down for one step), since a task keeps\n" +
-				"its own id when it moves. A task's nested DETAIL lines travel with it; nested\n" +
-				"sub-TASKS are items of their own, so a task that has them cannot be moved, and\n" +
-				"a task can only be reordered among its siblings.\n" +
+				"its own id when it moves. The whole subtree travels — the task's nested DETAIL\n" +
+				"lines, its nested sub-TASKS, and their detail — so the destination names the\n" +
+				"SIBLING to reorder past. A task can only be reordered among its siblings;\n" +
+				"moving one under a different parent is re-parenting, not reordering, and is\n" +
+				"refused.\n" +
 				"`send` hands a pending item to a live, cleanly idle agent NOW and marks it [-];\n" +
 				"idleness is re-checked at delivery, and a failed send returns the item to [ ].\n" +
 				"Normally you do not need `send`: the daemon hands out the next task by itself.",

--- a/internal/cli/move_snapshot_test.go
+++ b/internal/cli/move_snapshot_test.go
@@ -1,0 +1,164 @@
+package cli
+
+// These live in the `cli` package (not cli_test) so they can hand taskMoveIn a
+// snapshot deliberately at odds with the file on disk. That is the whole point
+// of the change under test: taskMove reads the checklist ONCE and every part of
+// the decision comes from that one read, so there is no second read for a
+// concurrent edit to answer differently. Driving taskMoveIn directly is how the
+// edit is placed exactly where the second read used to be.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+)
+
+// moveSnapshotFixture writes a checklist and returns an App addressing it by
+// --path, the path, and the snapshot taskMove would have taken. Resolution by
+// --path needs no store or config, so a bare App is enough.
+func moveSnapshotFixture(t *testing.T, content string) (*frontend.App, string, []domain.ChecklistItem) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "tasks.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	app := &frontend.App{}
+	tasks, err := app.ListTasks("", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return app, path, tasks
+}
+
+// TestTaskMoveReportsFromTheSnapshotItResolved: an edit landing where the
+// SECOND read used to be must not change what the command reports. Here the
+// resolved task is last in its snapshot, so the answer is "already at the
+// bottom" and nothing is written — even though a re-read would now find a
+// sibling below it and happily move the task past a list item that appeared
+// after the command was issued.
+func TestTaskMoveReportsFromTheSnapshotItResolved(t *testing.T) {
+	const before = "- [ ] a\n- [ ] b\n"
+	app, path, tasks := moveSnapshotFixture(t, before)
+
+	// The edit: a new sibling appears below the resolved task. This is exactly
+	// where the old code's second read happened.
+	const mutated = "- [ ] a\n- [ ] b\n- [ ] c\n"
+	if err := os.WriteFile(path, []byte(mutated), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The scenario is only meaningful if a re-read would answer differently —
+	// assert that, so a future refactor cannot leave this test passing
+	// vacuously against a snapshot and a file that happen to agree. The
+	// divergence is in the OFF-THE-END verdict rather than the destination
+	// number: both lists step "down" from #2 to #3, but #3 is past the end of
+	// the snapshot (an edge report, no write) and a real position in the
+	// re-read (a write that moves the task past a sibling the caller never saw).
+	reread, err := app.ListTasks("", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	offEnd := func(list []domain.ChecklistItem) bool {
+		to, _, derr := moveDestination("down", 2, list)
+		if derr != nil {
+			t.Fatal(derr)
+		}
+		return to < 1 || to > len(list)
+	}
+	if offEnd(tasks) == offEnd(reread) {
+		t.Fatal("precondition: the edit must change whether the step runs off the end")
+	}
+	if !offEnd(tasks) {
+		t.Fatal("precondition: against the snapshot the task should have no sibling below it")
+	}
+
+	var out bytes.Buffer
+	if err := taskMoveIn(app, &out, "", path, []string{"#2", "down"}, tasks); err != nil {
+		t.Fatalf("taskMoveIn: %v", err)
+	}
+	if !strings.Contains(out.String(), "already at the bottom") {
+		t.Errorf("the edge must be reported from the resolving snapshot, got %q", out.String())
+	}
+	// What it printed and what it did agree: nothing was written.
+	if got := readFixture(t, path); got != mutated {
+		t.Errorf("reporting an edge must write nothing:\ngot  %q\nwant %q", got, mutated)
+	}
+}
+
+// TestTaskMoveLandingMatchesTheWrite: when the move DOES go through, the
+// position it reports is where the task actually ended up. The snapshot and the
+// file agree here, so this pins the ordinary case the previous test's edit
+// case is measured against — a subtree move lands earlier than the destination
+// it stepped to, and the message must say so.
+func TestTaskMoveLandingMatchesTheWrite(t *testing.T) {
+	const before = "- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n"
+	app, path, tasks := moveSnapshotFixture(t, before)
+
+	var out bytes.Buffer
+	if err := taskMoveIn(app, &out, "", path, []string{"#1", "down"}, tasks); err != nil {
+		t.Fatalf("taskMoveIn: %v", err)
+	}
+	const want = "- [ ] b\n- [ ] a\n  - [ ] a1\n  - [ ] a2\n"
+	if got := readFixture(t, path); got != want {
+		t.Fatalf("after the move:\ngot  %q\nwant %q", got, want)
+	}
+	if !strings.Contains(out.String(), "moved task #1 to position #2") {
+		t.Errorf("the reported landing must match the write, got %q", out.String())
+	}
+	// And the file really does put it there.
+	after, err := app.ListTasks("", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after[1].Text != "a" {
+		t.Errorf("position #2 holds %q, want the moved task", after[1].Text)
+	}
+}
+
+// TestTaskMoveGuardRefusesWhenTheResolvedTaskMoved: an edit that shifts the
+// resolved task out from under its index is still caught by expectText inside
+// the lock. The single snapshot narrows the window; it does not replace the
+// guard, and nothing here should suggest it does.
+func TestTaskMoveGuardRefusesWhenTheResolvedTaskMoved(t *testing.T) {
+	app, path, tasks := moveSnapshotFixture(t, "- [ ] a\n- [ ] b\n- [ ] c\n")
+
+	// A new task is inserted ABOVE the resolved one, so index #2 now names a
+	// different task than the snapshot resolved.
+	const mutated = "- [ ] zero\n- [ ] a\n- [ ] b\n- [ ] c\n"
+	if err := os.WriteFile(path, []byte(mutated), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	err := taskMoveIn(app, &out, "", path, []string{"#2", "down"}, tasks)
+	if err == nil {
+		t.Fatalf("a shifted target must be refused, got output %q", out.String())
+	}
+	if got := readFixture(t, path); got != mutated {
+		t.Errorf("a refused move must not rewrite the file:\ngot  %q\nwant %q", got, mutated)
+	}
+}
+
+// TestTaskMoveRejectsBadRefBeforeReading: the syntax check must stay ahead of
+// the checklist read, or `move xyz 2` against a missing file reports the file
+// error instead of the typo that caused it. Hoisting the check into taskMove
+// (it used to sit inside taskItemArg, which read the file itself) is what keeps
+// that ordering.
+func TestTaskMoveRejectsBadRefBeforeReading(t *testing.T) {
+	app := &frontend.App{}
+	missing := filepath.Join(t.TempDir(), "does-not-exist.md")
+
+	var out bytes.Buffer
+	err := taskMove(app, &out, "", missing, []string{"xyz", "2"})
+	if err == nil {
+		t.Fatal("an invalid reference must error")
+	}
+	if !strings.Contains(err.Error(), "invalid task number") {
+		t.Errorf("the typo must be reported, not the file error, got %v", err)
+	}
+}

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -314,24 +314,94 @@ func checklistParent(items []ChecklistItem, k int) int {
 	return -1
 }
 
-// hasNestedSubTasks reports whether the checklist item at lines[i] has checklist
-// items nested under it. Those are NOT part of its detail block — a nested "[ ]"
-// bounds the block — so a move that carried only the block would leave them
-// behind. MoveChecklistItem declines rather than orphan them.
-func hasNestedSubTasks(lines []string, i int) bool {
+// SiblingPosition returns the 1-based position of the item one sibling step
+// before (delta < 0) or after (delta > 0) the item at 1-based `index`, or 0
+// when it has no sibling in that direction.
+//
+// It is what "up"/"down" must mean once a move carries a whole subtree. The
+// step is one SIBLING, not one position: the position after a parent is its
+// first CHILD, and asking MoveChecklistItem to swap those two is re-parenting,
+// which it refuses. Stepping by position would therefore make `move X down`
+// and the TUI's J fail on exactly the nested lists this reordering exists for.
+//
+// Nested descendants of the neighbouring siblings are skipped, since they sit
+// between two siblings in position order. The scan stops at the first item
+// SHALLOWER than the one being moved — that is the parent's own line going up,
+// or a different parent's going down, and neither direction has any more
+// siblings past it.
+func SiblingPosition(items []ChecklistItem, index, delta int) int {
+	if index < 1 || index > len(items) || delta == 0 {
+		return 0
+	}
+	parent := checklistParent(items, index-1)
+	depth := indentWidth(items[index-1].Prefix)
+	step := 1
+	if delta < 0 {
+		step = -1
+	}
+	for i := index - 1 + step; i >= 0 && i < len(items); i += step {
+		if checklistParent(items, i) == parent {
+			return i + 1
+		}
+		if indentWidth(items[i].Prefix) < depth {
+			return 0
+		}
+	}
+	return 0
+}
+
+// SubtreeSize is how many checklist items travel with the item at 1-based
+// `index` when it is moved: the item itself plus every item nested under it.
+// It is 1 for a leaf. Callers that must predict where a moved item LANDS need
+// it — moving down past a sibling advances the item by that sibling's subtree
+// size, not by one — which is what keeps the TUI's cursor on the task it just
+// moved rather than on whichever one took its row.
+func SubtreeSize(items []ChecklistItem, index int) int {
+	if index < 1 || index > len(items) {
+		return 0
+	}
+	depth := indentWidth(items[index-1].Prefix)
+	n := 1
+	for i := index; i < len(items); i++ {
+		if indentWidth(items[i].Prefix) <= depth {
+			break
+		}
+		n++
+	}
+	return n
+}
+
+// subtreeEnd is the exclusive end line of EVERYTHING under the checklist item
+// at lines[i]: its own line, its detail block, every nested sub-task, and each
+// of those sub-tasks' detail, however deep. `lines[i:subtreeEnd(lines, i)]` is
+// the run MoveChecklistItem relocates.
+//
+// It is the wider sibling of detailBlockEnd. That one stops at the first nested
+// checklist item, because a nested "[ ]" is its own task rather than folded
+// detail — the right boundary for DELIVERING one item, and for splicing a new
+// item in beside it. Moving needs the other answer: a sub-task left where its
+// parent used to be is re-parented onto whatever now precedes it, which is the
+// same silent tree rewrite that carrying detail is meant to prevent.
+//
+// Only indentation bounds the scan: the run ends at the first non-blank line
+// indented at or below the item. Interior blank lines are included (a blank
+// between a parent and its sub-tasks must not cut the subtree in half), but
+// trailing ones are not — `end` only advances on a non-blank deeper line — so a
+// blank separator before the NEXT sibling stays where it is instead of
+// travelling with the move.
+func subtreeEnd(lines []string, i int) int {
 	base := indentWidth(lines[i])
+	end := i + 1
 	for j := i + 1; j < len(lines); j++ {
 		if strings.TrimSpace(lines[j]) == "" {
 			continue
 		}
 		if indentWidth(lines[j]) <= base {
-			return false
+			break
 		}
-		if checklistItemRE.MatchString(lines[j]) {
-			return true
-		}
+		end = j + 1
 	}
-	return false
+	return end
 }
 
 // detailBlockEnd is the exclusive end line of the checklist item at lines[i]
@@ -875,36 +945,36 @@ func DeleteChecklistItem(content string, index int) (string, error) {
 }
 
 // MoveChecklistItem moves the item at 1-based position `from` to 1-based
-// position `to`, carrying its nested detail with it, and returns the updated
+// position `to`, carrying everything nested under it, and returns the updated
 // content. Positions are the same numbering ParseChecklist and the `hap task`
-// CLI expose: after the move the item IS item `to`, and the items it displaced
-// shift by one. Moving an item to its own position is a no-op that returns the
-// content byte-for-byte unchanged.
+// CLI expose. `to` names the SIBLING the item is reordered past: moving down
+// puts it directly after that sibling's own subtree, moving up directly before
+// the item at `to`. For a flat list that is exactly "the item is now item `to`".
+// With sub-tasks in play the landing position is `to` going UP, and going DOWN
+// it is `to + SubtreeSize(to) - SubtreeSize(from)` — usually EARLIER than `to`,
+// because the whole source subtree vacated the positions above it. Callers that
+// report or predict where the item ended up must compute it; `to` is the
+// destination asked for, not the answer. Moving an item to its own position is
+// a no-op that returns the content byte-for-byte unchanged.
 //
-// The item travels as its whole block (detailBlockEnd), for the reason
-// DeleteChecklistItem does: detail lines belong to their item only by being
-// indented deeper than it, so moving the title alone would leave the detail
-// behind to be folded into — and delivered with — whatever task ends up above
-// it, while the moved task arrives bare. Reordering is exactly the operation
-// that would otherwise scramble every task's instructions at once.
+// The item travels as its whole SUBTREE (subtreeEnd): its own line, its detail
+// block, every nested sub-task, and each of those sub-tasks' detail. Detail
+// lines belong to their item only by being indented deeper than it, and a
+// nested "[ ]" is its own item bounded the same way, so moving anything less
+// rewrites the tree — the title alone would hand its instructions to whatever
+// task ends up above it and arrive bare, and the title-plus-detail would strand
+// the children under whatever now precedes them. Reordering is exactly the
+// operation that would otherwise scramble every task's instructions at once.
 //
-// Reordering is SIBLINGS-ONLY, and the two refusals below are why. A nested
-// "[ ]" is its own item, not detail, so it is neither carried along nor stepped
-// over — without these guards, moving a parent would strand its sub-tasks at
-// the old position (orphaned under whatever precedes it) and moving any item to
-// a position inside another's nesting would silently adopt that nesting. Both
-// rewrite the tree the operator wrote, which is worse than declining:
+// Reordering is still SIBLINGS-ONLY: source and destination must have the same
+// PARENT, not merely the same indent depth. Equal depth is not siblinghood —
+// two sub-tasks under different parents are equally indented, and swapping them
+// would move one under the other's parent. That guard also keeps `to` out of
+// the moved subtree, since every item inside it has the moved item (or one of
+// its descendants) as a parent. Re-parenting is a different operation from
+// reordering; it stays refused rather than done silently.
 //
-//   - an item with nested sub-tasks cannot move (its children would not follow);
-//   - source and destination must be SIBLINGS — same parent, not merely the
-//     same indent depth. Equal depth is not siblinghood: two sub-tasks under
-//     different parents are equally indented, and swapping them would move one
-//     under the other's parent.
-//
-// Everything a flat list can express — the shape hap writes and the shape
-// nearly every checklist has — is unaffected.
-//
-// The block is re-inserted VERBATIM; indentation and bullet style are the
+// The subtree is re-inserted VERBATIM; indentation and bullet style are the
 // operator's. Both positions must name an existing item; neither is clamped, so
 // a caller that computed a target off the end gets an error instead of a silent
 // no-op. Blank separators do NOT travel with the item: they sit between items
@@ -923,34 +993,55 @@ func MoveChecklistItem(content string, from, to int) (string, error) {
 		return content, nil
 	}
 	lines := strings.Split(content, "\n")
-	if hasNestedSubTasks(lines, items[from-1].LineNo) {
-		return "", fmt.Errorf("task #%d has nested sub-tasks, which would be left behind — move or unnest them first", from)
-	}
 	// Same PARENT, not merely the same depth. Equal indentation is not
 	// siblinghood: two sub-tasks under different parents sit at the same depth,
 	// so a depth-only check would let one be moved under the other's parent —
-	// the reparenting this refusal exists to prevent.
+	// the reparenting this refusal exists to prevent. It doubles as the guard
+	// that `to` is not inside the subtree about to be cut.
 	if a, b := checklistParent(items, from-1), checklistParent(items, to-1); a != b {
 		return "", fmt.Errorf("task #%d and position #%d are under different parents — a task can only be reordered among its siblings", from, to)
 	}
 	start := items[from-1].LineNo
-	end := detailBlockEnd(lines, start)
+	end := subtreeEnd(lines, start)
 	block := append([]string(nil), lines[start:end]...)
 
+	// How many ITEMS travel with the move — the parent plus every descendant.
+	// Renumbering below shifts by this, not by one.
+	moved := 0
+	for _, it := range items {
+		if it.LineNo >= start && it.LineNo < end {
+			moved++
+		}
+	}
+	// The two nesting models must agree before anything is rewritten.
+	// subtreeEnd reads LINES and stops at the first one indented at or below the
+	// item; checklistParent reads ITEMS and skips non-item lines entirely. A bare
+	// prose line at the parent's own indent, sitting between it and a sub-task,
+	// splits them: the parser still calls that sub-task a child, but the line
+	// scan stops short of it, so the move would leave it behind — re-parented
+	// onto whatever now precedes it, the one thing carrying the subtree exists to
+	// prevent. Which of the two readings is "right" is genuinely ambiguous (the
+	// prose belongs to neither), so decline and let the operator resolve it
+	// rather than pick one and silently rewrite the tree.
+	if want := SubtreeSize(items, from); moved != want {
+		return "", fmt.Errorf("task #%d has sub-tasks separated from it by a line at its own indent — the move would leave them behind; indent or remove that line first", from)
+	}
+
 	// Cut first, then locate the target in what REMAINS: the destination is a
-	// position in the final list, and removing the block renumbers everything
+	// position in the final list, and removing the subtree renumbers everything
 	// after it.
 	rest := append(append([]string(nil), lines[:start]...), lines[end:]...)
 	restItems := ParseChecklist(strings.Join(rest, "\n"))
 
-	// Moving DOWN, the items between `from` and `to` each shift up by one, so
-	// the destination lands after the item now sitting at to-1. Moving UP, the
-	// destination is simply before the item now at `to` — unshifted, since every
-	// item before `from` kept its number.
+	// Moving DOWN, every item past the cut shifts up by `moved`, so the sibling
+	// originally at `to` now sits at index to-moved-1; the subtree lands after
+	// that sibling's OWN subtree, or it would be wedged between it and its
+	// children. Moving UP, the destination is simply before the item now at `to`
+	// — unshifted, since every item before `from` kept its number.
 	var at int
 	if to > from {
-		anchor := restItems[to-2].LineNo
-		at = detailBlockEnd(rest, anchor)
+		anchor := restItems[to-moved-1].LineNo
+		at = subtreeEnd(rest, anchor)
 	} else {
 		at = restItems[to-1].LineNo
 	}

--- a/internal/domain/tasklist_test.go
+++ b/internal/domain/tasklist_test.go
@@ -796,19 +796,258 @@ func TestMoveChecklistItem(t *testing.T) {
 	}
 }
 
-// TestMoveChecklistItemRefusesToRewriteNesting pins the siblings-only rule. A
-// nested "[ ]" is its own item, not detail, so it neither travels with a parent
-// nor is stepped over — without these refusals a move would strand a parent's
-// sub-tasks at the old position or adopt someone else's nesting at the new one.
-func TestMoveChecklistItemRefusesToRewriteNesting(t *testing.T) {
-	// Moving a parent would leave a1 orphaned under whatever precedes it.
-	parent := "- [ ] a\n  - [ ] a1\n- [ ] b\n"
-	if _, err := MoveChecklistItem(parent, 1, 3); err == nil {
-		t.Error("moving a task with nested sub-tasks must be refused")
-	} else if !strings.Contains(err.Error(), "nested sub-tasks") {
+// TestSiblingPositionAndSubtreeSize: one "up"/"down" step is one SIBLING, not
+// one position. The position after a parent is its own first child, and asking
+// MoveChecklistItem to swap those two is re-parenting, which it refuses — so a
+// position-stepping `move X down` (or the TUI's J) would fail on every nested
+// list. SubtreeSize is the companion the TUI needs to predict where the moved
+// task lands so its cursor follows it rather than a sub-task.
+func TestSiblingPositionAndSubtreeSize(t *testing.T) {
+	// 1 a, 2 a1, 3 a2, 4 b, 5 b1, 6 c
+	items := ParseChecklist("- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n  - [ ] b1\n- [ ] c\n")
+	if len(items) != 6 {
+		t.Fatalf("fixture parsed %d items, want 6", len(items))
+	}
+	steps := []struct {
+		name         string
+		index, delta int
+		want         int
+	}{
+		{"parent steps over its own children to the next parent", 1, 1, 4},
+		{"parent steps back over the previous parent's children", 4, -1, 1},
+		{"first parent has nothing above it", 1, -1, 0},
+		{"last parent has nothing below it", 6, 1, 0},
+		{"sub-task steps to its own sibling", 2, 1, 3},
+		{"sub-task steps back to its own sibling", 3, -1, 2},
+		{"last sub-task does not escape into the next parent", 3, 1, 0},
+		{"first sub-task does not escape up into its parent", 2, -1, 0},
+		{"an only child has no sibling either way", 5, 1, 0},
+		{"an only child has no sibling above it", 5, -1, 0},
+		{"out of range yields no sibling", 0, 1, 0},
+		{"a zero step yields no sibling", 1, 0, 0},
+	}
+	for _, tc := range steps {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SiblingPosition(items, tc.index, tc.delta); got != tc.want {
+				t.Errorf("SiblingPosition(#%d, %+d) = %d, want %d", tc.index, tc.delta, got, tc.want)
+			}
+		})
+	}
+	for index, want := range map[int]int{1: 3, 2: 1, 3: 1, 4: 2, 5: 1, 6: 1, 0: 0, 7: 0} {
+		if got := SubtreeSize(items, index); got != want {
+			t.Errorf("SubtreeSize(#%d) = %d, want %d", index, got, want)
+		}
+	}
+	// Siblinghood is the PARENT, not the depth, so two children of the same
+	// parent indented unequally are still siblings and must step to each other.
+	// Everything here uses uniform two-space indent otherwise, which would hide
+	// a depth-based regression.
+	ragged := ParseChecklist("- [ ] root\n  - [ ] A\n    - [ ] a1\n - [ ] C\n")
+	if got := SiblingPosition(ragged, 2, 1); got != 4 {
+		t.Errorf("a shallower next sibling is still a sibling: got %d, want 4", got)
+	}
+	if got := SiblingPosition(ragged, 4, -1); got != 2 {
+		t.Errorf("a deeper previous sibling is still a sibling: got %d, want 2", got)
+	}
+	if got := SubtreeSize(ragged, 2); got != 2 {
+		t.Errorf("SubtreeSize must follow indentation, not sibling depth: got %d, want 2", got)
+	}
+
+	// Every step SiblingPosition reports must be a move MoveChecklistItem
+	// accepts — the two rules cannot be allowed to drift, or "down" would step
+	// onto a destination the mutator then refuses.
+	for _, content := range []string{
+		"- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n  - [ ] b1\n- [ ] c\n",
+		"- [ ] root\n  - [ ] A\n    - [ ] a1\n - [ ] C\n",
+	} {
+		parsed := ParseChecklist(content)
+		for i := 1; i <= len(parsed); i++ {
+			for _, d := range []int{-1, 1} {
+				to := SiblingPosition(parsed, i, d)
+				if to == 0 {
+					continue
+				}
+				if _, err := MoveChecklistItem(content, i, to); err != nil {
+					t.Errorf("SiblingPosition(#%d, %+d) = %d in %q, but the move is refused: %v", i, d, to, content, err)
+				}
+			}
+		}
+	}
+}
+
+// TestMoveChecklistItemCarriesSubtree: a reorder moves the item's WHOLE
+// subtree — its own line, its detail, its nested sub-tasks, and their detail.
+// Moving less rewrites the tree: the title alone hands its instructions to
+// whatever ends up above it, and title-plus-detail strands the children under
+// whatever now precedes them. This used to be refused outright, which made
+// every parent in a nested list unmovable — the common shape now that
+// sub-items are folded into what the agent is delivered.
+func TestMoveChecklistItemCarriesSubtree(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		from, to int
+		want     string
+	}{
+		{
+			// A parent with two sub-tasks, moved DOWN past a leaf sibling.
+			"parent with two sub-tasks down",
+			"- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n",
+			1, 4,
+			"- [ ] b\n- [ ] a\n  - [ ] a1\n  - [ ] a2\n",
+		},
+		{
+			// The same list rearranged the other way: the leaf moves UP past
+			// the whole subtree rather than landing inside it.
+			"leaf up past a parent with two sub-tasks",
+			"- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n",
+			4, 1,
+			"- [ ] b\n- [ ] a\n  - [ ] a1\n  - [ ] a2\n",
+		},
+		{
+			// A parent moved back UP over a sibling, restoring the first case's
+			// input — the move round-trips.
+			"parent with two sub-tasks up",
+			"- [ ] b\n- [ ] a\n  - [ ] a1\n  - [ ] a2\n",
+			2, 1,
+			"- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n",
+		},
+		{
+			// A sub-task's OWN detail lines are inside the parent's subtree and
+			// must travel too — they are deeper than the parent, so nothing but
+			// an indentation bound can be used to find them.
+			"sub-task detail travels with the parent",
+			"- [ ] a\n  - [ ] a1\n    detail for a1\n- [ ] b\n",
+			1, 3,
+			"- [ ] b\n- [ ] a\n  - [ ] a1\n    detail for a1\n",
+		},
+		{
+			// Past ANOTHER parent that has children: the destination's own
+			// subtree must be cleared, or the moved parent lands wedged between
+			// that parent and its sub-tasks — adopting them.
+			"parent past a parent that also has children",
+			"- [ ] a\n  - [ ] a1\n- [ ] b\n  - [ ] b1\n  - [ ] b2\n",
+			1, 3,
+			"- [ ] b\n  - [ ] b1\n  - [ ] b2\n- [ ] a\n  - [ ] a1\n",
+		},
+		{
+			// And back again, so the pair is a true round-trip.
+			"parent back up over a parent with children",
+			"- [ ] b\n  - [ ] b1\n  - [ ] b2\n- [ ] a\n  - [ ] a1\n",
+			4, 1,
+			"- [ ] a\n  - [ ] a1\n- [ ] b\n  - [ ] b1\n  - [ ] b2\n",
+		},
+		{
+			// Grandchildren ride along: the subtree is bounded by indentation,
+			// not by one level of nesting.
+			"whole three-level subtree travels",
+			"- [ ] a\n  - [ ] a1\n    - [ ] a1x\n- [ ] b\n",
+			1, 4,
+			"- [ ] b\n- [ ] a\n  - [ ] a1\n    - [ ] a1x\n",
+		},
+		{
+			// Reordering two parents that BOTH have children, one level down —
+			// the sibling arithmetic is not special-cased to top level.
+			"nested parents with children swap",
+			"- [ ] root\n  - [ ] A\n    - [ ] a1\n  - [ ] B\n    - [ ] b1\n",
+			2, 4,
+			"- [ ] root\n  - [ ] B\n    - [ ] b1\n  - [ ] A\n    - [ ] a1\n",
+		},
+		{
+			// A blank line between a parent and its sub-task must NOT cut the
+			// subtree in half — the blank is interior, so subtreeEnd keeps
+			// scanning. Making it a boundary would orphan a1 while leaving
+			// every other case in this file green.
+			"blank line inside a subtree does not cut it",
+			"- [ ] a\n\n  - [ ] a1\n- [ ] b\n",
+			1, 3,
+			"- [ ] b\n- [ ] a\n\n  - [ ] a1\n",
+		},
+		{
+			// An ABSOLUTE destination two siblings away (what `hap task move 1 5`
+			// asks for) steps over a whole intervening subtree. Note "a" lands at
+			// position 4, not 5: its own subtree vacated the slots above the
+			// destination, which is why callers must not print `to`.
+			"absolute destination past an intervening subtree",
+			"- [ ] a\n  - [ ] a1\n- [ ] b\n  - [ ] b1\n- [ ] c\n",
+			1, 5,
+			"- [ ] b\n  - [ ] b1\n- [ ] c\n- [ ] a\n  - [ ] a1\n",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := MoveChecklistItem(tc.content, tc.from, tc.to)
+			if err != nil {
+				t.Fatalf("MoveChecklistItem(%d→%d): %v", tc.from, tc.to, err)
+			}
+			if got != tc.want {
+				t.Errorf("MoveChecklistItem(%d→%d):\ngot  %q\nwant %q", tc.from, tc.to, got, tc.want)
+			}
+			// A move only reorders: the same items must survive, so a subtree
+			// that was dropped or duplicated is caught even if the text lines
+			// up by accident.
+			before, after := ParseChecklist(tc.content), ParseChecklist(got)
+			if len(before) != len(after) {
+				t.Fatalf("item count changed: %d → %d", len(before), len(after))
+			}
+			seen := map[string]int{}
+			for _, it := range before {
+				seen[it.Prefix+it.Text]++
+			}
+			for _, it := range after {
+				seen[it.Prefix+it.Text]--
+			}
+			for k, n := range seen {
+				if n != 0 {
+					t.Errorf("item %q changed count by %d — a move must not add, drop, or re-indent items", k, -n)
+				}
+			}
+		})
+	}
+}
+
+// TestMoveChecklistItemRefusesSplitSubtree: the two nesting models must agree
+// before anything is rewritten. subtreeEnd reads LINES and stops at the first
+// one indented at or below the item; checklistParent reads ITEMS and skips
+// non-item lines. A bare prose line at the parent's own indent, between it and
+// a sub-task, splits them — the parser still calls the sub-task a child, but
+// the line scan stops short of it. Carrying the smaller run would leave that
+// child behind, re-parented onto whatever now precedes it, which is exactly
+// what a subtree-carrying move exists to prevent. Which reading is right is
+// genuinely ambiguous, so it declines.
+func TestMoveChecklistItemRefusesSplitSubtree(t *testing.T) {
+	split := "- [ ] a\nnotes\n  - [ ] a1\n- [ ] b\n"
+	// The parser calls a1 a child of a, so the disagreement is real.
+	items := ParseChecklist(split)
+	if got := SubtreeSize(items, 1); got != 2 {
+		t.Fatalf("precondition: the parser should see a1 as a's child (SubtreeSize=2), got %d", got)
+	}
+	got, err := MoveChecklistItem(split, 1, 3)
+	if err == nil {
+		t.Fatalf("a subtree split by a line at the parent's own indent must be refused, got %q", got)
+	}
+	if !strings.Contains(err.Error(), "leave them behind") {
 		t.Errorf("the refusal should name the reason, got %v", err)
 	}
-	// Its own detail is still fine to carry — only sub-TASKS block the move.
+	if got != "" {
+		t.Errorf("a refused move must return no content, got %q", got)
+	}
+	// Indenting the separator resolves the ambiguity, and the move goes through
+	// carrying everything.
+	fixed := "- [ ] a\n  notes\n  - [ ] a1\n- [ ] b\n"
+	if got, err := MoveChecklistItem(fixed, 1, 3); err != nil {
+		t.Errorf("an indented separator must not block the move: %v", err)
+	} else if want := "- [ ] b\n- [ ] a\n  notes\n  - [ ] a1\n"; got != want {
+		t.Errorf("indented separator:\ngot  %q\nwant %q", got, want)
+	}
+}
+
+// TestMoveChecklistItemRefusesToRewriteNesting pins the siblings-only rule.
+// Reordering carries a whole subtree, but it never RE-PARENTS: a destination
+// under a different parent would adopt someone else's nesting, rewriting the
+// tree the operator wrote.
+func TestMoveChecklistItemRefusesToRewriteNesting(t *testing.T) {
+	// A parent's own detail travels with it, as it always has.
 	ok := "- [ ] a\n  - just detail\n- [ ] b\n"
 	if _, err := MoveChecklistItem(ok, 1, 2); err != nil {
 		t.Errorf("plain detail must not block a move: %v", err)
@@ -846,8 +1085,11 @@ func TestMoveChecklistItemRefusesToRewriteNesting(t *testing.T) {
 		t.Errorf("sibling reorder:\ngot  %q\nwant %q", got, want)
 	}
 	// Refusals never touch the content.
-	for _, c := range []string{parent, nested} {
-		if got, _ := MoveChecklistItem(c, 1, 3); got != "" {
+	for _, c := range []struct {
+		content  string
+		from, to int
+	}{{nested, 2, 3}, {cousins, 2, 4}, {deep, 3, 5}} {
+		if got, _ := MoveChecklistItem(c.content, c.from, c.to); got != "" {
 			t.Errorf("a refused move must return no content, got %q", got)
 		}
 	}

--- a/internal/tui/tasks_test.go
+++ b/internal/tui/tasks_test.go
@@ -298,6 +298,16 @@ func readTasks(t *testing.T, path string) string {
 	return string(data)
 }
 
+// writeTasks replaces the fixture checklist, for tests that need a shape
+// taskAppModel's flat three-item default cannot express (nesting). Follow it
+// with syncModel so the model reloads.
+func writeTasks(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestTasksTabSpaceMarksAndAdvances(t *testing.T) {
 	m := taskModel(t)
 	// Space on the group header is a no-op with a hint, not a mark.
@@ -860,6 +870,178 @@ func TestTasksReorderKeys(t *testing.T) {
 	m = upd.(Model)
 	if cmd != nil || !strings.Contains(m.message, "move the cursor onto a task") {
 		t.Errorf("J on a header should only hint, got cmd=%v message=%q", cmd != nil, m.message)
+	}
+}
+
+// TestTasksReorderCarriesSubtree: K/J on a parent moves it together with its
+// sub-tasks, and one step is one SIBLING rather than one row. Two things would
+// break a naive ±1: J on a parent would target its own first child (which
+// MoveTask refuses as re-parenting), and the cursor nudge would land on a
+// sub-task, so the next keypress would move THAT one.
+func TestTasksReorderCarriesSubtree(t *testing.T) {
+	m, _, path := taskAppModel(t)
+	writeTasks(t, path, "- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n")
+	m = syncModel(t, m)
+	m = press(t, m, "down") // row 1 = item #1 (a), the parent
+
+	if r := m.selectedTaskRow(); r == nil || r.item != 1 {
+		t.Fatalf("precondition: cursor should be on the parent, got %+v", r)
+	}
+	upd, cmd := m.Update(pressKeyMsg("J"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("J on a parent with sub-tasks should run a move, not refuse")
+	}
+	// "b" is a leaf, so the parent advances exactly one row past it.
+	if got := m.cursors[tabTasks]; got != 2 {
+		t.Errorf("cursor should follow the moved parent to row 2, got %d", got)
+	}
+	m, res := runAction(t, m, cmd)
+	if res.err != nil {
+		t.Fatal(res.err)
+	}
+	want := "- [ ] b\n- [ ] a\n  - [ ] a1\n  - [ ] a2\n"
+	if got := readTasks(t, path); got != want {
+		t.Errorf("after J:\ngot  %q\nwant %q", got, want)
+	}
+	m = syncModel(t, m)
+	if r := m.selectedTaskRow(); r == nil || r.itemText != "a" {
+		t.Fatalf("cursor should still be on the moved parent, got %+v", r)
+	}
+
+	// K brings it back, and the cursor tracks it again.
+	upd, cmd = m.Update(pressKeyMsg("K"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("K on the parent should run a move")
+	}
+	if got := m.cursors[tabTasks]; got != 1 {
+		t.Errorf("cursor should follow the moved parent back to row 1, got %d", got)
+	}
+	if m, res = runAction(t, m, cmd); res.err != nil {
+		t.Fatal(res.err)
+	}
+	if got, want := readTasks(t, path), "- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n"; got != want {
+		t.Errorf("after K:\ngot  %q\nwant %q", got, want)
+	}
+	m = syncModel(t, m)
+
+	// A sub-task with no sibling below it refuses rather than escaping into the
+	// next parent — reordering never re-parents.
+	m = press(t, m, "down", "down") // row 3 = item #3 (a2)
+	if r := m.selectedTaskRow(); r == nil || r.itemText != "a2" {
+		t.Fatalf("precondition: cursor should be on the last sub-task, got %+v", r)
+	}
+	before := readTasks(t, path)
+	upd, cmd = m.Update(pressKeyMsg("J"))
+	m = upd.(Model)
+	if cmd != nil {
+		t.Error("J on the last sub-task must not run a move")
+	}
+	if !strings.Contains(m.message, "already at the bottom") {
+		t.Errorf("the refusal should explain itself, got %q", m.message)
+	}
+	if got := readTasks(t, path); got != before {
+		t.Errorf("a refused move must not rewrite the file:\ngot  %q\nwant %q", got, before)
+	}
+}
+
+// TestTasksReorderCarriesSubtreePastAParentWithChildren: stepping down past a
+// sibling that ALSO has sub-tasks must clear that sibling's whole subtree, or
+// the moved parent lands wedged between it and its children — and the cursor
+// nudge must be the destination's subtree size, not one.
+func TestTasksReorderCarriesSubtreePastAParentWithChildren(t *testing.T) {
+	m, _, path := taskAppModel(t)
+	writeTasks(t, path, "- [ ] a\n  - [ ] a1\n- [ ] b\n  - [ ] b1\n  - [ ] b2\n")
+	m = syncModel(t, m)
+	m = press(t, m, "down") // row 1 = item #1 (a)
+
+	upd, cmd := m.Update(pressKeyMsg("J"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("J should run a move")
+	}
+	// b's subtree is three items, so a lands three rows down.
+	if got := m.cursors[tabTasks]; got != 4 {
+		t.Errorf("cursor should clear the destination's subtree to row 4, got %d", got)
+	}
+	m, res := runAction(t, m, cmd)
+	if res.err != nil {
+		t.Fatal(res.err)
+	}
+	want := "- [ ] b\n  - [ ] b1\n  - [ ] b2\n- [ ] a\n  - [ ] a1\n"
+	if got := readTasks(t, path); got != want {
+		t.Errorf("after J:\ngot  %q\nwant %q", got, want)
+	}
+	m = syncModel(t, m)
+	if r := m.selectedTaskRow(); r == nil || r.itemText != "a" {
+		t.Fatalf("cursor should be on the moved parent, not a sub-task, got %+v", r)
+	}
+}
+
+// TestTasksReorderUpOverASubtree: the UP nudge takes the other branch of the
+// asymmetric cursor arithmetic (the destination's position, not its subtree
+// size), so it needs its own multi-row case — stepping up past a parent with
+// two sub-tasks moves the cursor three rows, not one.
+func TestTasksReorderUpOverASubtree(t *testing.T) {
+	m, _, path := taskAppModel(t)
+	writeTasks(t, path, "- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n")
+	m = syncModel(t, m)
+	m = press(t, m, "down", "down", "down", "down") // row 4 = item #4 (b)
+	if r := m.selectedTaskRow(); r == nil || r.itemText != "b" {
+		t.Fatalf("precondition: cursor should be on b, got %+v", r)
+	}
+
+	upd, cmd := m.Update(pressKeyMsg("K"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("K should run a move")
+	}
+	if got := m.cursors[tabTasks]; got != 1 {
+		t.Errorf("cursor should clear the whole subtree up to row 1, got %d", got)
+	}
+	m, res := runAction(t, m, cmd)
+	if res.err != nil {
+		t.Fatal(res.err)
+	}
+	want := "- [ ] b\n- [ ] a\n  - [ ] a1\n  - [ ] a2\n"
+	if got := readTasks(t, path); got != want {
+		t.Errorf("after K:\ngot  %q\nwant %q", got, want)
+	}
+	m = syncModel(t, m)
+	if r := m.selectedTaskRow(); r == nil || r.itemText != "b" {
+		t.Fatalf("cursor should be on the moved task, got %+v", r)
+	}
+}
+
+// TestTasksReorderRestoresCursorOnFailure: the nudge is OPTIMISTIC — it runs
+// before the move lands so the cursor visibly follows the task. When the move
+// is then refused, the cursor must go back: a subtree move can travel several
+// rows, so a stranded cursor sits on an unrelated task, and the next K/J would
+// move THAT one with a text guard that legitimately passes.
+func TestTasksReorderRestoresCursorOnFailure(t *testing.T) {
+	m, _, path := taskAppModel(t)
+	writeTasks(t, path, "- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n")
+	m = syncModel(t, m)
+	m = press(t, m, "down") // row 1 = item #1 (a)
+	before := m.cursors[tabTasks]
+
+	upd, cmd := m.Update(pressKeyMsg("J"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("J should run a move")
+	}
+	if m.cursors[tabTasks] == before {
+		t.Fatal("precondition: the nudge should have moved the cursor")
+	}
+	// Rewrite the file underneath so the expected-text guard refuses.
+	writeTasks(t, path, "- [ ] something else entirely\n")
+	m, res := runAction(t, m, cmd)
+	if res.err == nil {
+		t.Fatal("a move against a changed file must be refused")
+	}
+	if got := m.cursors[tabTasks]; got != before {
+		t.Errorf("a refused move must put the cursor back to row %d, got %d", before, got)
 	}
 }
 

--- a/internal/tui/tasks_test.go
+++ b/internal/tui/tasks_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1042,6 +1043,98 @@ func TestTasksReorderRestoresCursorOnFailure(t *testing.T) {
 	}
 	if got := m.cursors[tabTasks]; got != before {
 		t.Errorf("a refused move must put the cursor back to row %d, got %d", before, got)
+	}
+}
+
+// TestTasksReorderUndoIgnoresOtherActionResults: mutations run concurrently and
+// the UI keeps accepting keys while one is in flight, so an UNRELATED action's
+// result can land between a reorder's keypress and its own result. Only the
+// move's own result may consume the cursor undo it stashed — otherwise a
+// successful earlier action clears it (stranding the cursor when the move then
+// fails) or a failed earlier action yanks the cursor back from a move that is
+// still pending.
+func TestTasksReorderUndoIgnoresOtherActionResults(t *testing.T) {
+	m, _, path := taskAppModel(t)
+	writeTasks(t, path, "- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n")
+	m = syncModel(t, m)
+	m = press(t, m, "down") // row 1 = item #1 (a)
+	before := m.cursors[tabTasks]
+
+	upd, cmd := m.Update(pressKeyMsg("J"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("J should run a move")
+	}
+	nudged := m.cursors[tabTasks]
+	if nudged == before {
+		t.Fatal("precondition: the nudge should have moved the cursor")
+	}
+	if m.cursorUndo == nil {
+		t.Fatal("precondition: the move should have stashed a cursor undo")
+	}
+
+	// An unrelated action SUCCEEDS while the move is still pending. It carries
+	// no token, so it must not clear the undo.
+	upd, _ = m.Update(actionResultMsg{message: "some other action finished"})
+	m = upd.(Model)
+	if m.cursorUndo == nil {
+		t.Error("an untagged success must not consume the move's cursor undo")
+	}
+	if got := m.cursors[tabTasks]; got != nudged {
+		t.Errorf("an untagged success must not move the cursor, got %d want %d", got, nudged)
+	}
+
+	// An unrelated action FAILS while the move is still pending. It must not
+	// roll the cursor back either — the move has not been decided yet.
+	upd, _ = m.Update(actionResultMsg{err: errors.New("some other action failed")})
+	m = upd.(Model)
+	if m.cursorUndo == nil {
+		t.Error("an untagged failure must not consume the move's cursor undo")
+	}
+	if got := m.cursors[tabTasks]; got != nudged {
+		t.Errorf("an untagged failure must not roll the cursor back, got %d want %d", got, nudged)
+	}
+
+	// The move's OWN failure does roll it back, and clears the undo.
+	upd, _ = m.Update(actionResultMsg{err: errors.New("nope"), token: m.cursorUndo.token})
+	m = upd.(Model)
+	if got := m.cursors[tabTasks]; got != before {
+		t.Errorf("the move's own failure must restore row %d, got %d", before, got)
+	}
+	if m.cursorUndo != nil {
+		t.Error("the move's own result must clear the undo")
+	}
+}
+
+// TestTasksReorderRefusesWhileOneIsInFlight: a second reorder inside the
+// refresh window would compute from stale rows AND overwrite the pending
+// move's cursor undo, leaving that move's failure un-undoable. Refuse it.
+func TestTasksReorderRefusesWhileOneIsInFlight(t *testing.T) {
+	m, _, path := taskAppModel(t)
+	writeTasks(t, path, "- [ ] a\n  - [ ] a1\n  - [ ] a2\n- [ ] b\n")
+	m = syncModel(t, m)
+	m = press(t, m, "down")
+
+	upd, cmd := m.Update(pressKeyMsg("J"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("the first J should run a move")
+	}
+	first := m.cursorUndo
+	if first == nil {
+		t.Fatal("precondition: the first move should have stashed a cursor undo")
+	}
+
+	upd, cmd = m.Update(pressKeyMsg("J"))
+	m = upd.(Model)
+	if cmd != nil {
+		t.Error("a second reorder while one is in flight must not run")
+	}
+	if !strings.Contains(m.message, "still in flight") {
+		t.Errorf("the refusal should explain itself, got %q", m.message)
+	}
+	if m.cursorUndo != first {
+		t.Error("a refused second reorder must not disturb the pending move's undo")
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -94,6 +94,10 @@ type actionResultMsg struct {
 	// if the pause request itself failed (the state never transitioned, so
 	// nothing will consume the flag otherwise).
 	pauseAction bool
+	// token identifies WHICH action produced this result, for state a
+	// keypress stashed awaiting its own completion. Zero for the untagged
+	// majority; see doTagged.
+	token actionToken
 }
 
 // openSendPromptMsg re-opens a second prompt after a LIVE escalation's
@@ -568,13 +572,30 @@ type Model struct {
 	// would be left sitting on an unrelated task — and the NEXT K/J would
 	// move that one, with a text guard that legitimately passes. A subtree
 	// move can travel several rows, so the wrong row is no longer adjacent.
+	//
+	// It is consumed ONLY by the result carrying its own token. Mutations run
+	// concurrently and every other action reports an untagged result, so
+	// without that match an unrelated action finishing first would clear the
+	// undo (stranding a move that then fails) or apply it (yanking the cursor
+	// back from a move still in flight).
 	cursorUndo *cursorUndo
+
+	// nextToken hands out actionToken values. Monotonic within one Model, and
+	// only ever read on the update loop.
+	nextToken actionToken
 }
 
-// cursorUndo is a cursor position to restore if the in-flight action fails.
+// actionToken identifies one mutation so its result can be matched to state
+// the keypress stashed for it. Zero means UNTAGGED: most actions need no such
+// state, and an untagged result must never consume another action's.
+type actionToken uint64
+
+// cursorUndo is a cursor position to restore if a specific in-flight action
+// fails, identified by the token that action's result will carry.
 type cursorUndo struct {
-	tab tab
-	pos int
+	tab   tab
+	pos   int
+	token actionToken
 }
 
 // renderNow returns the clock the Agents tab renders Age against: the
@@ -1161,16 +1182,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.err != nil {
 			m.status = &statusNote{text: msg.err.Error(), err: true, at: time.Now()}
-			// The action that moved the cursor ahead of itself did not happen,
-			// so put it back rather than leave it on a task nobody selected.
-			if u := m.cursorUndo; u != nil {
-				m.cursors[u.tab] = u.pos
-				m.scrollCursorIntoView()
-			}
 		} else if msg.message != "" {
 			m.status = &statusNote{text: msg.message, at: time.Now()}
 		}
-		m.cursorUndo = nil
+		// Only THIS action's own result may consume the undo it stashed. Other
+		// mutations run concurrently and report untagged results; letting one
+		// of those land here would either clear the undo (stranding a move that
+		// then fails) or apply it while the move is still in flight.
+		if u := m.cursorUndo; u != nil && msg.token != 0 && msg.token == u.token {
+			if msg.err != nil {
+				// The action that moved the cursor ahead of itself did not
+				// happen, so put it back rather than leave it on a task nobody
+				// selected.
+				m.cursors[u.tab] = u.pos
+				if u.tab == m.tab {
+					m.scrollCursorIntoView()
+				}
+			}
+			m.cursorUndo = nil
+		}
 		// The status area shrinks the page by 2 — keep the cursor visible.
 		m.clampListViewport()
 		return m, m.refresh()
@@ -1711,11 +1741,23 @@ func (m *Model) beginAction() {
 	m.clampListViewport()
 }
 
-// do runs a mutation and reports its outcome. The inflight Add happens here,
-// on the update loop — before Program.Run can return — so Run's drain never
-// races the counter from zero (bubbletea always launches a returned Cmd, so
-// the paired Done is guaranteed).
+// do runs a mutation and reports its outcome, UNTAGGED: nothing in the model
+// is waiting on this particular result, so it must not be mistaken for one
+// that is. Actions that stash state for their own completion use doTagged.
 func (m Model) do(okMsg string, fn func(context.Context) error) tea.Cmd {
+	return m.doTagged(0, okMsg, fn)
+}
+
+// doTagged runs a mutation and reports its outcome, stamping the result with
+// tok so Update can tell THIS action's completion from any other's. Mutations
+// are concurrent and unordered — the UI keeps accepting keys while one is in
+// flight — so state a keypress stashes for its own result (see cursorUndo) has
+// to be matched, not merely consumed by whichever result lands next.
+//
+// The inflight Add happens here, on the update loop — before Program.Run can
+// return — so Run's drain never races the counter from zero (bubbletea always
+// launches a returned Cmd, so the paired Done is guaranteed).
+func (m Model) doTagged(tok actionToken, okMsg string, fn func(context.Context) error) tea.Cmd {
 	ctx, wg := m.ctx, m.inflight
 	if wg != nil {
 		wg.Add(1)
@@ -1725,9 +1767,9 @@ func (m Model) do(okMsg string, fn func(context.Context) error) tea.Cmd {
 			defer wg.Done()
 		}
 		if err := fn(ctx); err != nil {
-			return actionResultMsg{err: err}
+			return actionResultMsg{err: err, token: tok}
 		}
-		return actionResultMsg{message: okMsg}
+		return actionResultMsg{message: okMsg, token: tok}
 	}
 }
 
@@ -2681,10 +2723,18 @@ func (m Model) taskGroupAgent(group int) *domain.AgentTransition {
 //
 // The nudge anticipates the async refresh rather than replacing it: m.data is
 // only reloaded when the actionResultMsg round-trip completes, so a second
-// press inside that window still reads stale rows and the expected-text guard
-// refuses it. The file is never at risk; the operator just has to press again.
-// One move per refresh is the honest cadence here.
+// press inside that window would read stale rows. It is refused outright below
+// rather than left to fail at the expected-text guard. One move per refresh is
+// the honest cadence here.
 func (m Model) moveSelectedTask(delta int) (tea.Model, tea.Cmd) {
+	// One reorder at a time. Both reasons are about the pending one: its rows
+	// are the ones a second press would compute from, and its cursorUndo is the
+	// only outstanding one — a second move would overwrite it, so a failure of
+	// the first could no longer be undone.
+	if m.cursorUndo != nil {
+		m.message = "a reorder is still in flight — press again in a moment"
+		return m, nil
+	}
 	r := m.selectedTaskRow()
 	if r == nil || r.item == 0 {
 		m.message = "K/J reorders checklist items — move the cursor onto a task"
@@ -2732,7 +2782,9 @@ func (m Model) moveSelectedTask(delta int) (tea.Model, tea.Cmd) {
 		// positions above the destination, so the item lands that much earlier.
 		landed = to + nudge - domain.SubtreeSize(items, r.item)
 	}
-	m.cursorUndo = &cursorUndo{tab: m.tab, pos: m.cursors[m.tab]}
+	m.nextToken++
+	tok := m.nextToken
+	m.cursorUndo = &cursorUndo{tab: m.tab, pos: m.cursors[m.tab], token: tok}
 	if c := m.cursors[m.tab] + nudge; c < 0 {
 		m.cursors[m.tab] = 0
 	} else if last := m.rowCount() - 1; c > last {
@@ -2742,7 +2794,7 @@ func (m Model) moveSelectedTask(delta int) (tea.Model, tea.Cmd) {
 	}
 	m.scrollCursorIntoView()
 	m.beginAction()
-	return m, m.do(fmt.Sprintf("task #%d moved to position #%d", from, landed),
+	return m, m.doTagged(tok, fmt.Sprintf("task #%d moved to position #%d", from, landed),
 		func(c context.Context) error {
 			// The snapshotted text is the staleness guard: the row positions
 			// this move was computed from are the ones last rendered, so if the

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -560,6 +560,21 @@ type Model struct {
 	// already true for every message processed afterward, regardless of
 	// which goroutine's result lands first.
 	pausePending bool
+
+	// cursorUndo restores the cursor when an OPTIMISTIC nudge turns out to
+	// have been wrong. moveSelectedTask moves the cursor before its move
+	// lands, so the operator sees it follow the task; if the move is then
+	// refused (a stale expected-text guard, or a domain refusal), the cursor
+	// would be left sitting on an unrelated task — and the NEXT K/J would
+	// move that one, with a text guard that legitimately passes. A subtree
+	// move can travel several rows, so the wrong row is no longer adjacent.
+	cursorUndo *cursorUndo
+}
+
+// cursorUndo is a cursor position to restore if the in-flight action fails.
+type cursorUndo struct {
+	tab tab
+	pos int
 }
 
 // renderNow returns the clock the Agents tab renders Age against: the
@@ -1146,9 +1161,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.err != nil {
 			m.status = &statusNote{text: msg.err.Error(), err: true, at: time.Now()}
+			// The action that moved the cursor ahead of itself did not happen,
+			// so put it back rather than leave it on a task nobody selected.
+			if u := m.cursorUndo; u != nil {
+				m.cursors[u.tab] = u.pos
+				m.scrollCursorIntoView()
+			}
 		} else if msg.message != "" {
 			m.status = &statusNote{text: msg.message, at: time.Now()}
 		}
+		m.cursorUndo = nil
 		// The status area shrinks the page by 2 — keep the cursor visible.
 		m.clampListViewport()
 		return m, m.refresh()
@@ -2639,7 +2661,9 @@ func (m Model) taskGroupAgent(group int) *domain.AgentTransition {
 }
 
 // moveSelectedTask reorders the task under the cursor by delta positions
-// (-1 = up, +1 = down) within its own source file, carrying its nested detail.
+// (-1 = up, +1 = down) within its own source file, carrying its whole subtree —
+// nested detail, nested sub-tasks, and their detail. One step therefore moves
+// the cursor past ONE sibling, which may be several rows.
 //
 // Three things have to be handled that no other Tasks action needs:
 //
@@ -2680,24 +2704,45 @@ func (m Model) moveSelectedTask(delta int) (tea.Model, tea.Cmd) {
 		m.message = "clear the search filter to reorder — positions count hidden tasks too"
 		return m, nil
 	}
-	to := r.item + delta
+	// One step is one SIBLING, not one row: the row after a parent is its own
+	// first sub-task, and asking to swap those two is re-parenting, which
+	// MoveTask refuses. Stepping by position would make K/J fail on exactly the
+	// nested lists a subtree-carrying move exists for.
+	items := m.data.tasks[r.group].Items
+	to := domain.SiblingPosition(items, r.item, delta)
 	// Refuse at the ends rather than clamping: a clamp would rewrite the file
 	// with identical content and report success, so holding the key at the top
 	// of the list would look like it was still doing something.
-	if n := len(m.data.tasks[r.group].Items); to < 1 || to > n {
-		m.message = fmt.Sprintf("task #%d is already at the %s of this list", r.item, edgeName(delta))
+	if n := len(items); to < 1 || to > n {
+		m.message = fmt.Sprintf("task #%d is already at the %s of its siblings", r.item, edgeName(delta))
 		return m, nil
 	}
 	app, path, from, text := m.app, canonicalTaskPath(r.path), r.item, r.itemText
 	m.taskMarks = nil
-	if delta > 0 && m.cursors[m.tab] < m.rowCount()-1 {
-		m.cursors[m.tab]++
-	} else if delta < 0 && m.cursors[m.tab] > 0 {
-		m.cursors[m.tab]--
+	// How far the moved task actually travels. Going DOWN it clears the whole
+	// destination sibling's subtree, so it advances by that sibling's size, not
+	// by one; going UP it lands exactly on the destination's position. A ±1
+	// nudge would leave the cursor on a sub-task, and the next keypress would
+	// move THAT one.
+	nudge := to - r.item
+	landed := to
+	if delta > 0 {
+		nudge = domain.SubtreeSize(items, to)
+		// Where it ENDS UP, which is not `to`: the source subtree vacates the
+		// positions above the destination, so the item lands that much earlier.
+		landed = to + nudge - domain.SubtreeSize(items, r.item)
+	}
+	m.cursorUndo = &cursorUndo{tab: m.tab, pos: m.cursors[m.tab]}
+	if c := m.cursors[m.tab] + nudge; c < 0 {
+		m.cursors[m.tab] = 0
+	} else if last := m.rowCount() - 1; c > last {
+		m.cursors[m.tab] = last
+	} else {
+		m.cursors[m.tab] = c
 	}
 	m.scrollCursorIntoView()
 	m.beginAction()
-	return m, m.do(fmt.Sprintf("task #%d moved to position #%d", from, to),
+	return m, m.do(fmt.Sprintf("task #%d moved to position #%d", from, landed),
 		func(c context.Context) error {
 			// The snapshotted text is the staleness guard: the row positions
 			// this move was computed from are the ones last rendered, so if the


### PR DESCRIPTION
## Why

`MoveChecklistItem` refused outright when an item had nested sub-tasks — `"task #N has nested sub-tasks, which would be left behind — move or unnest them first"`. That made **no parent in a nested list reorderable at all**, which is the common shape now that sub-items are folded into what an agent is actually delivered (#238 / #242).

## What changed

**The move carries the whole subtree.** `subtreeEnd` (new) is the item's line, its detail block, every nested sub-task, and each of those sub-tasks' detail. It is bounded only by indentation — it ends at the first non-blank line indented at or below the item — so nesting depth is irrelevant and a blank line between a parent and its children does not cut the subtree in half. `hasNestedSubTasks` is gone.

**`detailBlockEnd` is unchanged and still used for delete and append.** It is the *narrow* bound: it stops at the first nested checklist item, because a nested `[ ]` is its own task rather than folded detail. That is the right answer for delivering one item and for splicing a new item in beside it, and `DeleteChecklistItem`'s contract depends on it (the TUI's multi-delete deletes bottom-up by descending index, which is only safe because a delete never renumbers the targets still queued above it). Moving needs the other answer, hence two helpers rather than one.

**Destination arithmetic shifts by the number of items that travel**, not by one, and a downward move inserts past the destination sibling's *own* subtree — otherwise the moved parent lands wedged between that sibling and its children, adopting them.

**`up`/`down` is one SIBLING, not one position** (`domain.SiblingPosition`), in both the CLI and the TUI's `K`/`J`. This is load-bearing rather than cosmetic: the position below a parent is its own first child, and swapping those two is re-parenting, which the mutator refuses. Without it, `move X down` and `J` would still have failed on exactly the nested lists this PR exists for.

**A subtree the two nesting models disagree about is refused, not rewritten.** `subtreeEnd` reads *lines* and stops at the first one indented at or below the item; `checklistParent` reads *items* and skips non-item lines entirely. A bare prose line at the parent's own indent, sitting between it and a sub-task, splits them — the parser still calls that sub-task a child, but the line scan stops short of it, so the move would leave it behind, re-parented onto whatever now precedes it. Which reading is correct is genuinely ambiguous (the prose belongs to neither), so it declines and names the fix rather than picking one and silently rewriting the tree.

```
- [ ] a
notes              ← at a's own indent: splits the two models
  - [ ] a1         ← the parser calls this a's child; the line scan never reaches it
- [ ] b
```

## Unchanged guarantees

The **same-parent sibling guard** is untouched: source and destination must share a parent, not merely an indent depth. It also turns out to be the proof that the destination can never land *inside* the subtree being cut — every item in there has the moved item (or one of its descendants) as its parent, never the moved item's own parent. Re-parenting stays a different operation from reordering, and stays refused.

Blank-separator handling is unchanged (they sit between items rather than belonging to one). The subtree is re-inserted verbatim; indentation and bullet style are the operator's.

## Reporting fixes that fell out of this

Both UIs previously printed the *requested* destination. Since a downward move vacates the slots above the destination, that is no longer where the item lands — `move #1 down` on a parent-of-two printed `position #4` for a task the list printed directly beneath it showed at `#2`. Both now compute and report the landing position.

The TUI also **restores its optimistic cursor nudge when a move fails**. The nudge runs before the move lands so the cursor visibly follows the task; it was survivable at ±1, but a subtree move can travel several rows, so a refused move (stale expected-text guard, or a domain refusal) left the cursor on an unrelated task — and the *next* `K`/`J` would move that one, with a text guard that legitimately passes.

## Docs

`hap help task` and the TUI's doc comment no longer describe the limitation; they describe the subtree behaviour, the sibling step, and the one remaining refusal.

## Tests

- 10 subtree-move cases: parent with two sub-tasks up and down, a sub-task that has its own detail, a parent moved past another parent that also has children, a three-level subtree, a blank line inside a subtree, and an absolute destination past an intervening subtree. Each also asserts via a multiset check that **no item was added, dropped, or re-indented** — so a subtree silently duplicated or orphaned is caught even when the text happens to line up.
- `SiblingPosition` / `SubtreeSize` tables including ragged indentation (siblings of a shared parent at *unequal* depths, which a depth-based implementation would get wrong), plus a cross-check that **every step `SiblingPosition` reports is a destination `MoveChecklistItem` accepts** — the two rules cannot be allowed to drift, or `down` would step onto something the mutator then refuses.
- The split-subtree refusal, and that indenting the separator resolves it.
- The existing re-parenting refusals (cousins at equal depth, nested cousins, landing inside another item's nesting) all still refuse and still return no content.
- TUI: the multi-row nudge in both directions, and the cursor restore on a refused move.

Full suite green across 3 consecutive runs; `go vet` and `golangci-lint` clean.
