### PR TITLE
feat: detect Claude API server-error and overloaded banners

### DIFF
--- a/internal/classify/testdata/classifications.golden
+++ b/internal/classify/testdata/classifications.golden
@@ -11,7 +11,9 @@ choice_codex_mcq.txt status=blocked type=choice verb= options=3
 choice_library.txt status=blocked type=choice verb= options=3
 codex_idle.txt status=idle type=idle verb= options=0
 error_build.txt status=blocked type=unclassifiable verb= options=0
+error_claude_api_overloaded.txt status=blocked type=error verb= options=0
 error_claude_api_retry.txt status=blocked type=error verb= options=0
+error_claude_api_server_error.txt status=blocked type=error verb= options=0
 error_claude_interrupted.txt status=blocked type=error verb= options=0
 error_claude_limit.txt status=blocked type=error verb= options=0
 error_codex_banner.txt status=idle type=error verb= options=0

--- a/internal/classify/testdata/transcripts/error_claude_api_overloaded.txt
+++ b/internal/classify/testdata/transcripts/error_claude_api_overloaded.txt
@@ -1,0 +1,1 @@
+● API Error: 529 Overloaded. This is a server-side issue, usually temporary — try again in a moment. If it persists, check https://status.claude.com.

--- a/internal/classify/testdata/transcripts/error_claude_api_server_error.txt
+++ b/internal/classify/testdata/transcripts/error_claude_api_server_error.txt
@@ -1,0 +1,1 @@
+● API Error: Server error mid-response. The response above may be incomplete.

--- a/internal/domain/claudeerror.go
+++ b/internal/domain/claudeerror.go
@@ -23,15 +23,27 @@ var (
 	// components (for example "2m 2s" or "45s"). Horizontal whitespace keeps
 	// the match confined to the rendered status line.
 	claudeAPIResponseRetryRE = regexp.MustCompile(`(?i)waiting[ \t]+for[ \t]+api[ \t]+response[ \t]*·[ \t]*will[ \t]+retry[ \t]+in[ \t]+(?:\d+[hms][ \t]*)+·[ \t]*check[ \t]+your[ \t]+network\b`)
+	// claudeAPIServerErrorRE matches Claude Code's transient mid-response
+	// server error banner ("API Error: Server error mid-response...").
+	// Horizontal whitespace keeps the match confined to the rendered banner
+	// line, same as claudeAPIResponseRetryRE above.
+	claudeAPIServerErrorRE = regexp.MustCompile(`(?i)api error:[ \t]*server error mid-response`)
+	// claudeAPIOverloadedRE matches Claude Code's overloaded-server banner
+	// ("API Error: 529 Overloaded..."). The status code is generalized (\d+)
+	// since Anthropic may surface other codes for the same overloaded
+	// condition, not just 529.
+	claudeAPIOverloadedRE = regexp.MustCompile(`(?i)api error:[ \t]*\d+[ \t]+overloaded\b`)
 )
 
 // Stable ErrorSummary labels for Claude's built-in error forms — used as the
 // error signature (`error:<kind>`) so paraphrased instances (different reset
 // times, preceding narration) dedup to one learned signature.
 const (
-	ClaudeErrorLimit       = "usage-limit"
-	ClaudeErrorInterrupted = "interrupted"
-	ClaudeErrorAPIRetry    = "api-response-retry"
+	ClaudeErrorLimit          = "usage-limit"
+	ClaudeErrorInterrupted    = "interrupted"
+	ClaudeErrorAPIRetry       = "api-response-retry"
+	ClaudeErrorAPIServerError = "api-server-error"
+	ClaudeErrorAPIOverloaded  = "api-overloaded"
 )
 
 // ClaudeErrorForm reports whether pane content shows one of Claude Code's
@@ -46,6 +58,10 @@ func ClaudeErrorForm(pane string) (kind string, ok bool) {
 		return ClaudeErrorInterrupted, true
 	case claudeAPIResponseRetryRE.MatchString(pane):
 		return ClaudeErrorAPIRetry, true
+	case claudeAPIServerErrorRE.MatchString(pane):
+		return ClaudeErrorAPIServerError, true
+	case claudeAPIOverloadedRE.MatchString(pane):
+		return ClaudeErrorAPIOverloaded, true
 	}
 	return "", false
 }

