### PR TITLE
#260 feat: show the version in the TUI header and flag a newer release

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -415,6 +415,7 @@ per-command env notes: layering is daemon env → `env_file` → `env` → the c
 | `tui.theme` | default | TUI color theme: default, dark, light, high-contrast (in the TUI Config tab, `e` on this row opens a ↑/↓ picker of the available themes) |
 | `cli.ai_agent_friendly_output` | true | append the "Next steps" footer to command output (for AI agents driving the CLI); never affects `hap help` / `--help`, which always show theirs |
 | `tui.terminal_bell` | true | ring the terminal bell (\a) on new escalations and on pauses caused by a different process |
+| `tui.disable_check_for_update` | false | turn off the GitHub release check (at most every 6h, TUI only) that puts `↑ vX.Y.Z available` in the header. it is the plugin's ONLY outbound network call; a locally built (`plugin link`) binary never checks |
 
 TUI palette colors (`tui.palette.*`) are config.toml-only — roles: `title`, `section`, `error`, `ok`, `paused`, `running`, `warn`, `help`. values are 256-color codes (`"205"`) or hex (`"#ff5faf"`).
 
@@ -973,6 +974,7 @@ hap signatures reembed
 
 - **escalations citing `not found in PATH`** — the daemon inherits herdr's environment, which can be narrower than your shell's. make sure the CLI is reachable from a non-login shell or use an absolute path in `llm.command`.
 - **upgrades not taking effect** — the daemon is a singleton that outlives binary upgrades. since v0.1.13, `hap daemon --ensure` (fired by herdr's event hooks) detects the version mismatch and replaces the old daemon automatically. `hap status` shows the running daemon's version and flags a stale one. on older versions run `pkill -f 'hap daemon'` once after upgrading.
+- **installing a newer release** — the TUI header shows `↑ vX.Y.Z available` when one exists. `hap update` installs it (it runs `herdr plugin install 0xGosu/herdr-auto-pilot --yes`), then run the `daemon --ensure` command it prints to hand the running daemon over immediately — it names the newly installed binary by absolute path when the `hap` on PATH is still the previous build (a plugin install does not repoint that symlink). this MUTATES the install — never run it unprompted. on a linked working-tree build it refuses without `--force`, because installing a release would replace that checkout.
 
 ## notes
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ and correctable.
   deploys, credential changes, …), a global pause/kill switch, a runaway-loop
   guard, and an error-retry ceiling all veto automation.
 - **Local by default** — learning data, history, and the audit log live in
-  SQLite on your machine. Hap sends no telemetry and makes no cloud call of
-  its own; an optional CLI you configure may use its provider's service.
+  SQLite on your machine. Hap sends no telemetry. Its only outbound call is a
+  version check that asks GitHub for the newest release (at most every 6h,
+  nothing about you is sent) so the TUI can flag an available update; switch it
+  off with `hap config set tui.disable_check_for_update true`. An optional CLI
+  you configure may use its provider's service.
 
 ## Quickstart
 
@@ -59,8 +62,27 @@ herdr plugin install 0xGosu/herdr-auto-pilot --yes
 
 ### Update to the latest version
 
