### PR TITLE
#1 feat: accept only the last markdown list from a generate-task reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,21 @@ file that isn't a registered `[[task_sources]]` entry is never capped.
 
 The command's stdout may be plain lines or a Markdown list/checklist. Hap
 normalizes it and surfaces it as an escalation; it never auto-accepts a
-generated task. Confirming the suggestion creates
+generated task. When the output contains a list, only the list items become
+tasks and the surrounding prose is kept as the escalation's rationale. When it
+contains **several** lists — the options a model weighed, then the work it
+settled on — only the **last** list becomes tasks; the others go to the
+rationale behind an `ignored N other list(s):` note, so a discarded option is
+never queued as work. A list ends at a Markdown heading, or at prose separated
+from it by a blank line; prose flush against the bullets, a lone blank line, an
+indented continuation line, anything inside a fenced code block, and a
+paragraph between consecutively numbered steps (`1.` … `2.`) all leave one list
+intact. A fenced *example* list never outranks a real one. The trade-off runs
+one way: a reply that groups a single task list under several headings, or
+appends a `Notes:` list, keeps only its final group — the rest shows up in the
+rationale, on an escalation nothing auto-accepts, so ask the prompt for one
+final flat list if your model likes sections. Confirming the suggestion
+creates
 `<state-dir>/tasks/<agent-name>.md`, marks the first task in progress,
 registers the file as that agent's task source, and sends only the first task.
 Later idle events consume the remaining tasks through the normal declared-task

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2664,6 +2664,61 @@ func TestIdleTaskGenListModeCapturesRationale(t *testing.T) {
 	}
 }
 
