### PR TITLE
#1 fix: self-heal hap's own binary path across plugin upgrades

### DIFF
--- a/.claude/skills/hap-development-local/SKILL.md
+++ b/.claude/skills/hap-development-local/SKILL.md
@@ -58,6 +58,10 @@ ln -sf /workspaces/herdr-auto-pilot/bin/hap /usr/local/bin/hap
 hap version   # → "hap (herd-auto-prompter) dev"  (confirms PATH = local build)
 ```
 
+(The TUI's **Quick Shortcuts** row also repoints it now — it reads *Repoint
+/usr/local/bin/hap … (currently stale)* whenever the link is dangling or points
+at another plugin install. `ln -sf` is still the quicker path from a shell.)
+
 Alternatively, skip the symlink entirely and always call `./bin/hap` from the
 repo root. But repointing it means `hap status` / `hap daemon --ensure` in any
 shell hit your dev build, which is what you usually want.
@@ -253,7 +257,8 @@ classification. cross-check the shape:
 
 ## gotchas recap
 
-- **link does not repoint `/usr/local/bin/hap`** — fix it manually or use `./bin/hap`.
+- **link does not repoint `/usr/local/bin/hap`** — fix it manually (`ln -sf`), via the
+  TUI Quick Shortcuts row, or use `./bin/hap`.
 - **link does not overwrite `bin/hap`** — the build/install step doesn't run on link.
 - **the daemon does not hot-reload** — always `hap daemon --ensure` after a rebuild.
 - **omitting `vectors cpu` breaks the build** — both tags always.

--- a/README.md
+++ b/README.md
@@ -64,12 +64,20 @@ release. `--yes` skips the interactive confirmation.
 
 ```sh
 herdr plugin install 0xGosu/herdr-auto-pilot --yes   # download & install the latest release
-hap daemon --ensure                                  # recommended: hot-swap the running daemon now
 ```
 
-`hap daemon --ensure` is optional but recommended — it swaps the running
-daemon for the new build immediately, so you don't have to wait for the next
-automatic restart.
+The install hands a running daemon over to the new build itself, and a daemon
+that somehow misses the handover notices its own binary is gone within ~10
+seconds and starts the replacement. `hap daemon --ensure` still forces the swap
+on demand, and `hap status` reports a daemon that could not hand over.
+
+This matters because a plugin release installs into its own directory: the
+previous binary is removed while the daemon is still running from it. Nothing
+about the live process breaks, but every child it spawns by path does — the MCP
+server your LLM CLI launches for `get_context`/`submit_decision`, and the
+embedding worker — so consults would come back empty until the daemon is
+replaced. Nothing on disk goes stale: the binary path is resolved at spawn
+time, never stored in your config.
 
 For a clean reinstall, uninstall first, then install:
 
@@ -152,6 +160,12 @@ Open the **Auto Prompter** pane with the hotkey above, switch to the **Config**
 tab, select **Create /usr/local/bin/hap symlink to this running binary** under
 **Quick Shortcuts**, and press `enter` to confirm. This makes `hap` available
 from any shell (provided `/usr/local/bin` is on your `PATH`).
+
+Each release installs into its own directory, so an upgrade leaves this symlink
+pointing at a version that no longer exists. The row then reads **Repoint
+/usr/local/bin/hap … (currently stale)** — select it again to fix the link. A
+symlink pointing at anything that is not one of hap's own installs is never
+touched; remove it by hand first if you want hap to own the name.
 
 After creating the symlink, you can also launch the TUI directly from any Bash
 shell instead of opening the Herdr pane with the hotkey:
@@ -1238,6 +1252,16 @@ Invariants:
   automatically; `hap status` shows the running daemon's version and flags
   a stale one. On older versions run `pkill -f 'hap daemon'` once after
   upgrading.
+- **After an upgrade, every LLM consult comes back empty** — the daemon is
+  running from a binary the upgrade removed, so it can no longer launch the
+  hap MCP server for its LLM CLI. `hap status` reports
+  `BINARY REMOVED (upgraded underneath it)`; `hap daemon --ensure` fixes it.
+  The install step and the daemon's own 10-second check normally handle this
+  without you noticing.
+- **`hap: command not found`, or `hap` runs an old version, after an upgrade**
+  — `/usr/local/bin/hap` points into the previous install directory. Open the
+  TUI **Config** tab and select the **Repoint /usr/local/bin/hap** row under
+  **Quick Shortcuts**.
 
 ## Pause/kill switch & audit
 

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/logging"
 	"github.com/0xGosu/herdr-auto-pilot/internal/mcpserver"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/selfpath"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store"
 	"github.com/0xGosu/herdr-auto-pilot/internal/tui"
 )
@@ -167,9 +168,34 @@ func buildApp(paths config.Paths) (*frontend.App, func(), error) {
 }
 
 func runDaemon(ctx context.Context, paths config.Paths, args []string) error {
-	ensure := len(args) > 0 && args[0] == "--ensure"
+	// Flags are parsed as a SET, not by position: `hap daemon --replace-only
+	// --ensure` used to fall through to the foreground daemon, which acquires
+	// the lock and blocks forever — inside scripts/install.sh that would hang
+	// `herdr plugin install`. An unrecognized flag is an error for the same
+	// reason: silently running a foreground daemon is the worst possible
+	// interpretation of a typo.
+	var ensure, replaceOnly bool
+	for _, arg := range args {
+		switch arg {
+		case "--ensure":
+			ensure = true
+		case "--replace-only":
+			// --replace-only swaps a running stale daemon but never starts
+			// one. It is what scripts/install.sh calls after fetching a new
+			// binary: an upgrade must hand the herd over to the new build
+			// immediately, yet the plugin BUILD step must not bring a daemon
+			// up on a fresh install (or in CI, where nothing asked for a
+			// monitor at all).
+			replaceOnly = true
+		default:
+			return fmt.Errorf("unknown flag for `hap daemon`: %s (see: hap help daemon)", arg)
+		}
+	}
+	if replaceOnly && !ensure {
+		return fmt.Errorf("--replace-only only applies to `hap daemon --ensure`")
+	}
 	if ensure {
-		return ensureDaemon(paths)
+		return ensureDaemon(paths, replaceOnly)
 	}
 
 	if _, err := logging.Setup(paths.StateDir, os.Getenv("HAP_DEBUG") == "1"); err != nil {
@@ -309,6 +335,29 @@ func runDaemon(ctx context.Context, paths config.Paths, args []string) error {
 		EmbedderFactory:   embedderFactory,
 		MatchIndexDir:     filepath.Join(paths.StateDir, "match-index"),
 		StateDir:          paths.StateDir,
+		// Hand the herd to the binary that replaced ours (plugin upgrade)
+		// instead of soldiering on with children we can no longer spawn.
+		//
+		// --ensure, not a bare `daemon`: we are still holding the lock when
+		// the successor starts, and a bare daemon would fail its single
+		// Acquire and die. --ensure sees a stale holder, waits for it to
+		// release, and only then takes over — which is exactly the handover
+		// we are performing.
+		HandOff: func(exePath string) error {
+			// The successor's own first act is this same crash-loop check, and
+			// a latched breaker makes it log "respawn suppressed" and exit 0 —
+			// after our cmd.Start() has already returned nil. The daemon would
+			// then read a spawn that succeeded, step aside, and leave the herd
+			// with nothing running (and `hap daemon --ensure` suppressed too).
+			// Refusing here keeps this daemon up instead.
+			if g, ok := crashguard.Read(paths.StateDir); ok {
+				cfg, _ := config.Load(paths.File())
+				if blocked, _, reason := crashguard.SpawnBlocked(g, embeddingDigest(cfg)); blocked {
+					return fmt.Errorf("crash-loop breaker would suppress the replacement daemon: %s", reason)
+				}
+			}
+			return spawnDaemon(paths, exePath, "daemon", "--ensure")
+		},
 	})
 	if err != nil {
 		return err
@@ -327,7 +376,7 @@ func embeddingDigest(cfg config.Config) string {
 	return fmt.Sprintf("%+v", cfg.Embedding)
 }
 
-func ensureDaemon(paths config.Paths) error {
+func ensureDaemon(paths config.Paths, replaceOnly bool) error {
 	// Crash-loop hard stop: after we've given up (still looping even with the
 	// embedder off), decline to respawn until the [embedding] config changes —
 	// this is what actually ends the storm herdr's per-event --ensure would
@@ -344,29 +393,61 @@ func ensureDaemon(paths config.Paths) error {
 			_ = crashguard.Write(paths.StateDir, cleared)
 		}
 	}
-	return daemonlock.EnsureFresh(paths, buildinfo.Version, 3*time.Second, daemonlock.Stop, func() error {
-		self, err := os.Executable()
-		if err != nil {
-			return err
-		}
-		cmd := exec.Command(self, "daemon")
-		cmd.Stdout = nil
-		// Capture the detached daemon's stderr to a file. A native abort in
-		// the embedder (llama.cpp GGML_ASSERT → SIGABRT) prints there and is
-		// invisible to Go recovery; without this it went to /dev/null and the
-		// only crash evidence vanished. Best-effort: a nil file means the
-		// child inherits no stderr (today's behaviour), never a failed launch.
-		if stderrLog := daemonhealth.OpenStderrLog(paths.StateDir); stderrLog != nil {
-			cmd.Stderr = stderrLog
-			defer stderrLog.Close() // the child dup'd the fd at Start
-		}
-		cmd.Stdin = nil
-		daemonlock.Detach(cmd)
-		if err := cmd.Start(); err != nil {
-			return err
-		}
-		return cmd.Process.Release()
+	if replaceOnlyBowsOut(replaceOnly, func() bool {
+		running, _, _ := daemonlock.Info(paths)
+		return running
+	}) {
+		return nil
+	}
+	self, err := selfpath.Resolve()
+	if err != nil {
+		return fmt.Errorf("resolve the hap binary to run as the daemon: %w", err)
+	}
+	return daemonlock.EnsureFresh(paths, buildinfo.Version, self, ensureWaitTimeout, daemonlock.Stop, func() error {
+		return spawnDaemon(paths, self, "daemon")
 	})
+}
+
+// ensureWaitTimeout bounds how long --ensure waits for a stale daemon to
+// release the lock after SIGTERM. It must cover a full teardown — the
+// background drain, the FAISS matcher and SQLite closes — because the
+// upgrade handoff spawns `--ensure` from a daemon that is doing exactly that,
+// and a successor that gives up early leaves the herd unmonitored.
+const ensureWaitTimeout = 10 * time.Second
+
+// replaceOnlyBowsOut reports whether a --replace-only run should do nothing.
+//
+// The gate is here rather than in EnsureFresh's start callback because
+// EnsureFresh also calls start to REPLACE a daemon it just stopped —
+// suppressing that would leave the herd with no monitor at all, the opposite
+// of the intent. It is deliberately a check-then-act: a daemon starting in
+// the gap just means --replace-only ensures one that was already fresh, which
+// is a no-op.
+func replaceOnlyBowsOut(replaceOnly bool, running func() bool) bool {
+	return replaceOnly && !running()
+}
+
+// spawnDaemon launches a detached hap from exePath with the given args.
+// Shared by --ensure and by a running daemon handing off to the binary that
+// replaced it, so both get the same detachment and stderr capture.
+func spawnDaemon(paths config.Paths, exePath string, args ...string) error {
+	cmd := exec.Command(exePath, args...)
+	cmd.Stdout = nil
+	// Capture the detached daemon's stderr to a file. A native abort in
+	// the embedder (llama.cpp GGML_ASSERT → SIGABRT) prints there and is
+	// invisible to Go recovery; without this it went to /dev/null and the
+	// only crash evidence vanished. Best-effort: a nil file means the
+	// child inherits no stderr (today's behaviour), never a failed launch.
+	if stderrLog := daemonhealth.OpenStderrLog(paths.StateDir); stderrLog != nil {
+		cmd.Stderr = stderrLog
+		defer stderrLog.Close() // the child dup'd the fd at Start
+	}
+	cmd.Stdin = nil
+	daemonlock.Detach(cmd)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return cmd.Process.Release()
 }
 
 // chdirStable moves the daemon onto a directory that outlives it; failure

--- a/cmd/hap/main_test.go
+++ b/cmd/hap/main_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
@@ -45,5 +47,66 @@ func TestEmbeddingDigestStableAndChangeSensitive(t *testing.T) {
 	c4 := write("[embedding]\ndisabled = true\n")
 	if embeddingDigest(c4) == embeddingDigest(c1) {
 		t.Error("toggling embedding.disabled must change the digest")
+	}
+}
+
+// TestReplaceOnlyBowsOutOnlyWhenNothingIsRunning pins both halves of the flag's
+// contract. install.sh calls it during the plugin BUILD step, so it must not
+// bring a daemon up on a fresh install or in CI — and it must still replace a
+// running one, because the gate sitting in EnsureFresh's start callback instead
+// would suppress the restart AFTER the stale daemon was stopped, leaving the
+// herd with no monitor at all.
+func TestReplaceOnlyBowsOutOnlyWhenNothingIsRunning(t *testing.T) {
+	tests := []struct {
+		name        string
+		replaceOnly bool
+		running     bool
+		wantBowOut  bool
+	}{
+		{name: "replace-only with nothing running does nothing", replaceOnly: true, wantBowOut: true},
+		{name: "replace-only with a daemon running proceeds", replaceOnly: true, running: true},
+		{name: "plain ensure with nothing running starts one", running: false},
+		{name: "plain ensure with a daemon running proceeds", running: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := replaceOnlyBowsOut(tt.replaceOnly, func() bool { return tt.running })
+			if got != tt.wantBowOut {
+				t.Fatalf("replaceOnlyBowsOut(%v, running=%v) = %v, want %v",
+					tt.replaceOnly, tt.running, got, tt.wantBowOut)
+			}
+		})
+	}
+}
+
+// TestDaemonFlagParsingRejectsUnknownAndOrderIndependent guards against the
+// worst failure mode of positional parsing: a flag hap does not recognize (or
+// one in an unexpected order) silently falling through to the FOREGROUND
+// daemon, which takes the lock and blocks forever — inside install.sh that
+// would hang `herdr plugin install`.
+func TestDaemonFlagParsingRejectsUnknownAndOrderIndependent(t *testing.T) {
+	paths := config.Paths{ConfigDir: t.TempDir(), StateDir: t.TempDir()}
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "unknown flag", args: []string{"--ensure", "--nope"}, wantErr: "unknown flag"},
+		{name: "unknown flag alone", args: []string{"--replace-onlyy"}, wantErr: "unknown flag"},
+		{name: "replace-only without ensure", args: []string{"--replace-only"}, wantErr: "only applies"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runDaemon(context.Background(), paths, tt.args)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("runDaemon(%v) = %v, want an error containing %q", tt.args, err, tt.wantErr)
+			}
+		})
+	}
+
+	// Reversed order must be accepted and must NOT start a daemon (nothing is
+	// running, and --replace-only is in effect).
+	if err := runDaemon(context.Background(), paths, []string{"--replace-only", "--ensure"}); err != nil {
+		t.Fatalf("reversed flag order = %v, want it accepted", err)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -670,6 +670,12 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 				line += fmt.Sprintf(" [also STALE: binary is %s; run: hap daemon --ensure]", buildinfo.Version)
 			}
 			fmt.Fprintf(out, "daemon:              %s\n", line)