-Re-run the install command to upgrade an existing install to the newest
-release. `--yes` skips the interactive confirmation.
+The TUI header flags a newer release next to the version
+(`Herd Auto Prompter v0.5.1 ↑ v0.5.2 available`). It learns that from a GitHub
+release check that runs at most every 6 hours while the TUI is open — the
+plugin's only outbound call, and off with
+`hap config set tui.disable_check_for_update true`. A locally built (`herdr
+plugin link`) binary never shows the hint.
+
+```sh
+hap update                                           # install the newest release
+```
+
+It prints the `daemon --ensure` command to run next. That command names the
+newly installed binary by absolute path whenever the `hap` on your PATH is
+still the previous build — a plugin install does not repoint that symlink, so
+a bare `hap daemon --ensure` could otherwise restart the version you just
+replaced.
+
+`hap update` runs the command below for you; run it directly if you prefer.
+`--yes` skips the interactive confirmation. On a linked working-tree build
+(`herdr plugin link`), `hap update` refuses without `--force` — installing a
+release there would replace your checkout.
 
 ```sh
 herdr plugin install 0xGosu/herdr-auto-pilot --yes   # download & install the latest release
@@ -963,9 +985,11 @@ adds/removes task sources (`t`/`x`), and clears learned data (`X`).
 Simple fields — numbers, booleans, and the `tui.theme` enum, including
 `llm.pane_excerpt_chars`, `llm.task_generate_timeout_seconds`,
 `embedding.model_context_window`, `safety.disable_never_auto_seed_patterns`,
-`tui.max_content_width` / `tui.max_content_height`, and `tui.terminal_bell`
+`tui.max_content_width` / `tui.max_content_height`, `tui.terminal_bell`
 (on by default — rings the terminal bell on a new escalation, and when the
-kill switch is paused by a *different* process than the TUI you're in) — edit
+kill switch is paused by a *different* process than the TUI you're in), and
+`tui.disable_check_for_update` (off by default — see *Update to the latest
+version*) — edit
 inline (`enter`) or via `hap config set <key> <value>`. Free-text fields (`llm.command`,
 `llm.command_start`, `llm.rewrite_action_fallback_template`,
 `llm.task_generate_command`,

--- a/docs/architect/herd-auto-prompter-architecture.md
+++ b/docs/architect/herd-auto-prompter-architecture.md
@@ -729,7 +729,11 @@ Exactly two tools:
   index live in the plugin's config/state dir with normal user permissions; the
   control socket is owner-only; the operator can clear/reset learned and audit
   data (`hap clear-data`). A dedicated no-egress test (`internal/privacy`) asserts
-  NFR-007.
+  NFR-007. It allows exactly ONE outbound call, by name: the TUI's release check
+  (`internal/updatecheck/fetch.go`), which asks GitHub for the newest published
+  version at most every 6h, sends nothing about the operator or their panes, and
+  is switched off by `[tui] disable_check_for_update`. Every other file importing
+  `net/http` still fails the test.
 
 ## 14. Key Design Decisions
 
@@ -847,7 +851,7 @@ the sections they gate.
 | **NFR-005** | Auditability completeness | Represent 100% of automated decisions and escalations in the audit log (1:1 action-to-record ratio); no autonomous action without a corresponding record. |
 | **NFR-005a** | Allowlist corpus regression | Maintain and CI-regression-test the irreversible-op corpus so seed patterns match 100% of it; a corpus miss fails the build. |
 | **NFR-006** | LLM fallback timeout | Bound LLM consultation by a configurable timeout; on timeout / missing / unparseable output, fail safe and escalate. |
-| **NFR-007** | Privacy / no telemetry | Keep all data local; make no outbound calls beyond the Herdr socket and the configured local LLM CLI; emit no telemetry. |
+| **NFR-007** | Privacy / no telemetry | Keep all data local; make no outbound calls beyond the Herdr socket, the configured local LLM CLI, and the opt-out GitHub release check (`internal/updatecheck`, version numbers only); emit no telemetry. |
 | **NFR-008** | Portability | Run on Linux and macOS, avoiding design that precludes a future Windows build. |
 | **NFR-009** | Control-mutation propagation | Reflect a control mutation (esp. pause/kill) issued from TUI/CLI in daemon behavior within a small bounded delay (target ≤ 1 s). |
 

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -3,6 +3,28 @@
 // which binary they belong to.
 package buildinfo
 
+import "strings"
+
 // Version is stamped by the release build
 // (-ldflags "-X github.com/0xGosu/herdr-auto-pilot/internal/buildinfo.Version=...").
 var Version = "dev"
+
+// Label renders Version for display (the TUI header).
+func Label() string { return LabelOf(Version) }
+
+// LabelOf gives a version string its customary "v" prefix ("0.5.2" → "v0.5.2").
+// A value that is already prefixed, or that is not a release version at all
+// (the "dev" default), is shown verbatim so a local build never reads "vdev".
+// An empty value renders as empty so the caller can omit it entirely; a
+// daemon's recorded lock-file version instead goes through
+// daemonlock.VersionLabel, which reports the empty case rather than hiding it.
+func LabelOf(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	if v[0] >= '0' && v[0] <= '9' {
+		return "v" + v
+	}
+	return v
+}

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,37 @@
+package buildinfo
+
+import "testing"
+
+func TestLabelOf(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare semver gets a v", "0.5.2", "v0.5.2"},
+		{"tag name already prefixed", "v0.5.2", "v0.5.2"},
+		{"unstamped default stays verbatim", "dev", "dev"},
+		{"makefile dev build stays verbatim", "dev-20260726120000", "dev-20260726120000"},
+		{"surrounding space trimmed", " 1.0.0 ", "v1.0.0"},
+		{"empty stays empty", "", ""},
+		{"blank stays empty", "   ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := LabelOf(tc.in); got != tc.want {
+				t.Errorf("LabelOf(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLabelUsesVersion keeps Label wired to the stamped package var.
+func TestLabelUsesVersion(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+
+	Version = "0.5.2"
+	if got := Label(); got != "v0.5.2" {
+		t.Errorf("Label() = %q, want %q", got, "v0.5.2")
+	}
+}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/updatecheck"
 )
 
 // The command registry is the single source of truth for dispatch, help, and
@@ -160,6 +161,31 @@ func buildCommands() {
 		},
 
 		// ---------------------------------------------------------------- Operate
+		{
+			Name:    "update",
+			Group:   groupOperate,
+			Summary: "install the newest hap release",
+			Usage:   []string{"hap update", "hap update --force"},
+			Flags: []FlagDoc{
+				{Name: "--force", Desc: "required when this binary is not a release (a `herdr plugin link` working tree): installing would replace that checkout"},
+			},
+			Details: "Runs `herdr plugin install " + updatecheck.Repo + " --yes` — the same\n" +
+				"upgrade the TUI header points at when it flags a newer version. The running\n" +
+				"daemon keeps working on the old binary until it is handed over; `hap daemon\n" +
+				"--ensure` does that immediately. The printed follow-up names the NEWLY\n" +
+				"installed binary by absolute path whenever `hap` on your PATH still resolves\n" +
+				"to the previous build, so the hand-over cannot restart the old version.\n" +
+				"The version check behind the header hint is the plugin's only outbound network\n" +
+				"call; turn it off with `hap config set tui.disable_check_for_update true`.\n" +
+				"That switch silences the TUI hint; `hap update` still asks GitHub which\n" +
+				"version it is installing, because you asked for the upgrade.",
+			Next: []Hint{
+				{Cmd: "hap daemon --ensure", Why: "hand the running daemon over to the new build now"},
+				{Cmd: "hap status", Why: "confirm the daemon is healthy on the new version"},
+			},
+			Examples: []string{"hap update"},
+			Handler:  update,
+		},
 		{
 			Name:    "status",
 			Group:   groupOperate,

--- a/internal/cli/hints_test.go
+++ b/internal/cli/hints_test.go
@@ -70,6 +70,12 @@ func TestNoCommandPrintsTwoFooters(t *testing.T) {
 		if c.Handler == nil {
 			continue
 		}
+		// `update` reinstalls the plugin over the operator's live install, so
+		// it is never swept. (runHerdrInstall also refuses under testing, so
+		// this exclusion is documentation, not the safety mechanism.)
+		if c.Name == "update" {
+			continue
+		}
 		// Bare, the "list" sub-op, and each documented example — the examples
 		// are what give the argument-taking verbs (task, task-source, rules,
 		// config, signatures) real coverage instead of an immediate usage error.

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/selfpath"
+	"github.com/0xGosu/herdr-auto-pilot/internal/updatecheck"
+)
+
+// updateTimeout bounds the reinstall. It downloads a binary, native libs, and
+// (optionally) the embedding model, so it is generous compared with the
+// 15s herdr CLI reads elsewhere.
+const updateTimeout = 15 * time.Minute
+
+// updateRunner performs the reinstall. It is a var so tests substitute a fake
+// and never invoke a real herdr.
+var updateRunner = runHerdrInstall
+
+// installedBinary and lookPath resolve which binary the operator should run
+// after the install. Vars so tests can describe an install layout without one.
+var (
+	installedBinary = selfpath.Installed
+	lookPath        = exec.LookPath
+)
+
+// herdrBin resolves the herdr binary the same way internal/herdr does:
+// HERDR_BIN_PATH, else "herdr" on PATH.
+func herdrBin() string {
+	if bin := os.Getenv("HERDR_BIN_PATH"); bin != "" {
+		return bin
+	}
+	return "herdr"
+}
+
+// updateArgs is the documented upgrade command (README "Update to the latest
+// version"): re-running install fetches and installs the newest release.
+func updateArgs() []string {
+	return []string{"plugin", "install", updatecheck.Repo, "--yes"}
+}
+
+// runHerdrInstall streams the reinstall's output to the operator, so a slow
+// download looks like progress rather than a hang.
+func runHerdrInstall(ctx context.Context, out io.Writer) error {
+	// A test must never reinstall the operator's plugin. The command registry
+	// is swept by tests that invoke every handler (see hints_test.go), and
+	// `--yes` suppresses every confirmation herdr would otherwise ask for, so
+	// this refusal is the structural guarantee — not the sweep's exclusion
+	// list, which the next registry test could forget.
+	if testing.Testing() {
+		return errors.New("refusing to install from a test")
+	}
+	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, herdrBin(), updateArgs()...)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("herdr plugin install: %w", err)
+	}
+	return nil
+}
+
+// update implements `hap update`: install the newest published release, then
+// tell the operator how to hand the running daemon over to it.
+func update(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
+	// A non-release binary is a `herdr plugin link` working tree, so installing
+	// over it REPLACES the developer's live checkout with a published release.
+	// That is the same build the header hint stays silent about; here it needs
+	// an explicit --force rather than a silent clobber.
+	if !updatecheck.IsRelease(buildinfo.Version) && !hasFlag(args, "--force") {
+		return fmt.Errorf("this build is %s, not a release — installing would replace a linked working tree; rerun as: hap update --force",
+			buildinfo.Label())
+	}
+	// Name the target up front: the install output is herdr's, not ours, so
+	// without this the operator cannot tell what version they are getting.
+	latest := latestKnownVersion(ctx, app)
+	if latest != "" {
+		fmt.Fprintf(out, "installing %s (current: %s)\n", latest, buildinfo.Label())
+	} else {
+		fmt.Fprintf(out, "installing the latest release (current: %s)\n", buildinfo.Label())
+	}
+	fmt.Fprintf(out, "running: %s %s\n", herdrBin(), strings.Join(updateArgs(), " "))
+
+	if err := updateRunner(ctx, out); err != nil {
+		return err
+	}
+	if latest != "" {
+		fmt.Fprintf(out, "\ninstalled %s\n", latest)
+	} else {
+		fmt.Fprintln(out, "\ninstall finished")
+	}
+	printEnsureStep(out)
+	return nil
+}
+
+// printEnsureStep names the binary that must run `daemon --ensure`.
+//
+// This process is the OLD build, and the operator's `hap` shortcut is a
+// symlink herdr does not repoint on install — so a bare `hap daemon --ensure`
+// can hand the daemon to the very binary the upgrade just replaced (or to one
+// that no longer exists). When the newly installed binary is discoverable and
+// is NOT what `hap` resolves to, the absolute path is printed instead.
+func printEnsureStep(out io.Writer) {
+	newBin := installedBinary()
+	if newBin == "" || sameAsPathHap(newBin) {
+		fmt.Fprintln(out, "run `hap daemon --ensure` to hand the running daemon over to the new build now")
+		return
+	}
+	fmt.Fprintf(out, "run `%s daemon --ensure` to hand the running daemon over to the new build now\n", newBin)
+	fmt.Fprintln(out, "(the full path is deliberate: `hap` on your PATH still points at the previous build)")
+}
+
+// sameAsPathHap reports whether `hap` on PATH already resolves to bin, in
+// which case the short command is safe to print.
+func sameAsPathHap(bin string) bool {
+	p, err := lookPath("hap")
+	if err != nil {
+		return false
+	}
+	return selfpath.Same(p, bin)
+}
+
+// hasFlag reports whether args carry the given flag.
+func hasFlag(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// latestKnownVersion resolves the release being installed: the cached check
+// first, then one live check. It is advisory — an unknown version only costs a
+// vaguer message, never the upgrade.
+func latestKnownVersion(ctx context.Context, app *frontend.App) string {
+	if app == nil {
+		return ""
+	}
+	if app.StateDir != "" {
+		if st, ok := updatecheck.Read(app.StateDir); ok && updatecheck.IsRelease(st.LatestVersion) {
+			return st.LatestVersion
+		}
+	}
+	status, err := app.CheckForUpdate(ctx)
+	if err != nil {
+		return ""
+	}
+	return status.Latest
+}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -1,0 +1,264 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/updatecheck"
+)
+
+// stubRunner swaps the reinstall for a fake, so no test invokes a real herdr.
+func stubRunner(t *testing.T, err error) *bool {
+	t.Helper()
+	ran := false
+	orig := updateRunner
+	t.Cleanup(func() { updateRunner = orig })
+	updateRunner = func(_ context.Context, _ io.Writer) error {
+		ran = true
+		return err
+	}
+	return &ran
+}
+
+// updateTestApp gives update() a cached latest version to report.
+func updateTestApp(t *testing.T, cached string) *frontend.App {
+	t.Helper()
+	dir := t.TempDir()
+	if cached != "" {
+		st := updatecheck.State{
+			CheckedAt:     time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC),
+			LatestVersion: cached,
+		}
+		if err := updatecheck.Write(dir, st); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &frontend.App{
+		StateDir: dir,
+		FetchLatestVersion: func(context.Context) (string, error) {
+			return "", errors.New("no network in tests")
+		},
+	}
+}
+
+// stampRelease makes this binary look like a published release, which is what
+// `hap update` requires before it will install anything.
+func stampRelease(t *testing.T, v string) {
+	t.Helper()
+	orig := buildinfo.Version
+	t.Cleanup(func() { buildinfo.Version = orig })
+	buildinfo.Version = v
+}
+
+func TestUpdateRunsInstallAndPointsAtEnsure(t *testing.T) {
+	stampRelease(t, "v0.5.1")
+
+	ran := stubRunner(t, nil)
+	var out bytes.Buffer
+	if err := update(context.Background(), updateTestApp(t, "v0.5.2"), &out, nil); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !*ran {
+		t.Fatal("update did not run the installer")
+	}
+	got := out.String()
+	for _, want := range []string{
+		"v0.5.2",              // the version being installed
+		"v0.5.1",              // the version being replaced
+		"plugin install",      // the documented upgrade command
+		updatecheck.Repo,      // ...aimed at this project
+		"hap daemon --ensure", // the hand-over follow-up
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestUpdateInstallFailureSurfaces keeps a failed reinstall from reading as a
+// success — the operator must not be told to hand a daemon over to nothing.
+func TestUpdateInstallFailureSurfaces(t *testing.T) {
+	stampRelease(t, "v0.5.1")
+	stubRunner(t, errors.New("install exploded"))
+	var out bytes.Buffer
+	err := update(context.Background(), updateTestApp(t, "v0.5.2"), &out, nil)
+	if err == nil {
+		t.Fatal("expected the install error to propagate")
+	}
+	if strings.Contains(out.String(), "hap daemon --ensure") {
+		t.Errorf("failed install still printed the hand-over step:\n%s", out.String())
+	}
+}
+
+// TestUpdateWithoutKnownVersion still upgrades: an unknown latest version only
+// makes the message vaguer, it never blocks the install.
+func TestUpdateWithoutKnownVersion(t *testing.T) {
+	stampRelease(t, "v0.5.1")
+	ran := stubRunner(t, nil)
+	var out bytes.Buffer
+	if err := update(context.Background(), updateTestApp(t, ""), &out, nil); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !*ran {
+		t.Fatal("update did not run the installer")
+	}
+	if !strings.Contains(out.String(), "hap daemon --ensure") {
+		t.Errorf("output missing the hand-over step:\n%s", out.String())
+	}
+}
+
+// TestUpdateRefusesOnDevBuildWithoutForce protects the `herdr plugin link`
+// working tree: installing a release over it would replace the checkout the
+// developer is running from.
+func TestUpdateRefusesOnDevBuildWithoutForce(t *testing.T) {
+	for _, version := range []string{"dev", "dev-20260726120000"} {
+		t.Run(version, func(t *testing.T) {
+			stampRelease(t, version)
+			ran := stubRunner(t, nil)
+			var out bytes.Buffer
+
+			err := update(context.Background(), updateTestApp(t, "v0.5.2"), &out, nil)
+			if err == nil {
+				t.Fatal("expected a refusal on a non-release build")
+			}
+			if *ran {
+				t.Fatal("refused but still ran the installer")
+			}
+			if !strings.Contains(err.Error(), "--force") {
+				t.Errorf("refusal does not name the escape hatch: %v", err)
+			}
+
+			// --force is the operator saying they mean it.
+			if err := update(context.Background(), updateTestApp(t, "v0.5.2"), &out, []string{"--force"}); err != nil {
+				t.Fatalf("update --force: %v", err)
+			}
+			if !*ran {
+				t.Error("--force did not run the installer")
+			}
+		})
+	}
+}
+
+// TestRunHerdrInstallRefusesUnderTest is the structural guarantee that no unit
+// test — in ANY package, including a future registry sweep — can reinstall the
+// operator's live plugin.
+func TestRunHerdrInstallRefusesUnderTest(t *testing.T) {
+	var out bytes.Buffer
+	if err := runHerdrInstall(context.Background(), &out); err == nil {
+		t.Fatal("runHerdrInstall must refuse to execute under `go test`")
+	}
+	if out.Len() != 0 {
+		t.Errorf("refusal still produced output: %q", out.String())
+	}
+}
+
+// stubBinaries describes the install layout the follow-up step is computed
+// from: what herdr now reports as installed, and what `hap` on PATH resolves
+// to. Empty strings mean "not discoverable".
+func stubBinaries(t *testing.T, installed, onPath string) {
+	t.Helper()
+	origInstalled, origLook := installedBinary, lookPath
+	t.Cleanup(func() { installedBinary, lookPath = origInstalled, origLook })
+	installedBinary = func() string { return installed }
+	lookPath = func(string) (string, error) {
+		if onPath == "" {
+			return "", errors.New("hap not on PATH")
+		}
+		return onPath, nil
+	}
+}
+
+// TestUpdatePointsEnsureAtTheNewBinary is the whole point of the follow-up
+// line: this process is the OLD build and the `hap` shortcut is not repointed
+// by an install, so a bare `hap daemon --ensure` can hand the daemon straight
+// back to the binary that was just replaced.
+func TestUpdatePointsEnsureAtTheNewBinary(t *testing.T) {
+	stampRelease(t, "v0.5.1")
+	stubRunner(t, nil)
+
+	newBin := filepath.Join(t.TempDir(), "new", "bin", "hap")
+	oldBin := filepath.Join(t.TempDir(), "old", "bin", "hap")
+	stubBinaries(t, newBin, oldBin)
+
+	var out bytes.Buffer
+	if err := update(context.Background(), updateTestApp(t, "v0.5.2"), &out, nil); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, newBin+" daemon --ensure") {
+		t.Errorf("follow-up step does not name the newly installed binary:\n%s", got)
+	}
+	if strings.Contains(got, "`hap daemon --ensure`") {
+		t.Errorf("follow-up step still offers the stale PATH binary:\n%s", got)
+	}
+	if !strings.Contains(got, "PATH") {
+		t.Errorf("output does not explain why the full path is used:\n%s", got)
+	}
+}
+
+// TestUpdateEnsureStepFallsBackToPlainCommand keeps the message readable when
+// the absolute path adds nothing: PATH already resolves to the new binary, or
+// no install dir can be discovered at all.
+func TestUpdateEnsureStepFallsBackToPlainCommand(t *testing.T) {
+	shared := filepath.Join(t.TempDir(), "bin", "hap")
+	if err := os.MkdirAll(filepath.Dir(shared), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shared, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name      string
+		installed string
+		onPath    string
+	}{
+		{"PATH already points at the new binary", shared, shared},
+		{"no install dir discoverable", "", "/usr/local/bin/hap"},
+		{"nothing discoverable at all", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stampRelease(t, "v0.5.1")
+			stubRunner(t, nil)
+			stubBinaries(t, tc.installed, tc.onPath)
+
+			var out bytes.Buffer
+			if err := update(context.Background(), updateTestApp(t, "v0.5.2"), &out, nil); err != nil {
+				t.Fatalf("update: %v", err)
+			}
+			if !strings.Contains(out.String(), "`hap daemon --ensure`") {
+				t.Errorf("expected the plain follow-up command:\n%s", out.String())
+			}
+		})
+	}
+}
+
+// TestUpdateArgsMatchDocs pins the argv against the README's upgrade command.
+func TestUpdateArgsMatchDocs(t *testing.T) {
+	want := "plugin install " + updatecheck.Repo + " --yes"
+	if got := strings.Join(updateArgs(), " "); got != want {
+		t.Errorf("update argv = %q, want %q", got, want)
+	}
+}
+
+// TestHerdrBinHonoursEnv keeps `hap update` on the same herdr the rest of the
+// plugin talks to.
+func TestHerdrBinHonoursEnv(t *testing.T) {
+	t.Setenv("HERDR_BIN_PATH", "/opt/herdr/bin/herdr")
+	if got := herdrBin(); got != "/opt/herdr/bin/herdr" {
+		t.Errorf("herdrBin() = %q, want the HERDR_BIN_PATH value", got)
+	}
+	t.Setenv("HERDR_BIN_PATH", "")
+	if got := herdrBin(); got != "herdr" {
+		t.Errorf("herdrBin() = %q, want the PATH fallback", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -476,6 +476,10 @@ type TUI struct {
 	// because of a DIFFERENT process (another TUI instance, or `hap
 	// pause`) — not when this instance's own operator pressed "p".
 	TerminalBell bool `toml:"terminal_bell"`
+	// DisableCheckForUpdate turns off the TUI's periodic release check — the
+	// plugin's only outbound network call (NFR-007). It is named negatively so
+	// the zero value keeps the check on, the way Embedding.Disabled does.
+	DisableCheckForUpdate bool `toml:"disable_check_for_update"`
 }
 
 // CLI configures the `hap` command-line output (as opposed to the TUI).

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -297,6 +297,10 @@ type App struct {
 	// Clock overrides the wall clock used for cache expiry; nil means
 	// time.Now. Tests inject it to exercise TTL boundaries deterministically.
 	Clock func() time.Time
+	// FetchLatestVersion resolves the newest published release tag for the
+	// update check; nil means the real GitHub call (updatecheck.Latest).
+	// Tests inject it so no test ever opens a network connection.
+	FetchLatestVersion func(ctx context.Context) (string, error)
 
 	// cwdMu/cwdCache memoize pane working directories for FillAgentCwds.
 	// Without this, the TUI's 2s refresh would spawn one `herdr pane get` per
@@ -1889,6 +1893,7 @@ var ConfigFields = []ConfigFieldDef{
 	{Key: "tui.max_content_height", TUIEditable: true},
 	{Key: "tui.theme", TUIEditable: true},
 	{Key: "tui.terminal_bell", TUIEditable: true},
+	{Key: "tui.disable_check_for_update", TUIEditable: true},
 	{Key: "cli.ai_agent_friendly_output", TUIEditable: true},
 }
 
@@ -2047,6 +2052,8 @@ func FieldValue(cfg config.Config, key string) string {
 		return cfg.TUI.Theme
 	case "tui.terminal_bell":
 		return strconv.FormatBool(cfg.TUI.TerminalBell)
+	case "tui.disable_check_for_update":
+		return strconv.FormatBool(cfg.TUI.DisableCheckForUpdate)
 	case "cli.ai_agent_friendly_output":
 		return strconv.FormatBool(cfg.CLI.AIAgentFriendlyOutput)
 	}
@@ -2286,6 +2293,13 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 				return fmt.Errorf("tui.terminal_bell must be true or false, got %q", value)
 			}
 			cfg.TUI.TerminalBell = v
+			return nil
+		case "tui.disable_check_for_update":
+			v, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("tui.disable_check_for_update must be true or false, got %q", value)
+			}
+			cfg.TUI.DisableCheckForUpdate = v
 			return nil
 		case "cli.ai_agent_friendly_output":
 			v, err := strconv.ParseBool(value)

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -2316,6 +2316,7 @@ func TestConfigFieldRegistryParity(t *testing.T) {
 		"tui.max_content_height":                   "12",
 		"tui.theme":                                "dark",
 		"tui.terminal_bell":                        "true",
+		"tui.disable_check_for_update":             "true",
 		"cli.ai_agent_friendly_output":             "false",
 	}
 

--- a/internal/frontend/updatestatus.go
+++ b/internal/frontend/updatestatus.go
@@ -1,0 +1,103 @@
+package frontend
+
+import (
+	"context"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/updatecheck"
+)
+
+// UpdateStatus is what the front-ends know about a newer release. It carries
+// only what the last cached check recorded — reading it never touches the
+// network (see App.CheckForUpdate for the call that does).
+type UpdateStatus struct {
+	// Available is true when Latest is a release newer than this binary.
+	Available bool
+	// Latest is the newest published release tag ("v0.5.2"), when known.
+	Latest string
+}
+
+// Hint is the one-line operator notice, or "" when nothing is available. Same
+// shape as DaemonHealth.Banner so a front-end can render it without branching.
+func (u UpdateStatus) Hint() string {
+	if !u.Available || u.Latest == "" {
+		return ""
+	}
+	return "↑ " + u.Latest + " available"
+}
+
+// UpdateCheckEnabled reports whether the release check may run at all: the
+// operator has not disabled it, a state dir exists to cache into, and this
+// binary is a release (a linked working-tree build never nags its developer).
+func (a *App) UpdateCheckEnabled(cfg config.Config) bool {
+	return !cfg.TUI.DisableCheckForUpdate &&
+		a.StateDir != "" &&
+		updatecheck.IsRelease(buildinfo.Version)
+}
+
+// UpdateStatus reports a newer release from the cached check. It reads one
+// local file, never errors, and never reaches the network, so front-ends can
+// call it on every refresh.
+func (a *App) UpdateStatus(cfg config.Config) UpdateStatus {
+	if !a.UpdateCheckEnabled(cfg) {
+		return UpdateStatus{}
+	}
+	st, ok := updatecheck.Read(a.StateDir)
+	if !ok || !updatecheck.IsNewer(buildinfo.Version, st.LatestVersion) {
+		return UpdateStatus{}
+	}
+	return UpdateStatus{Available: true, Latest: st.LatestVersion}
+}
+
+// UpdateCheckDue reports whether a fresh fetch is warranted — the check is
+// enabled and the cached result has aged out.
+func (a *App) UpdateCheckDue(cfg config.Config) bool {
+	if !a.UpdateCheckEnabled(cfg) {
+		return false
+	}
+	st, _ := updatecheck.Read(a.StateDir)
+	return updatecheck.Due(st, a.now(), updatecheck.TTL)
+}
+
+// fetchLatest resolves the injected fetcher, defaulting to the real one. Tests
+// set App.FetchLatestVersion so they never open a socket.
+func (a *App) fetchLatest(ctx context.Context) (string, error) {
+	if a.FetchLatestVersion != nil {
+		return a.FetchLatestVersion(ctx)
+	}
+	return updatecheck.Latest(ctx, nil)
+}
+
+// CheckForUpdate performs the release check and records the result. It is the
+// only path that reaches the network, so callers run it off the hot path (the
+// TUI fires it as a background command, `hap update` calls it directly).
+//
+// A failed fetch is recorded — not returned as a front-end error — so the
+// retry backs off instead of running on every tick; the previously known
+// version is preserved. The returned error is for callers that want to report
+// it (the CLI does); the TUI ignores it.
+func (a *App) CheckForUpdate(ctx context.Context) (UpdateStatus, error) {
+	if a.StateDir == "" {
+		return UpdateStatus{}, nil
+	}
+	prev, _ := updatecheck.Read(a.StateDir)
+	latest, err := a.fetchLatest(ctx)
+	if err != nil {
+		prev.FailedAt = a.now()
+		_ = updatecheck.Write(a.StateDir, prev)
+		return UpdateStatus{}, err
+	}
+	// A cache we cannot persist only costs a re-fetch next time, so the write
+	// error is dropped rather than failing a check that already succeeded.
+	_ = updatecheck.Write(a.StateDir, updatecheck.State{CheckedAt: a.now(), LatestVersion: latest})
+	return statusFor(latest), nil
+}
+
+// statusFor builds the status for a freshly fetched tag.
+func statusFor(latest string) UpdateStatus {
+	if !updatecheck.IsNewer(buildinfo.Version, latest) {
+		return UpdateStatus{Latest: latest}
+	}
+	return UpdateStatus{Available: true, Latest: latest}
+}

--- a/internal/frontend/updatestatus_test.go
+++ b/internal/frontend/updatestatus_test.go
@@ -1,0 +1,221 @@
+package frontend_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/updatecheck"
+)
+
+// updateApp builds an App wired for the update check: a state dir to cache
+// into, a fixed clock, and an injected fetcher so no test opens a socket.
+func updateApp(t *testing.T, latest string, fetchErr error) (*frontend.App, string, time.Time) {
+	t.Helper()
+	dir := t.TempDir()
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	app := &frontend.App{
+		StateDir: dir,
+		Clock:    func() time.Time { return now },
+		FetchLatestVersion: func(context.Context) (string, error) {
+			if fetchErr != nil {
+				return "", fetchErr
+			}
+			return latest, nil
+		},
+	}
+	return app, dir, now
+}
+
+// stampVersion pins the running binary's version for one test.
+func stampVersion(t *testing.T, v string) {
+	t.Helper()
+	orig := buildinfo.Version
+	t.Cleanup(func() { buildinfo.Version = orig })
+	buildinfo.Version = v
+}
+
+func TestUpdateStatusHint(t *testing.T) {
+	if got := (frontend.UpdateStatus{}).Hint(); got != "" {
+		t.Errorf("empty status hint = %q, want empty", got)
+	}
+	if got := (frontend.UpdateStatus{Latest: "v0.5.2"}).Hint(); got != "" {
+		t.Errorf("not-available status hint = %q, want empty", got)
+	}
+	want := "↑ v0.5.2 available"
+	if got := (frontend.UpdateStatus{Available: true, Latest: "v0.5.2"}).Hint(); got != want {
+		t.Errorf("hint = %q, want %q", got, want)
+	}
+}
+
+func TestUpdateStatusReadsCache(t *testing.T) {
+	stampVersion(t, "v0.5.1")
+	app, dir, now := updateApp(t, "", nil)
+	if err := updatecheck.Write(dir, updatecheck.State{CheckedAt: now, LatestVersion: "v0.5.2"}); err != nil {
+		t.Fatal(err)
+	}
+	got := app.UpdateStatus(config.Config{})
+	if !got.Available || got.Latest != "v0.5.2" {
+		t.Fatalf("UpdateStatus = %+v, want v0.5.2 available", got)
+	}
+}
+
+// TestUpdateStatusSuppressed covers every reason the header must stay quiet.
+func TestUpdateStatusSuppressed(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		cached  string
+		disable bool
+		noState bool
+	}{
+		{name: "disabled by config", version: "v0.5.1", cached: "v0.5.2", disable: true},
+		{name: "dev build", version: "dev", cached: "v9.9.9"},
+		{name: "makefile dev build", version: "dev-20260726120000", cached: "v9.9.9"},
+		{name: "already current", version: "v0.5.2", cached: "v0.5.2"},
+		{name: "cache is older", version: "v0.5.2", cached: "v0.5.1"},
+		{name: "no cache", version: "v0.5.1"},
+		{name: "no state dir", version: "v0.5.1", cached: "v0.5.2", noState: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stampVersion(t, tc.version)
+			app, dir, now := updateApp(t, "", nil)
+			if tc.cached != "" {
+				if err := updatecheck.Write(dir, updatecheck.State{CheckedAt: now, LatestVersion: tc.cached}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.noState {
+				app.StateDir = ""
+			}
+			var cfg config.Config
+			cfg.TUI.DisableCheckForUpdate = tc.disable
+
+			if got := app.UpdateStatus(cfg); got.Available {
+				t.Errorf("UpdateStatus = %+v, want nothing available", got)
+			}
+			if got := app.UpdateStatus(cfg).Hint(); got != "" {
+				t.Errorf("hint = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestUpdateCheckDue(t *testing.T) {
+	stampVersion(t, "v0.5.1")
+	app, dir, now := updateApp(t, "", nil)
+
+	if !app.UpdateCheckDue(config.Config{}) {
+		t.Error("a never-checked state dir must be due")
+	}
+	if err := updatecheck.Write(dir, updatecheck.State{CheckedAt: now, LatestVersion: "v0.5.2"}); err != nil {
+		t.Fatal(err)
+	}
+	if app.UpdateCheckDue(config.Config{}) {
+		t.Error("a just-checked state dir must not be due")
+	}
+	if err := updatecheck.Write(dir, updatecheck.State{CheckedAt: now.Add(-updatecheck.TTL), LatestVersion: "v0.5.2"}); err != nil {
+		t.Fatal(err)
+	}
+	if !app.UpdateCheckDue(config.Config{}) {
+		t.Error("an aged-out check must be due")
+	}
+
+	// Disabled and dev builds must never schedule a network call at all.
+	var off config.Config
+	off.TUI.DisableCheckForUpdate = true
+	if app.UpdateCheckDue(off) {
+		t.Error("a disabled check must never be due")
+	}
+	stampVersion(t, "dev")
+	if app.UpdateCheckDue(config.Config{}) {
+		t.Error("a dev build must never schedule a check")
+	}
+}
+
+func TestCheckForUpdateWritesCache(t *testing.T) {
+	stampVersion(t, "v0.5.1")
+	app, dir, now := updateApp(t, "v0.5.2", nil)
+
+	got, err := app.CheckForUpdate(context.Background())
+	if err != nil {
+		t.Fatalf("CheckForUpdate: %v", err)
+	}
+	if !got.Available || got.Latest != "v0.5.2" {
+		t.Errorf("CheckForUpdate = %+v, want v0.5.2 available", got)
+	}
+	st, ok := updatecheck.Read(dir)
+	if !ok || st.LatestVersion != "v0.5.2" || !st.CheckedAt.Equal(now) {
+		t.Errorf("cache = %+v (ok=%v), want v0.5.2 stamped at %v", st, ok, now)
+	}
+	if app.UpdateCheckDue(config.Config{}) {
+		t.Error("a fresh check must leave the next one not due")
+	}
+}
+
+// TestCheckForUpdateFailureBacksOff pins the offline path: the failure is
+// recorded (so the retry backs off) and the last known version survives.
+func TestCheckForUpdateFailureBacksOff(t *testing.T) {
+	stampVersion(t, "v0.5.1")
+	app, dir, now := updateApp(t, "", errors.New("no network"))
+	if err := updatecheck.Write(dir, updatecheck.State{
+		CheckedAt: now.Add(-48 * time.Hour), LatestVersion: "v0.5.2"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := app.CheckForUpdate(context.Background()); err == nil {
+		t.Fatal("expected the fetch error to reach the caller")
+	}
+	st, ok := updatecheck.Read(dir)
+	if !ok || !st.FailedAt.Equal(now) {
+		t.Errorf("failure was not recorded: %+v (ok=%v)", st, ok)
+	}
+	if st.LatestVersion != "v0.5.2" {
+		t.Errorf("a failed check discarded the known version: %+v", st)
+	}
+	if app.UpdateCheckDue(config.Config{}) {
+		t.Error("a failed check must back the next one off, not retry immediately")
+	}
+	// The header still reports what was last known.
+	if got := app.UpdateStatus(config.Config{}); !got.Available {
+		t.Errorf("UpdateStatus after a failed check = %+v, want the cached version", got)
+	}
+}
+
+// TestCheckForUpdateSameVersion records the result without claiming an update.
+func TestCheckForUpdateSameVersion(t *testing.T) {
+	stampVersion(t, "v0.5.2")
+	app, _, _ := updateApp(t, "v0.5.2", nil)
+
+	got, err := app.CheckForUpdate(context.Background())
+	if err != nil {
+		t.Fatalf("CheckForUpdate: %v", err)
+	}
+	if got.Available {
+		t.Errorf("CheckForUpdate = %+v, want nothing available", got)
+	}
+	if got.Latest != "v0.5.2" {
+		t.Errorf("latest = %q, want it recorded anyway", got.Latest)
+	}
+}
+
+// TestCheckForUpdateWithoutStateDir must not panic or fetch.
+func TestCheckForUpdateWithoutStateDir(t *testing.T) {
+	called := false
+	app := &frontend.App{FetchLatestVersion: func(context.Context) (string, error) {
+		called = true
+		return "v9.9.9", nil
+	}}
+	got, err := app.CheckForUpdate(context.Background())
+	if err != nil || got.Available {
+		t.Errorf("CheckForUpdate = %+v, %v; want a quiet no-op", got, err)
+	}
+	if called {
+		t.Error("fetched despite having nowhere to cache the result")
+	}
+}

--- a/internal/privacy/privacy_test.go
+++ b/internal/privacy/privacy_test.go
@@ -1,6 +1,9 @@
 // Package privacy holds the no-telemetry verification (NFR-007, SC-6): the
-// plugin makes no outbound network calls beyond the local Herdr socket and
-// the operator-configured local LLM CLI.
+// plugin sends no telemetry and makes no outbound network call beyond the
+// local Herdr socket, the operator-configured local LLM CLI, and ONE
+// exception — the opt-out release check in internal/updatecheck/fetch.go,
+// which asks GitHub for the newest published version and nothing else. That
+// file is allowlisted by name below; net/http from anywhere else still fails.
 package privacy
 
 import (
@@ -27,6 +30,14 @@ var forbiddenImports = map[string]string{
 // allowedNetURLFiles may import net/url for non-network purposes.
 var allowedNetURLFiles = map[string]bool{
 	"internal/store/store.go": true, // SQLite DSN query encoding
+}
+
+// allowedHTTPFiles may import net/http. Exactly one file qualifies: the
+// release check, which the operator can switch off with
+// [tui] disable_check_for_update. Keep this list at one entry — every
+// addition widens a promise the README makes to users.
+var allowedHTTPFiles = map[string]bool{
+	"internal/updatecheck/fetch.go": true, // opt-out GitHub release check
 }
 
 func TestNoTelemetryImports(t *testing.T) {
@@ -60,6 +71,9 @@ func TestNoTelemetryImports(t *testing.T) {
 				continue
 			}
 			if ip == "net/url" && allowedNetURLFiles[filepath.ToSlash(rel)] {
+				continue
+			}
+			if ip == "net/http" && allowedHTTPFiles[filepath.ToSlash(rel)] {
 				continue
 			}
 			if reason == "" {
@@ -107,6 +121,20 @@ func TestNetUsageIsLocalOnly(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestHTTPAllowlistStaysMinimal pins the egress exception to the single
+// release-check file. Widening it changes what the README promises users, so
+// it must be a deliberate edit here — never a quiet addition.
+func TestHTTPAllowlistStaysMinimal(t *testing.T) {
+	want := "internal/updatecheck/fetch.go"
+	if len(allowedHTTPFiles) != 1 || !allowedHTTPFiles[want] {
+		t.Fatalf("net/http allowlist must contain exactly %q, got %v", want, allowedHTTPFiles)
+	}
+	root := repoRoot(t)
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(want))); err != nil {
+		t.Errorf("allowlisted file is missing — drop the entry instead: %v", err)
 	}
 }
 

--- a/internal/selfpath/selfpath.go
+++ b/internal/selfpath/selfpath.go
@@ -81,6 +81,24 @@ func PluginRoot() string {
 	return filepath.Dir(filepath.Dir(exe))
 }
 
+// Installed reports the hap binary herdr's registry currently points at,
+// IGNORING the running one. Resolve deliberately prefers the running binary,
+// which is exactly wrong right after `hap update`: that process is the OLD
+// build, and so is any stale `hap` shortcut on PATH. Callers that must name
+// the freshly installed binary (so `hap daemon --ensure` hands the daemon to
+// the new version, not the one being replaced) use this instead.
+//
+// It returns "" when nothing can be discovered — a linked working tree that
+// herdr reports without an install dir, or a herdr that cannot be reached.
+func Installed() string {
+	for _, find := range []func() string{fromHerdrRegistry, fromInstallDirs} {
+		if p := find(); executable(p) {
+			return p
+		}
+	}
+	return ""
+}
+
 // Missing reports whether path no longer names an executable file. The daemon
 // polls this against the path it started from to notice its own replacement.
 func Missing(path string) bool {

--- a/internal/selfpath/selfpath_test.go
+++ b/internal/selfpath/selfpath_test.go
@@ -221,3 +221,32 @@ func TestPluginRootIsTwoLevelsAboveTheBinary(t *testing.T) {
 		t.Fatalf("PluginRoot = %q, want %q", got, root)
 	}
 }
+
+// TestInstalledIgnoresTheRunningBinary is the `hap update` contract: right
+// after an install, the running process and the operator's PATH shortcut are
+// both the OLD build, so Installed must report what herdr installed instead —
+// otherwise `hap daemon --ensure` hands the daemon back to the binary the
+// upgrade just replaced.
+func TestInstalledIgnoresTheRunningBinary(t *testing.T) {
+	dir := isolate(t)
+	plugins := filepath.Join(dir, "config", "herdr", "plugins", "github")
+	newBin := writeExe(t, filepath.Join(plugins, "herd-auto-prompter-0.5.2", "bin", "hap"))
+
+	// A PATH shortcut pointing at the previous build must not win.
+	pathBin := writeExe(t, filepath.Join(dir, "path-bin", "hap"))
+	t.Setenv("PATH", filepath.Dir(pathBin))
+
+	got := Installed()
+	if got != newBin {
+		t.Fatalf("Installed = %q, want the installed binary %q", got, newBin)
+	}
+}
+
+// TestInstalledReportsNothingWhenUndiscoverable keeps the caller's fallback
+// path honest: a linked working tree has no install dir at all.
+func TestInstalledReportsNothingWhenUndiscoverable(t *testing.T) {
+	isolate(t)
+	if got := Installed(); got != "" {
+		t.Errorf("Installed = %q, want empty when nothing is installed", got)
+	}
+}

--- a/internal/tui/header_test.go
+++ b/internal/tui/header_test.go
@@ -1,0 +1,193 @@
+package tui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+)
+
+// headerLine is the first rendered line: title + version + running state.
+func headerLine(t *testing.T, m Model) string {
+	t.Helper()
+	return strings.SplitN(m.View(), "\n", 2)[0]
+}
+
+// ansiSeq matches the SGR escapes lipgloss emits when it resolves to a color
+// profile; the header assertions compare plain text, not styling.
+var ansiSeq = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string { return ansiSeq.ReplaceAllString(s, "") }
+
+// TestHeaderShowsVersion asserts the binary version sits next to the product
+// name, so an operator can tell which build the pane is running.
+func TestHeaderShowsVersion(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{"release tag", "v0.5.2", "v0.5.2"},
+		{"bare semver", "0.5.2", "v0.5.2"},
+		{"local dev build", "dev", "dev"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := buildinfo.Version
+			t.Cleanup(func() { buildinfo.Version = orig })
+			buildinfo.Version = tc.version
+
+			line := headerLine(t, listModel(t, 4, 24))
+			if !strings.Contains(line, headerName) {
+				t.Fatalf("header lost the product name: %q", line)
+			}
+			at := strings.Index(line, tc.want)
+			if at < 0 {
+				t.Fatalf("header %q does not carry version %q", line, tc.want)
+			}
+			if at < strings.Index(line, "Prompter") {
+				t.Errorf("version must follow the name, got %q", line)
+			}
+			// The version must not displace the running/paused state.
+			if !strings.Contains(line, "running") {
+				t.Errorf("header lost the running state: %q", line)
+			}
+		})
+	}
+}
+
+// TestHeaderOmitsEmptyVersion guards the stray separator an unstamped (empty)
+// version would otherwise leave after the title.
+func TestHeaderOmitsEmptyVersion(t *testing.T) {
+	orig := buildinfo.Version
+	t.Cleanup(func() { buildinfo.Version = orig })
+
+	buildinfo.Version = "0.5.2"
+	withVersion := headerLine(t, listModel(t, 4, 24))
+
+	buildinfo.Version = ""
+	line := headerLine(t, listModel(t, 4, 24))
+	if line == withVersion {
+		t.Fatalf("empty version rendered the same header as a stamped one: %q", line)
+	}
+	if strings.Contains(line, "v0.5.2") {
+		t.Errorf("header still carries a version: %q", line)
+	}
+	// Nothing may sit between the name and the state separator.
+	if !strings.Contains(stripANSI(line), headerName+"  ●") {
+		t.Errorf("empty version must leave the header untouched, got %q", line)
+	}
+}
+
+// TestHeaderDropsVersionInNarrowPane covers the layout invariant: the header
+// is emitted unclamped, so a version that would not fit is dropped rather
+// than wrapped onto a second row.
+func TestHeaderDropsVersionInNarrowPane(t *testing.T) {
+	orig := buildinfo.Version
+	t.Cleanup(func() { buildinfo.Version = orig })
+	buildinfo.Version = "0.5.2"
+
+	m := listModel(t, 4, 24)
+	m.width = 30 // narrower than name + version + state
+	line := stripANSI(headerLine(t, m))
+	if strings.Contains(line, "v0.5.2") {
+		t.Errorf("narrow pane must drop the version, got %q", line)
+	}
+	if !strings.Contains(line, headerName) {
+		t.Errorf("narrow pane dropped the product name: %q", line)
+	}
+}
+
+// TestHeaderShowsUpdateHint covers the "newer release available" notice: it
+// follows the version, keeps the running state, and is styled apart from both.
+func TestHeaderShowsUpdateHint(t *testing.T) {
+	orig := buildinfo.Version
+	t.Cleanup(func() { buildinfo.Version = orig })
+	buildinfo.Version = "v0.5.1"
+
+	m := listModel(t, 4, 24)
+	m.data.update = frontend.UpdateStatus{Available: true, Latest: "v0.5.2"}
+	line := stripANSI(headerLine(t, m))
+
+	if !strings.Contains(line, "v0.5.1") {
+		t.Errorf("header lost the running version: %q", line)
+	}
+	hint := "↑ v0.5.2 available"
+	at := strings.Index(line, hint)
+	if at < 0 {
+		t.Fatalf("header %q does not carry %q", line, hint)
+	}
+	if at < strings.Index(line, "v0.5.1") {
+		t.Errorf("the hint must follow the version, got %q", line)
+	}
+	if !strings.Contains(line, "running") {
+		t.Errorf("the hint displaced the running state: %q", line)
+	}
+}
+
+// TestHeaderWithoutUpdateIsUnchanged pins that the common case — no newer
+// release — leaves the header exactly as it was.
+func TestHeaderWithoutUpdateIsUnchanged(t *testing.T) {
+	orig := buildinfo.Version
+	t.Cleanup(func() { buildinfo.Version = orig })
+	buildinfo.Version = "v0.5.1"
+
+	m := listModel(t, 4, 24)
+	// Latest known, but not newer: the daemon still shows nothing.
+	m.data.update = frontend.UpdateStatus{Latest: "v0.5.1"}
+	line := stripANSI(headerLine(t, m))
+	if strings.Contains(line, "available") {
+		t.Errorf("header advertised an update that is not newer: %q", line)
+	}
+}
+
+// TestNarrowPaneDropsHintBeforeVersion pins the drop ORDER: the header is
+// emitted unclamped, so when it cannot all fit, the least essential segment
+// (the hint) goes first and the version survives.
+func TestNarrowPaneDropsHintBeforeVersion(t *testing.T) {
+	orig := buildinfo.Version
+	t.Cleanup(func() { buildinfo.Version = orig })
+	buildinfo.Version = "v0.5.1"
+
+	m := listModel(t, 4, 24)
+	m.data.update = frontend.UpdateStatus{Available: true, Latest: "v0.5.2"}
+	// Wide enough for "Herd Auto Prompter v0.5.1  ● running", too narrow for
+	// the hint as well.
+	m.width = 40
+	line := stripANSI(headerLine(t, m))
+
+	if strings.Contains(line, "available") {
+		t.Errorf("narrow pane kept the hint: %q", line)
+	}
+	if !strings.Contains(line, "v0.5.1") {
+		t.Errorf("narrow pane dropped the version before the hint: %q", line)
+	}
+	if runewidth.StringWidth(line) > m.width {
+		t.Errorf("header overflows the pane (%d > %d): %q", runewidth.StringWidth(line), m.width, line)
+	}
+}
+
+// TestVersionStyleDiffersFromTitle is the "different color" contract: in every
+// theme (and after a palette override) the version must not read as part of
+// the title.
+func TestVersionStyleDiffersFromTitle(t *testing.T) {
+	for name, p := range themes {
+		st := newStyles(p)
+		if st.version.GetForeground() == st.title.GetForeground() {
+			t.Errorf("theme %q: version color %q equals title color %q", name, p.section, p.title)
+		}
+	}
+
+	// A section override must reach the version style (it shares that role).
+	cfg := config.TUI{}
+	cfg.Palette.Section = "99"
+	if got := newStyles(resolvePalette(cfg)).version.GetForeground(); got != lipgloss.Color("99") {
+		t.Errorf("section override did not reach the version style: got %v", got)
+	}
+}

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -96,7 +96,11 @@ func resolvePalette(t config.TUI) palette {
 // styles are the concrete lipgloss styles the views render with, all
 // derived from one palette (CR-020, CR-024, CR-026).
 type styles struct {
-	title       lipgloss.Style
+	title lipgloss.Style
+	// version renders the build version beside the header title; it borrows
+	// the section role so every theme keeps it distinct from title, and it
+	// stays non-bold to read as secondary.
+	version     lipgloss.Style
 	activeTab   lipgloss.Style
 	inactiveTab lipgloss.Style
 	paused      lipgloss.Style
@@ -116,6 +120,7 @@ func newStyles(p palette) styles {
 	}
 	return styles{
 		title:       lipgloss.NewStyle().Bold(true).Foreground(p.title),
+		version:     lipgloss.NewStyle().Foreground(p.section),
 		activeTab:   lipgloss.NewStyle().Bold(true).Underline(true),
 		inactiveTab: lipgloss.NewStyle().Faint(true),
 		paused:      lipgloss.NewStyle().Bold(true).Foreground(p.paused),

--- a/internal/tui/palette_test.go
+++ b/internal/tui/palette_test.go
@@ -141,6 +141,7 @@ func TestPaletteNewStylesWiresPalette(t *testing.T) {
 	}{
 		{"title", sa.title, a.title},
 		{"section", sa.section, a.section},
+		{"version", sa.version, a.section}, // shares the section role
 		{"err", sa.err, a.err},
 		{"ok", sa.ok, a.ok},
 		{"paused", sa.paused, a.paused},

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -25,9 +25,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mattn/go-runewidth"
 
+	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/updatecheck"
 )
 
 type tab int
@@ -67,8 +69,18 @@ type refreshMsg struct {
 	// flight, so "l: retry LLM" is disabled while one is running (the daemon
 	// re-checks authoritatively). Populated only for retryable escalations.
 	pendingConsult map[string]bool
-	err            error
+	// update reports a newer release from the LAST CACHED check — a local file
+	// read, never a network call (updateCheckCmd does the fetch).
+	update frontend.UpdateStatus
+	// updateDue is true when that cached result has aged out, so the tick
+	// handler knows to fire a background check.
+	updateDue bool
+	err       error
 }
+
+// updateCheckedMsg reports that a background release check finished; the
+// result itself is read back from the cache on the next refresh.
+type updateCheckedMsg struct{}
 
 // sigDetailMsg carries an asynchronously loaded signature detail.
 type sigDetailMsg struct {
@@ -546,6 +558,16 @@ type Model struct {
 	// the model's zero-valued starting state and ring for escalations or a
 	// pause that already existed before the TUI even started.
 	initialized bool
+	// updateChecking is true while a background release check is in flight, so
+	// the 2s tick fires at most one at a time.
+	updateChecking bool
+	// lastUpdateCheck is when this TUI last LAUNCHED a check. The persisted
+	// cache is the normal backoff, but it is written by the check itself: a
+	// state dir that cannot be written (read-only, full) would leave the cache
+	// permanently "due" and turn the 2s tick into a fetch loop. This in-memory
+	// floor is independent of the file, and also covers the gap between a
+	// finished check and the refresh that reports the new cache state.
+	lastUpdateCheck time.Time
 	// lastMaxEscalationID / lastPaused are the bell-diffing baseline from
 	// the last successful refresh. Deliberately not derived from m.data,
 	// since the refreshMsg handler overwrites m.data unconditionally even
@@ -1003,7 +1025,32 @@ func refreshData(ctx context.Context, app *frontend.App) refreshMsg {
 		return msg
 	}
 	msg.tasks = frontend.TaskGroups(msg.cfg)
+	// Both of these read the cached check file only — the fetch itself runs in
+	// updateCheckCmd, off this path, because refreshData runs on every tick.
+	msg.update = app.UpdateStatus(msg.cfg)
+	msg.updateDue = app.UpdateCheckDue(msg.cfg)
 	return msg
+}
+
+// updateCheckAllowed gates the background release check on all three bounds:
+// the cached result has aged out, no check is already in flight, and this TUI
+// has not launched one within the TTL regardless of what the cache says.
+func (m Model) updateCheckAllowed(now time.Time) bool {
+	if !m.data.updateDue || m.updateChecking {
+		return false
+	}
+	return m.lastUpdateCheck.IsZero() || now.Sub(m.lastUpdateCheck) >= updatecheck.TTL
+}
+
+// updateCheckCmd runs the release check in the background. Its error is
+// deliberately dropped: a failed check is recorded in the cache (which backs
+// the retry off) and must never surface as a TUI error line.
+func (m Model) updateCheckCmd() tea.Cmd {
+	app, ctx := m.app, m.ctx
+	return func() tea.Msg {
+		_, _ = app.CheckForUpdate(ctx)
+		return updateCheckedMsg{}
+	}
 }
 
 // buildRuleItems lays out the Config tab rows from the current config.
@@ -1141,6 +1188,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.lastPaused = msg.status.Paused
 			m.initialized = true
 		}
+		// A failed refresh returns before the update fields are filled, so
+		// carry the last known ones forward — the hint must not blink out of
+		// the header for every frame a store read happens to fail.
+		if msg.err != nil {
+			msg.update, msg.updateDue = m.data.update, m.data.updateDue
+		}
 		m.data = msg
 		m.items = buildRuleItems(msg.cfg)
 		// A failed refresh carries a zero config; keep the current palette
@@ -1218,7 +1271,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case openTaskSourceFieldMsg:
 		return m.openTaskSourceFieldPrompt(msg)
 	case tickMsg:
-		return m, tea.Batch(m.refresh(), tick())
+		cmds := []tea.Cmd{m.refresh(), tick()}
+		if m.updateCheckAllowed(time.Now()) {
+			m.updateChecking = true
+			m.lastUpdateCheck = time.Now()
+			cmds = append(cmds, m.updateCheckCmd())
+		}
+		return m, tea.Batch(cmds...)
+	case updateCheckedMsg:
+		m.updateChecking = false
+		// Pick the result up through the normal refresh path (it reads the
+		// cache the check just wrote).
+		return m, m.refresh()
 	case clockTickMsg:
 		// Repaint only: advance the Age clock, never re-query the store.
 		m.now = time.Time(msg)
@@ -3335,6 +3399,19 @@ func (m Model) wrapWidth() int {
 // the legacy fixed caps so even a pre-resize frame shows more than before.
 const fallbackContentWidth = 120
 
+// headerName is the product name the header line leads with.
+const headerName = "Herd Auto Prompter"
+
+// headerWidth is the pane width the header line must fit in. It deliberately
+// ignores MaxContentWidth (which narrows list rows, not the header) and only
+// falls back when the pane size has not arrived yet.
+func (m Model) headerWidth() int {
+	if m.width > 0 {
+		return m.width
+	}
+	return fallbackContentWidth
+}
+
 // contentWidth is the usable width for list rows: the full terminal width by
 // default, optionally capped by [tui] max_content_width, floored so a narrow
 // terminal stays readable.
@@ -4469,11 +4546,33 @@ func (m Model) View() string {
 	st := m.styles()
 	var b strings.Builder
 
-	state := st.running.Render("● running")
+	stateText, stateStyle := "● running", st.running
 	if m.data.status.Paused {
-		state = st.paused.Render("■ PAUSED (kill switch)")
+		stateText, stateStyle = "■ PAUSED (kill switch)", st.paused
 	}
-	fmt.Fprintf(&b, "%s  %s\n", st.title.Render("Herd Auto Prompter"), state)
+	state := stateStyle.Render(stateText)
+	// Unlike list rows the header is emitted unclamped, so a header too wide
+	// for the pane would wrap and push the body one row past the bottom,
+	// breaking the fixed header accounting in listPageSize/detailPageSize.
+	// Segments are therefore dropped, never wrapped, when the pane is too
+	// narrow: the update hint is dropped first (it is the least essential),
+	// the version second.
+	head := st.title.Render(headerName)
+	plain := headerName
+	fits := func(extra string) bool {
+		return runewidth.StringWidth(plain+extra+"  "+stateText) <= m.headerWidth()
+	}
+	if v := buildinfo.Label(); v != "" && fits(" "+v) {
+		head += " " + st.version.Render(v)
+		plain += " " + v
+	}
+	// The update hint uses warn (bold) rather than the version's color: it is
+	// an action the operator should notice, not a static fact.
+	if hint := m.data.update.Hint(); hint != "" && fits(" "+hint) {
+		head += " " + st.warn.Render(hint)
+		plain += " " + hint
+	}
+	fmt.Fprintf(&b, "%s  %s\n", head, state)
 
 	var tabs []string
 	for i, name := range tabNames {

--- a/internal/tui/updatecheck_test.go
+++ b/internal/tui/updatecheck_test.go
@@ -1,0 +1,100 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/updatecheck"
+)
+
+// TestUpdateCheckAllowedGates covers the three bounds on firing a background
+// release check. The check reaches the network, so "may it run" is the part
+// worth pinning — the header rendering is covered in header_test.go.
+func TestUpdateCheckAllowedGates(t *testing.T) {
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name      string
+		due       bool
+		checking  bool
+		lastCheck time.Time
+		want      bool
+	}{
+		{name: "due, idle, never checked", due: true, want: true},
+		{name: "not due", due: false, want: false},
+		{name: "already in flight", due: true, checking: true, want: false},
+		// The cache is the normal backoff, but it is written by the check
+		// itself: a state dir that cannot be written would leave it due
+		// forever, so the in-memory floor must also hold.
+		{name: "due but just checked in this process", due: true,
+			lastCheck: now.Add(-time.Minute), want: false},
+		{name: "due and the in-memory floor has aged out", due: true,
+			lastCheck: now.Add(-updatecheck.TTL), want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var m Model
+			m.data.updateDue = tc.due
+			m.updateChecking = tc.checking
+			m.lastUpdateCheck = tc.lastCheck
+			if got := m.updateCheckAllowed(now); got != tc.want {
+				t.Errorf("updateCheckAllowed = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTickFiresOneCheckThenBacksOff is the anti-stacking regression: the 2s
+// tick must not launch a second check while one is in flight, nor immediately
+// after one completes.
+func TestTickFiresOneCheckThenBacksOff(t *testing.T) {
+	m := listModel(t, 1, 24)
+	m.data.updateDue = true
+
+	// First tick: the check is due and nothing is in flight → it launches.
+	mm, _ := m.Update(tickMsg(time.Now()))
+	m = mm.(Model)
+	if !m.updateChecking {
+		t.Fatal("the first tick did not launch a check")
+	}
+	if m.lastUpdateCheck.IsZero() {
+		t.Error("the launch was not stamped, so the in-memory backoff cannot hold")
+	}
+
+	// Second tick while it is still running: must not launch another.
+	if m.updateCheckAllowed(time.Now()) {
+		t.Error("a check is in flight but another was allowed")
+	}
+
+	// The check completes; the flag clears, but the floor still bars a retry.
+	mm, cmd := m.Update(updateCheckedMsg{})
+	m = mm.(Model)
+	if m.updateChecking {
+		t.Error("updateChecking was not cleared when the check finished")
+	}
+	if cmd == nil {
+		t.Error("a finished check must refresh so the new cache state is read")
+	}
+	if m.updateCheckAllowed(time.Now()) {
+		t.Error("a check that just finished must not immediately re-run")
+	}
+}
+
+// TestFailedRefreshKeepsUpdateHint pins that a store/daemon read error does not
+// blink the hint out of the header — the same reason the palette is preserved.
+func TestFailedRefreshKeepsUpdateHint(t *testing.T) {
+	m := listModel(t, 1, 24)
+	m.data.update = frontend.UpdateStatus{Available: true, Latest: "v0.5.2"}
+	m.data.updateDue = true
+
+	mm, _ := m.Update(refreshMsg{err: errors.New("induced refresh failure")})
+	m = mm.(Model)
+
+	if m.data.update.Hint() == "" {
+		t.Error("a failed refresh dropped the update hint")
+	}
+	if !m.data.updateDue {
+		t.Error("a failed refresh dropped the due flag, delaying the next check")
+	}
+}

--- a/internal/updatecheck/cache.go
+++ b/internal/updatecheck/cache.go
@@ -1,0 +1,86 @@
+package updatecheck
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// FileName is the cached check record inside the state dir.
+const FileName = "update.check.json"
+
+// TTL is how long a check result (success OR failure) is reused before the
+// next fetch. A failure backs off exactly like a success so a host with no
+// network path retries at most this often instead of on every tick.
+const TTL = 6 * time.Hour
+
+// State is the persisted result of the last release check.
+type State struct {
+	// CheckedAt is when the last SUCCESSFUL fetch completed.
+	CheckedAt time.Time `json:"checked_at"`
+	// LatestVersion is the release tag that fetch reported ("v0.5.2").
+	LatestVersion string `json:"latest_version"`
+	// FailedAt is when the last fetch failed; it backs the retry off without
+	// discarding a previously known LatestVersion.
+	FailedAt time.Time `json:"failed_at,omitempty"`
+}
+
+// Path is the cache file's location in the state dir.
+func Path(stateDir string) string { return filepath.Join(stateDir, FileName) }
+
+// Write atomically persists s (temp file + rename, matching daemonhealth.Write
+// and config.Save), so a concurrent reader never sees a torn record.
+func Write(stateDir string, s State) error {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(stateDir, ".update-check-*.json")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, Path(stateDir))
+}
+
+// Read returns the persisted record and whether one was found. A missing file
+// yields ok=false with no error; so does a malformed one — a corrupt cache is
+// treated as "never checked", never as a failure.
+func Read(stateDir string) (State, bool) {
+	data, err := os.ReadFile(Path(stateDir))
+	if err != nil {
+		return State{}, false
+	}
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		return State{}, false
+	}
+	return s, true
+}
+
+// Due reports whether a fresh fetch should run: never checked, or the last
+// attempt (successful or failed) is older than ttl. A record stamped in the
+// future — a clock jump — is treated as due rather than trusted forever.
+func Due(s State, now time.Time, ttl time.Duration) bool {
+	last := s.CheckedAt
+	if s.FailedAt.After(last) {
+		last = s.FailedAt
+	}
+	if last.IsZero() {
+		return true
+	}
+	if last.After(now) {
+		return true
+	}
+	return now.Sub(last) >= ttl
+}

--- a/internal/updatecheck/cache_test.go
+++ b/internal/updatecheck/cache_test.go
@@ -1,0 +1,96 @@
+package updatecheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCacheRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := State{
+		CheckedAt:     time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC),
+		LatestVersion: "v0.5.2",
+	}
+	if err := Write(dir, want); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, ok := Read(dir)
+	if !ok {
+		t.Fatal("Read reported no record after Write")
+	}
+	if got.LatestVersion != want.LatestVersion || !got.CheckedAt.Equal(want.CheckedAt) {
+		t.Errorf("round trip = %+v, want %+v", got, want)
+	}
+}
+
+// TestWriteLeavesNoTempFiles guards the temp+rename write: a leaked temp file
+// in the state dir would accumulate on every check.
+func TestWriteLeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, State{LatestVersion: "v1.0.0"}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != FileName {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("state dir = %v, want just %q", names, FileName)
+	}
+}
+
+// TestReadMissingOrMalformed pins "no signal, never an error": a corrupt cache
+// must read as "never checked" rather than break the TUI.
+func TestReadMissingOrMalformed(t *testing.T) {
+	t.Run("missing", func(t *testing.T) {
+		if _, ok := Read(t.TempDir()); ok {
+			t.Error("Read reported a record for an empty state dir")
+		}
+	})
+	t.Run("malformed", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, FileName), []byte("{not json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := Read(dir); ok {
+			t.Error("Read accepted a malformed record")
+		}
+	})
+}
+
+func TestDue(t *testing.T) {
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		st   State
+		want bool
+	}{
+		{"never checked", State{}, true},
+		{"just checked", State{CheckedAt: now.Add(-time.Minute)}, false},
+		{"one tick short of the ttl", State{CheckedAt: now.Add(-TTL + time.Second)}, false},
+		{"exactly at the ttl", State{CheckedAt: now.Add(-TTL)}, true},
+		{"long past the ttl", State{CheckedAt: now.Add(-48 * time.Hour)}, true},
+		// A failure backs off like a success, so an offline host does not
+		// retry on every tick.
+		{"recent failure backs off", State{FailedAt: now.Add(-time.Minute)}, false},
+		{"stale failure retries", State{FailedAt: now.Add(-TTL)}, true},
+		{"failure after an old success still backs off",
+			State{CheckedAt: now.Add(-48 * time.Hour), FailedAt: now.Add(-time.Minute)}, false},
+		// A record stamped in the future (clock jump) must not pin the check
+		// off forever.
+		{"future timestamp is due", State{CheckedAt: now.Add(time.Hour)}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Due(tc.st, now, TTL); got != tc.want {
+				t.Errorf("Due(%+v) = %v, want %v", tc.st, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/updatecheck/fetch.go
+++ b/internal/updatecheck/fetch.go
@@ -1,0 +1,67 @@
+package updatecheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Repo is the GitHub project hap releases from. It also names the argument
+// `hap update` hands to `herdr plugin install`.
+const Repo = "0xGosu/herdr-auto-pilot"
+
+// latestReleaseURL is the only remote endpoint the plugin ever contacts.
+// GitHub answers it unauthenticated (rate-limited per IP), which is fine for a
+// check that runs at most once every TTL.
+const latestReleaseURL = "https://api.github.com/repos/" + Repo + "/releases/latest"
+
+// requestTimeout bounds the whole exchange. The check is a nicety, so it fails
+// fast rather than holding a goroutine open on a black-holed network.
+const requestTimeout = 5 * time.Second
+
+// maxBody caps how much of the response is read: the release payload is a few
+// KB, and a cap keeps a misbehaving endpoint from feeding the process memory.
+const maxBody = 1 << 20
+
+// DefaultClient is the client Latest uses when passed nil.
+func DefaultClient() *http.Client { return &http.Client{Timeout: requestTimeout} }
+
+// Latest reports the newest published release tag ("v0.5.2"). Every failure —
+// offline, rate-limited, malformed body — comes back as an error for the
+// caller to record and otherwise ignore; nothing here is fatal.
+func Latest(ctx context.Context, client *http.Client) (string, error) {
+	if client == nil {
+		client = DefaultClient()
+	}
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "hap-update-check")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("release check: unexpected status %s", resp.Status)
+	}
+	var payload struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxBody)).Decode(&payload); err != nil {
+		return "", fmt.Errorf("release check: %w", err)
+	}
+	if !IsRelease(payload.TagName) {
+		return "", fmt.Errorf("release check: unusable tag %q", payload.TagName)
+	}
+	return payload.TagName, nil
+}

--- a/internal/updatecheck/fetch_test.go
+++ b/internal/updatecheck/fetch_test.go
@@ -1,0 +1,117 @@
+package updatecheck
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fetchFrom points Latest at a test server. The production URL is a const, so
+// the test drives the same request-building and parsing through a client whose
+// transport rewrites the destination.
+func fetchFrom(t *testing.T, handler http.HandlerFunc) (string, error) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	client := srv.Client()
+	base := srv.URL
+	client.Transport = rewriteTransport{base: base, next: srv.Client().Transport}
+	return Latest(context.Background(), client)
+}
+
+// rewriteTransport sends every request to the test server instead of GitHub.
+type rewriteTransport struct {
+	base string
+	next http.RoundTripper
+}
+
+func (r rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	u := *req.URL
+	target, err := http.NewRequest(req.Method, r.base+u.Path, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	target.Header = req.Header
+	return r.next.RoundTrip(target.WithContext(req.Context()))
+}
+
+func TestLatestParsesTag(t *testing.T) {
+	var gotAccept string
+	tag, err := fetchFrom(t, func(w http.ResponseWriter, req *http.Request) {
+		gotAccept = req.Header.Get("Accept")
+		w.Write([]byte(`{"tag_name":"v0.5.2","name":"0.5.2"}`))
+	})
+	if err != nil {
+		t.Fatalf("Latest: %v", err)
+	}
+	if tag != "v0.5.2" {
+		t.Errorf("tag = %q, want %q", tag, "v0.5.2")
+	}
+	if gotAccept != "application/vnd.github+json" {
+		t.Errorf("Accept header = %q", gotAccept)
+	}
+}
+
+// TestLatestFailures pins that every remote misbehavior is a plain error for
+// the caller to record — never a panic, never a bogus version.
+func TestLatestFailures(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{"rate limited", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}},
+		{"server error", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}},
+		{"malformed body", func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte("<html>not json</html>"))
+		}},
+		{"missing tag", func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(`{"name":"0.5.2"}`))
+		}},
+		{"unusable tag", func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(`{"tag_name":"nightly"}`))
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tag, err := fetchFrom(t, tc.handler)
+			if err == nil {
+				t.Fatalf("expected an error, got tag %q", tag)
+			}
+			if tag != "" {
+				t.Errorf("failed fetch returned a tag: %q", tag)
+			}
+		})
+	}
+}
+
+// blockedTransport fails every request, so this test cannot reach the network
+// even if the cancellation it is checking for stops working.
+type blockedTransport struct{}
+
+func (blockedTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("network blocked in tests")
+}
+
+// TestLatestCancelledContext keeps the check from outliving its caller.
+func TestLatestCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := Latest(ctx, &http.Client{Transport: blockedTransport{}}); err == nil {
+		t.Error("expected an error for a cancelled context")
+	}
+}
+
+// TestRepoMatchesInstallTarget keeps the checked repo and the documented
+// upgrade command in sync — they must name the same project.
+func TestRepoMatchesInstallTarget(t *testing.T) {
+	if !strings.Contains(latestReleaseURL, Repo) {
+		t.Errorf("release URL %q does not target %q", latestReleaseURL, Repo)
+	}
+}