+func TestIdleTaskGenMultipleListsKeepsLastList(t *testing.T) {
+	// A model that reasons out loud often lists the options it weighed before
+	// listing the work it settled on. Only the LAST list is real work: the
+	// superseded one must not become a confirmable task, and must show up in
+	// the rationale instead so the operator can see what was dropped. The
+	// suggestion still carries the RAW text — the confirm path runs the same
+	// parse, so both sides pick the same list.
+	raw := "I weighed two approaches:\n" +
+		"\n" +
+		"- Rewrite the parser from scratch\n" +
+		"- Patch the existing regex\n" +
+		"\n" +
+		"Final tasks:\n" +
+		"\n" +
+		"- Add multi-list handling to the parser\n" +
+		"- Cover it with unit tests"
+	h, _ := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+		return raw, nil
+	})
+	h.herdr.setPane("Task is complete.\n")
+
+	ctx := context.Background()
+	h.push("agent-20", "idle")
+	var esc []domain.AuditRecord
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ = h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	if want := domain.SuggestTaskPrefix + raw; esc[0].Suggestion != want {
+		t.Errorf("suggestion = %q, want %q", esc[0].Suggestion, want)
+	}
+	// The superseded list's items are surfaced as rationale, not as tasks.
+	if !strings.Contains(esc[0].Rationale, "Rewrite the parser from scratch") {
+		t.Errorf("rationale should carry the dropped list, got %q", esc[0].Rationale)
+	}
+	if !strings.Contains(esc[0].Rationale, "ignored 1 other list") {
+		t.Errorf("rationale should note the dropped list, got %q", esc[0].Rationale)
+	}
+	// The accepted list's items are tasks, so they stay out of the rationale.
+	if strings.Contains(esc[0].Rationale, "Add multi-list handling to the parser") {
+		t.Errorf("rationale must not include the accepted list, got %q", esc[0].Rationale)
+	}
+	// What the confirm path would write: only the last list.
+	tasks := domain.NormalizeGeneratedTasks(strings.TrimPrefix(esc[0].Suggestion, domain.SuggestTaskPrefix))
+	want := []string{"Add multi-list handling to the parser", "Cover it with unit tests"}
+	if len(tasks) != len(want) {
+		t.Fatalf("confirm-time tasks = %v, want %v", tasks, want)
+	}
+	for i := range want {
+		if tasks[i] != want[i] {
+			t.Errorf("confirm-time task[%d] = %q, want %q", i, tasks[i], want[i])
+		}
+	}
+}
+
 func TestIdleTaskGenPlainModeHasNoRationaleProse(t *testing.T) {
 	// A plain (no-list) generation ignores nothing, so the success escalation
 	// carries only the bare "[reason]" tag — no extra prose grafted on.

--- a/internal/domain/taskgen.go
+++ b/internal/domain/taskgen.go
@@ -55,8 +55,8 @@ func AgentBusy(status string) bool {
 // match, which is how list-mode drops prose. The whitespace after the bullet
 // char is load-bearing: it keeps a tight horizontal rule ("---", "***") from
 // matching at all. A spaced rule ("- - -") does match here but has no
-// alphanumeric body, so the mode-detection check in NormalizeGeneratedTasks
-// still refuses to treat it as a list marker.
+// alphanumeric body, so the mode-detection check in lastListBlock still refuses
+// to treat it as a list marker.
 // The ordered marker is built from the shared taskIDSepPat (tasklist.go), so an
 // escaped "1\." is stripped like a plain "1." — an LLM echoing a checklist it
 // read from an escaped file would otherwise leave the marker inside the task
@@ -68,6 +68,178 @@ var listItemRE = regexp.MustCompile(`^\s*(?:(?:[-*+]|\d+` + taskIDSepPat + `)\s+
 func isFenceLine(line string) bool {
 	trimmed := strings.TrimSpace(line)
 	return strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~")
+}
+
+// atxHeadingRE matches a Markdown ATX heading ("# Plan", "### Tasks"). A
+// heading always starts a new section, so it ends whatever list precedes it
+// even when the model wrote no blank line before it.
+var atxHeadingRE = regexp.MustCompile(`^\s*#{1,6}\s`)
+
+// orderedMarkerRE captures the number of an ordered list marker ("1.", "2)").
+// It must agree with listItemRE's ordered branch — same separator set, same
+// required trailing whitespace — so every line it reads a number from is also
+// a list item.
+var orderedMarkerRE = regexp.MustCompile(`^\s*(\d+)` + taskIDSepPat + `\s`)
+
+// orderedMarkerNum returns the number of a line's ordered list marker, or 0
+// when the line is unordered (or the number does not fit an int).
+func orderedMarkerNum(line string) int {
+	m := orderedMarkerRE.FindStringSubmatch(line)
+	if m == nil {
+		return 0
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// listBlock is one run of list lines: the marker lines that no section break
+// separates, as a half-open [start,end) line range ending at the run's last
+// marker. Task-bearing lines are counted twice over — once in total, once
+// excluding code fences — so a fenced EXAMPLE list can never outrank a real
+// one. The ordered-marker numbers let a numbered list that a paragraph
+// interrupts be recognized as ONE list rather than two.
+type listBlock struct {
+	start, end int
+	tasks      int // marker lines with a real (alphanumeric) body
+	plainTasks int // ditto, outside any code fence
+	firstNum   int // first ordered-marker number, 0 when the run is unordered
+	lastNum    int // last ordered-marker number, 0 when the run is unordered
+}
+
+// scanListBlocks splits the output into list blocks in source order.
+//
+// A block ends at an unmarked line that is BOTH
+//   - separated from the list by a blank line, or an ATX heading; and
+//   - indented no deeper than the line that opened the block, so it is a new
+//     section rather than one item's continuation (the same indentation test
+//     nestedContinuationLines uses for checklist detail).
+//
+// Those two requirements keep the split conservative. Prose written flush
+// against a list ("- Fix the parser" / "then, once green:" / "- Add
+// validation") is one interrupted list, not two; an indented continuation line
+// under an item never splits its list; and a blank line alone does not end a
+// block either — that is a loose Markdown list, still one list.
+//
+// Fenced regions are DATA, not prose: a command inside a ```sh block would
+// otherwise read as a blank-separated section break (and a "# comment" in one
+// as a heading), splitting a list around an example the model was only
+// illustrating. So nothing inside a fence ends a block. Marker lines in there
+// still join it, because a model that wraps its WHOLE reply in a fence must
+// still yield tasks — they are just counted as fenced, which is what keeps an
+// illustrative list from beating a real one.
+func scanListBlocks(lines []string) []listBlock {
+	var blocks []listBlock
+	cur := listBlock{start: -1}
+	curIndent := 0
+	// A prose line at the very top is "blank separated" from nothing, which is
+	// harmless: there is no open block for it to close.
+	blankSeen := true
+	inFence := false
+	flush := func() {
+		if cur.start >= 0 {
+			blocks = append(blocks, cur)
+		}
+		cur, curIndent = listBlock{start: -1}, 0
+	}
+	for i, line := range lines {
+		if isFenceLine(line) {
+			inFence = !inFence
+			continue
+		}
+		if m := listItemRE.FindStringSubmatch(line); m != nil {
+			if cur.start < 0 {
+				cur.start, curIndent = i, indentWidth(line)
+			}
+			cur.end = i + 1
+			if hasAlphanumeric(m[1]) {
+				cur.tasks++
+				if !inFence {
+					cur.plainTasks++
+				}
+			}
+			if n := orderedMarkerNum(line); n > 0 {
+				if cur.firstNum == 0 {
+					cur.firstNum = n
+				}
+				cur.lastNum = n
+			}
+			blankSeen = false
+			continue
+		}
+		if inFence {
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			blankSeen = true
+			continue
+		}
+		separated := blankSeen || atxHeadingRE.MatchString(line)
+		if cur.start >= 0 && separated && indentWidth(line) <= curIndent {
+			flush()
+		}
+		blankSeen = false
+	}
+	flush()
+	return mergeNumberedRuns(blocks)
+}
+
+// mergeNumberedRuns rejoins adjacent blocks whose ordered numbering runs
+// straight on ("1." … paragraph … "2."). A model explaining each numbered step
+// in its own paragraph writes ONE list, and splitting it would drop every step
+// but the last. Continued numbering is the evidence: a genuinely new list
+// restarts at 1, so it never merges.
+func mergeNumberedRuns(blocks []listBlock) []listBlock {
+	var out []listBlock
+	for _, b := range blocks {
+		if n := len(out); n > 0 && out[n-1].lastNum > 0 && b.firstNum == out[n-1].lastNum+1 {
+			prev := &out[n-1]
+			prev.end = b.end
+			prev.tasks += b.tasks
+			prev.plainTasks += b.plainTasks
+			prev.lastNum = b.lastNum
+			continue
+		}
+		out = append(out, b)
+	}
+	return out
+}
+
+// lastListBlock picks the block that holds the tasks: the LAST task-bearing
+// one, preferring a block with at least one UNFENCED task so a trailing fenced
+// example never replaces the real list. It returns that block's [start,end)
+// line range, how many other task-bearing blocks it supersedes, and whether one
+// was found at all. A model that reasons out loud often writes several lists —
+// options it considered, then the work it settled on — and only the final one
+// is the task list; the rest is reasoning that belongs in the rationale.
+//
+// ok is exactly the old whole-document "list mode" predicate: some non-fence
+// line carries a marker AND an alphanumeric body. A marker with no body (an
+// empty "- ", a spaced rule "- - -") joins a block but never makes one
+// task-bearing, so it can neither flip a plain block into list mode nor become
+// the "last list" and starve the real one.
+func lastListBlock(lines []string) (start, end, superseded int, ok bool) {
+	blocks := scanListBlocks(lines)
+	pick, plainPick, candidates := -1, -1, 0
+	for i, b := range blocks {
+		if b.tasks == 0 {
+			continue
+		}
+		candidates++
+		pick = i
+		if b.plainTasks > 0 {
+			plainPick = i
+		}
+	}
+	if candidates == 0 {
+		return 0, 0, 0, false
+	}
+	if plainPick >= 0 {
+		pick = plainPick
+	}
+	return blocks[pick].start, blocks[pick].end, candidates - 1, true
 }
 
 // emphasisBody is the text an asterisk-emphasis span may wrap: it must begin
@@ -133,6 +305,19 @@ func stripInlineEmphasis(s string) string {
 // ellipsis. Measured in runes so a multibyte tail is never split.
 const maxGeneratedRationale = 500
 
+// supersededListNote is the prefix NormalizeGeneratedTasksWithRationale puts in
+// front of the rationale when it dropped other lists, so the operator sees that
+// a list was discarded even after excerpt truncates the tail. It says "other"
+// rather than "earlier" because a dropped list may also FOLLOW the winning one
+// (a trailing fenced example).
+func supersededListNote(n int) string {
+	noun := " other list:"
+	if n > 1 {
+		noun = " other lists:"
+	}
+	return "ignored " + strconv.Itoa(n) + noun
+}
+
 // NormalizeGeneratedTasks parses a generate-task CLI's raw stdout into a clean
 // list of task strings. See NormalizeGeneratedTasksWithRationale for the parse
 // rules; this drops the rationale for callers that only need the tasks.
@@ -142,22 +327,39 @@ func NormalizeGeneratedTasks(raw string) []string {
 }
 
 // NormalizeGeneratedTasksWithRationale parses a generate-task CLI's raw stdout
-// into a clean list of task strings and, in list mode, the ignored non-list
-// prose joined as rationale text. The model may return one task or several,
-// plain or as a Markdown list. The parser picks a mode from the content: if ANY
-// line carries a real list/checkbox marker, the whole block is treated as a list
-// and ONLY marked lines become tasks — so a lead-in sentence ("Here are the
-// tasks:") preceding a bullet list is dropped rather than written as an item.
-// If no line carries a marker, it falls back to plain mode, where each
-// non-empty line is a task (a single- or multi-line plain response). Each task
-// is reduced to its bare text with Markdown inline emphasis (bold/italic/code)
-// stripped, and lines without a letter or digit are dropped. Returns nil tasks
-// when nothing usable remains.
+// into a clean list of task strings and, in list mode, everything it ignored
+// joined as rationale text. The model may return one task or several, plain or
+// as a Markdown list. The parser picks a mode from the content: if ANY line
+// carries a real list/checkbox marker, the output is treated as a list and ONLY
+// marked lines become tasks — so a lead-in sentence ("Here are the tasks:")
+// preceding a bullet list is dropped rather than written as an item. If no line
+// carries a marker, it falls back to plain mode, where each non-empty line is a
+// task (a single- or multi-line plain response). Each task is reduced to its
+// bare text with Markdown inline emphasis (bold/italic/code) stripped, and
+// lines without a letter or digit are dropped. Returns nil tasks when nothing
+// usable remains.
 //
-// The rationale is collected ONLY in list mode: it is the dropped, unmarked,
-// non-fence, non-blank prose (the model's reasoning around the list), collapsed
-// to a single line and capped at maxGeneratedRationale runes. In plain mode
-// nothing is ignored, so rationale is "".
+// When the output holds SEVERAL lists, only ONE becomes tasks — the last
+// task-bearing one, preferring an unfenced list (lastListBlock picks it; see
+// scanListBlocks for what separates two lists). A model that reasons out loud
+// commonly lists the options it weighed before listing the work it settled on;
+// taking every marked line would write the discarded options into the agent's
+// checklist as real tasks. The superseded lists are not lost — they go to the
+// rationale with their markers intact, behind a short "ignored N other list(s):"
+// note. The trade-off is deliberate and one-directional: a model that groups ONE
+// task list under several headings, or appends a "Notes:" list, has all but the
+// final group demoted to rationale. That is visible to the operator on an
+// escalation nothing auto-accepts, whereas the old union quietly queued the
+// model's rejected options as work.
+//
+// The rationale is collected ONLY in list mode: the unmarked, non-fence,
+// non-blank prose around the list plus any superseded list's items, in source
+// order, collapsed to a single line and capped at maxGeneratedRationale runes
+// — with the "ignored N other list(s):" note, when there is one, prepended
+// ahead of all of it so truncation cannot eat the signal. Marker-only lines
+// ("- ", "[ ] ", the spaced rule "- - -") are list artifacts rather than
+// reasoning and stay out of it. In plain mode nothing is ignored, so rationale
+// is "".
 func NormalizeGeneratedTasksWithRationale(raw string) (tasks []string, rationale string) {
 	lines := strings.Split(raw, "\n")
 
@@ -165,21 +367,15 @@ func NormalizeGeneratedTasksWithRationale(raw string) (tasks []string, rationale
 	// (letters/digits); else plain mode. Requiring the body keeps an empty
 	// marker ("- ", "[ ] ") or a spaced horizontal rule ("- - -", "* * *")
 	// from flipping an otherwise-plain block into list mode and dropping its
-	// prose lines.
-	listMode := false
-	for _, line := range lines {
-		if isFenceLine(line) {
-			continue
-		}
-		if m := listItemRE.FindStringSubmatch(line); m != nil && hasAlphanumeric(m[1]) {
-			listMode = true
-			break
-		}
-	}
+	// prose lines. lastListBlock applies exactly that test, and also tells us
+	// WHICH of several lists is the task list.
+	start, end, superseded, listMode := lastListBlock(lines)
 
 	var ignored []string
-	for _, line := range lines {
+	inFence := false
+	for i, line := range lines {
 		if isFenceLine(line) {
+			inFence = !inFence
 			continue
 		}
 		var t string
@@ -188,8 +384,21 @@ func NormalizeGeneratedTasksWithRationale(raw string) (tasks []string, rationale
 			// captured as rationale so the model's reasoning is not lost.
 			m := listItemRE.FindStringSubmatch(line)
 			if m == nil {
-				if p := strings.TrimSpace(line); p != "" {
+				// Unmarked fenced content is code the model illustrated with,
+				// not reasoning — the same reading scanListBlocks takes — so it
+				// is dropped rather than pasted into the rationale column.
+				if p := strings.TrimSpace(line); p != "" && !inFence {
 					ignored = append(ignored, p)
+				}
+				continue
+			}
+			if i < start || i >= end {
+				// A marked line from a superseded list. Keep it in the
+				// rationale verbatim (marker included, so the operator can see
+				// it was a list) but never as a task. Bodyless markers are
+				// artifacts, not reasoning.
+				if hasAlphanumeric(m[1]) {
+					ignored = append(ignored, strings.TrimSpace(line))
 				}
 				continue
 			}
@@ -206,6 +415,11 @@ func NormalizeGeneratedTasksWithRationale(raw string) (tasks []string, rationale
 		if t != "" && hasAlphanumeric(t) {
 			tasks = append(tasks, t)
 		}
+	}
+	// Lead with the drop note so it survives the truncation below: the tail of a
+	// long rationale is exactly where a superseded list would otherwise vanish.
+	if superseded > 0 {
+		ignored = append([]string{supersededListNote(superseded)}, ignored...)
 	}
 	// excerpt (safety.go) collapses whitespace to a single line and caps the
 	// rune count with an ellipsis — a rationale is a compact one-liner rendered

--- a/internal/domain/taskgen.go
+++ b/internal/domain/taskgen.go
@@ -95,21 +95,67 @@ func orderedMarkerNum(line string) int {
 	return n
 }
 
+// fencedRegions marks the lines that sit INSIDE a code fence, so both the
+// block scan and the emit loop can treat that content as DATA the model
+// illustrated with rather than as tasks or reasoning. Without it a command in a
+// ```sh block reads as a blank-separated section break, a "# comment" in one
+// reads as a heading, and a "- name: build" in a ```yaml block becomes a task.
+//
+// It returns nil — meaning NO line is fenced — in the two cases where hap
+// cannot tell data from the real thing:
+//
+//   - an ODD number of fence delimiters. The reply was truncated, or it nested
+//     fences (which isFenceLine cannot tell apart), so "inside" is a guess. A
+//     wrong guess is worse than none: it would mark the real trailing list as
+//     data and hand the operator the rejected options instead.
+//   - no task-bearing marker OUTSIDE a fence. That is a model fencing its whole
+//     answer, where the fenced list IS the answer.
+//
+// A nil mask degrades to reading fenced content exactly as the pre-fence-aware
+// parser did — plain source order decides, and a fenced list can still win — so
+// both fallbacks fail toward keeping tasks.
+func fencedRegions(lines []string) []bool {
+	mask := make([]bool, len(lines))
+	inFence, delimiters, plainTask := false, 0, false
+	for i, line := range lines {
+		if isFenceLine(line) {
+			delimiters++
+			inFence = !inFence
+			continue
+		}
+		mask[i] = inFence
+		if inFence {
+			continue
+		}
+		if m := listItemRE.FindStringSubmatch(line); m != nil && hasAlphanumeric(m[1]) {
+			plainTask = true
+		}
+	}
+	if delimiters%2 != 0 || !plainTask {
+		return nil
+	}
+	return mask
+}
+
+// isFenced reports whether line i is fenced content per mask. A nil mask means
+// fences are transparent — see fencedRegions.
+func isFenced(mask []bool, i int) bool {
+	return mask != nil && mask[i]
+}
+
 // listBlock is one run of list lines: the marker lines that no section break
 // separates, as a half-open [start,end) line range ending at the run's last
-// marker. Task-bearing lines are counted twice over — once in total, once
-// excluding code fences — so a fenced EXAMPLE list can never outrank a real
-// one. The ordered-marker numbers let a numbered list that a paragraph
+// marker. The ordered-marker numbers let a numbered list that a paragraph
 // interrupts be recognized as ONE list rather than two.
 type listBlock struct {
 	start, end int
 	tasks      int // marker lines with a real (alphanumeric) body
-	plainTasks int // ditto, outside any code fence
 	firstNum   int // first ordered-marker number, 0 when the run is unordered
 	lastNum    int // last ordered-marker number, 0 when the run is unordered
 }
 
-// scanListBlocks splits the output into list blocks in source order.
+// scanListBlocks splits the output into list blocks in source order, skipping
+// the fenced content fenceMask marks.
 //
 // A block ends at an unmarked line that is BOTH
 //   - separated from the list by a blank line, or an ATX heading; and
@@ -123,21 +169,16 @@ type listBlock struct {
 // under an item never splits its list; and a blank line alone does not end a
 // block either — that is a loose Markdown list, still one list.
 //
-// Fenced regions are DATA, not prose: a command inside a ```sh block would
-// otherwise read as a blank-separated section break (and a "# comment" in one
-// as a heading), splitting a list around an example the model was only
-// illustrating. So nothing inside a fence ends a block. Marker lines in there
-// still join it, because a model that wraps its WHOLE reply in a fence must
-// still yield tasks — they are just counted as fenced, which is what keeps an
-// illustrative list from beating a real one.
-func scanListBlocks(lines []string) []listBlock {
+// A fence is a block-level element: it never ends a list by itself, so a code
+// sample between two items leaves them one list, but the line AFTER it starts a
+// fresh paragraph and so counts as separated.
+func scanListBlocks(lines []string, fenceMask []bool) []listBlock {
 	var blocks []listBlock
 	cur := listBlock{start: -1}
 	curIndent := 0
 	// A prose line at the very top is "blank separated" from nothing, which is
 	// harmless: there is no open block for it to close.
 	blankSeen := true
-	inFence := false
 	flush := func() {
 		if cur.start >= 0 {
 			blocks = append(blocks, cur)
@@ -145,8 +186,8 @@ func scanListBlocks(lines []string) []listBlock {
 		cur, curIndent = listBlock{start: -1}, 0
 	}
 	for i, line := range lines {
-		if isFenceLine(line) {
-			inFence = !inFence
+		if isFenceLine(line) || isFenced(fenceMask, i) {
+			blankSeen = true
 			continue
 		}
 		if m := listItemRE.FindStringSubmatch(line); m != nil {
@@ -156,9 +197,6 @@ func scanListBlocks(lines []string) []listBlock {
 			cur.end = i + 1
 			if hasAlphanumeric(m[1]) {
 				cur.tasks++
-				if !inFence {
-					cur.plainTasks++
-				}
 			}
 			if n := orderedMarkerNum(line); n > 0 {
 				if cur.firstNum == 0 {
@@ -167,9 +205,6 @@ func scanListBlocks(lines []string) []listBlock {
 				cur.lastNum = n
 			}
 			blankSeen = false
-			continue
-		}
-		if inFence {
 			continue
 		}
 		if strings.TrimSpace(line) == "" {
@@ -198,7 +233,6 @@ func mergeNumberedRuns(blocks []listBlock) []listBlock {
 			prev := &out[n-1]
 			prev.end = b.end
 			prev.tasks += b.tasks
-			prev.plainTasks += b.plainTasks
 			prev.lastNum = b.lastNum
 			continue
 		}
@@ -208,36 +242,30 @@ func mergeNumberedRuns(blocks []listBlock) []listBlock {
 }
 
 // lastListBlock picks the block that holds the tasks: the LAST task-bearing
-// one, preferring a block with at least one UNFENCED task so a trailing fenced
-// example never replaces the real list. It returns that block's [start,end)
-// line range, how many other task-bearing blocks it supersedes, and whether one
-// was found at all. A model that reasons out loud often writes several lists —
-// options it considered, then the work it settled on — and only the final one
-// is the task list; the rest is reasoning that belongs in the rationale.
+// one. It returns that block's [start,end) line range, how many other
+// task-bearing blocks it supersedes, and whether one was found at all. A model
+// that reasons out loud often writes several lists — options it considered,
+// then the work it settled on — and only the final one is the task list; the
+// rest is reasoning that belongs in the rationale. A trailing fenced EXAMPLE
+// list cannot win, because fenceMask has already removed it from the scan.
 //
-// ok is exactly the old whole-document "list mode" predicate: some non-fence
-// line carries a marker AND an alphanumeric body. A marker with no body (an
-// empty "- ", a spaced rule "- - -") joins a block but never makes one
-// task-bearing, so it can neither flip a plain block into list mode nor become
-// the "last list" and starve the real one.
-func lastListBlock(lines []string) (start, end, superseded int, ok bool) {
-	blocks := scanListBlocks(lines)
-	pick, plainPick, candidates := -1, -1, 0
+// ok is exactly the old whole-document "list mode" predicate: some visible line
+// carries a marker AND an alphanumeric body. A marker with no body (an empty
+// "- ", a spaced rule "- - -") joins a block but never makes one task-bearing,
+// so it can neither flip a plain block into list mode nor become the "last
+// list" and starve the real one.
+func lastListBlock(lines []string, fenceMask []bool) (start, end, superseded int, ok bool) {
+	blocks := scanListBlocks(lines, fenceMask)
+	pick, candidates := -1, 0
 	for i, b := range blocks {
 		if b.tasks == 0 {
 			continue
 		}
 		candidates++
 		pick = i
-		if b.plainTasks > 0 {
-			plainPick = i
-		}
 	}
 	if candidates == 0 {
 		return 0, 0, 0, false
-	}
-	if plainPick >= 0 {
-		pick = plainPick
 	}
 	return blocks[pick].start, blocks[pick].end, candidates - 1, true
 }
@@ -339,9 +367,10 @@ func NormalizeGeneratedTasks(raw string) []string {
 // lines without a letter or digit are dropped. Returns nil tasks when nothing
 // usable remains.
 //
-// When the output holds SEVERAL lists, only ONE becomes tasks — the last
-// task-bearing one, preferring an unfenced list (lastListBlock picks it; see
-// scanListBlocks for what separates two lists). A model that reasons out loud
+// When the output holds SEVERAL lists, only the LAST task-bearing one becomes
+// tasks (lastListBlock picks it; see scanListBlocks for what separates two
+// lists, and fencedRegions for why an illustrative fenced list is not one of
+// them). A model that reasons out loud
 // commonly lists the options it weighed before listing the work it settled on;
 // taking every marked line would write the discarded options into the agent's
 // checklist as real tasks. The superseded lists are not lost — they go to the
@@ -369,13 +398,16 @@ func NormalizeGeneratedTasksWithRationale(raw string) (tasks []string, rationale
 	// from flipping an otherwise-plain block into list mode and dropping its
 	// prose lines. lastListBlock applies exactly that test, and also tells us
 	// WHICH of several lists is the task list.
-	start, end, superseded, listMode := lastListBlock(lines)
+	// Fenced content is data, not tasks and not reasoning. The SAME mask drives
+	// the block scan and this loop, so the two can never disagree about which
+	// lines are visible; when it is nil, both fall back to reading fenced text
+	// as ordinary output (see fencedRegions).
+	fenceMask := fencedRegions(lines)
+	start, end, superseded, listMode := lastListBlock(lines, fenceMask)
 
 	var ignored []string
-	inFence := false
 	for i, line := range lines {
-		if isFenceLine(line) {
-			inFence = !inFence
+		if isFenceLine(line) || isFenced(fenceMask, i) {
 			continue
 		}
 		var t string
@@ -384,10 +416,7 @@ func NormalizeGeneratedTasksWithRationale(raw string) (tasks []string, rationale
 			// captured as rationale so the model's reasoning is not lost.
 			m := listItemRE.FindStringSubmatch(line)
 			if m == nil {
-				// Unmarked fenced content is code the model illustrated with,
-				// not reasoning — the same reading scanListBlocks takes — so it
-				// is dropped rather than pasted into the rationale column.
-				if p := strings.TrimSpace(line); p != "" && !inFence {
+				if p := strings.TrimSpace(line); p != "" {
 					ignored = append(ignored, p)
 				}
 				continue

--- a/internal/domain/taskgen.go
+++ b/internal/domain/taskgen.go
@@ -95,19 +95,74 @@ func orderedMarkerNum(line string) int {
 	return n
 }
 
-// fencedRegions marks the lines that sit INSIDE a code fence, so both the
-// block scan and the emit loop can treat that content as DATA the model
-// illustrated with rather than as tasks or reasoning. Without it a command in a
-// ```sh block reads as a blank-separated section break, a "# comment" in one
-// reads as a heading, and a "- name: build" in a ```yaml block becomes a task.
+// fenceDelimiter is a parsed Markdown code-fence line: which character the run
+// is made of ("`" or "~"), how long that run is, and whether an info string
+// ("```yaml") follows it. All three decide whether a later delimiter CLOSES
+// this fence — see parseFenceDelimiter.
+type fenceDelimiter struct {
+	char byte
+	run  int
+	info bool
+}
+
+// parseFenceDelimiter reads a line as a code-fence delimiter, reporting false
+// when it is not one. Per CommonMark a fence is at least three of the SAME
+// character, optionally indented, optionally followed by an info string; a
+// backtick fence's info string may not itself contain a backtick.
+//
+// This is stricter than isFenceLine on purpose. isFenceLine answers the loose
+// "does this look like a fence", which is all the fail-open paths need;
+// matching an opener to its closer needs the character and the run length, or
+// a "~~~" reads as closing a "```" block and everything below it escapes the
+// fence.
+func parseFenceDelimiter(line string) (fenceDelimiter, bool) {
+	t := strings.TrimLeft(line, " \t")
+	if t == "" || (t[0] != '`' && t[0] != '~') {
+		return fenceDelimiter{}, false
+	}
+	c := t[0]
+	run := 0
+	for run < len(t) && t[run] == c {
+		run++
+	}
+	if run < 3 {
+		return fenceDelimiter{}, false
+	}
+	rest := strings.TrimSpace(t[run:])
+	if c == '`' && strings.ContainsRune(rest, '`') {
+		return fenceDelimiter{}, false
+	}
+	return fenceDelimiter{char: c, run: run, info: rest != ""}, true
+}
+
+// closes reports whether d ends a fence opened by open. CommonMark requires
+// the same character, a run at least as long as the opener's, and no info
+// string. Anything else that merely looks like a fence — the other flavour, a
+// shorter run, a run carrying an info string — is ordinary content INSIDE the
+// open block.
+func (d fenceDelimiter) closes(open fenceDelimiter) bool {
+	return d.char == open.char && d.run >= open.run && !d.info
+}
+
+// fencedRegions marks the lines a code fence covers — its delimiters and
+// everything between them — so both the block scan and the emit loop can treat
+// that content as DATA the model illustrated with rather than as tasks or
+// reasoning. Without it a command in a ```sh block reads as a blank-separated
+// section break, a "# comment" in one reads as a heading, and a "- name: build"
+// in a ```yaml block becomes a task.
+//
+// Openers are matched to closers properly (see fenceDelimiter.closes), so a
+// "~~~" inside a backtick block does not end it. Counting delimiters instead
+// would let a mismatched pair balance out and release every line below it back
+// into the task list — the exact unsafe reading this exists to prevent.
 //
 // It returns nil — meaning NO line is fenced — in the two cases where hap
 // cannot tell data from the real thing:
 //
-//   - an ODD number of fence delimiters. The reply was truncated, or it nested
-//     fences (which isFenceLine cannot tell apart), so "inside" is a guess. A
-//     wrong guess is worse than none: it would mark the real trailing list as
-//     data and hand the operator the rejected options instead.
+//   - a fence is still OPEN at the end. The reply was truncated mid-block, so
+//     "inside" is a guess, and a wrong guess is worse than none: it would mark
+//     the real trailing list as data and hand the operator the rejected options
+//     instead.
 //   - no task-bearing marker OUTSIDE a fence. That is a model fencing its whole
 //     answer, where the fenced list IS the answer.
 //
@@ -116,11 +171,19 @@ func orderedMarkerNum(line string) int {
 // both fallbacks fail toward keeping tasks.
 func fencedRegions(lines []string) []bool {
 	mask := make([]bool, len(lines))
-	inFence, delimiters, plainTask := false, 0, false
+	var open fenceDelimiter
+	inFence, plainTask := false, false
 	for i, line := range lines {
-		if isFenceLine(line) {
-			delimiters++
-			inFence = !inFence
+		if d, ok := parseFenceDelimiter(line); ok {
+			mask[i] = true
+			switch {
+			case !inFence:
+				open, inFence = d, true
+			case d.closes(open):
+				inFence = false
+			}
+			// A delimiter that neither opens nor closes is content; mask[i] is
+			// already set, and the fence stays open.
 			continue
 		}
 		mask[i] = inFence
@@ -131,7 +194,7 @@ func fencedRegions(lines []string) []bool {
 			plainTask = true
 		}
 	}
-	if delimiters%2 != 0 || !plainTask {
+	if inFence || !plainTask {
 		return nil
 	}
 	return mask

--- a/internal/domain/taskgen_test.go
+++ b/internal/domain/taskgen_test.go
@@ -403,9 +403,9 @@ func TestNormalizeGeneratedTasksLastListWins(t *testing.T) {
 			"Tasks:",
 		},
 		{
-			// A trailing fenced EXAMPLE of the checklist format must not
-			// replace the real list: an unfenced task-bearing block always
-			// outranks a fenced one, wherever it sits.
+			// A trailing fenced EXAMPLE of the checklist format is data, so it
+			// is neither a task nor a superseded "list" — the real list wins
+			// outright and the operator is not told anything was dropped.
 			"trailing fenced example never wins",
 			"- [ ] Add multi-list handling\n" +
 				"- [ ] Cover it with tests\n\n" +
@@ -414,7 +414,57 @@ func TestNormalizeGeneratedTasksLastListWins(t *testing.T) {
 				"- [ ] example item\n" +
 				"```",
 			[]string{"Add multi-list handling", "Cover it with tests"},
-			"ignored 1 other list: Format used: - [ ] example item",
+			"Format used:",
+		},
+		{
+			// A fenced snippet whose lines merely START like list items (a diff
+			// hunk, YAML) must not become tasks, nor make hap claim it dropped
+			// a list.
+			"fenced diff hunk is data, not a list",
+			"Planned diff:\n\n" +
+				"```diff\n" +
+				"- oldCall()\n" +
+				"+ newCall()\n" +
+				"```\n\n" +
+				"Tasks:\n\n" +
+				"- Apply the diff",
+			[]string{"Apply the diff"},
+			"Planned diff: Tasks:",
+		},
+		{
+			// A fence flush against prose on BOTH sides still separates the
+			// lists: a fence is block-level, so the line after it begins a new
+			// paragraph even with no blank line.
+			"fence flush against prose still separates lists",
+			"I weighed two approaches:\n\n" +
+				"- Rewrite the parser\n" +
+				"- Patch the regex\n" +
+				"```sh\n" +
+				"go test ./...\n" +
+				"```\n" +
+				"Final tasks:\n\n" +
+				"- Add multi-list handling\n" +
+				"- Cover it with tests",
+			[]string{"Add multi-list handling", "Cover it with tests"},
+			"ignored 1 other list: I weighed two approaches: - Rewrite the parser - Patch the regex Final tasks:",
+		},
+		{
+			// An UNCLOSED fence makes "inside" a guess, so fence awareness
+			// switches off entirely and plain source order decides. Failing
+			// open matters: trusting the bogus parity would mark the real
+			// trailing list as data and hand back the rejected options.
+			"unbalanced fence falls back to source order",
+			"Options I considered:\n\n" +
+				"- Rewrite the parser\n" +
+				"- Patch the regex\n\n" +
+				"Reproduce with:\n\n" +
+				"```sh\n" +
+				"go test ./...\n\n" +
+				"Final tasks:\n\n" +
+				"- Add a fence-parity guard\n" +
+				"- Add regression tests",
+			[]string{"Add a fence-parity guard", "Add regression tests"},
+			"ignored 1 other list: Options I considered: - Rewrite the parser - Patch the regex Reproduce with: go test ./... Final tasks:",
 		},
 		{
 			// A numbered list whose steps carry their own explanation
@@ -526,13 +576,18 @@ func TestLastListBlock(t *testing.T) {
 		{"two blocks pick the second", "- a\n\nProse:\n\n- b", 4, 5, 1, true},
 		{"heading splits with no blank line", "- a\n## Tasks\n- b", 2, 3, 1, true},
 		{"continued numbering rejoins", "1. a\n\nWhy:\n\n2. b", 0, 5, 0, true},
-		{"unfenced block beats a later fenced one", "- a\n\nFormat:\n\n```\n- b\n```", 0, 1, 1, true},
+		{"fenced example is not a candidate at all", "- a\n\nFormat:\n\n```\n- b\n```", 0, 1, 0, true},
 		{"a wholly fenced list still wins", "```\n- a\n```", 1, 2, 0, true},
+		// Same shape as the case above but with an UNCLOSED fence: parity is
+		// untrustworthy, so fence awareness switches off and the fenced list
+		// becomes an ordinary candidate that wins on source order.
+		{"unbalanced fence disables fence awareness", "- a\n\nFormat:\n\n```\n- b", 5, 6, 1, true},
 		{"bodyless trailing block is not a candidate", "- a\n\nProse.\n\n- - -", 0, 1, 0, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			start, end, superseded, ok := lastListBlock(strings.Split(tc.raw, "\n"))
+			lines := strings.Split(tc.raw, "\n")
+			start, end, superseded, ok := lastListBlock(lines, fencedRegions(lines))
 			if ok != tc.wantOK {
 				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
 			}
@@ -544,6 +599,33 @@ func TestLastListBlock(t *testing.T) {
 			}
 			if superseded != tc.wantSuperNum {
 				t.Errorf("superseded = %d, want %d", superseded, tc.wantSuperNum)
+			}
+		})
+	}
+}
+
+// TestOrderedMarkerNum: mergeNumberedRuns rejoins two runs only when the second
+// starts at the first's last number plus one, so a number the parser cannot
+// represent must read as "unordered" (0) rather than wrap or panic — otherwise
+// a huge id could forge a continuation and glue two unrelated lists together.
+func TestOrderedMarkerNum(t *testing.T) {
+	tests := []struct {
+		line string
+		want int
+	}{
+		{"1. Fix the parser", 1},
+		{"23) Fix the parser", 23},
+		{"  4: Fix the parser", 4},
+		{`5\. Fix the parser`, 5},
+		{"- Fix the parser", 0},
+		{"1.Fix the parser", 0}, // no space after the separator: not a marker
+		{"Fix 1. the parser", 0},
+		{"99999999999999999999. Fix the parser", 0}, // out of int range
+	}
+	for _, tc := range tests {
+		t.Run(tc.line, func(t *testing.T) {
+			if got := orderedMarkerNum(tc.line); got != tc.want {
+				t.Errorf("orderedMarkerNum(%q) = %d, want %d", tc.line, got, tc.want)
 			}
 		})
 	}

--- a/internal/domain/taskgen_test.go
+++ b/internal/domain/taskgen_test.go
@@ -310,6 +310,288 @@ func TestNormalizeGeneratedTasksWithRationale(t *testing.T) {
 	}
 }
 
+// TestNormalizeGeneratedTasksLastListWins: when the model writes SEVERAL lists
+// — options it weighed, then the work it settled on — only the last one becomes
+// tasks. The superseded lists must not reach the agent's checklist, and must
+// not be lost either: they go to the rationale with their markers, behind an
+// "ignored N other list(s):" note that survives truncation.
+//
+// The split is deliberately conservative: a list is only ended by an ATX
+// heading, or by prose that a BLANK LINE separates from it. Prose flush against
+// a list, a bare blank line, and indented continuation lines all keep one list
+// intact — those cases are pinned here so a future widening cannot silently
+// start dropping real tasks.
+func TestNormalizeGeneratedTasksLastListWins(t *testing.T) {
+	tests := []struct {
+		name          string
+		raw           string
+		wantTasks     []string
+		wantRationale string
+	}{
+		{
+			// The motivating shape: a considered-options list, then the real
+			// task list, separated by a blank line and a lead-in.
+			"second list supersedes the first",
+			"I considered these approaches:\n\n" +
+				"- Rewrite the parser\n" +
+				"- Patch the regex\n\n" +
+				"Final tasks:\n\n" +
+				"- [ ] Add multi-list handling\n" +
+				"- [ ] Cover it with tests",
+			[]string{"Add multi-list handling", "Cover it with tests"},
+			"ignored 1 other list: I considered these approaches: - Rewrite the parser - Patch the regex Final tasks:",
+		},
+		{
+			// A heading always ends a list, even with no blank line before it.
+			"heading splits without a blank line",
+			"- Draft option A\n" +
+				"## Tasks\n" +
+				"- [ ] Do the real work",
+			[]string{"Do the real work"},
+			"ignored 1 other list: - Draft option A ## Tasks",
+		},
+		{
+			// Prose flush against the bullets is an interruption, not a new
+			// list — both items stay tasks (guards the pinned behavior in
+			// TestNormalizeGeneratedTasksWithRationale).
+			"prose without a blank line does not split",
+			"Because the suite is red:\n- Fix the parser\nthen, once green:\n- Add validation",
+			[]string{"Fix the parser", "Add validation"},
+			"Because the suite is red: then, once green:",
+		},
+		{
+			// A blank line alone is a loose Markdown list, still one list.
+			"blank line alone does not split",
+			"- First task\n\n- Second task",
+			[]string{"First task", "Second task"},
+			"",
+		},
+		{
+			// An indented continuation line under an item must not split its
+			// list, even with a blank line before it.
+			"indented continuation does not split",
+			"- First task\n" +
+				"\n" +
+				"    extra detail about the first task\n" +
+				"- Second task",
+			[]string{"First task", "Second task"},
+			"extra detail about the first task",
+		},
+		{
+			// A trailing bodyless block ("- - -") is never task-bearing, so the
+			// real list above it still wins — and the rule text stays out of
+			// the rationale as a list artifact.
+			"bodyless trailing block never wins",
+			"- Real task one\n- Real task two\n\nWrap up.\n\n- - -",
+			[]string{"Real task one", "Real task two"},
+			"Wrap up.",
+		},
+		{
+			// A fenced command between items is DATA, not a section break: the
+			// list must survive it whole. "go test ./..." is unmarked,
+			// blank-separated and un-indented, so without the fence rule it
+			// would split the list and drop everything above it.
+			"fenced code between items does not split",
+			"Tasks:\n\n" +
+				"- Run the test suite\n\n" +
+				"```sh\n" +
+				"# install deps first\n" +
+				"go test ./...\n" +
+				"```\n\n" +
+				"- Fix any failures",
+			[]string{"Run the test suite", "Fix any failures"},
+			"Tasks:",
+		},
+		{
+			// A trailing fenced EXAMPLE of the checklist format must not
+			// replace the real list: an unfenced task-bearing block always
+			// outranks a fenced one, wherever it sits.
+			"trailing fenced example never wins",
+			"- [ ] Add multi-list handling\n" +
+				"- [ ] Cover it with tests\n\n" +
+				"Format used:\n\n" +
+				"```md\n" +
+				"- [ ] example item\n" +
+				"```",
+			[]string{"Add multi-list handling", "Cover it with tests"},
+			"ignored 1 other list: Format used: - [ ] example item",
+		},
+		{
+			// A numbered list whose steps carry their own explanation
+			// paragraphs is ONE list: continued numbering ("1." then "2.")
+			// rejoins the runs, so no step is dropped.
+			"paragraph between numbered steps does not split",
+			"1. Fix the flaky auth test\n\n" +
+				"Rationale: the suite is red.\n\n" +
+				"2. Add a retry guard",
+			[]string{"Fix the flaky auth test", "Add a retry guard"},
+			"Rationale: the suite is red.",
+		},
+		{
+			// Restarted numbering is a genuinely new list, so last-wins still
+			// applies to two ordered lists.
+			"restarted numbering is a new list",
+			"Considered:\n\n1. Rewrite it\n\nChosen:\n\n1. Patch it",
+			[]string{"Patch it"},
+			"ignored 1 other list: Considered: 1. Rewrite it Chosen:",
+		},
+		{
+			// ACCEPTED TRADE-OFF, pinned so it cannot drift unnoticed: one task
+			// list grouped under several headings keeps only the final group,
+			// and a trailing "Notes:" list replaces the tasks. Both are visible
+			// to the operator in the rationale on an escalation nothing
+			// auto-accepts.
+			"heading-grouped sections keep only the last group",
+			"## Backend\n\n- [ ] Add the endpoint\n\n## Frontend\n\n- [ ] Wire the form",
+			[]string{"Wire the form"},
+			"ignored 1 other list: ## Backend - [ ] Add the endpoint ## Frontend",
+		},
+		{
+			"trailing notes list supersedes the tasks",
+			"Tasks:\n\n- [ ] Add the endpoint\n- [ ] Wire the form\n\nNotes:\n\n- Requires network access",
+			[]string{"Requires network access"},
+			"ignored 1 other list: Tasks: - [ ] Add the endpoint - [ ] Wire the form Notes:",
+		},
+		{
+			// CRLF output splits into lines carrying a trailing "\r"; the
+			// blank/indent tests tolerate it, so the split lands the same way.
+			"CRLF line endings split the same way",
+			"Options:\r\n\r\n- Rewrite it\r\n\r\nTasks:\r\n\r\n- Patch it\r\n",
+			[]string{"Patch it"},
+			"ignored 1 other list: Options: - Rewrite it Tasks:",
+		},
+		{
+			// Three lists: the note pluralizes and both earlier lists are kept.
+			"three lists keep only the last",
+			"## Rejected\n\n- Option A\n\n## Maybe\n\n- Option B\n\n## Tasks\n\n- [ ] Ship it",
+			[]string{"Ship it"},
+			"ignored 2 other lists: ## Rejected - Option A ## Maybe - Option B ## Tasks",
+		},
+		{
+			// Only the LAST list needs a body: an earlier list of real options
+			// followed by a bodyless marker run must not resurrect the options.
+			"superseded list is dropped even when the last list is short",
+			"Options:\n\n- Rewrite it\n- Patch it\n\nDecision:\n\n1. Patch it now",
+			[]string{"Patch it now"},
+			"ignored 1 other list: Options: - Rewrite it - Patch it Decision:",
+		},
+		{
+			// Single-list output is untouched by the block logic.
+			"single list is unchanged",
+			"Here are the tasks:\n\n- First real task\n- Second real task",
+			[]string{"First real task", "Second real task"},
+			"Here are the tasks:",
+		},
+		{
+			// Plain mode has no lists at all, so nothing is superseded and the
+			// note never appears.
+			"plain mode is unchanged",
+			"First task\n\nSecond task",
+			[]string{"First task", "Second task"},
+			"",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTasks, gotRationale := NormalizeGeneratedTasksWithRationale(tc.raw)
+			if len(gotTasks) != len(tc.wantTasks) {
+				t.Fatalf("tasks = %v, want %v", gotTasks, tc.wantTasks)
+			}
+			for i := range gotTasks {
+				if gotTasks[i] != tc.wantTasks[i] {
+					t.Errorf("task[%d] = %q, want %q", i, gotTasks[i], tc.wantTasks[i])
+				}
+			}
+			if gotRationale != tc.wantRationale {
+				t.Errorf("rationale = %q, want %q", gotRationale, tc.wantRationale)
+			}
+		})
+	}
+}
+
+// TestLastListBlock exercises the segmentation directly: the caller only ever
+// observes the chosen range through the tasks it yields, so an off-by-one that
+// happens to land on a prose line would pass every end-to-end case.
+func TestLastListBlock(t *testing.T) {
+	tests := []struct {
+		name                             string
+		raw                              string
+		wantStart, wantEnd, wantSuperNum int
+		wantOK                           bool
+	}{
+		{"no list at all", "Just prose\nand more prose", 0, 0, 0, false},
+		{"bodyless markers are not a list", "Do it\n- - -", 0, 0, 0, false},
+		{"single block spans its markers", "Intro:\n- a\n- b\ntrailing prose", 1, 3, 0, true},
+		{"blank inside a block keeps one range", "- a\n\n- b", 0, 3, 0, true},
+		{"two blocks pick the second", "- a\n\nProse:\n\n- b", 4, 5, 1, true},
+		{"heading splits with no blank line", "- a\n## Tasks\n- b", 2, 3, 1, true},
+		{"continued numbering rejoins", "1. a\n\nWhy:\n\n2. b", 0, 5, 0, true},
+		{"unfenced block beats a later fenced one", "- a\n\nFormat:\n\n```\n- b\n```", 0, 1, 1, true},
+		{"a wholly fenced list still wins", "```\n- a\n```", 1, 2, 0, true},
+		{"bodyless trailing block is not a candidate", "- a\n\nProse.\n\n- - -", 0, 1, 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end, superseded, ok := lastListBlock(strings.Split(tc.raw, "\n"))
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if start != tc.wantStart || end != tc.wantEnd {
+				t.Errorf("range = [%d,%d), want [%d,%d)", start, end, tc.wantStart, tc.wantEnd)
+			}
+			if superseded != tc.wantSuperNum {
+				t.Errorf("superseded = %d, want %d", superseded, tc.wantSuperNum)
+			}
+		})
+	}
+}
+
+// TestStripNoopGeneratedLinesMergesBlocksItSplits: the sentinel stripper runs
+// BEFORE this parse and only ever deletes lines. Deleting one can merge two
+// blocks but never create a split, so it can only move the parse toward keeping
+// more tasks — the safe direction. Pinned because a stripper that blanked lines
+// instead of removing them would silently start dropping the first list.
+func TestStripNoopGeneratedLinesMergesBlocksItSplits(t *testing.T) {
+	stripped, declined := StripNoopGeneratedLines("- Fix the parser\n\n@noop\n\n- Add tests")
+	if !declined {
+		t.Fatal("the sentinel line must be recognized")
+	}
+	tasks, rationale := NormalizeGeneratedTasksWithRationale(stripped)
+	want := []string{"Fix the parser", "Add tests"}
+	if len(tasks) != len(want) {
+		t.Fatalf("tasks = %v, want %v — removing the sentinel must not split the list", tasks, want)
+	}
+	for i := range want {
+		if tasks[i] != want[i] {
+			t.Errorf("task[%d] = %q, want %q", i, tasks[i], want[i])
+		}
+	}
+	if rationale != "" {
+		t.Errorf("rationale = %q, want empty — one merged list ignores nothing", rationale)
+	}
+}
+
+// TestNormalizeGeneratedTasksSupersededNoteSurvivesTruncation: the drop note
+// leads the rationale, so an operator still sees that a list was discarded even
+// when the ignored text overflows maxGeneratedRationale and the tail is cut.
+func TestNormalizeGeneratedTasksSupersededNoteSurvivesTruncation(t *testing.T) {
+	raw := "- " + strings.Repeat("x", maxGeneratedRationale+50) + "\n\n" +
+		"Real work:\n\n- Do the one real task"
+	tasks, rationale := NormalizeGeneratedTasksWithRationale(raw)
+	if len(tasks) != 1 || tasks[0] != "Do the one real task" {
+		t.Fatalf("tasks = %v, want the single last-list item", tasks)
+	}
+	if !strings.HasPrefix(rationale, supersededListNote(1)) {
+		t.Errorf("rationale must lead with the drop note, got %q", rationale)
+	}
+	if runes := []rune(rationale); len(runes) != maxGeneratedRationale+1 {
+		t.Errorf("rationale rune count = %d, want %d", len(runes), maxGeneratedRationale+1)
+	}
+}
+
 // TestNormalizeGeneratedTasksRationaleCapped: a huge block of ignored prose is
 // truncated to maxGeneratedRationale runes with a trailing ellipsis, so an
 // escalation rationale line stays bounded no matter how much the model wrote.

--- a/internal/domain/taskgen_test.go
+++ b/internal/domain/taskgen_test.go
@@ -449,6 +449,68 @@ func TestNormalizeGeneratedTasksLastListWins(t *testing.T) {
 			"ignored 1 other list: I weighed two approaches: - Rewrite the parser - Patch the regex Final tasks:",
 		},
 		{
+			// A "~~~" inside a backtick block is CONTENT, not a closer. Counting
+			// delimiters instead of matching them balances this reply out, ends
+			// the fence early, and releases the rest of the snippet back into the
+			// task list — a YAML key becoming work the agent is handed.
+			"mismatched fence delimiter does not close the block",
+			"Tasks:\n\n" +
+				"- Add multi-list handling\n\n" +
+				"```yaml\n" +
+				"- name: build\n" +
+				"~~~\n" +
+				"- name: deploy\n" +
+				"```\n\n" +
+				"- Cover it with tests",
+			[]string{"Add multi-list handling", "Cover it with tests"},
+			"Tasks:",
+		},
+		{
+			// The mirror: a "```" inside a tilde block does not close it either.
+			"backtick delimiter does not close a tilde block",
+			"Tasks:\n\n" +
+				"- Add multi-list handling\n\n" +
+				"~~~yaml\n" +
+				"- name: build\n" +
+				"```\n" +
+				"- name: deploy\n" +
+				"~~~\n\n" +
+				"- Cover it with tests",
+			[]string{"Add multi-list handling", "Cover it with tests"},
+			"Tasks:",
+		},
+		{
+			// A closer must be at least as long as its opener, so a three-tick
+			// run inside a four-tick block is content — which is exactly how a
+			// model nests a fenced example inside a fenced example.
+			"short delimiter does not close a longer fence",
+			"Tasks:\n\n" +
+				"- Add multi-list handling\n\n" +
+				"````md\n" +
+				"```\n" +
+				"- fenced example item\n" +
+				"```\n" +
+				"````\n\n" +
+				"- Cover it with tests",
+			[]string{"Add multi-list handling", "Cover it with tests"},
+			"Tasks:",
+		},
+		{
+			// A run carrying an info string is an OPENER, never a closer, so it
+			// cannot end the block it sits inside.
+			"a delimiter with an info string never closes",
+			"Tasks:\n\n" +
+				"- Add multi-list handling\n\n" +
+				"```sh\n" +
+				"echo hi\n" +
+				"```go\n" +
+				"- not a task\n" +
+				"```\n\n" +
+				"- Cover it with tests",
+			[]string{"Add multi-list handling", "Cover it with tests"},
+			"Tasks:",
+		},
+		{
 			// An UNCLOSED fence makes "inside" a guess, so fence awareness
 			// switches off entirely and plain source order decides. Failing
 			// open matters: trusting the bogus parity would mark the real
@@ -554,6 +616,67 @@ func TestNormalizeGeneratedTasksLastListWins(t *testing.T) {
 			}
 			if gotRationale != tc.wantRationale {
 				t.Errorf("rationale = %q, want %q", gotRationale, tc.wantRationale)
+			}
+		})
+	}
+}
+
+// TestParseFenceDelimiterAndCloses pins the CommonMark matching rules
+// directly. Treating every fence-looking line as an interchangeable toggle
+// lets a mismatched pair balance out, which ends a block early and releases
+// its contents back into the task list as work.
+func TestParseFenceDelimiterAndCloses(t *testing.T) {
+	parses := []struct {
+		line     string
+		ok       bool
+		char     byte
+		run      int
+		infoOnly bool
+	}{
+		{line: "```", ok: true, char: '`', run: 3},
+		{line: "~~~", ok: true, char: '~', run: 3},
+		{line: "````", ok: true, char: '`', run: 4},
+		{line: "   ```", ok: true, char: '`', run: 3}, // indented openers are legal
+		{line: "```yaml", ok: true, char: '`', run: 3, infoOnly: true},
+		{line: "~~~ go ", ok: true, char: '~', run: 3, infoOnly: true},
+		{line: "``", ok: false}, // too short
+		{line: "~~", ok: false}, // too short
+		{line: "", ok: false},   // blank
+		{line: "- [ ] a", ok: false},
+		{line: "``` a ` b", ok: false}, // a backtick info string may not hold a backtick
+	}
+	for _, tc := range parses {
+		t.Run("parse "+tc.line, func(t *testing.T) {
+			d, ok := parseFenceDelimiter(tc.line)
+			if ok != tc.ok {
+				t.Fatalf("parseFenceDelimiter(%q) ok = %v, want %v", tc.line, ok, tc.ok)
+			}
+			if !ok {
+				return
+			}
+			if d.char != tc.char || d.run != tc.run || d.info != tc.infoOnly {
+				t.Errorf("parseFenceDelimiter(%q) = %+v, want char %q run %d info %v",
+					tc.line, d, tc.char, tc.run, tc.infoOnly)
+			}
+		})
+	}
+
+	open := fenceDelimiter{char: '`', run: 3}
+	closers := []struct {
+		name string
+		d    fenceDelimiter
+		want bool
+	}{
+		{"same char, same run", fenceDelimiter{char: '`', run: 3}, true},
+		{"same char, longer run", fenceDelimiter{char: '`', run: 5}, true},
+		{"other char", fenceDelimiter{char: '~', run: 3}, false},
+		{"shorter run", fenceDelimiter{char: '`', run: 2}, false},
+		{"carries an info string", fenceDelimiter{char: '`', run: 3, info: true}, false},
+	}
+	for _, tc := range closers {
+		t.Run("closes "+tc.name, func(t *testing.T) {
+			if got := tc.d.closes(open); got != tc.want {
+				t.Errorf("%+v.closes(%+v) = %v, want %v", tc.d, open, got, tc.want)
 			}
 		})
 	}

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -684,6 +684,63 @@ func TestConfirmGeneratedMultipleTasksWritesChecklist(t *testing.T) {
 	}
 }
 
+func TestConfirmGeneratedMultipleListsWritesOnlyLastList(t *testing.T) {
+	// The suggestion carries the model's RAW output, which may hold several
+	// Markdown lists — options it weighed, then the work it settled on. Only the
+	// LAST list is real work, so only its items reach the checklist and only its
+	// first item is sent. The daemon validated the same raw text with the same
+	// parser, so the two sides cannot disagree about which list won.
+	app, st := testApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	ctx := context.Background()
+
+	name, _ := st.EnsureAgentName(ctx, "w1:p1")
+	suggestion := domain.SuggestTaskPrefix +
+		"I weighed two approaches:\n" +
+		"\n" +
+		"- Rewrite the parser from scratch\n" +
+		"- Patch the existing regex\n" +
+		"\n" +
+		"Final tasks:\n" +
+		"\n" +
+		"- [ ] Add multi-list handling\n" +
+		"- [ ] Cover it with unit tests"
+	id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: "w1:p1", SituationType: domain.SituationIdle, Trigger: "t",
+		Action: "escalated", Status: "escalated",
+		Suggestion: suggestion, CreatedAt: time.Now(),
+	})
+
+	if err := app.Confirm(ctx, id, true); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(stateDir, "tasks", name+".md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("tasks file not written: %v", err)
+	}
+	want := "- [-] 1. Add multi-list handling\n- [ ] 2. Cover it with unit tests\n"
+	if !strings.Contains(string(body), want) {
+		t.Errorf("tasks file = %q, want only the last list %q", body, want)
+	}
+	// Nothing from the superseded list may be written as work.
+	for _, dropped := range []string{"Rewrite the parser from scratch", "Patch the existing regex", "I weighed two approaches"} {
+		if strings.Contains(string(body), dropped) {
+			t.Errorf("tasks file must not carry the superseded list item %q, got %q", dropped, body)
+		}
+	}
+	wantPrompt := domain.DeclaredTask{
+		Task: "Add multi-list handling", Path: path, AgentName: name,
+	}.Prompt()
+	if len(fake.inputs) != 1 || fake.inputs[0] != wantPrompt {
+		t.Errorf("delivered %v, want only the last list's first task as %q", fake.inputs, wantPrompt)
+	}
+}
+
 func TestConfirmGeneratedTaskIsIdempotent(t *testing.T) {
 	// A double-submit (or re-confirm after resolution) must not re-send the
 	// task or accumulate duplicate task sources: the atomic claim lets only the

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -185,6 +185,12 @@ pane_excerpt_chars = 5000          # pane context included in the consult
 # every other line is kept as the suggestion's rationale (capped, shown on the
 # escalation). Without any list marker, each non-empty line is a task instead —
 # so asking for a markdown list is the reliable way to separate tasks from notes.
+# If the reply holds SEVERAL lists (options the model weighed, then the work it
+# chose), only the LAST list becomes tasks; the others join the rationale. A
+# list ends at a markdown heading, or at prose separated from it by a blank line
+# — prose flush against the bullets, fenced code, and a paragraph between
+# consecutively numbered steps do not split it. So ask for ONE final flat list:
+# a reply that groups its tasks under several headings keeps only the last group.
 # (Renamed from generate_task_command; the old key no longer loads — update it.)
 task_generate_command = [
   "claude", "--model", "opus", "--permission-mode", "auto", "-p",


### PR DESCRIPTION
## Why

`llm.task_generate_command` returns free-form model text. `NormalizeGeneratedTasksWithRationale` flipped the **whole document** into list mode as soon as any line carried a list marker, then treated **every** marked line anywhere in the output as a task.

That breaks on the common real shape where a model reasons out loud — it lists the options it weighed, then the work it settled on:

```
I considered these approaches:

- Rewrite the parser
- Patch the regex

Final tasks:

- [ ] Add multi-list handling
- [ ] Cover it with tests
```

All four lines became tasks and landed in the agent's `tasks.md`, so the model's *rejected* options were queued as real work.

## What changed

**Only the last task-bearing list becomes tasks.** The superseded lists are not lost — they go to the rationale with their markers, behind a short `ignored N other list(s):` note placed **first** so the 500-rune `excerpt` truncation cannot eat the signal.

Both consumers call the same parser on the same raw text — `daemon.handleTaskGenOutcome` (validates and builds the rationale) and `frontend.acceptGeneratedTask` (re-parses the RAW suggestion at confirm time) — so they cannot disagree about which list won.

### What separates two lists

Deliberately conservative. A list ends only at a Markdown heading, or at prose that a blank line separates from it. All of these leave **one** list intact:

- prose written flush against the bullets (`- Fix the parser` / `then, once green:` / `- Add validation`)
- a lone blank line (a loose Markdown list)
- an indented continuation line
- anything inside a fenced code block
- a paragraph between consecutively numbered steps — `1.` … prose … `2.` rejoins, because continued numbering is evidence of one list; a restart at `1.` does not

### Code fences are opaque to the split

The second commit. `isFenceLine` only ever matched the *delimiters*, so the lines **inside** a fence still drove segmentation: a `go test ./...` line read as a blank-separated section break, and a `# install deps` comment read as a heading — either one splitting a list and dropping every task above it.

A shared mask (`fencedRegions`) now marks fenced lines, and **both** the block scan and the emit loop consume it, so they cannot disagree about which lines are visible. Fenced content is data: never a task, never rationale, never a candidate list. That also fixes a pre-existing bug where `- name: build` inside a ```` ```yaml ```` block became a real task.

The mask **fails open** in the two cases where "inside" is a guess, both toward keeping tasks:

- an **odd** number of fence delimiters (truncated output, or nested fences `isFenceLine` cannot tell apart) — trusting bogus parity would mark the real trailing list as data and hand back the rejected options;
- a reply whose **only** list is fenced — that is a model fencing its whole answer, where the fenced list *is* the answer.

## The trade-off, pinned rather than papered over

A reply that groups **one** task list under several headings, or appends a `Notes:` list, keeps only its final group. Both shapes have tests asserting exactly that, so the behaviour is a decision rather than a surprise.

An earlier review proposed a "only supersede when the winning list is at least as long" guard. I did not take it: it still drops `1. X` / prose / `2. Y`, and it breaks the motivating case whenever the model's final list is shorter than its options list — unreliable in both directions. The dropped list is always visible in the rationale, on an escalation nothing auto-accepts, and the README and sample prompt now tell you to ask for one final flat list.

## Docs

`README.md` and the `sample/config.toml` comment describe the last-list rule, what does and does not split a list, and the heading/`Notes:` trade-off.

## Tests

- `TestNormalizeGeneratedTasksLastListWins` — 20 cases: two lists split by blank + prose, an ATX heading with no blank line before it, prose flush against bullets (guards the existing pinned behaviour), a lone blank line, indented continuation, a bodyless trailing `- - -`, three lists (plural note), CRLF, a fenced snippet between items, a trailing fenced example, a fenced diff hunk, a fence flush against prose on both sides, and an unbalanced fence.
- `TestLastListBlock` — 11 cases asserting the chosen `[start,end)` range and the supersede count directly, so an off-by-one that happens to land on a prose line cannot pass.
- `TestOrderedMarkerNum`, including an out-of-range number, so a future `ParseInt` switch cannot forge a numbering continuation.
- `TestStripNoopGeneratedLinesMergesBlocksItSplits` — the sentinel stripper only deletes lines, so it can only merge blocks, never split one; pinned because a stripper that blanked lines instead would silently start dropping the first list.
- `TestNormalizeGeneratedTasksSupersededNoteSurvivesTruncation` — the note leads the rationale and survives the cap.
- `daemon_test.go`: a two-list generation escalates with the RAW suggestion, the rationale carries the dropped list, and the accepted list stays out of it.
- `frontend_test.go`: confirming a two-list RAW suggestion writes only the last list — proving daemon-validate and confirm-parse agree.

Existing coverage unchanged: `TestNormalizeGeneratedTasks` (28 cases), `…RealSample`, `…WithRationale`, `…RationaleCapped`, `TestStripNoopGeneratedLines*` all pass untouched.

Full suite green locally; `go vet` and `golangci-lint` clean.