--- a/internal/domain/claudeerror_test.go
+++ b/internal/domain/claudeerror_test.go
@@ -15,6 +15,9 @@ func TestClaudeErrorForm(t *testing.T) {
 		{"interrupted prompt", "⎿  Interrupted · What should Claude do instead?\n", true},
 		{"api retry minutes and seconds", "✻ Waiting for API response · will retry in 2m 2s · check your network\n", true},
 		{"api retry seconds", "✽  waiting for api response · will retry in 45s · check your network\n", true},
+		{"api server error mid-response", "● API Error: Server error mid-response. The response above may be incomplete.\n", true},
+		{"api overloaded", "● API Error: 529 Overloaded. This is a server-side issue, usually temporary — try again in a moment. If it persists, check https://status.claude.com.\n", true},
+		{"api overloaded other code", "● API Error: 503 Overloaded. Try again shortly.\n", true},
 		// Ordinary error-shaped narration must NOT match (the whole point of
 		// the tightening).
 		{"narrated build failure", "ERROR: build failed with exit code 1\nThe build failed. Retry, skip, or abort?\n", false},
@@ -22,6 +25,7 @@ func TestClaudeErrorForm(t *testing.T) {
 		{"narrated interrupt word", "the download was interrupted midway and resumed\n", false},
 		{"narrated network retry", "Waiting for an API response; I will retry after checking your network.\n", false},
 		{"retry without network warning", "Waiting for API response · will retry in 2m 2s\n", false},
+		{"narrated api error mention", "there was an API error in the code, let me fix it\n", false},
 		{"empty", "", false},
 	}
 	for _, tc := range cases {
@@ -46,5 +50,11 @@ func TestClaudeErrorFormKind(t *testing.T) {
 	}
 	if kind, _ := ClaudeErrorForm("Waiting for API response · will retry in 2m 2s · check your network\n"); kind != ClaudeErrorAPIRetry {
 		t.Errorf("API retry kind = %q, want %q", kind, ClaudeErrorAPIRetry)
+	}
+	if kind, _ := ClaudeErrorForm("API Error: Server error mid-response. The response above may be incomplete.\n"); kind != ClaudeErrorAPIServerError {
+		t.Errorf("API server error kind = %q, want %q", kind, ClaudeErrorAPIServerError)
+	}
+	if kind, _ := ClaudeErrorForm("API Error: 529 Overloaded. This is a server-side issue, usually temporary.\n"); kind != ClaudeErrorAPIOverloaded {
+		t.Errorf("API overloaded kind = %q, want %q", kind, ClaudeErrorAPIOverloaded)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds two new blocking error kinds to `domain.ClaudeErrorForm`: `api-server-error` ("API Error: Server error mid-response...") and `api-overloaded` ("API Error: NNN Overloaded...", status code generalized beyond 529) — samples captured in `claude_error.log` at the repo root.
- No changes needed to `internal/classify/classify.go`: the existing `AgentType: "claude", Situation: "error", Regex: nil` rule already defers entirely to `domain.ClaudeErrorForm`.
- Both new regexes use horizontal-whitespace-only matching (`[ \t]`) to stay confined to their rendered banner line, consistent with the existing `claudeAPIResponseRetryRE` in the same file.

## Test plan
- [x] `go test ./internal/domain/... ./internal/classify/... -v -count=1` — new cases pass, golden fixtures regenerated and reviewed
- [x] `go test ./... -count=1` — full untagged suite passes except one pre-existing, unrelated tag-free-build failure (`TestResolveSignatureMintsThenRemapsSemantically`, needs the `vectors` tag + FAISS)
- [x] `gofmt -l .` / `go vet ./...` clean
- [x] Reviewed via `gosu-code-reviewer` subagent; addressed all findings (whitespace-matching consistency, missing `\b` boundary, added non-529 test case)