--- a/internal/updatecheck/version.go
+++ b/internal/updatecheck/version.go
@@ -1,0 +1,83 @@
+// Package updatecheck tells an operator that a newer hap release exists.
+//
+// It is split so the network stays in one place: version.go and cache.go are
+// pure logic plus local file I/O, and fetch.go is the ONLY file in the plugin
+// permitted to import net/http (see internal/privacy — NFR-007 bans egress
+// everywhere else). Every failure mode here is non-fatal: a check that cannot
+// run simply leaves the header without a hint.
+package updatecheck
+
+import (
+	"strconv"
+	"strings"
+)
+
+// parse splits a release version into its numeric components. It accepts an
+// optional "v" prefix and ignores any pre-release/build suffix, so both the
+// release tag ("v0.5.2") and a bare manifest version ("0.5.2") parse. ok is
+// false for anything that is not a release version — notably the "dev" and
+// "dev-<timestamp>" values local builds are stamped with.
+func parse(v string) (nums [3]int, ok bool) {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	if v == "" {
+		return nums, false
+	}
+	// Drop a pre-release/build suffix: 1.2.3-rc1 and 1.2.3+meta compare as 1.2.3.
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) == 0 || len(parts) > 3 {
+		return nums, false
+	}
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return nums, false
+		}
+		nums[i] = n
+	}
+	return nums, true
+}
+
+// IsRelease reports whether v names a release version (and so can be compared).
+func IsRelease(v string) bool {
+	_, ok := parse(v)
+	return ok
+}
+
+// Compare orders two release versions: -1 if a < b, 0 if equal, 1 if a > b.
+// A value that is not a release version sorts below one that is; two
+// unparseable values compare equal, which keeps callers from acting on them.
+func Compare(a, b string) int {
+	na, oka := parse(a)
+	nb, okb := parse(b)
+	switch {
+	case !oka && !okb:
+		return 0
+	case !oka:
+		return -1
+	case !okb:
+		return 1
+	}
+	for i := range na {
+		switch {
+		case na[i] < nb[i]:
+			return -1
+		case na[i] > nb[i]:
+			return 1
+		}
+	}
+	return 0
+}
+
+// IsNewer reports whether latest is a release strictly newer than current.
+// It is false whenever current is not itself a release version, so a linked
+// working-tree build ("dev", "dev-<timestamp>") never nags its developer.
+func IsNewer(current, latest string) bool {
+	if !IsRelease(current) || !IsRelease(latest) {
+		return false
+	}
+	return Compare(latest, current) > 0
+}