+		case h.BinaryReplaced:
+			// Alive and beating, but its own binary is gone: it can no longer
+			// spawn the MCP server or the embed worker, so every consult comes
+			// back empty. Worse than STALE; the same remedy fixes it.
+			fmt.Fprintf(out, "daemon:              %s — BINARY REMOVED (upgraded underneath it); LLM consults cannot run; run: hap daemon --ensure\n",
+				label)
 		case h.VersionStale:
 			// A holder from another binary keeps old bugs alive; make the
 			// mismatch and the remedy impossible to miss.
@@ -716,7 +722,7 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 	// suggestion is always the one that matters: revive the daemon, lift the
 	// kill switch, or work the queue.
 	var hints []Hint
-	if app.DaemonInfo != nil && (!h.Running || h.Hung || h.VersionStale) {
+	if app.DaemonInfo != nil && (!h.Running || h.Hung || h.VersionStale || h.BinaryReplaced) {
 		hints = append(hints, Hint{Cmd: "hap daemon --ensure", Why: "start, or replace, the daemon"})
 	}
 	if st.Paused {
@@ -738,7 +744,7 @@ func status(ctx context.Context, app *frontend.App, out io.Writer) error {
 	// A hung daemon or a latched crash-loop give-up is a failure state: exit
 	// non-zero so scripted checks and the operator notice, even though the
 	// status body already explained it.
-	if h.Hung || h.GaveUp || h.CrashLooping {
+	if h.Hung || h.GaveUp || h.CrashLooping || h.BinaryReplaced {
 		return ErrUnhealthy
 	}
 	return nil

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -182,6 +182,31 @@ func TestStatusShowsDaemonLine(t *testing.T) {
 	}
 }
 
+// A daemon whose binary an upgrade removed still beats, so nothing else in
+// status would show it — yet its LLM consults all come back empty. It must be
+// named, given the remedy, and exit non-zero for scripted checks.
+func TestStatusRemovedBinaryIsUnhealthy(t *testing.T) {
+	app, _ := testApp(t)
+	stateDir := t.TempDir()
+	app.StateDir = stateDir
+	app.DaemonInfo = func() (bool, int, string) { return true, 4242, buildinfo.Version }
+	if err := daemonhealth.Write(stateDir, daemonhealth.Health{
+		PID: 4242, Version: buildinfo.Version, HeartbeatAt: time.Now(),
+		Embedder: daemonhealth.EmbedderReady,
+		ExePath:  "/removed/bin/hap", BinaryReplaced: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "status")
+	if !errors.Is(err, cli.ErrUnhealthy) {
+		t.Errorf("status error = %v, want ErrUnhealthy", err)
+	}
+	if !strings.Contains(out, "BINARY REMOVED") || !strings.Contains(out, "hap daemon --ensure") {
+		t.Errorf("status must name the removed binary and its remedy, got:\n%s", out)
+	}
+}
+
 func TestStatusHungDaemonUnhealthy(t *testing.T) {
 	app, _ := testApp(t)
 	stateDir := t.TempDir()

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -93,13 +93,15 @@ func buildCommands() {
 			Name:    "daemon",
 			Group:   groupCore,
 			Summary: "run the monitoring daemon (the process that watches agents and answers them)",
-			Usage:   []string{"hap daemon", "hap daemon --ensure"},
+			Usage:   []string{"hap daemon", "hap daemon --ensure", "hap daemon --ensure --replace-only"},
 			Flags: []FlagDoc{
-				{Name: "--ensure", Desc: "start a daemon only if none is running; replace one left by an older binary (this is what herdr's event hook runs, and how you pick up a rebuild)"},
+				{Name: "--ensure", Desc: "start a daemon only if none is running; replace one left by an older binary or a binary at a different path (this is what herdr's event hook runs, and how you pick up a rebuild)"},
+				{Name: "--replace-only", Desc: "with --ensure: replace a running daemon, but never start one when none is running (used by the plugin install step, so installing hap does not bring a daemon up as a side effect)"},
 			},
 			Details: "Without --ensure the daemon runs in the foreground and holds the state-dir lock.\n" +
 				"Exactly one daemon may run per state dir. After upgrading or rebuilding hap, run\n" +
-				"`hap daemon --ensure` — `hap status` reports a daemon from an older binary as STALE.",
+				"`hap daemon --ensure` — `hap status` reports a daemon from an older binary as STALE,\n" +
+				"and one whose own binary an upgrade removed as BINARY REMOVED.",
 			Examples: []string{"hap daemon --ensure", "hap status"},
 			Next: []Hint{
 				{Cmd: "hap status", Why: "confirm the daemon is running and healthy"},

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -28,6 +28,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/logging"
 	"github.com/0xGosu/herdr-auto-pilot/internal/match"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/selfpath"
 	"github.com/0xGosu/herdr-auto-pilot/internal/taskfile"
 	"github.com/0xGosu/herdr-auto-pilot/internal/verifyunblock"
 )
@@ -35,6 +36,12 @@ import (
 // unblockCheckDelay is fixed rather than operator-configurable: post-action
 // delivery verification should behave consistently across installations.
 const unblockCheckDelay = time.Second
+
+// handoffRetryInterval paces retries after a failed upgrade handoff
+// (checkOwnBinary). Long enough that a repeatedly-failing spawn cannot storm,
+// short enough that a successor which was still being written when we first
+// tried is picked up while the operator is still watching.
+const handoffRetryInterval = time.Minute
 
 // Options configures a Daemon.
 type Options struct {
@@ -72,6 +79,17 @@ type Options struct {
 	MutateTaskFile func(path string, fn func(content string) (string, error)) error
 	// PaneReadLines is how much recent pane content classification sees.
 	PaneReadLines int
+	// ResolveSelf returns the path of a live hap binary (selfpath.Resolve in
+	// prod). The daemon compares it against the binary it started from to
+	// notice a plugin upgrade that replaced it underneath.
+	ResolveSelf func() (string, error)
+	// HandOff starts a replacement daemon from the given binary, when this
+	// daemon's own binary has been replaced (a detached `daemon --ensure`
+	// spawn in prod). It is called at most once successfully — after that
+	// this daemon exits — but a failed attempt is retried on a later
+	// heartbeat, so it must be safe to call more than once. A nil HandOff
+	// leaves this daemon running and only flags health.
+	HandOff func(exePath string) error
 }
 
 // Daemon is the monitor/decide/act loop.
@@ -80,6 +98,17 @@ type Daemon struct {
 	// verifyUnblockDelay is initialized from unblockCheckDelay. Tests in this
 	// package shorten it to keep asynchronous verification coverage fast.
 	verifyUnblockDelay time.Duration
+
+	// exePath is the binary this daemon started from, resolved once at Run
+	// before anything can replace it, and never written again — so the
+	// heartbeat's check needs no lock. binaryReplaced latches when that file
+	// is gone and the takeover could not happen; handedOff latches once a
+	// successor IS starting; lastHandoff (unix nanos) paces retries after a
+	// failed attempt. See checkOwnBinary.
+	exePath        string
+	binaryReplaced atomic.Bool
+	handedOff      atomic.Bool
+	lastHandoff    atomic.Int64
 
 	mu         sync.RWMutex
 	cfg        config.Config
@@ -348,6 +377,9 @@ func New(opt Options) (*Daemon, error) {
 	if opt.PaneReadLines <= 0 {
 		opt.PaneReadLines = 50
 	}
+	if opt.ResolveSelf == nil {
+		opt.ResolveSelf = selfpath.Resolve
+	}
 	d := &Daemon{
 		opt:                  opt,
 		verifyUnblockDelay:   unblockCheckDelay,
@@ -609,27 +641,109 @@ func (d *Daemon) writeHealth(startedAt time.Time) {
 	}
 	state, diag := d.embedderHealth()
 	h := daemonhealth.Health{
-		PID:          os.Getpid(),
-		Version:      buildinfo.Version,
-		StartedAt:    startedAt,
-		HeartbeatAt:  d.opt.Clock.Now(),
-		Embedder:     state,
-		EmbedderDiag: diag,
+		PID:            os.Getpid(),
+		Version:        buildinfo.Version,
+		StartedAt:      startedAt,
+		HeartbeatAt:    d.opt.Clock.Now(),
+		Embedder:       state,
+		EmbedderDiag:   diag,
+		ExePath:        d.exePath,
+		BinaryReplaced: d.binaryReplaced.Load(),
 	}
 	if err := daemonhealth.Write(d.opt.StateDir, h); err != nil {
 		slog.Debug("heartbeat write failed", "error", err)
 	}
 }
 
+// checkOwnBinary detects that this daemon's own executable was replaced —
+// what a plugin upgrade does, since herdr installs each release into its own
+// directory and unlinks the previous one. The process survives that, but every
+// child it spawns by path does not: the LLM CLI can no longer launch `hap mcp`
+// (so consults come back with no decision at all) and the embed worker fails
+// until the degrade latch trips. Nothing else notices — the version in the lock
+// file still matches, because it is OUR version.
+//
+// It returns true when the caller should stop the loop: a live successor was
+// found and started, and this daemon's job is to get out of its way. With no
+// successor to hand to it keeps running and flags health instead — a daemon
+// that can no longer spawn children still beats no daemon at all, and the
+// operator's remedy (`hap daemon --ensure` from a good binary) is the same.
+func (d *Daemon) checkOwnBinary() bool {
+	if d.exePath == "" || d.handedOff.Load() {
+		return false
+	}
+	if !selfpath.Missing(d.exePath) {
+		return false
+	}
+	// Flag health BEFORE requiring a HandOff hook: noticing costs one Stat,
+	// and an operator reading `hap status` deserves the answer whether or not
+	// this build can do anything about it.
+	successor, err := d.opt.ResolveSelf()
+	if err != nil || successor == "" || selfpath.Same(successor, d.exePath) {
+		if d.binaryReplaced.CompareAndSwap(false, true) {
+			slog.Error("this daemon's binary was removed and no replacement could be found; "+
+				"child processes (LLM MCP server, embed worker) will fail until a new daemon takes over",
+				"exe_path", d.exePath, "error", err)
+		}
+		return false
+	}
+	if d.opt.HandOff == nil {
+		if d.binaryReplaced.CompareAndSwap(false, true) {
+			slog.Error("this daemon's binary was removed and it cannot start a replacement itself",
+				"exe_path", d.exePath, "successor", successor)
+		}
+		return false
+	}
+	// A failed handoff must be RETRYABLE — the successor may simply not be
+	// fully installed yet, or the fork may have hit a transient limit — but
+	// not retried every 10s heartbeat, which would spawn-storm. One attempt
+	// per interval, and the latch is only taken on success (below), where it
+	// guarantees the spawn already in flight is not raced by a second one.
+	now := d.opt.Clock.Now()
+	if last := d.lastHandoff.Load(); last != 0 && now.Sub(time.Unix(0, last)) < handoffRetryInterval {
+		return false
+	}
+	d.lastHandoff.Store(now.UnixNano())
+
+	slog.Warn("hap was upgraded underneath this daemon; handing the herd over to the new binary",
+		"old", d.exePath, "new", successor)
+	if err := d.opt.HandOff(successor); err != nil {
+		// The successor never started, so stopping would leave nothing
+		// monitoring. Stay up, degraded, and retry on a later heartbeat.
+		d.binaryReplaced.Store(true)
+		slog.Error("could not start the replacement daemon; staying up with a removed binary",
+			"new", successor, "error", err, "retry_in", handoffRetryInterval)
+		return false
+	}
+	// Latch only now: from here the successor is starting and a second spawn
+	// would race it for the daemon lock.
+	d.handedOff.Store(true)
+	return true
+}
+
 // Run drives the daemon until ctx is done. It never panics: every handler
 // runs under the fail-safe guard (NFR-004).
 func (d *Daemon) Run(ctx context.Context) error {
+	// Everything Run starts roots at a context IT controls. Run can now
+	// return without the caller's ctx being cancelled (the upgrade handoff
+	// below), and the background goroutines — the event subscriber above all,
+	// which loops on reconnect backoff — would then never unwind, so
+	// shutdownBackground would wait on them forever and the process would sit
+	// there holding the daemon lock the successor is waiting for. The defer
+	// that cancels it is registered below, AFTER shutdownBackground, so LIFO
+	// puts the cancel before the drain that depends on it.
+	ctx, cancelRun := context.WithCancel(ctx)
 	// Heartbeat first: publish a fresh health record (stamped with THIS pid)
 	// as the very first action, before the slower socket/subscriber setup, so
 	// a status check during startup sees this daemon's beat — not a dead
 	// predecessor's stale file left by a hard abort. Refreshed on a ticker
 	// below; removed on clean shutdown so a graceful stop reads as gone.
 	startedAt := d.opt.Clock.Now()
+	// Resolve once, before anything can replace it: this is the identity the
+	// heartbeat publishes and checkOwnBinary watches.
+	if self, err := d.opt.ResolveSelf(); err == nil {
+		d.exePath = self
+	}
 	d.writeHealth(startedAt)
 	if d.opt.StateDir != "" {
 		defer func() { _ = daemonhealth.Remove(d.opt.StateDir) }()
@@ -651,6 +765,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 	}()
 	defer d.shutdownBackground()
+	// Registered after the drain so it runs before it (LIFO): the goroutines
+	// shutdownBackground waits on are the ones this cancel releases.
+	defer cancelRun()
 
 	// Control socket: reload/wake nudges from front-ends and mcp.
 	var ctl *control.Server
@@ -710,6 +827,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case <-heartbeat.C:
+			// Checked on the heartbeat rather than the 1-minute sweep: until
+			// the handoff happens every consult this daemon runs comes back
+			// empty, so the window is worth keeping short. It costs one Stat.
+			if d.checkOwnBinary() {
+				return nil
+			}
 			d.writeHealth(startedAt)
 		case <-sweep.C:
 			logging.Guard("periodic-sweep", func() error {

--- a/internal/daemon/selfreplace_test.go
+++ b/internal/daemon/selfreplace_test.go
@@ -1,0 +1,299 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+)
+
+// writeExe creates a file with the execute bit, standing in for an installed
+// hap binary.
+func writeExe(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// selfReplaceDaemon builds the minimum Daemon checkOwnBinary needs. The full
+// harness is deliberately avoided: this decision reads only the recorded exe
+// path and the two injected hooks, and building a whole daemon would couple
+// the test to everything else that has to be wired for Run.
+func selfReplaceDaemon(exePath string, resolve func() (string, error), handOff func(string) error) *Daemon {
+	return &Daemon{
+		opt:     Options{ResolveSelf: resolve, HandOff: handOff, Clock: ports.SystemClock{}},
+		exePath: exePath,
+	}
+}
+
+// The upgrade case: our binary is gone, a new one is installed elsewhere. The
+// daemon must start the successor and step aside — every child it would spawn
+// from the removed path (the MCP server the LLM CLI launches, the embed
+// worker) fails, so staying up serves nothing.
+func TestCheckOwnBinaryHandsOffToReplacement(t *testing.T) {
+	dir := t.TempDir()
+	removed := filepath.Join(dir, "old", "bin", "hap")
+	successor := writeExe(t, filepath.Join(dir, "new", "bin", "hap"))
+
+	var handedTo []string
+	d := selfReplaceDaemon(removed,
+		func() (string, error) { return successor, nil },
+		func(exe string) error { handedTo = append(handedTo, exe); return nil })
+
+	if !d.checkOwnBinary() {
+		t.Fatal("checkOwnBinary = false; a replaced binary must end the loop")
+	}
+	if len(handedTo) != 1 || handedTo[0] != successor {
+		t.Fatalf("handed off to %v, want exactly [%s]", handedTo, successor)
+	}
+	if d.binaryReplaced.Load() {
+		t.Error("a successful handoff is not a degraded state; health must not flag it")
+	}
+	// The heartbeat keeps ticking while the spawn is in flight; a second
+	// handoff would race the first for the daemon lock.
+	if d.checkOwnBinary() {
+		t.Error("checkOwnBinary fired twice; the handoff must be one-shot")
+	}
+	if len(handedTo) != 1 {
+		t.Fatalf("handed off %d times, want exactly 1", len(handedTo))
+	}
+}
+
+// With no successor to hand to, exiting would leave the herd unmonitored. Stay
+// up, degraded, and let health say so.
+func TestCheckOwnBinaryWithoutSuccessorStaysUpAndFlags(t *testing.T) {
+	dir := t.TempDir()
+	removed := filepath.Join(dir, "old", "bin", "hap")
+
+	handoffs := 0
+	d := selfReplaceDaemon(removed,
+		func() (string, error) { return "", fmt.Errorf("nothing found") },
+		func(string) error { handoffs++; return nil })
+
+	if d.checkOwnBinary() {
+		t.Fatal("checkOwnBinary = true with no successor; the daemon must keep running")
+	}
+	if handoffs != 0 {
+		t.Errorf("handoff attempted %d times with no successor", handoffs)
+	}
+	if !d.binaryReplaced.Load() {
+		t.Error("health must flag a removed binary so `hap status` can report it")
+	}
+}
+
+// A successor that will not start is, for now, the same situation as none at
+// all: stay up and report it.
+func TestCheckOwnBinaryStaysUpWhenHandoffFails(t *testing.T) {
+	dir := t.TempDir()
+	removed := filepath.Join(dir, "old", "bin", "hap")
+	successor := writeExe(t, filepath.Join(dir, "new", "bin", "hap"))
+
+	d := selfReplaceDaemon(removed,
+		func() (string, error) { return successor, nil },
+		func(string) error { return fmt.Errorf("spawn refused") })
+
+	if d.checkOwnBinary() {
+		t.Fatal("checkOwnBinary = true after a failed handoff; nothing would be monitoring")
+	}
+	if !d.binaryReplaced.Load() {
+		t.Error("a failed handoff must be reported as degraded")
+	}
+}
+
+// A failure must not be terminal. The successor may simply have been mid-write
+// when we first tried (install.sh unpacks while the daemon runs), so the
+// attempt is retried — but paced, not once per 10s heartbeat, which would
+// spawn-storm a genuinely broken successor.
+func TestCheckOwnBinaryRetriesAFailedHandoffOnceThePaceElapses(t *testing.T) {
+	dir := t.TempDir()
+	removed := filepath.Join(dir, "old", "bin", "hap")
+	successor := writeExe(t, filepath.Join(dir, "new", "bin", "hap"))
+
+	attempts := 0
+	failNext := true
+	d := selfReplaceDaemon(removed,
+		func() (string, error) { return successor, nil },
+		func(string) error {
+			attempts++
+			if failNext {
+				return fmt.Errorf("spawn refused")
+			}
+			return nil
+		})
+
+	if d.checkOwnBinary() || attempts != 1 {
+		t.Fatalf("first attempt: returned true or attempts=%d, want false and 1", attempts)
+	}
+	// An immediate second heartbeat must NOT retry.
+	if d.checkOwnBinary() || attempts != 1 {
+		t.Fatalf("retry was not paced: attempts=%d, want still 1", attempts)
+	}
+	// Once the interval has elapsed it retries, and succeeds this time.
+	d.lastHandoff.Store(time.Now().Add(-2 * handoffRetryInterval).UnixNano())
+	failNext = false
+	if !d.checkOwnBinary() {
+		t.Fatal("checkOwnBinary = false; the retry succeeded and should end the loop")
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+// The handoff is the first path that returns from Run WITHOUT the caller's
+// context being cancelled. Everything Run started must still unwind: the event
+// subscriber loops on reconnect backoff until its context is done, so a Run
+// that returned while its goroutines rooted at the (still live) parent context
+// hung forever in the background drain — holding the daemon lock the successor
+// was waiting for, which left the herd with no daemon at all. Verified against
+// a real daemon before the fix.
+func TestRunReturnsPromptlyAfterHandoff(t *testing.T) {
+	dir := t.TempDir()
+	// The daemon must start from a binary that exists and then lose it, so the
+	// heartbeat check sees a replacement rather than a path that was never there.
+	removed := writeExe(t, filepath.Join(dir, "old", "bin", "hap"))
+	successor := writeExe(t, filepath.Join(dir, "new", "bin", "hap"))
+
+	h := newHarness(t, "")
+	// Take the harness's daemon off its own Run before re-running it here with
+	// the self-replacement hooks wired in.
+	h.stop()
+
+	handedOff := make(chan string, 1)
+	// Signalled by the hook rather than read off d.exePath: that field is
+	// written by Run's goroutine, so polling it from here would be a data race.
+	identified := make(chan struct{}, 1)
+	d, err := New(Options{
+		ConfigPath: h.cfgPath,
+		Store:      h.store,
+		Herdr:      h.herdr,
+		Events:     &fakeEvents{ch: make(chan domain.AgentTransition, 1)},
+		StateDir:   t.TempDir(),
+		ResolveSelf: func() (string, error) {
+			// The first call is Run recording our identity; later calls are the
+			// heartbeat looking for a successor.
+			if _, err := os.Stat(removed); err == nil {
+				select {
+				case identified <- struct{}{}:
+				default:
+				}
+				return removed, nil
+			}
+			return successor, nil
+		},
+		HandOff: func(exe string) error { handedOff <- exe; return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A context that is never cancelled: the point of the test is that Run
+	// tears itself down without one.
+	done := make(chan error, 1)
+	go func() { done <- d.Run(context.Background()) }()
+
+	select {
+	case <-identified:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run never resolved its own binary")
+	}
+	if err := os.Remove(removed); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case exe := <-handedOff:
+		if exe != successor {
+			t.Fatalf("handed off to %q, want %q", exe, successor)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("no handoff within 30s of the binary being removed")
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run after handoff = %v, want nil", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return after handing off — its background goroutines never unwound")
+	}
+}
+
+func TestCheckOwnBinaryNoOpCases(t *testing.T) {
+	dir := t.TempDir()
+	live := writeExe(t, filepath.Join(dir, "bin", "hap"))
+	successor := writeExe(t, filepath.Join(dir, "new", "bin", "hap"))
+	removed := filepath.Join(dir, "old", "bin", "hap")
+
+	tests := []struct {
+		name    string
+		exePath string
+		resolve func() (string, error)
+		handOff func(string) error
+	}{
+		{
+			name:    "binary still on disk",
+			exePath: live,
+			resolve: func() (string, error) { return successor, nil },
+			handOff: func(string) error { return nil },
+		},
+		{
+			name: "exe path unknown",
+			// Resolution failed at startup, so there is nothing to compare
+			// against; guessing would restart a healthy daemon.
+			exePath: "",
+			resolve: func() (string, error) { return successor, nil },
+			handOff: func(string) error { return nil },
+		},
+		{
+			// Still flagged for health (see the assertion below); it just
+			// cannot start the replacement itself.
+			name:    "no handoff configured",
+			exePath: removed,
+			resolve: func() (string, error) { return successor, nil },
+			handOff: nil,
+		},
+		{
+			name: "resolver returns our own removed path",
+			// Nothing replaced us — the binary is simply gone. Handing off to
+			// the same dead path would spawn nothing.
+			exePath: removed,
+			resolve: func() (string, error) { return removed, nil },
+			handOff: func(string) error { return nil },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := selfReplaceDaemon(tt.exePath, tt.resolve, tt.handOff)
+			if d.checkOwnBinary() {
+				t.Fatal("checkOwnBinary = true; the daemon must keep running")
+			}
+		})
+	}
+}
+
+// Noticing a removed binary costs one Stat, so health reports it even when
+// this daemon has no way to start a replacement — an operator reading
+// `hap status` deserves the answer either way.
+func TestCheckOwnBinaryFlagsHealthWithoutAHandoffHook(t *testing.T) {
+	dir := t.TempDir()
+	removed := filepath.Join(dir, "old", "bin", "hap")
+	successor := writeExe(t, filepath.Join(dir, "new", "bin", "hap"))
+
+	d := selfReplaceDaemon(removed, func() (string, error) { return successor, nil }, nil)
+	if d.checkOwnBinary() {
+		t.Fatal("checkOwnBinary = true with no handoff hook")
+	}
+	if !d.binaryReplaced.Load() {
+		t.Error("health must flag the removed binary even when the takeover is not wired")
+	}
+}

--- a/internal/daemonhealth/health.go
+++ b/internal/daemonhealth/health.go
@@ -59,6 +59,17 @@ type Health struct {
 	// daemons and whenever the engine offers no diagnostics — readers must
 	// treat it as optional and fall back to the bare Embedder state.
 	EmbedderDiag *EmbedderDiag `json:"embedder_diag,omitempty"`
+	// ExePath is the binary this daemon is running as. A plugin upgrade
+	// installs the new release beside the old one and unlinks it, so this
+	// path can stop existing under a perfectly live process — at which point
+	// every child it spawns from that path (the MCP server the LLM CLI
+	// launches, the embed worker) fails. Absent on older daemons.
+	ExePath string `json:"exe_path,omitempty"`
+	// BinaryReplaced records that ExePath has gone away and no successor
+	// could be found to hand off to. The daemon keeps running (something
+	// monitoring beats nothing), but it is degraded in a way only
+	// `hap daemon --ensure` from a fresh binary can fix.
+	BinaryReplaced bool `json:"binary_replaced,omitempty"`
 }
 
 // EmbedderDiag is the heartbeat's copy of embedder.Diagnostics. It lives here

--- a/internal/daemonlock/daemonlock.go
+++ b/internal/daemonlock/daemonlock.go
@@ -9,29 +9,35 @@ import (
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/selfpath"
 )
 
 // EnsureFresh implements `hap daemon --ensure`: start a daemon when none is
-// running, no-op when the running one matches version, and gracefully
+// running, no-op when the running one matches this binary, and gracefully
 // replace one left behind by a different binary. stop asks a pid to shut
 // down (SIGTERM); start launches a detached daemon. waitTimeout bounds how
 // long a stale daemon gets to release the lock after stop.
-func EnsureFresh(paths config.Paths, version string, waitTimeout time.Duration, stop func(pid int) error, start func() error) error {
-	running, pid, ver := Info(paths)
+//
+// exePath is this binary's path; a holder running from a DIFFERENT one is
+// stale even at the same version, because an upgrade that reuses the version
+// string still unlinks the old binary and strands every child the running
+// daemon spawns from it. Pass "" to compare on version alone.
+func EnsureFresh(paths config.Paths, version, exePath string, waitTimeout time.Duration, stop func(pid int) error, start func() error) error {
+	running, pid, ver, exe := info(paths)
 	if !running {
 		return start()
 	}
-	if ver == version {
+	if current(ver, exe, version, exePath) {
 		return nil
 	}
 	if pid <= 0 {
 		// A fresh holder truncates then rewrites the lock file; one
 		// re-probe skips that microsecond window before giving up.
 		time.Sleep(100 * time.Millisecond)
-		if running, pid, ver = Info(paths); !running {
+		if running, pid, ver, exe = info(paths); !running {
 			return start()
 		}
-		if ver == version {
+		if current(ver, exe, version, exePath) {
 			return nil
 		}
 	}
@@ -46,6 +52,22 @@ func EnsureFresh(paths config.Paths, version string, waitTimeout time.Duration, 
 			pid, VersionLabel(ver), waitTimeout)
 	}
 	return start()
+}
+
+// current reports whether the running holder is the binary we would start.
+// The path check only applies when BOTH sides are known and resolvable: a
+// pre-path lock file records none, and an unresolvable path would otherwise
+// make every --ensure kill a perfectly good daemon. Paths are compared
+// through symlinks so invoking via /usr/local/bin/hap does not read as a
+// different install than <plugin>/bin/hap.
+func current(holderVersion, holderExe, version, exePath string) bool {
+	if holderVersion != version {
+		return false
+	}
+	if holderExe == "" || exePath == "" {
+		return true
+	}
+	return selfpath.Same(holderExe, exePath)
 }
 
 // WaitReleased polls until no daemon holds the lock or the timeout elapses.

--- a/internal/daemonlock/lock_unix.go
+++ b/internal/daemonlock/lock_unix.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/selfpath"
 )
 
 // Lock is a flock-based singleton guard so only one daemon monitors the
@@ -50,7 +51,17 @@ func Acquire(paths config.Paths) (*Lock, error) {
 	}
 	// An unwritten pid would permanently dead-end every future --ensure in
 	// its "pid unreadable" branch, so a failed write must fail the acquire.
-	if _, err := fmt.Fprintf(f, "%d\n%s\n", os.Getpid(), buildinfo.Version); err != nil {
+	// The third line is the binary this daemon runs as. Version alone cannot
+	// tell a same-version binary installed at a NEW path (an upgrade that
+	// kept the version string, or any local rebuild) from the live one, and
+	// the old path is gone by then — every child the daemon spawns from it
+	// would fail. A path we cannot resolve is recorded empty and simply
+	// disables the path comparison.
+	exe, err := selfpath.Resolve()
+	if err != nil {
+		exe = ""
+	}
+	if _, err := fmt.Fprintf(f, "%d\n%s\n%s\n", os.Getpid(), buildinfo.Version, exe); err != nil {
 		f.Close()
 		return nil, fmt.Errorf("write lock file: %w", err)
 	}
@@ -71,27 +82,40 @@ func (l *Lock) Release() {
 // concern. version is "" for holders older than the pid+version format;
 // pid is 0 when unreadable.
 func Info(paths config.Paths) (running bool, pid int, version string) {
+	running, pid, version, _ = info(paths)
+	return running, pid, version
+}
+
+// info is Info plus the holder's binary path, which only EnsureFresh needs.
+// exePath is "" for a holder older than the pid+version+path format, and for
+// one that could not resolve its own binary.
+func info(paths config.Paths) (running bool, pid int, version, exePath string) {
 	f, err := os.OpenFile(lockPath(paths), os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
-		return false, 0, ""
+		return false, 0, "", ""
 	}
 	defer f.Close()
 	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err == nil {
 		syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-		return false, 0, ""
+		return false, 0, "", ""
 	}
 	// Read through the already-open fd: re-opening the path could race a
 	// holder that just replaced the file.
 	data, err := io.ReadAll(f)
 	if err != nil {
-		return true, 0, ""
+		return true, 0, "", ""
 	}
-	lines := strings.SplitN(string(data), "\n", 3)
+	// SplitN with one more field than we read keeps a two-line lock from an
+	// older daemon parseable — it simply yields no path.
+	lines := strings.SplitN(string(data), "\n", 4)
 	pid, _ = strconv.Atoi(strings.TrimSpace(lines[0]))
 	if len(lines) > 1 {
 		version = strings.TrimSpace(lines[1])
 	}
-	return true, pid, version
+	if len(lines) > 2 {
+		exePath = strings.TrimSpace(lines[2])
+	}
+	return true, pid, version, exePath
 }
 
 // Stop asks a daemon to shut down gracefully (SIGTERM cancels its run

--- a/internal/daemonlock/lock_unix_test.go
+++ b/internal/daemonlock/lock_unix_test.go
@@ -68,7 +68,8 @@ func TestAcquireWritesPidAndVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := fmt.Sprintf("%d\n%s\n", os.Getpid(), buildinfo.Version)
+	self, _ := os.Executable()
+	want := fmt.Sprintf("%d\n%s\n%s\n", os.Getpid(), buildinfo.Version, self)
 	if string(data) != want {
 		t.Errorf("lock file = %q, want %q", data, want)
 	}
@@ -88,7 +89,8 @@ func TestAcquireTruncatesStaleContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := fmt.Sprintf("%d\n%s\n", os.Getpid(), buildinfo.Version)
+	self, _ := os.Executable()
+	want := fmt.Sprintf("%d\n%s\n%s\n", os.Getpid(), buildinfo.Version, self)
 	if string(data) != want {
 		t.Errorf("stale bytes must not survive acquire: got %q, want %q", data, want)
 	}
@@ -130,6 +132,43 @@ func TestInfoLegacyPidOnlyFormat(t *testing.T) {
 	running, pid, version := daemonlock.Info(paths)
 	if !running || pid != 1234 || version != "" {
 		t.Errorf("Info = (%v, %d, %q), want (true, 1234, \"\")", running, pid, version)
+	}
+}
+
+// The lock gained a third line (the holder's binary path). A daemon written by
+// an older hap has only two, and must still be identified rather than read as
+// a corrupt lock nobody can replace.
+func TestInfoLegacyTwoLineFormat(t *testing.T) {
+	paths := testPaths(t)
+	holdLock(t, paths, "1234\nv0.1.0\n")
+	running, pid, version := daemonlock.Info(paths)
+	if !running || pid != 1234 || version != "v0.1.0" {
+		t.Errorf("Info = (%v, %d, %q), want (true, 1234, \"v0.1.0\")", running, pid, version)
+	}
+}
+
+func TestAcquireRecordsBinaryPath(t *testing.T) {
+	paths := testPaths(t)
+	lk, err := daemonlock.Acquire(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lk.Release()
+
+	data, err := os.ReadFile(lockFile(paths))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("lock file = %q, want three lines (pid, version, exe path)", data)
+	}
+	self, err := os.Executable()
+	if err != nil {
+		t.Skipf("os.Executable unavailable: %v", err)
+	}
+	if lines[2] != self {
+		t.Errorf("recorded exe path = %q, want the running binary %q", lines[2], self)
 	}
 }
 
@@ -180,12 +219,109 @@ func TestStopTerminatesProcessAndToleratesGonePid(t *testing.T) {
 	}
 }
 
+// writeExe creates a file with the execute bit, standing in for an installed
+// hap binary at a particular path.
+func writeExe(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestEnsureFreshPathStaleness covers the upgrade shape the version check
+// alone cannot see: a holder running the SAME version from a binary that is
+// no longer the one we would start. Its children (the MCP server, the embed
+// worker) are spawned by path, so it must be replaced even though nothing
+// about the version says so.
+func TestEnsureFreshPathStaleness(t *testing.T) {
+	dir := t.TempDir()
+	oldExe := writeExe(t, filepath.Join(dir, "old", "bin", "hap"))
+	newExe := writeExe(t, filepath.Join(dir, "new", "bin", "hap"))
+	// A symlink to the current binary is how an operator's /usr/local/bin/hap
+	// reaches it; that must NOT read as a different install.
+	linked := filepath.Join(dir, "usr-local-hap")
+	if err := os.Symlink(newExe, linked); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name        string
+		lockContent string
+		exePath     string
+		wantStop    bool
+	}{
+		{
+			name:        "same version, replaced binary is stale",
+			lockContent: "4242\nv0.1.0\n" + oldExe + "\n",
+			exePath:     newExe,
+			wantStop:    true,
+		},
+		{
+			name:        "same version and same binary is current",
+			lockContent: "4242\nv0.1.0\n" + newExe + "\n",
+			exePath:     newExe,
+		},
+		{
+			name:        "path reached through a symlink is the same binary",
+			lockContent: "4242\nv0.1.0\n" + newExe + "\n",
+			exePath:     linked,
+		},
+		{
+			name: "holder recorded no path: version alone decides",
+			// A daemon from before the path was recorded. Killing it on an
+			// unknowable path would make every --ensure a restart.
+			lockContent: "4242\nv0.1.0\n",
+			exePath:     newExe,
+		},
+		{
+			name:        "our own path is unknown: version alone decides",
+			lockContent: "4242\nv0.1.0\n" + oldExe + "\n",
+			exePath:     "",
+		},
+		{
+			name: "holder path no longer exists but matches ours",
+			// Both sides name the same removed file. It cannot be resolved, so
+			// the comparison is skipped rather than treated as a mismatch.
+			lockContent: "4242\nv0.1.0\n" + filepath.Join(dir, "gone", "hap") + "\n",
+			exePath:     filepath.Join(dir, "gone", "hap"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			paths := testPaths(t)
+			release := holdLock(t, paths, tc.lockContent)
+			var stopped, started int
+			stop := func(int) error {
+				stopped++
+				release()
+				return nil
+			}
+			start := func() error { started++; return nil }
+
+			if err := daemonlock.EnsureFresh(paths, "v0.1.0", tc.exePath, 300*time.Millisecond, stop, start); err != nil {
+				t.Fatalf("EnsureFresh: %v", err)
+			}
+			if (stopped > 0) != tc.wantStop {
+				t.Errorf("stop called = %v, want %v", stopped > 0, tc.wantStop)
+			}
+			if (started > 0) != tc.wantStop {
+				t.Errorf("start called = %v, want %v", started > 0, tc.wantStop)
+			}
+		})
+	}
+}
+
 func TestEnsureFresh(t *testing.T) {
 	const held = "4242\nv0.1.0\n"
 	tests := []struct {
 		name        string
 		lockContent string // "" = no daemon running
 		version     string // current binary version passed to EnsureFresh
+		exePath     string // current binary path passed to EnsureFresh ("" = unknown)
 		stopFrees   bool   // stop releases the lock (daemon exits)
 		stopErr     bool   // stop itself fails
 		wantErr     bool
@@ -228,7 +364,7 @@ func TestEnsureFresh(t *testing.T) {
 				started = append(started, 1)
 				return nil
 			}
-			err := daemonlock.EnsureFresh(paths, tc.version, 300*time.Millisecond, stop, start)
+			err := daemonlock.EnsureFresh(paths, tc.version, tc.exePath, 300*time.Millisecond, stop, start)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("EnsureFresh error = %v, wantErr %v", err, tc.wantErr)
 			}

--- a/internal/daemonlock/lock_windows.go
+++ b/internal/daemonlock/lock_windows.go
@@ -27,6 +27,11 @@ func (l *Lock) Release() {}
 // start (which then fails in Acquire with the message above).
 func Info(paths config.Paths) (running bool, pid int, version string) { return false, 0, "" }
 
+// info is the path-aware variant EnsureFresh uses; same stub contract.
+func info(paths config.Paths) (running bool, pid int, version, exePath string) {
+	return false, 0, "", ""
+}
+
 // Stop is unreachable on Windows (Info never reports a holder).
 func Stop(pid int) error {
 	return errors.New("the daemon is not yet supported on Windows")

--- a/internal/embedder/client.go
+++ b/internal/embedder/client.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/selfpath"
 )
 
 // Client is the production EmbedderPort: it runs the CGO embedder engine
@@ -108,7 +109,7 @@ func (w *worker) shutdown() {
 func (c *Client) spawn() (*worker, error) {
 	exe := c.execPath
 	if exe == "" {
-		e, err := os.Executable()
+		e, err := selfpath.Resolve()
 		if err != nil {
 			return nil, fmt.Errorf("resolve hap binary for embed worker: %w", err)
 		}

--- a/internal/embedder/embedder.go
+++ b/internal/embedder/embedder.go
@@ -18,12 +18,12 @@ package embedder
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/selfpath"
 )
 
 // DefaultModelFile is the bundled embedding model installed by install.sh.
@@ -210,13 +210,9 @@ func ResolveModelPath(cfg config.Embedding) string {
 // PluginRoot locates the plugin install dir from the running binary:
 // install.sh places the binary at <root>/bin/hap, so root is two levels up.
 // Falls back to the working directory when the executable can't be resolved.
+// It defers to selfpath so a daemon whose own binary was replaced by an
+// upgrade finds the NEW plugin dir — the old one no longer holds models/ or
+// the lib/ the binary is rpath'd against.
 func PluginRoot() string {
-	exe, err := os.Executable()
-	if err != nil {
-		return "."
-	}
-	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
-		exe = resolved
-	}
-	return filepath.Dir(filepath.Dir(exe))
+	return selfpath.PluginRoot()
 }

--- a/internal/frontend/daemonhealth.go
+++ b/internal/frontend/daemonhealth.go
@@ -40,6 +40,12 @@ type DaemonHealth struct {
 	PID          int
 	Version      string
 	VersionStale bool // running a different binary than this one
+	// BinaryReplaced: the running daemon's own executable was removed (a
+	// plugin upgrade installs the new release elsewhere) and it found no
+	// successor to hand the herd to. It is alive and beating, but every child
+	// it spawns by path — the MCP server the LLM CLI launches, the embed
+	// worker — fails, so consults come back empty.
+	BinaryReplaced bool
 	// Hung: a held lock with a stale heartbeat — alive but not progressing.
 	Hung         bool
 	HeartbeatAge time.Duration
@@ -101,6 +107,7 @@ func (a *App) AssessDaemonHealth() DaemonHealth {
 				h.EmbedderNote = rec.EmbedderNote()
 			}
 			h.EmbedderDiagLines = rec.EmbedderDiagLines()
+			h.BinaryReplaced = rec.BinaryReplaced
 		}
 	}
 	if g, ok := crashguard.Read(a.StateDir); ok {
@@ -135,7 +142,11 @@ func (a *App) AssessDaemonHealth() DaemonHealth {
 // Severity ranks the health for a single-banner/exit-code front-end.
 func (h DaemonHealth) Severity() DaemonSeverity {
 	switch {
-	case h.Hung || h.GaveUp || h.CrashLooping:
+	// BinaryReplaced ranks with the hard failures, not with STALE: a stale
+	// daemon still works (it is merely old), whereas one whose binary is gone
+	// cannot spawn the MCP server or the embed worker at all — every consult
+	// comes back empty, which is indistinguishable from broken automation.
+	case h.Hung || h.GaveUp || h.CrashLooping || h.BinaryReplaced:
 		return DaemonError
 	case h.EmbeddingAutoDisabled || h.EmbedderDegraded || (h.Running && h.VersionStale):
 		return DaemonWarn
@@ -155,6 +166,8 @@ func (h DaemonHealth) Banner() string {
 			h.RecentRestarts, crashguard.Window, h.StderrLog)
 	case h.Hung:
 		return fmt.Sprintf("⚠ DAEMON NOT RESPONDING — no heartbeat for %s; see %s", formatAge(h.HeartbeatAge), h.StderrLog)
+	case h.BinaryReplaced:
+		return "⚠ DAEMON BINARY REMOVED (upgraded underneath it) — LLM consults cannot run; run: hap daemon --ensure"
 	case h.EmbeddingAutoDisabled:
 		return "⚠ semantic matching AUTO-DISABLED by crash-loop breaker — " + h.Reason
 	case h.EmbedderDegraded:

--- a/internal/frontend/daemonhealth_test.go
+++ b/internal/frontend/daemonhealth_test.go
@@ -246,6 +246,42 @@ func TestAssessVersionStale(t *testing.T) {
 	}
 }
 
+// A daemon whose own binary was removed by an upgrade is alive and beating,
+// but cannot spawn the MCP server or the embed worker — so it outranks STALE
+// and is an error, not a warning.
+func TestAssessBinaryReplaced(t *testing.T) {
+	app := appWithDaemon(t, true, 100, buildinfo.Version)
+	daemonhealth.Write(app.StateDir, daemonhealth.Health{
+		PID: 100, Version: buildinfo.Version, HeartbeatAt: time.Now(),
+		Embedder: daemonhealth.EmbedderReady, ExePath: "/gone/bin/hap", BinaryReplaced: true,
+	})
+	h := app.AssessDaemonHealth()
+	if !h.BinaryReplaced {
+		t.Fatalf("BinaryReplaced must be read from the heartbeat: %+v", h)
+	}
+	if h.Severity() != DaemonError {
+		t.Errorf("severity = %v, want error — consults cannot run at all", h.Severity())
+	}
+	if !strings.Contains(h.Banner(), "BINARY REMOVED") ||
+		!strings.Contains(h.Banner(), "hap daemon --ensure") {
+		t.Errorf("banner = %q, want the removed-binary condition and its remedy", h.Banner())
+	}
+}
+
+// A healthy daemon must not be flagged, so the heartbeat's absence of the
+// field is not read as a problem.
+func TestAssessBinaryReplacedAbsentOnHealthyDaemon(t *testing.T) {
+	app := appWithDaemon(t, true, 100, buildinfo.Version)
+	daemonhealth.Write(app.StateDir, daemonhealth.Health{
+		PID: 100, Version: buildinfo.Version, HeartbeatAt: time.Now(),
+		Embedder: daemonhealth.EmbedderReady, ExePath: "/live/bin/hap",
+	})
+	h := app.AssessDaemonHealth()
+	if h.BinaryReplaced || h.Severity() != DaemonOK {
+		t.Errorf("healthy daemon flagged: %+v (severity %v)", h, h.Severity())
+	}
+}
+
 func TestAssessVersionStaleWithoutStateDir(t *testing.T) {
 	// Version-staleness must be detectable from DaemonInfo alone (no state dir),
 	// since it only compares the lock's recorded version to this binary.

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/selfpath"
 )
 
 // fastFailWindow bounds how quickly a CLI run must error out to count as a
@@ -50,7 +51,7 @@ type Adapter struct {
 	// fast-fail retry, so a rescue run never gets the other command's keys.
 	CommandEnv      EnvSpec
 	CommandStartEnv EnvSpec
-	// SelfPath overrides the {self} placeholder (defaults to os.Executable).
+	// SelfPath overrides the {self} placeholder (defaults to selfpath.Resolve).
 	SelfPath string
 	// TaskGenTemplate is the argv template for the one-shot idle task
 	// suggestion (llm.task_generate_command); placeholders {self},
@@ -176,12 +177,15 @@ func (a *Adapter) Consult(ctx context.Context, req domain.LLMRequest) (*domain.L
 }
 
 // resolveSelf resolves the {self} placeholder: the configured override, else
-// this binary's path.
+// a LIVE hap binary. It must be live, not merely the path this process
+// started from: {self} is what the LLM CLI spawns as the MCP server, and after
+// a plugin upgrade the old path is gone — the CLI would silently come up with
+// no get_context/submit_decision at all.
 func (a *Adapter) resolveSelf() (string, error) {
 	if a.SelfPath != "" {
 		return a.SelfPath, nil
 	}
-	self, err := os.Executable()
+	self, err := selfpath.Resolve()
 	if err != nil {
 		return "", fmt.Errorf("resolve self path: %w", err)
 	}

--- a/internal/llm/taskgen.go
+++ b/internal/llm/taskgen.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -34,12 +33,9 @@ func (a *Adapter) GenerateTask(ctx context.Context, req domain.TaskGenRequest) (
 	if !a.GenerateTaskConfigured() {
 		return "", fmt.Errorf("no generate-task CLI configured")
 	}
-	self := a.SelfPath
-	if self == "" {
-		var err error
-		if self, err = os.Executable(); err != nil {
-			return "", fmt.Errorf("resolve self path: %w", err)
-		}
+	self, err := a.resolveSelf()
+	if err != nil {
+		return "", err
 	}
 	// The first generation for an agent uses task_generate_command_start when
 	// configured; an empty start template falls back to the base command.

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -9,10 +9,13 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/control"
@@ -48,30 +51,103 @@ type rpcError struct {
 	Message string `json:"message"`
 }
 
-// Run serves MCP until stdin closes.
-func (s *Server) Run(ctx context.Context, in io.Reader, out io.Writer) error {
-	scanner := bufio.NewScanner(in)
-	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
-	enc := json.NewEncoder(out)
+// shutdownGrace bounds a tool call dispatched AFTER a shutdown signal has
+// already arrived. It must comfortably exceed the store's busy timeout (5s,
+// internal/store) so a write merely contending with the daemon still lands:
+// the whole point is not to lose a decision the operator's LLM produced. It
+// deliberately does not apply to ordinary calls, which stay bounded only by
+// the caller — capping those would drop decisions this change exists to save.
+const shutdownGrace = 30 * time.Second
 
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
-		var req rpcRequest
-		if err := json.Unmarshal(line, &req); err != nil {
-			continue // unparseable frame: ignore, fail-safe
-		}
-		if req.ID == nil {
-			continue // notification (e.g. notifications/initialized)
-		}
-		resp := s.handle(ctx, req)
-		if err := enc.Encode(resp); err != nil {
-			return err
+// Run serves MCP until stdin closes or ctx is cancelled (SIGTERM/Ctrl+C).
+//
+// Frames are read on their own goroutine because a blocking read on stdin
+// cannot be interrupted: the LLM CLI that launched us holds the pipe open, so
+// waiting on Scan alone made `hap mcp` ignore signals entirely and linger with
+// the SQLite handle open. Dispatch stays on this goroutine, so cancellation
+// can only land BETWEEN frames and an in-flight tool call always completes.
+func (s *Server) Run(ctx context.Context, in io.Reader, out io.Writer) error {
+	enc := json.NewEncoder(out)
+	frames, scanErr := readFrames(in)
+
+	for {
+		select {
+		case <-ctx.Done():
+			// A signal is an ordinary end of service, not a failure: return nil
+			// so the process exits 0 and the caller's deferred store Close runs.
+			return nil
+		case line, ok := <-frames:
+			if !ok {
+				return <-scanErr
+			}
+			var req rpcRequest
+			if err := json.Unmarshal(line, &req); err != nil {
+				continue // unparseable frame: ignore, fail-safe
+			}
+			if req.ID == nil {
+				continue // notification (e.g. notifications/initialized)
+			}
+			// Normally the handler just gets ctx. Only once a signal has
+			// already landed does it get a detached, separately-bounded
+			// context: the frame was read before the cancel, so a
+			// submit_decision reaching us in that window must still complete
+			// rather than fail with "context canceled" and drop the decision.
+			callCtx, cancel := dispatchContext(ctx)
+			resp := s.handle(callCtx, req)
+			cancel()
+			if err := enc.Encode(resp); err != nil {
+				// The client went away mid-reply (a killed CLI closes the pipe).
+				// That is teardown, not an error worth a non-zero exit.
+				if isPipeClosed(err) {
+					return nil
+				}
+				return err
+			}
 		}
 	}
-	return scanner.Err()
+}
+
+// readFrames pumps line-delimited frames off in until EOF, then reports the
+// scanner's error on scanErr.
+//
+// When Run exits on a cancelled context this goroutine may still be parked on
+// a read (or on the unbuffered send) — a blocking read on an OS pipe cannot be
+// unblocked from the outside. That is deliberate: `hap mcp` is a one-shot
+// process that exits immediately after Run returns, so the goroutine dies with
+// it. Callers embedding Run in a longer-lived process must close in.
+func readFrames(in io.Reader) (<-chan []byte, <-chan error) {
+	frames := make(chan []byte)
+	scanErr := make(chan error, 1)
+	go func() {
+		defer close(frames)
+		scanner := bufio.NewScanner(in)
+		scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+		for scanner.Scan() {
+			if len(scanner.Bytes()) == 0 {
+				continue
+			}
+			// Scan reuses its buffer, so the frame must be copied before it
+			// crosses the channel and outlives the next Scan.
+			frames <- append([]byte(nil), scanner.Bytes()...)
+		}
+		scanErr <- scanner.Err()
+	}()
+	return frames, scanErr
+}
+
+// dispatchContext returns the context one tool call runs under: ctx itself
+// while we are serving normally, or a detached, grace-bounded copy once ctx
+// has already been cancelled. The returned cancel is always safe to call.
+func dispatchContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx.Err() == nil {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(context.WithoutCancel(ctx), shutdownGrace)
+}
+
+// isPipeClosed reports whether err is the client having closed our stdout.
+func isPipeClosed(err error) bool {
+	return errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) || errors.Is(err, os.ErrClosed)
 }
 
 func (s *Server) handle(ctx context.Context, req rpcRequest) rpcResponse {

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -64,47 +64,96 @@ const shutdownGrace = 30 * time.Second
 // Frames are read on their own goroutine because a blocking read on stdin
 // cannot be interrupted: the LLM CLI that launched us holds the pipe open, so
 // waiting on Scan alone made `hap mcp` ignore signals entirely and linger with
-// the SQLite handle open. Dispatch stays on this goroutine, so cancellation
-// can only land BETWEEN frames and an in-flight tool call always completes.
+// the SQLite handle open. Dispatch stays on this goroutine, so a tool call
+// already running when the signal lands always completes — and a frame that
+// merely arrived first is drained on the way out (see serve), so the signal
+// cannot swallow a decision the client had already sent.
 func (s *Server) Run(ctx context.Context, in io.Reader, out io.Writer) error {
-	enc := json.NewEncoder(out)
 	frames, scanErr := readFrames(in)
+	return s.serve(ctx, json.NewEncoder(out), frames, scanErr)
+}
 
+// serve is Run's loop over an already-running frame reader, split out so the
+// cancellation race below can be exercised deterministically.
+func (s *Server) serve(ctx context.Context, enc *json.Encoder, frames <-chan []byte, scanErr <-chan error) error {
 	for {
 		select {
 		case <-ctx.Done():
 			// A signal is an ordinary end of service, not a failure: return nil
 			// so the process exits 0 and the caller's deferred store Close runs.
-			return nil
+			//
+			// But not before draining: when a frame and the cancellation are
+			// ready at the same instant, select picks BETWEEN THEM AT RANDOM,
+			// so returning straight from here would discard a frame the reader
+			// had already handed over — a submit_decision that reached us
+			// before the signal, which is precisely what the grace window
+			// exists to protect.
+			return s.drainReady(ctx, enc, frames)
 		case line, ok := <-frames:
 			if !ok {
 				return <-scanErr
 			}
-			var req rpcRequest
-			if err := json.Unmarshal(line, &req); err != nil {
-				continue // unparseable frame: ignore, fail-safe
-			}
-			if req.ID == nil {
-				continue // notification (e.g. notifications/initialized)
-			}
-			// Normally the handler just gets ctx. Only once a signal has
-			// already landed does it get a detached, separately-bounded
-			// context: the frame was read before the cancel, so a
-			// submit_decision reaching us in that window must still complete
-			// rather than fail with "context canceled" and drop the decision.
-			callCtx, cancel := dispatchContext(ctx)
-			resp := s.handle(callCtx, req)
-			cancel()
-			if err := enc.Encode(resp); err != nil {
-				// The client went away mid-reply (a killed CLI closes the pipe).
-				// That is teardown, not an error worth a non-zero exit.
-				if isPipeClosed(err) {
-					return nil
-				}
+			if stop, err := s.dispatch(ctx, enc, line); stop || err != nil {
 				return err
 			}
 		}
 	}
+}
+
+// drainReady dispatches every frame the reader has ALREADY delivered, then
+// returns. Each one goes through dispatch, so it gets the detached grace
+// context (ctx is cancelled by the time we are here).
+//
+// The default case bounds this to what is in hand: it never waits for the
+// client to send more, so a shutdown cannot be held open. Bytes still inside
+// the scanner, not yet handed to the channel, are not recoverable — "delivered
+// to the channel" is the strongest boundary this can honour, and it is the one
+// the race above actually straddles.
+func (s *Server) drainReady(ctx context.Context, enc *json.Encoder, frames <-chan []byte) error {
+	for {
+		select {
+		case line, ok := <-frames:
+			if !ok {
+				// stdin ended too; the signal is still the reason we stop, so
+				// this is a clean exit rather than the scanner's error.
+				return nil
+			}
+			if stop, err := s.dispatch(ctx, enc, line); stop || err != nil {
+				return err
+			}
+		default:
+			return nil
+		}
+	}
+}
+
+// dispatch handles one frame and writes its response. stop reports that the
+// loop should end: the client has gone away, or err is set.
+func (s *Server) dispatch(ctx context.Context, enc *json.Encoder, line []byte) (stop bool, err error) {
+	var req rpcRequest
+	if err := json.Unmarshal(line, &req); err != nil {
+		return false, nil // unparseable frame: ignore, fail-safe
+	}
+	if req.ID == nil {
+		return false, nil // notification (e.g. notifications/initialized)
+	}
+	// Normally the handler just gets ctx. Only once a signal has already
+	// landed does it get a detached, separately-bounded context: the frame was
+	// read before the cancel, so a submit_decision reaching us in that window
+	// must still complete rather than fail with "context canceled" and drop
+	// the decision.
+	callCtx, cancel := dispatchContext(ctx)
+	resp := s.handle(callCtx, req)
+	cancel()
+	if err := enc.Encode(resp); err != nil {
+		// The client went away mid-reply (a killed CLI closes the pipe). That
+		// is teardown, not an error worth a non-zero exit.
+		if isPipeClosed(err) {
+			return true, nil
+		}
+		return true, err
+	}
+	return false, nil
 }
 
 // readFrames pumps line-delimited frames off in until EOF, then reports the

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -719,3 +719,86 @@ func TestDispatchContextBoundsOnlyAfterCancel(t *testing.T) {
 		t.Errorf("grace = %v, want comfortably more than the store's 5s busy timeout", remaining)
 	}
 }
+
+// A frame the reader already delivered must be dispatched even though the
+// context is cancelled: when both select cases are ready Go picks one at
+// RANDOM, so returning straight from the cancel branch would silently discard
+// a submit_decision that arrived before the signal — exactly the loss the
+// grace window exists to prevent. Driving serve() with a pre-filled channel
+// and an already-cancelled context makes the race deterministic; through Run()
+// it would only reproduce by luck.
+func TestServeDispatchesAlreadyDeliveredFrameOnCancel(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	const reqID = "req-raced"
+	if _, err := st.StageLLMRequest(ctx, domain.LLMRequest{
+		RequestID: reqID, Signature: "idle:aaaa", SituationType: domain.SituationIdle,
+		AgentType: "claude", ContextJSON: "{}", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	frame, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{
+			"name": "submit_decision",
+			"arguments": map[string]any{
+				"recommend_action": "proceed", "confident_score": 90, "rationale": "test",
+			},
+		},
+	})
+	frames := make(chan []byte, 1)
+	frames <- frame
+
+	cancelled, stop := context.WithCancel(context.Background())
+	stop()
+
+	var out strings.Builder
+	srv := &Server{Store: st, DefaultRequestID: reqID}
+	if err := srv.serve(cancelled, json.NewEncoder(&out), frames, make(chan error, 1)); err != nil {
+		t.Fatalf("serve = %v, want nil", err)
+	}
+	if out.Len() == 0 {
+		t.Error("the already-delivered frame got no response")
+	}
+
+	dec, err := st.LLMDecisionByRequest(ctx, reqID)
+	if err != nil {
+		t.Fatalf("read staged decision: %v", err)
+	}
+	if dec == nil {
+		t.Fatal("a decision delivered before the signal was dropped by the cancel branch")
+	}
+}
+
+// The drain must not hold shutdown open waiting for a client that has stopped
+// sending: it dispatches what is in hand and returns.
+func TestServeDrainDoesNotWaitForMoreFrames(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	// Open (never closed) and empty: a drain that waited would block forever.
+	frames := make(chan []byte)
+	cancelled, stop := context.WithCancel(context.Background())
+	stop()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- (&Server{Store: st}).serve(cancelled, json.NewEncoder(io.Discard), frames, make(chan error, 1))
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("serve = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serve blocked draining an empty channel instead of returning")
+	}
+}

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -566,3 +566,156 @@ func TestMCPSubmitNoopNormalized(t *testing.T) {
 		t.Fatalf("tools/list should document @noop: %s", text)
 	}
 }
+
+// A SIGTERM (Ctrl+C, or the LLM CLI being killed) must end the server. Run
+// used to block in a stdin Scan that the signal could not interrupt, so
+// `hap mcp` ignored the signal entirely and lingered holding the SQLite
+// handle open.
+func TestMCPRunReturnsOnContextCancel(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	// A pipe with no writer models the real thing: the parent CLI holds our
+	// stdin open, so nothing will ever close it for us.
+	inR, inW := io.Pipe()
+	defer inW.Close()
+	outR, outW := io.Pipe()
+	go io.Copy(io.Discard, outR)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- (&Server{Store: st}).Run(ctx, inR, outW) }()
+
+	cancel()
+	select {
+	case err := <-done:
+		// nil, not ctx.Err(): a signal is a normal end of service, and a
+		// non-nil error would exit the process non-zero with an "error:" line.
+		if err != nil {
+			t.Fatalf("Run after cancel = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after the context was cancelled")
+	}
+}
+
+// Cancellation lands between frames, so a tool call already running when the
+// signal arrives still completes — an operator decision that reached
+// submit_decision must not be lost to a SIGTERM racing the write.
+func TestMCPInFlightSubmitSurvivesCancel(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	const reqID = "req-inflight"
+	if _, err := st.StageLLMRequest(ctx, domain.LLMRequest{
+		RequestID: reqID, Signature: "idle:aaaa", SituationType: domain.SituationIdle,
+		AgentType: "claude", ContextJSON: "{}", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	inR, inW := io.Pipe()
+	defer inW.Close()
+	outR, outW := io.Pipe()
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- (&Server{Store: st, DefaultRequestID: reqID}).Run(runCtx, inR, outW) }()
+
+	req, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{
+			"name": "submit_decision",
+			"arguments": map[string]any{
+				"recommend_action": "proceed", "confident_score": 90, "rationale": "test",
+			},
+		},
+	})
+	if _, err := inW.Write(append(req, '\n')); err != nil {
+		t.Fatal(err)
+	}
+	sc := bufio.NewScanner(outR)
+	if !sc.Scan() {
+		t.Fatal("no response to submit_decision")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+
+	dec, err := st.LLMDecisionByRequest(ctx, reqID)
+	if err != nil {
+		t.Fatalf("read staged decision: %v", err)
+	}
+	if dec == nil {
+		t.Fatal("the submitted decision was not persisted")
+	}
+}
+
+// A client that dies mid-reply closes our stdout. That is teardown, not a
+// failure worth a non-zero exit.
+func TestMCPRunTreatsClosedStdoutAsCleanEnd(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	inR, inW := io.Pipe()
+	defer inW.Close()
+	outR, outW := io.Pipe()
+	// Close the read end so the very first write fails with ErrClosedPipe.
+	outR.Close()
+
+	done := make(chan error, 1)
+	go func() { done <- (&Server{Store: st}).Run(context.Background(), inR, outW) }()
+	fmt.Fprintln(inW, `{"jsonrpc":"2.0","id":1,"method":"ping"}`)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run with a closed stdout = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after stdout closed")
+	}
+}
+
+// The shutdown grace must apply ONLY once a signal has landed. Bounding every
+// tool call would newly cap submit_decision, and a write merely contending
+// with the daemon (the store's busy timeout is 5s) would then fail with
+// "context deadline exceeded" — dropping exactly the decision this change
+// exists to preserve.
+func TestDispatchContextBoundsOnlyAfterCancel(t *testing.T) {
+	live := context.Background()
+	got, cancel := dispatchContext(live)
+	cancel()
+	if _, ok := got.Deadline(); ok {
+		t.Error("an ordinary call must not gain a deadline")
+	}
+	if got != live {
+		t.Error("an ordinary call must run under the caller's own context")
+	}
+
+	cancelled, stop := context.WithCancel(context.Background())
+	stop()
+	got, cancel = dispatchContext(cancelled)
+	defer cancel()
+	if got.Err() != nil {
+		t.Error("a call dispatched after cancel must run on a LIVE context, not the cancelled one")
+	}
+	deadline, ok := got.Deadline()
+	if !ok {
+		t.Fatal("a call dispatched after cancel must be separately bounded")
+	}
+	if remaining := time.Until(deadline); remaining <= 5*time.Second {
+		t.Errorf("grace = %v, want comfortably more than the store's 5s busy timeout", remaining)
+	}
+}

--- a/internal/selfpath/selfpath.go
+++ b/internal/selfpath/selfpath.go
@@ -1,0 +1,287 @@
+// Package selfpath resolves a path to a LIVE hap executable.
+//
+// Every self-spawn in hap — the {self} placeholder handed to the operator's
+// LLM CLI so it can launch `hap mcp`, the embed-worker subprocess, the daemon
+// re-exec — needs to name this binary on disk. os.Executable() alone is not
+// enough: herdr installs each plugin release into its own directory
+// (~/.config/herdr/plugins/<source>/herd-auto-prompter-*/bin/hap) and an
+// upgrade unlinks the old one, so a long-lived process keeps reporting a path
+// that no longer exists (Go strips the " (deleted)" suffix procfs appends).
+// Every child spawned from that path then fails with ENOENT, silently: the LLM
+// CLI cannot start the MCP server, the embedder latches degraded mode.
+//
+// Resolve therefore VALIDATES os.Executable's answer and, only when it has gone
+// away, looks for the binary that replaced it.
+package selfpath
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// EnvOverride names the environment variable that pins the resolved path. It
+// is both the test seam and the escape hatch for installs this package cannot
+// discover on its own.
+const EnvOverride = "HAP_SELF_PATH"
+
+// pluginID is the herdr plugin id; it names both the registry entry and the
+// install directory prefix.
+const pluginID = "herd-auto-prompter"
+
+// herdrLookupTimeout bounds the `herdr plugin list` fallback so a wedged herdr
+// cannot stall a spawn. It only runs once the running executable has vanished.
+const herdrLookupTimeout = 5 * time.Second
+
+// ErrNotFound reports that no live hap executable could be located.
+var ErrNotFound = errors.New("no live hap executable found")
+
+var (
+	cacheMu sync.Mutex
+	// cached holds the last successful FALLBACK answer (never the fast-path
+	// one, which is already free to compute). It is re-validated on every use
+	// so a second upgrade is picked up too.
+	cached string
+)
+
+// Resolve returns the path of a live hap executable, preferring the running
+// one. Callers use it for re-exec and for the {self} placeholder.
+func Resolve() (string, error) {
+	if p := os.Getenv(EnvOverride); p != "" {
+		// An explicit override is authoritative: report it as-is rather than
+		// silently substituting something else, so a wrong value is visible.
+		return p, nil
+	}
+	// Fast path: the running binary, if it is still on disk. One Stat, and it
+	// is the answer in every case except an upgrade.
+	if exe, err := os.Executable(); err == nil && executable(exe) {
+		return exe, nil
+	}
+	return resolveReplacement()
+}
+
+// PluginRoot locates the plugin install dir from the resolved binary:
+// install.sh places it at <root>/bin/hap, so root is two levels up. Falls back
+// to the working directory when nothing can be resolved.
+func PluginRoot() string {
+	exe, err := Resolve()
+	if err != nil {
+		return "."
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return filepath.Dir(filepath.Dir(exe))
+}
+
+// Missing reports whether path no longer names an executable file. The daemon
+// polls this against the path it started from to notice its own replacement.
+func Missing(path string) bool {
+	return path != "" && !executable(path)
+}
+
+// Same reports whether two paths name the same file once symlinks are
+// resolved, so /usr/local/bin/hap and <plugin>/bin/hap do not read as
+// different binaries. Two paths that are literally equal are the same even
+// when neither can be resolved — a removed binary is still itself. Beyond
+// that, an unresolvable path compares false: nothing can be concluded about
+// a file that is not there.
+func Same(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	if filepath.Clean(a) == filepath.Clean(b) {
+		return true
+	}
+	ra, err := canonical(a)
+	if err != nil {
+		return false
+	}
+	rb, err := canonical(b)
+	if err != nil {
+		return false
+	}
+	return ra == rb
+}
+
+func canonical(p string) (string, error) {
+	if p == "" {
+		return "", ErrNotFound
+	}
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(resolved)
+}
+
+// executable reports whether path is a regular file with an execute bit.
+func executable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	return info.Mode().Perm()&0o111 != 0
+}
+
+// resolveReplacement finds the binary that replaced a vanished one. Ordered
+// most to least authoritative; each candidate must exist to be accepted.
+func resolveReplacement() (string, error) {
+	cacheMu.Lock()
+	prev := cached
+	cacheMu.Unlock()
+	if executable(prev) {
+		return prev, nil
+	}
+
+	for _, candidate := range []struct {
+		how  string
+		find func() string
+	}{
+		{"herdr plugin registry", fromHerdrRegistry},
+		{"herdr plugin install dir", fromInstallDirs},
+		{"PATH", fromPATH},
+	} {
+		if p := candidate.find(); executable(p) {
+			cacheMu.Lock()
+			cached = p
+			cacheMu.Unlock()
+			// The result is EXECUTED (as the successor daemon, as the embed
+			// worker, and as the MCP server the operator's LLM CLI launches),
+			// so which fallback picked it is worth an operator-visible record
+			// rather than a silent substitution.
+			slog.Warn("the running hap binary is gone; resolved a replacement",
+				"replacement", p, "found_via", candidate.how)
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("%w (the running binary was removed, likely by a plugin upgrade)", ErrNotFound)
+}
+
+// fromHerdrRegistry asks herdr where the plugin is installed now. This is the
+// authoritative answer after an upgrade, because herdr rewrote the registry
+// itself.
+func fromHerdrRegistry() string {
+	bin := os.Getenv("HERDR_BIN_PATH")
+	if bin == "" {
+		bin = "herdr"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), herdrLookupTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, "plugin", "list", "--json")
+	// A deleted cwd would make the spawn itself fail; the daemon already runs
+	// from a stable dir, but this path is reachable from short-lived CLIs too.
+	cmd.Dir = stableDir()
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	var env struct {
+		Result struct {
+			Plugins []struct {
+				PluginID   string `json:"plugin_id"`
+				PluginRoot string `json:"plugin_root"`
+			} `json:"plugins"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(out, &env); err != nil {
+		return ""
+	}
+	for _, p := range env.Result.Plugins {
+		if p.PluginID == pluginID && p.PluginRoot != "" {
+			return filepath.Join(p.PluginRoot, "bin", "hap")
+		}
+	}
+	return ""
+}
+
+// fromInstallDirs scans herdr's plugin install tree directly, for when herdr
+// itself cannot be reached. Install dirs are version-stamped, so the newest
+// one wins.
+func fromInstallDirs() string {
+	root := PluginInstallRoot()
+	if root == "" {
+		return ""
+	}
+	matches, err := filepath.Glob(filepath.Join(root, "*", pluginID+"*", "bin", "hap"))
+	if err != nil {
+		return ""
+	}
+	var newest string
+	var newestMod time.Time
+	for _, m := range matches {
+		info, err := os.Stat(m)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		if newest == "" || info.ModTime().After(newestMod) {
+			newest, newestMod = m, info.ModTime()
+		}
+	}
+	return newest
+}
+
+// fromPATH is the last resort: the operator's own `hap` shortcut
+// (/usr/local/bin/hap), which is how a linked working tree or an install this
+// package cannot otherwise discover is found.
+//
+// It is last for a reason. Whatever it returns gets EXECUTED, and PATH is
+// inherited from whoever launched the daemon, so a `hap` earlier in PATH than
+// the operator's own would be run. The exposure is bounded by ordering (the
+// two authoritative sources are tried first, and this is reached only once
+// the running binary has been removed) and by the resolution being logged;
+// anyone who can write an earlier PATH entry for this process can already
+// choose what it runs. Do not promote this above the herdr-anchored lookups.
+func fromPATH() string {
+	p, err := exec.LookPath("hap")
+	if err != nil {
+		return ""
+	}
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return ""
+	}
+	return resolved
+}
+
+// PluginInstallRoot returns the directory herdr installs plugins under
+// (<config home>/herdr/plugins), or "" when the config home cannot be
+// resolved. Callers use it to tell a hap WE installed from an unrelated
+// binary that happens to be named hap.
+func PluginInstallRoot() string {
+	home := configHome()
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, "herdr", "plugins")
+}
+
+func configHome() string {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config")
+}
+
+// stableDir picks a directory that is certain to exist, so spawning a helper
+// never fails merely because the inherited cwd was deleted.
+func stableDir() string {
+	if wd, err := os.Getwd(); err == nil {
+		return wd
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return home
+	}
+	return string(filepath.Separator)
+}

--- a/internal/selfpath/selfpath_test.go
+++ b/internal/selfpath/selfpath_test.go
@@ -1,0 +1,210 @@
+package selfpath
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeExe creates a file with the execute bit, standing in for a hap binary.
+func writeExe(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// isolate points every discovery fallback at an empty world so a test only
+// sees the candidates it sets up itself, and clears the process-wide cache.
+func isolate(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv(EnvOverride, "")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	t.Setenv("HERDR_BIN_PATH", filepath.Join(dir, "no-such-herdr"))
+	t.Setenv("PATH", filepath.Join(dir, "empty-bin"))
+	cacheMu.Lock()
+	cached = ""
+	cacheMu.Unlock()
+	t.Cleanup(func() {
+		cacheMu.Lock()
+		cached = ""
+		cacheMu.Unlock()
+	})
+	return dir
+}
+
+func TestResolvePrefersEnvOverride(t *testing.T) {
+	dir := isolate(t)
+	// Deliberately a path that does NOT exist: an explicit override is
+	// authoritative, so a wrong value must surface rather than be replaced.
+	want := filepath.Join(dir, "pinned", "hap")
+	t.Setenv(EnvOverride, want)
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Resolve = %q, want the override %q", got, want)
+	}
+}
+
+func TestResolveUsesRunningBinaryWhenItStillExists(t *testing.T) {
+	isolate(t)
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skipf("os.Executable unavailable: %v", err)
+	}
+
+	got, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != exe {
+		t.Fatalf("Resolve = %q, want the running test binary %q", got, exe)
+	}
+}
+
+func TestResolveFallsBackToNewestInstallDir(t *testing.T) {
+	dir := isolate(t)
+	plugins := filepath.Join(dir, "config", "herdr", "plugins", "github")
+	old := writeExe(t, filepath.Join(plugins, "herd-auto-prompter-0.4.50", "bin", "hap"))
+	recent := writeExe(t, filepath.Join(plugins, "herd-auto-prompter-0.4.51", "bin", "hap"))
+	// Version-stamped dirs sort unhelpfully once versions reach two digits, so
+	// discovery goes by mtime: make the intended winner unambiguously newer.
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(old, past, past); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	got := fromInstallDirs()
+	if got != recent {
+		t.Fatalf("fromInstallDirs = %q, want the newest install %q", got, recent)
+	}
+}
+
+func TestResolveReplacementSkipsNonExecutableCandidate(t *testing.T) {
+	dir := isolate(t)
+	plugins := filepath.Join(dir, "config", "herdr", "plugins", "github")
+	// A downloaded-but-not-yet-chmod'ed binary must not be handed out as the
+	// successor: spawning it would fail with EACCES.
+	noexec := filepath.Join(plugins, "herd-auto-prompter-0.4.51", "bin", "hap")
+	writeExe(t, noexec)
+	if err := os.Chmod(noexec, 0o644); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	if _, err := resolveReplacement(); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("resolveReplacement err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestResolveReplacementFindsPATHShortcut(t *testing.T) {
+	dir := isolate(t)
+	bin := filepath.Join(dir, "path-bin")
+	want := writeExe(t, filepath.Join(bin, "hap"))
+	t.Setenv("PATH", bin)
+
+	got, err := resolveReplacement()
+	if err != nil {
+		t.Fatalf("resolveReplacement: %v", err)
+	}
+	if got != want {
+		t.Fatalf("resolveReplacement = %q, want %q", got, want)
+	}
+}
+
+func TestResolveReplacementCacheRevalidates(t *testing.T) {
+	dir := isolate(t)
+	bin := filepath.Join(dir, "path-bin")
+	first := writeExe(t, filepath.Join(bin, "hap"))
+	t.Setenv("PATH", bin)
+
+	if got, err := resolveReplacement(); err != nil || got != first {
+		t.Fatalf("first resolveReplacement = %q, %v; want %q", got, err, first)
+	}
+	// A second upgrade removes the cached answer too. The cache must not
+	// outlive the file it names.
+	if err := os.Remove(first); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	second := writeExe(t, filepath.Join(dir, "path-bin2", "hap"))
+	t.Setenv("PATH", filepath.Join(dir, "path-bin2"))
+
+	got, err := resolveReplacement()
+	if err != nil {
+		t.Fatalf("second resolveReplacement: %v", err)
+	}
+	if got != second {
+		t.Fatalf("second resolveReplacement = %q, want the new binary %q", got, second)
+	}
+}
+
+func TestResolveReplacementReportsNothingFound(t *testing.T) {
+	isolate(t)
+	if _, err := resolveReplacement(); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("resolveReplacement err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestMissing(t *testing.T) {
+	dir := t.TempDir()
+	live := writeExe(t, filepath.Join(dir, "hap"))
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"live binary", live, false},
+		{"removed binary", filepath.Join(dir, "gone"), true},
+		{"unknown path", "", false},
+		{"directory", dir, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Missing(tt.path); got != tt.want {
+				t.Fatalf("Missing(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSameResolvesSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	real := writeExe(t, filepath.Join(dir, "plugin", "bin", "hap"))
+	link := filepath.Join(dir, "usr-local-hap")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	other := writeExe(t, filepath.Join(dir, "other", "bin", "hap"))
+
+	if !Same(link, real) {
+		t.Fatal("Same(symlink, target) = false; a PATH shortcut must not read as a different binary")
+	}
+	if Same(real, other) {
+		t.Fatal("Same(distinct binaries) = true")
+	}
+	if Same(real, filepath.Join(dir, "gone")) {
+		t.Fatal("Same(live, missing) = true; an unresolvable path must compare false")
+	}
+	if Same("", "") {
+		t.Fatal("Same(\"\", \"\") = true; an unknown path must compare false")
+	}
+}
+
+func TestPluginRootIsTwoLevelsAboveTheBinary(t *testing.T) {
+	dir := isolate(t)
+	root := filepath.Join(dir, "plugin")
+	t.Setenv(EnvOverride, writeExe(t, filepath.Join(root, "bin", "hap")))
+
+	if got := PluginRoot(); got != root {
+		t.Fatalf("PluginRoot = %q, want %q", got, root)
+	}
+}

--- a/internal/selfpath/selfpath_test.go
+++ b/internal/selfpath/selfpath_test.go
@@ -20,6 +20,19 @@ func writeExe(t *testing.T, path string) string {
 	return path
 }
 
+// resolved canonicalizes an expected path the way the code under test does.
+// On macOS a t.TempDir() path lives under the /var → /private/var symlink, so
+// comparing a raw temp path against a value that went through EvalSymlinks
+// fails there while passing on Linux.
+func resolved(t *testing.T, path string) string {
+	t.Helper()
+	out, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", path, err)
+	}
+	return out
+}
+
 // isolate points every discovery fallback at an empty world so a test only
 // sees the candidates it sets up itself, and clears the process-wide cache.
 func isolate(t *testing.T) string {
@@ -116,7 +129,7 @@ func TestResolveReplacementFindsPATHShortcut(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveReplacement: %v", err)
 	}
-	if got != want {
+	if got != resolved(t, want) {
 		t.Fatalf("resolveReplacement = %q, want %q", got, want)
 	}
 }
@@ -127,7 +140,7 @@ func TestResolveReplacementCacheRevalidates(t *testing.T) {
 	first := writeExe(t, filepath.Join(bin, "hap"))
 	t.Setenv("PATH", bin)
 
-	if got, err := resolveReplacement(); err != nil || got != first {
+	if got, err := resolveReplacement(); err != nil || got != resolved(t, first) {
 		t.Fatalf("first resolveReplacement = %q, %v; want %q", got, err, first)
 	}
 	// A second upgrade removes the cached answer too. The cache must not
@@ -142,7 +155,7 @@ func TestResolveReplacementCacheRevalidates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second resolveReplacement: %v", err)
 	}
-	if got != second {
+	if got != resolved(t, second) {
 		t.Fatalf("second resolveReplacement = %q, want the new binary %q", got, second)
 	}
 }
@@ -204,7 +217,7 @@ func TestPluginRootIsTwoLevelsAboveTheBinary(t *testing.T) {
 	root := filepath.Join(dir, "plugin")
 	t.Setenv(EnvOverride, writeExe(t, filepath.Join(root, "bin", "hap")))
 
-	if got := PluginRoot(); got != root {
+	if got := PluginRoot(); got != resolved(t, root) {
 		t.Fatalf("PluginRoot = %q, want %q", got, root)
 	}
 }

--- a/internal/tui/shortcut.go
+++ b/internal/tui/shortcut.go
@@ -4,15 +4,37 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/selfpath"
 )
 
 const hapShortcutPath = "/usr/local/bin/hap"
 
+// shortcutState describes what the shortcut path currently holds, so the menu
+// can say whether the action creates, repoints, or does nothing.
+type shortcutState int
+
+const (
+	// shortcutAbsent: nothing at the path — the action creates it.
+	shortcutAbsent shortcutState = iota
+	// shortcutCurrent: already resolves to the running binary.
+	shortcutCurrent
+	// shortcutStale: a link we recognize as ours, pointing somewhere dead or
+	// superseded — the action repoints it.
+	shortcutStale
+	// shortcutForeign: something we must not touch (a real file, or a link to
+	// a live binary that is not one of ours).
+	shortcutForeign
+)
+
 // installHAPShortcut links the exact executable backing this TUI process. It
-// deliberately does not use argv[0] or PATH, either of which could identify a
-// wrapper or a different hap installation.
+// deliberately does not use argv[0], which could identify a wrapper rather
+// than the binary itself. (selfpath does consult PATH, but only as a last
+// resort once the running binary has been removed — the very case where
+// "the executable backing this process" no longer names anything.)
 func installHAPShortcut() error {
-	executable, err := os.Executable()
+	executable, err := selfpath.Resolve()
 	if err != nil {
 		return fmt.Errorf("locate the running hap binary: %w", err)
 	}
@@ -23,38 +45,166 @@ func installHAPShortcut() error {
 	return ensureExecutableSymlink(executable, hapShortcutPath)
 }
 
-// ensureExecutableSymlink creates target without replacing anything already
-// there. Re-running the shortcut is successful when target already resolves to
-// source, while an unrelated file/link is left untouched and reported.
-func ensureExecutableSymlink(source, target string) error {
-	resolvedSource, err := filepath.EvalSymlinks(source)
+// hapShortcutState reports what the shortcut path holds relative to the
+// running binary, for labelling the menu row.
+func hapShortcutState() shortcutState {
+	executable, err := selfpath.Resolve()
 	if err != nil {
-		return fmt.Errorf("resolve symlink source %s: %w", source, err)
+		return shortcutForeign
 	}
-	resolvedSource, err = filepath.Abs(resolvedSource)
+	state, _ := classifyShortcut(executable, hapShortcutPath)
+	return state
+}
+
+// shortcutLabel renders the menu row for a shortcut state, so the operator
+// knows what pressing enter will do before they press it — an upgrade turns
+// "create" into "repoint" without anything else changing on screen.
+func shortcutLabel(state shortcutState) string {
+	switch state {
+	case shortcutCurrent:
+		return "Recreate " + hapShortcutPath + " symlink (already points at this binary)"
+	case shortcutStale:
+		return "Repoint " + hapShortcutPath + " symlink to this running binary (currently stale)"
+	default:
+		return "Create " + hapShortcutPath + " symlink to this running binary"
+	}
+}
+
+// shortcutConfirm is the confirmation prompt matching a shortcut state.
+func shortcutConfirm(state shortcutState) string {
+	if state == shortcutStale {
+		return "Repoint " + hapShortcutPath + " to the currently running hap binary? [Y/n]"
+	}
+	return "Create " + hapShortcutPath + " symlink to the currently running hap binary? [Y/n]"
+}
+
+// shortcutResult is the message reported after a successful action.
+func shortcutResult(state shortcutState) string {
+	if state == shortcutStale {
+		return "repointed " + hapShortcutPath + " symlink"
+	}
+	return "created " + hapShortcutPath + " symlink"
+}
+
+// classifyShortcut inspects target and reports what it is relative to source.
+// A shortcutForeign result always carries the error explaining why.
+func classifyShortcut(source, target string) (shortcutState, error) {
+	resolvedSource, err := resolveAbs(source)
 	if err != nil {
-		return fmt.Errorf("make symlink source absolute: %w", err)
+		return shortcutForeign, fmt.Errorf("resolve symlink source %s: %w", source, err)
 	}
 
 	info, err := os.Lstat(target)
-	if err == nil {
-		if info.Mode()&os.ModeSymlink == 0 {
-			return fmt.Errorf("%s already exists and is not a symlink", target)
-		}
-		resolvedTarget, resolveErr := filepath.EvalSymlinks(target)
-		if resolveErr == nil {
-			resolvedTarget, resolveErr = filepath.Abs(resolvedTarget)
-		}
-		if resolveErr == nil && filepath.Clean(resolvedTarget) == filepath.Clean(resolvedSource) {
-			return nil
-		}
-		return fmt.Errorf("%s already points to a different target; remove it first", target)
+	if os.IsNotExist(err) {
+		return shortcutAbsent, nil
 	}
-	if !os.IsNotExist(err) {
-		return fmt.Errorf("inspect %s: %w", target, err)
+	if err != nil {
+		return shortcutForeign, fmt.Errorf("inspect %s: %w", target, err)
 	}
-	if err := os.Symlink(resolvedSource, target); err != nil {
-		return fmt.Errorf("create %s symlink: %w", target, err)
+	if info.Mode()&os.ModeSymlink == 0 {
+		return shortcutForeign, fmt.Errorf("%s already exists and is not a symlink", target)
+	}
+
+	resolvedTarget, err := resolveAbs(target)
+	if err != nil {
+		// A DANGLING link — what an upgrade leaves behind, since herdr installs
+		// each release in its own directory and removes the old one. Refusing
+		// here (the old behaviour) left the operator's `hap` command broken
+		// with no in-app way to fix it.
+		return shortcutStale, nil
+	}
+	if resolvedTarget == resolvedSource {
+		return shortcutCurrent, nil
+	}
+	// A live binary somewhere else. Supersede it only when it is recognizably
+	// a hap from a herdr plugin install (a previous version of ourselves);
+	// anything else is the operator's and stays untouched.
+	if ownedByHerdrPlugin(resolvedTarget) {
+		return shortcutStale, nil
+	}
+	return shortcutForeign, fmt.Errorf("%s already points to a different target; remove it first", target)
+}
+
+// resolveAbs canonicalizes a path through symlinks. Both callers need the
+// same two steps, and a failure in either means "cannot be resolved".
+func resolveAbs(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(resolved)
+}
+
+// ownedByHerdrPlugin reports whether path is a hap binary living inside THIS
+// machine's herdr plugin install tree — i.e. a hap we installed, safe to
+// supersede. Anchored at the real install root rather than matched as a
+// substring, so an unrelated `.../herdr/plugins/...` path elsewhere on disk
+// cannot claim to be ours.
+func ownedByHerdrPlugin(path string) bool {
+	if filepath.Base(path) != "hap" {
+		return false
+	}
+	root := selfpath.PluginInstallRoot()
+	if root == "" {
+		return false
+	}
+	// path arrives resolved (the caller EvalSymlinks'd it); resolve the root
+	// the same way where it exists, so a symlinked config home still matches.
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// ensureExecutableSymlink points target at source. Re-running is successful
+// when target already resolves to source; a stale link left by an upgrade is
+// repointed; an unrelated file, or a link to someone else's live binary, is
+// left untouched and reported.
+func ensureExecutableSymlink(source, target string) error {
+	state, err := classifyShortcut(source, target)
+	if err != nil {
+		return err
+	}
+	resolvedSource, err := resolveAbs(source)
+	if err != nil {
+		return fmt.Errorf("resolve symlink source %s: %w", source, err)
+	}
+
+	switch state {
+	case shortcutCurrent:
+		return nil
+	case shortcutAbsent:
+		if err := os.Symlink(resolvedSource, target); err != nil {
+			return fmt.Errorf("create %s symlink: %w", target, err)
+		}
+		return nil
+	case shortcutStale:
+		return repointSymlink(resolvedSource, target)
+	}
+	// classifyShortcut always pairs shortcutForeign with an error, which the
+	// guard above returned; keep a message rather than silently succeeding.
+	return fmt.Errorf("%s cannot be updated", target)
+}
+
+// repointSymlink replaces target atomically, so a concurrent `hap` in another
+// shell never observes the path missing. The temp link sits in the same
+// directory because rename cannot cross filesystems.
+func repointSymlink(source, target string) error {
+	tmp := target + ".hap-tmp"
+	// A leftover temp link from an interrupted repoint would fail Symlink.
+	if err := os.Remove(tmp); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("clear stale temp link %s: %w", tmp, err)
+	}
+	if err := os.Symlink(source, tmp); err != nil {
+		return fmt.Errorf("create replacement symlink for %s: %w", target, err)
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("repoint %s: %w", target, err)
 	}
 	return nil
 }

--- a/internal/tui/shortcut_test.go
+++ b/internal/tui/shortcut_test.go
@@ -24,7 +24,9 @@ func TestConfigQuickShortcutsSectionIsLast(t *testing.T) {
 	view := m.View()
 
 	header := strings.LastIndex(view, "Quick Shortcuts")
-	row := strings.LastIndex(view, "Create /usr/local/bin/hap symlink to this running binary")
+	// The row's verb depends on what /usr/local/bin/hap currently holds
+	// (create / repoint / recreate), so match the part that never changes.
+	row := strings.LastIndex(view, "/usr/local/bin/hap symlink")
 	if header < 0 || row < header {
 		t.Fatalf("Quick Shortcuts section or install row missing:\n%s", view)
 	}
@@ -79,7 +81,7 @@ func TestConfigShortcutYesAndDefaultEnterExecute(t *testing.T) {
 				t.Fatal("install command must remain asynchronous until Bubble Tea runs it")
 			}
 			msg, ok := cmd().(actionResultMsg)
-			if !ok || msg.err != nil || msg.message != "created /usr/local/bin/hap symlink" {
+			if !ok || msg.err != nil || !strings.Contains(msg.message, "/usr/local/bin/hap symlink") {
 				t.Fatalf("unexpected shortcut result: %+v", msg)
 			}
 			if runs != 1 || m.confirm != nil {
@@ -170,5 +172,184 @@ func TestEnsureExecutableSymlinkRefusesDifferentLink(t *testing.T) {
 	linked, readErr := os.Readlink(target)
 	if readErr != nil || linked != other {
 		t.Fatalf("existing symlink was changed: target=%q err=%v", linked, readErr)
+	}
+}
+
+// A plugin upgrade installs the new release in a new directory and removes the
+// old one, leaving this shortcut dangling. Refusing to touch it (the original
+// behaviour) left the operator's `hap` command permanently broken with no
+// in-app remedy, so a dead link is now repointed.
+func TestEnsureExecutableSymlinkRepointsDanglingLink(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "new-install", "bin", "hap")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "hap")
+	if err := os.Symlink(filepath.Join(dir, "removed-install", "bin", "hap"), target); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureExecutableSymlink(source, target); err != nil {
+		t.Fatalf("dangling link should be repointed, got %v", err)
+	}
+	linked, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatalf("repointed link does not resolve: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linked != want {
+		t.Fatalf("symlink resolves to %q, want the running binary %q", linked, want)
+	}
+}
+
+// An upgrade can also leave the link pointing at a still-present OLD plugin
+// install. That is a hap we put there, so it is superseded — unlike an
+// unrelated binary, which the refusal test above protects.
+func TestEnsureExecutableSymlinkRepointsPreviousPluginInstall(t *testing.T) {
+	dir := t.TempDir()
+	// Ownership is anchored at THIS machine's install root, so the test has to
+	// place its fake installs inside it.
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	source := filepath.Join(dir, "config", "herdr", "plugins", "github", "herd-auto-prompter-0.4.51", "bin", "hap")
+	old := filepath.Join(dir, "config", "herdr", "plugins", "github", "herd-auto-prompter-0.4.50", "bin", "hap")
+	for _, path := range []string{source, old} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("binary"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	target := filepath.Join(dir, "hap")
+	if err := os.Symlink(old, target); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureExecutableSymlink(source, target); err != nil {
+		t.Fatalf("link to a previous plugin install should be repointed, got %v", err)
+	}
+	linked, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linked != want {
+		t.Fatalf("symlink resolves to %q, want %q", linked, want)
+	}
+}
+
+// The repoint must never leave the path empty: a shell resolving `hap` while
+// it happens has to see either the old link or the new one.
+func TestRepointSymlinkIsAtomic(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "hap-new")
+	if err := os.WriteFile(source, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "hap")
+	if err := os.Symlink(filepath.Join(dir, "gone"), target); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- repointSymlink(source, target) }()
+	// Poll Lstat throughout: rename(2) replaces the entry in one step, so the
+	// name must resolve at every observation.
+	for {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("repointSymlink: %v", err)
+			}
+			if _, err := os.Lstat(target); err != nil {
+				t.Fatalf("target missing after repoint: %v", err)
+			}
+			return
+		default:
+			if _, err := os.Lstat(target); err != nil {
+				t.Fatalf("target disappeared mid-repoint: %v", err)
+			}
+		}
+	}
+}
+
+func TestClassifyShortcut(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "hap-current")
+	other := filepath.Join(dir, "hap-other")
+	for _, path := range []string{source, other} {
+		if err := os.WriteFile(path, []byte("binary"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	link := func(t *testing.T, name, dest string) string {
+		t.Helper()
+		path := filepath.Join(dir, name)
+		if err := os.Symlink(dest, path); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	plainFile := filepath.Join(dir, "not-a-link")
+	if err := os.WriteFile(plainFile, []byte("keep me"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		target  string
+		want    shortcutState
+		wantErr bool
+	}{
+		{"absent", filepath.Join(dir, "nothing-here"), shortcutAbsent, false},
+		{"already ours", link(t, "current-link", source), shortcutCurrent, false},
+		{"dangling", link(t, "dead-link", filepath.Join(dir, "removed")), shortcutStale, false},
+		{"live foreign binary", link(t, "foreign-link", other), shortcutForeign, true},
+		{"regular file", plainFile, shortcutForeign, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := classifyShortcut(source, tt.target)
+			if got != tt.want {
+				t.Errorf("classifyShortcut = %v, want %v", got, tt.want)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("classifyShortcut err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestShortcutLabelsMatchState(t *testing.T) {
+	tests := []struct {
+		state      shortcutState
+		wantLabel  string
+		wantResult string
+	}{
+		{shortcutAbsent, "Create", "created"},
+		{shortcutCurrent, "Recreate", "created"},
+		{shortcutStale, "Repoint", "repointed"},
+		{shortcutForeign, "Create", "created"},
+	}
+	for _, tt := range tests {
+		if got := shortcutLabel(tt.state); !strings.HasPrefix(got, tt.wantLabel) {
+			t.Errorf("shortcutLabel(%v) = %q, want it to start with %q", tt.state, got, tt.wantLabel)
+		}
+		if got := shortcutResult(tt.state); !strings.HasPrefix(got, tt.wantResult) {
+			t.Errorf("shortcutResult(%v) = %q, want it to start with %q", tt.state, got, tt.wantResult)
+		}
+		if got := shortcutConfirm(tt.state); !strings.HasSuffix(got, "[Y/n]") {
+			t.Errorf("shortcutConfirm(%v) = %q, want a Y/n prompt", tt.state, got)
+		}
 	}
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1084,7 +1084,7 @@ func buildRuleItems(cfg config.Config) []ruleItem {
 	items = append(items, ruleItem{
 		kind:  "shortcut",
 		key:   "install-hap",
-		label: "Create /usr/local/bin/hap symlink to this running binary",
+		label: shortcutLabel(hapShortcutState()),
 	})
 	return items
 }
@@ -3863,15 +3863,18 @@ func (m Model) activateSelectedConfig() (tea.Model, tea.Cmd) {
 	if install == nil {
 		install = installHAPShortcut
 	}
+	// Read the state once, here, so the prompt and the result message agree
+	// with each other and with the row the operator selected.
+	state := hapShortcutState()
 	m.message = ""
 	m.confirm = &confirmation{
-		label: "Create /usr/local/bin/hap symlink to the currently running hap binary? [Y/n]",
+		label: shortcutConfirm(state),
 		onConfirm: func() tea.Cmd {
 			return func() tea.Msg {
 				if err := install(); err != nil {
 					return actionResultMsg{err: err}
 				}
-				return actionResultMsg{message: "created /usr/local/bin/hap symlink"}
+				return actionResultMsg{message: shortcutResult(state)}
 			}
 		},
 	}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -106,3 +106,24 @@ else
   echo "warning: embedding model download failed; semantic matching will fall back to text search" >&2
   echo "         retry later with: bash scripts/install.sh" >&2
 fi
+
+# Hand a RUNNING daemon over to the binary we just installed. An upgrade puts
+# the new release in a new directory and unlinks the old one, but the live
+# daemon keeps running from the removed path — and every child it spawns from
+# there (the MCP server the LLM CLI launches, the embed worker) then fails, so
+# consults silently come back empty. Without this the swap waited for herdr's
+# next pane.agent_detected / workspace.created event, which may be hours away.
+#
+# --replace-only never STARTS a daemon: a fresh install (and any CI run of this
+# script) must not bring one up as a side effect of building the plugin.
+#
+# This runs inside herdr's [[build]] step, so herdr may not have registered the
+# new plugin directory yet — which is fine: the daemon we start is spawned from
+# THIS binary's own path (it exists, so hap's self-resolution never reaches the
+# registry lookup). Best-effort — a plugin install must not fail because the
+# handover did not take; `hap daemon --ensure` still fixes it.
+if "./${DEST}" daemon --ensure --replace-only; then
+  echo "handed a running daemon over to the new binary (if one was running)"
+else
+  echo "note: could not hand over a running daemon; run 'hap daemon --ensure' if hap was already running" >&2
+fi


### PR DESCRIPTION
## Problem

herdr installs each plugin release into its **own** directory and unlinks the previous one. A long-lived `hap daemon` keeps running from the removed binary — and Go **strips** the `" (deleted)"` suffix procfs appends, so `os.Executable()` returns a plain path to a file that no longer exists.

The process survives that. Everything it spawns *by path* does not, silently:

| what | consequence |
|---|---|
| `{self}` in `--mcp-config` | the LLM CLI can no longer launch `hap mcp`, so it comes up with **no** `get_context`/`submit_decision` — every consult returns nothing |
| the `embed-worker` child | fails until the degrade latch trips; semantic matching falls back to BM25 |
| `embedder.PluginRoot()` | `models/` and the `lib/` rpath resolve into the removed directory |
| `/usr/local/bin/hap` | dangles — and the TUI action that exists to fix it **refused** to, because a dead link took the "points at a different target; remove it first" branch |

Nothing on disk goes stale (there is no `claude mcp add`, no `.mcp.json` writer — `{self}` is expanded at spawn time). The staleness is entirely in the **running process**, and nothing noticed it: the version in `daemon.lock` still matched, because it is *our* version.

Separately, `hap mcp` ignored SIGTERM/Ctrl+C — `Run` blocked in a stdin `Scan` the signal could not interrupt — so a killed LLM CLI left orphaned processes each holding a SQLite handle open.

## Changes

- **`internal/selfpath` (new)** — validates `os.Executable()` and, only once the binary is gone, finds the replacement: herdr registry (`herdr plugin list --json`) → install-dir glob → PATH. The fast path is one `Stat` and covers every non-upgrade call. Wired into `internal/llm` (`resolveSelf`), `internal/embedder` (worker spawn + `PluginRoot`), `cmd/hap` (`ensureDaemon`) and `internal/tui/shortcut.go`.
- **`daemon.lock` records the holder's binary path** (third line); `EnsureFresh` treats a path mismatch as stale, so a same-version install at a new path is replaced too. Two-line locks from older daemons still parse, and the comparison is skipped whenever either side is unknown.
- **The daemon watches its own binary** on the existing 10s heartbeat (`daemon.checkOwnBinary`) and hands the herd to the successor — spawned as `daemon --ensure` so it tolerates the brief lock overlap. With no successor to hand to it **stays up** and flags health instead; a failed handoff is retried, paced at one attempt per minute.
- **`Run` cancels its own derived context before the background drain.** This was a real bug the live test caught: returning on any path other than `ctx.Done` left the event subscriber looping on reconnect backoff, so the process hung forever in `shutdownBackground` still holding the lock the successor was waiting for.
- **`hap status` and the TUI banner** report `BINARY REMOVED (upgraded underneath it)` and exit non-zero — it outranks `STALE`, since a stale daemon still works whereas this one cannot run a consult at all.
- **`scripts/install.sh`** calls `daemon --ensure --replace-only` — a new flag that replaces a running daemon but **never starts one**, so the plugin build step has no side effect on a fresh install or in CI. Daemon flags are now parsed as a set with unknown flags rejected, so a typo can no longer fall through to a foreground daemon that takes the lock and blocks forever.
- **`/usr/local/bin/hap` repoints** (atomically, symlink + rename) when it dangles or points at another herdr plugin install, anchored at this machine's real install root. A regular file, or a symlink to a live binary that is not ours, is still refused. The TUI row and prompt say which it will do.
- **`hap mcp` shuts down gracefully** — frames are read on their own goroutine so the signal is observed; cancellation can only land *between* frames, and a call dispatched after a signal runs on a detached, separately-bounded context so a `submit_decision` already in flight is never lost; a closed stdout is a clean exit, not a failure.

## Testing

New coverage: `internal/selfpath` (resolution order, cache revalidation, `Missing`/`Same`), `daemonlock` (3-line round-trip, legacy 2-line parse, path-staleness table incl. the symlink and unknown-path cases), `internal/daemon` (handoff, no-successor, failed-handoff retry pacing, and the teardown regression), `cmd/hap` (the `--replace-only` gate, flag parsing), `mcpserver` (cancel, in-flight decision survives, closed stdout, grace-window scoping), `frontend`/`cli` (banner, status line, exit code).

`TestRunReturnsPromptlyAfterHandoff` was confirmed to **fail with a 20s hang** when the context fix is reverted.

Verified live against real daemons: `--replace-only` starts nothing when idle; a new install at a different path swaps the daemon; removing a running daemon's install directory triggers the handoff within ~10s with the old daemon exiting cleanly and no gap in coverage.

Full suite, `gofmt`, `go vet` and `golangci-lint` are clean; the new code is race-clean.

> One runner hit `TestAutoSendIdleSkipsBusyAndBlockedAgents` once. It passed 3/3 alone and 3/3 whole-package on this branch, and unmodified `main` (c32ca7d) failed 1/3 in the same package on a *different* test — pre-existing whole-package flakiness, not a regression.

## Docs

`README.md` (upgrade section + two new troubleshooting entries), `hap help daemon` (the new flag), and the stale-symlink gotcha in the `hap-development-local` skill.