--- a/internal/updatecheck/version_test.go
+++ b/internal/updatecheck/version_test.go
@@ -1,0 +1,82 @@
+package updatecheck
+
+import "testing"
+
+func TestIsRelease(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"v0.5.2", true},
+		{"0.5.2", true},
+		{"1.0", true},
+		{"2", true},
+		{"v1.2.3-rc1", true},
+		{"dev", false},
+		{"dev-20260726120000", false},
+		{"", false},
+		{"   ", false},
+		{"v", false},
+		{"1.2.3.4", false},
+		{"1.x.3", false},
+		{"-1.0.0", false},
+	}
+	for _, tc := range cases {
+		if got := IsRelease(tc.in); got != tc.want {
+			t.Errorf("IsRelease(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCompare(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"v0.5.2", "v0.5.2", 0},
+		{"0.5.2", "v0.5.2", 0}, // prefix is cosmetic
+		{"v0.5.1", "v0.5.2", -1},
+		{"v0.5.2", "v0.5.1", 1},
+		{"v0.5.9", "v0.6.0", -1},
+		{"v0.9.0", "v1.0.0", -1},
+		{"v1.0.0", "v0.9.9", 1},
+		{"v1.2.3-rc1", "v1.2.3", 0}, // suffix ignored
+		{"v1.2", "v1.2.0", 0},       // missing components are zero
+		{"dev", "dev", 0},           // two unparseable values never order
+		{"dev", "v0.1.0", -1},       // a non-release sorts below a release
+		{"v0.1.0", "dev", 1},
+	}
+	for _, tc := range cases {
+		if got := Compare(tc.a, tc.b); got != tc.want {
+			t.Errorf("Compare(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+// TestIsNewer is the operator-visible contract: only a real release upgrade
+// may light the header hint.
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		name            string
+		current, latest string
+		want            bool
+	}{
+		{"patch upgrade", "v0.5.1", "v0.5.2", true},
+		{"minor upgrade", "v0.5.9", "v0.6.0", true},
+		{"same version", "v0.5.2", "v0.5.2", false},
+		{"downgrade", "v0.5.2", "v0.5.1", false},
+		{"prefix mismatch is not a change", "0.5.2", "v0.5.2", false},
+		{"dev build never nags", "dev", "v9.9.9", false},
+		{"makefile dev build never nags", "dev-20260726120000", "v9.9.9", false},
+		{"unstamped never nags", "", "v9.9.9", false},
+		{"garbage latest is ignored", "v0.5.1", "not-a-version", false},
+		{"empty latest is ignored", "v0.5.1", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsNewer(tc.current, tc.latest); got != tc.want {
+				t.Errorf("IsNewer(%q, %q) = %v, want %v", tc.current, tc.latest, got, tc.want)
+			}
+		})
+	}
+}

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -251,6 +251,9 @@ theme = ""                 # named palette: default | dark | light | high-contra
                            # empty/unknown = default (the original look)
 terminal_bell = true       # ring the terminal bell (\a) on new escalations and on
                            # pauses caused by a different process; default on
+disable_check_for_update = false  # turn off the periodic GitHub release check — the
+                           # plugin's only outbound call; the header flags a newer
+                           # release, install it with `hap update`
 
 # Optional per-role color overrides layered on the selected theme; unset
 # roles inherit the theme. Values are terminal colors ("205", "#ff5faf").


### PR DESCRIPTION
Closes #260.

The TUI header showed only the product name, so an operator could not tell which build a pane was running, and nothing told them a newer release existed.

```
Herd Auto Prompter v0.5.1 ↑ v0.5.2 available  ● running
 Agents | Tasks | Escalations | Audit | Rules | Config
```

The version uses the palette's `section` role (distinct from the title in every theme, and the existing `[tui.palette] section` override reaches it); the upgrade hint uses `warn`. Both are **dropped rather than wrapped** when the pane is too narrow — hint first, version second. The header is emitted unclamped, so a wrapped line would push the body one row past the bottom and break the fixed chrome accounting in `listPageSize`/`detailPageSize`.

## The network-call exception to the privacy guard

**This is the plugin's first outbound call**, which contradicts `README.md`'s "Hap sends no telemetry and makes no cloud call" and `internal/privacy`'s ban on `net/http` (NFR-007).

The guard is **narrowed, not removed**:

- `net/http` is allowlisted for exactly one file, `internal/updatecheck/fetch.go`. Any other file importing it still fails `TestNoTelemetryImports`.
- A new `TestHTTPAllowlistStaysMinimal` pins that list at one entry and asserts the file exists, so widening the exception has to be a deliberate edit with a visible diff.
- `README.md`, `docs/architect/…` (§13 and the NFR-007 row), and the `hap` skill now name the exception.

What it actually does: one `GET https://api.github.com/repos/0xGosu/herdr-auto-pilot/releases/latest`, at most every 6h, only while the TUI is open, sending nothing about the operator or their panes. It reads `tag_name` and nothing else, under a 5s timeout and a 1 MiB response cap. Operators switch it off with `hap config set tui.disable_check_for_update true` (negative name, so the zero value keeps it on).

## The two safety refusals

**1. No test can reinstall the operator's plugin.** `runHerdrInstall` refuses under `testing.Testing()`. This is not hypothetical: `TestNoCommandPrintsTwoFooters` sweeps the registry and invokes *every* handler three ways, so without this a plain `go test ./internal/cli/` would have run a real `herdr plugin install --yes` against the live install — with `--yes` suppressing every confirmation. The sweep also skips the verb, but the refusal is the structural guarantee: the next registry test cannot forget it.

**2. `hap update` refuses on a non-release build without `--force`.** Installing over a `herdr plugin link` working tree replaces that checkout. This is the same build the header hint stays silent about; here it needs an explicit flag rather than a silent clobber.

## `hap update` and the daemon hand-over

`hap update` runs `herdr plugin install 0xGosu/herdr-auto-pilot --yes`, then names the binary to hand the running daemon over to. That follow-up prints the **newly installed** binary by absolute path whenever `hap` on PATH still resolves to the previous build — an install does not repoint that symlink, and the update process is itself the old binary, so a bare `hap daemon --ensure` could restart the version just replaced. New `selfpath.Installed()` answers that by asking herdr's registry and *ignoring* the running executable (`Resolve` deliberately prefers it, which is exactly wrong here).

## Bounds on the background check

The fetch runs as a background `tea.Cmd`, never on the 2s refresh path, gated three ways: the cached TTL, a one-at-a-time in-flight flag, and an in-memory floor that holds **even when the cache cannot be written** — otherwise a read-only or full state dir would leave the cache permanently "due" and turn the tick into a fetch loop. Its error is dropped (a failed check must never surface as a TUI error line) and is cached like a success so an offline host backs off. The hint is carried across a failed refresh so it does not blink out of the header.

## Tests

New `internal/updatecheck` suite (comparison incl. `dev`/`dev-<ts>` never nagging, cache round-trip + malformed/missing, TTL and clock-jump boundaries, `Latest` against `httptest` covering 403/malformed/unusable-tag); frontend gating and backoff with an injected fetcher; TUI scheduling (anti-stacking, floor, failed-refresh carry-forward) and header rendering/drop-order; CLI argv, both refusals, and the ensure-path resolution; `selfpath.Installed`. **No test opens a network connection** — `App.FetchLatestVersion` and a blocked `RoundTripper` are the seams.

Full suite green on a clean serial run (27 packages, `-tags "vectors cpu"`); `gofmt`, `go vet ./...`, `golangci-lint` clean.

Patch release: the manifest version is deliberately untouched.