### PR TITLE
#1 docs: reconcile the docs with the shipped code, and fix two task-source help bugs

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -59,7 +59,7 @@ listings are tab-separated; `hap state-dir` and `hap config path` print a bare v
 
 **escalation** — when confidence is below the threshold, the plugin surfaces the situation to the operator instead of acting automatically.
 
-**never-auto patterns** — destructive operations (force-push, `rm -rf`, deploys, credential changes, etc.) are never automated regardless of confidence. the plugin ships with 38 strict seed patterns plus broader heuristic seed rules.
+**never-auto patterns** — destructive operations (force-push, `rm -rf`, deploys, credential changes, etc.) are never automated regardless of confidence. the plugin ships with 40 strict seed patterns plus broader heuristic seed rules.
 
 **signatures** — a situation signature is a fingerprint of a classified agent state (volatile data like paths, hashes, timestamps is masked). signatures start in shadow mode and graduate to autonomous after enough consistent confirmations. you can inspect, filter, and delete them via the `signatures` command (alias: `sigs`).
 
@@ -76,7 +76,7 @@ hap is not a wrapper around the coding agents; it observes and drives them from 
 **the monitor loop** — for every agent, the daemon runs this cycle:
 
 1. **subscribe** — one `events.subscribe` per socket connection to herdr's event stream; the daemon receives a status/attention event whenever an agent's pane changes (idle, waiting on a prompt, etc.). existing panes replay as `pane_created`.
-2. **capture** — on an attention event the daemon waits a short `capture_delay` (10s on an agent's first event, 500ms after) so the agent's TUI has finished painting and event bursts coalesce, then reads the pane content via the herdr CLI (`pane read --source recent` for classification, `--source visible` to recover a standing menu at confirm time).
+2. **capture** — on an attention event the daemon waits a short `capture_delay` (10s on an agent's first event, 2000ms after) so the agent's TUI has finished painting and event bursts coalesce, then reads the pane content via the herdr CLI (`pane read --source recent` for classification, `--source visible` to recover a standing menu at confirm time).
 3. **classify** — the pane text is classified into a situation type (`idle` / `approval` / `choice` / `error`), extracting options, permission verb, or error summary.
 4. **match** — volatile data (paths, hashes, timestamps) is masked and the situation is resolved to a learned signature via embedding vector search → BM25 text fallback → exact hash. a matched signature carries the operator's past decision and a confidence.
 5. **decide** — if a confident, graduated (autonomous) rule applies and passes every safety gate (kill switch, never-auto patterns, irreversible heuristic, rate/retry guards), the daemon **acts**. otherwise it **escalates** to the operator — or first **consults the local LLM** (if configured), whose suggestion is re-gated through the same safety controls.
@@ -387,7 +387,7 @@ edits made through `hap config set` / `set-threshold` apply live — the command
 | `limits.max_error_retries` | 2 | max retries per error signature |
 | `safety.disable_never_auto_seed_patterns` | false | disable every shipped strict and heuristic never-auto rule |
 | `llm.timeout_seconds` | 60 | timeout for LLM fallback calls |
-| `llm.auto_act_confidence_threshold` | 999 (never) | min LLM self-reported confidence (0-100) to auto-act on a consult decision; below it (or no score) the situation escalates with reason `[llm_low_confidence]`. 999 is unreachable = never auto-act |
+| `llm.auto_act_confidence_threshold` | 99 | min LLM self-reported confidence (0-100) to auto-act on a consult decision; below it (or no score) the situation escalates with reason `[llm_low_confidence]`. the default only auto-acts on a near-certain score; set anything above 100 (e.g. 999) to make it unreachable = never auto-act |
 | `llm.pane_excerpt_chars` | 5000 | pane excerpt size in characters for LLM consult context |
 | `llm.enable_rewrite_action` | false | have the consult LLM review/adapt learned free-text replies before delivery (see llm action review) |
 | `llm.rewrite_action_fallback_template` | `{original_text}` (original sent as-is) | optional wrapper around the original when the action review fails (placeholders: `{original_text}`, `{agent_name}`) |
@@ -410,8 +410,9 @@ per-command env notes: layering is daemon env → `env_file` → `env` → the c
 | `embedding.model_context_window` | 0 (built-in default: 512 for MiniLM) | max tokens fed to the embedder before truncation; MUST NOT exceed what the model supports (over 512 hard-aborts a BERT/MiniLM native lib). raise only when `model_path` points at a larger-window model; values below 256 clamp up |
 | `embedding.embed_timeout_ms` | 0 (built-in default: 2000) | stall guard per warm embed call. a model larger than the bundled MiniLM can exceed it on EVERY call, which latches semantic matching onto text search permanently — raise it alongside `model_path`. `hap status` reports the budgets in force and whether the failures were timeouts. values below 100 clamp up, above 600000 (10 min) clamp down |
 | `embedding.warm_timeout_ms` | 0 (built-in default: 30000) | stall guard for the FIRST call of each embed worker, which includes loading the model; raise for slow/large model loads. values below 1000 clamp up, above 600000 (10 min) clamp down |
-| `embedding.pane_salient_chars` | 800 | fallback signature window for idle/unclassified situations (trailing N chars) |
+| `embedding.pane_salient_chars` | 500 | fallback signature window for idle/unclassified situations (trailing N chars) |
 | `tui.max_content_width` | 0 (full width) | cap variable-width list columns; 0 = full width |
+| `tui.max_content_height` | 0 (full height) | cap the rows a list body may use; 0 = full height |
 | `tui.theme` | default | TUI color theme: default, dark, light, high-contrast (in the TUI Config tab, `e` on this row opens a ↑/↓ picker of the available themes) |
 | `cli.ai_agent_friendly_output` | true | append the "Next steps" footer to command output (for AI agents driving the CLI); never affects `hap help` / `--help`, which always show theirs |
 | `tui.terminal_bell` | true | ring the terminal bell (\a) on new escalations and on pauses caused by a different process |
@@ -419,9 +420,9 @@ per-command env notes: layering is daemon env → `env_file` → `env` → the c
 
 TUI palette colors (`tui.palette.*`) are config.toml-only — roles: `title`, `section`, `error`, `ok`, `paused`, `running`, `warn`, `help`. values are 256-color codes (`"205"`) or hex (`"#ff5faf"`).
 
-some settings are table-valued and live in `config.toml` only (not settable via `hap config set`): `[[capture_delay]]`, `[[task_sources]]`, `[[classifier]]`, and `[[safety.never_auto_rules]]`.
+some settings are table-valued and live in `config.toml` only (not settable via `hap config set`): `[[capture_delay]]`, `[[task_sources]]`, `[[classifier]]`, `[[safety.never_auto_rules]]`, `safety.disabled_seed_patterns` (the list `hap rules disable-seed` writes), the inline `[llm.*_env]` tables (only the `*_env_file` PATHS are settable — the tables hold secrets), and `[tui.palette]`.
 
-**capture delay** — the classification pane read waits a per-agent delay so the agent TUI has painted and event bursts coalesce. defaults: 10000ms (10s) on an agent's first event, 500ms after. override per agent type:
+**capture delay** — the classification pane read waits a per-agent delay so the agent TUI has painted and event bursts coalesce. defaults: 10000ms (10s) on an agent's first event, 2000ms after. override per agent type:
 
 ```toml
 [[capture_delay]]
@@ -450,7 +451,21 @@ remove a custom rule by index:
 hap rules remove <index>
 ```
 
-the 38 strict seed rules cover: force-push, `git reset --hard`, `rm -rf`, `sudo rm`, `DROP TABLE`, `TRUNCATE TABLE`, `DELETE FROM`, deploys to prod, `npm publish`, `terraform apply/destroy`, credential rotation, and more; broader heuristic seed rules catch suspected irreversible language. all shipped rules are active unless `safety.disable_never_auto_seed_patterns=true`. the old `safety.disable_seed` key still loads with a deprecation warning and is rewritten under the new name on the next config save.
+silence a single shipped seed rule that is too aggressive for this repo (e.g. a
+heuristic firing on a legitimate word), keeping the rest of the safety net:
+
+```bash
+hap rules list                     # take the stable `seed <id>` from the listing
+hap rules disable-seed <id>        # writes safety.disabled_seed_patterns
+hap rules enable-seed <id>         # restore it
+```
+
+the id is a short hash of the pattern, so it names the same rule across
+upgrades (and is rejected if that pattern no longer ships). one seed rule is a
+single regex that can cover several phrasings — disabling it silences all of
+them, not just the phrase you saw.
+
+the 40 strict seed rules cover: force-push, `git reset --hard`, `rm -rf`, `sudo rm`, `DROP TABLE`, `TRUNCATE TABLE`, `DELETE FROM`, deploys to prod, `npm publish`, `terraform apply/destroy`, credential rotation, and more; broader heuristic seed rules catch suspected irreversible language. all shipped rules are active unless `safety.disable_never_auto_seed_patterns=true`. the old `safety.disable_seed` key still loads with a deprecation warning and is rewritten under the new name on the next config save.
 
 the config key for custom patterns is `never_auto_patterns` (the old name `allowlist_patterns` still loads as a deprecated alias):
 
@@ -561,9 +576,8 @@ hap task-source set <index> max-tasks 40               # the refill/creation cap
 ```
 
 the *Config* tab's `enter` on a task-source row is the same edit: it opens a
-picker of the three settings, then asks for the value (the picker marks a row
-`blocked while <other>=true` when the mutually exclusive partner is on). all are
-also settable at creation time —
+picker of the three settings, then asks for the value (the three compose, so no
+row is ever blocked by another). all are also settable at creation time —
 `hap task-source add [--auto-send-when-idle] [--enable-llm-review-before-auto-send] [--max-tasks N]`,
 and the *Config* tab's `t` prompt takes the same words:
 `<path> [agent] [workspace] [--auto-send-when-idle] [--enable-llm-review-before-auto-send] [--max-tasks N]`
@@ -647,6 +661,10 @@ hap task backend-dev done 2                # tick item 2 off ([x])
 hap task backend-dev undone 2              # re-open item 2 ([ ])
 hap task backend-dev update 2 "new text"   # edit text, keep status
 hap task backend-dev remove 2              # delete item 2
+hap task backend-dev move 5 2              # reorder: put item 5 at position 2
+hap task backend-dev move 5 up             # or: up | down (one step)
+#   a task moves together with its indented detail lines and nested sub-tasks,
+#   and reorders only among its own siblings.
 hap task backend-dev send 3 [--yes]        # deliver pending item 3 to the live
 #   agent NOW (y/N confirmation unless --yes). only a pending [ ] item on a
 #   cleanly idle agent qualifies — idleness is re-checked at the moment of
@@ -775,7 +793,7 @@ command = [
   "--allowedTools", "mcp__hap__get_context,mcp__hap__submit_decision",
 ]
 timeout_seconds = 120
-auto_act_confidence_threshold = 999   # 0-100; 999 = never auto-act (default). needs an LLM CLI that reports a confidence score
+auto_act_confidence_threshold = 99    # 0-100, default 99; >100 (e.g. 999) = never auto-act. needs an LLM CLI that reports a confidence score
 pane_excerpt_chars = 5000
 ```
 
@@ -837,7 +855,7 @@ command       = ["claude", "-p", "...", "--model", "haiku"]
 command_start = ["claude", "-p", "...", "--model", "opus"]   # first consult per agent only
 ```
 
-every LLM suggestion is re-gated through the never-auto patterns, kill switch, and rate guards. the LLM may act automatically only when its self-reported confidence score meets `auto_act_confidence_threshold` (0-100; default 999 = never) AND the action doesn't contradict learned history; below the threshold, with no reported score, or on timeout / no submission, the situation escalates. the old boolean `auto_act` still loads as a deprecated alias (`true` → threshold 0, `false` → 999) and is migrated on next save.
+every LLM suggestion is re-gated through the never-auto patterns, kill switch, and rate guards. the LLM may act automatically only when its self-reported confidence score meets `auto_act_confidence_threshold` (0-100; default 99, so a near-certain score does auto-act — set it above 100 to disable) AND the action doesn't contradict learned history; below the threshold, with no reported score, or on timeout / no submission, the situation escalates. the old boolean `auto_act` still loads as a deprecated alias (`true` → threshold 0, `false` → 999) and is migrated on next save.
 
 ## llm action review (optional)
 
@@ -876,11 +894,28 @@ hap paths           # both, labeled
 
 example: `cd "$(hap state-dir)"` jumps into the state directory.
 
-## version
+## version and upgrade
 
 ```bash
 hap version
+hap update            # reinstall the newest release: herdr plugin install 0xGosu/herdr-auto-pilot --yes
+hap update --force    # required on a `herdr plugin link` dev build, which an install would replace
 ```
+
+`hap update` prints the version it moved to, then the follow-up that hands the
+running daemon to the new build. **it names an absolute path on purpose** — an
+install does not repoint `hap` on your `PATH`, so a bare `hap daemon --ensure`
+can hand the daemon straight back to the binary that was just replaced:
+
+```bash
+/path/to/new/hap daemon --ensure
+```
+
+the TUI header shows the running version and, when the release check finds a
+newer one, `↑ vX.Y.Z available`. that check is the plugin's only outbound
+network call — turn it off with `hap config set tui.disable_check_for_update
+true`. `hap update` still queries GitHub even with the switch on, because you
+asked it to.
 
 ## recipes
 
@@ -972,6 +1007,7 @@ hap signatures reembed
 
 ## troubleshooting
 
+- **an agent looks blocked but nothing shows up in `hap escalations`** — re-run the capture pipeline for it by hand: `hap capture <agent-name-or-pane-id>`. the daemon classifies that pane right now, as if herdr had raised an attention event (it needs a running, current daemon). then check `hap escalations` after a few seconds, or `hap audit --limit 10` to see the decision even if it did not escalate.
 - **escalations citing `not found in PATH`** — the daemon inherits herdr's environment, which can be narrower than your shell's. make sure the CLI is reachable from a non-login shell or use an absolute path in `llm.command`.
 - **upgrades not taking effect** — the daemon is a singleton that outlives binary upgrades. since v0.1.13, `hap daemon --ensure` (fired by herdr's event hooks) detects the version mismatch and replaces the old daemon automatically. `hap status` shows the running daemon's version and flags a stale one. on older versions run `pkill -f 'hap daemon'` once after upgrading.
 - **installing a newer release** — the TUI header shows `↑ vX.Y.Z available` when one exists. `hap update` installs it (it runs `herdr plugin install 0xGosu/herdr-auto-pilot --yes`), then run the `daemon --ensure` command it prints to hand the running daemon over immediately — it names the newly installed binary by absolute path when the `hap` on PATH is still the previous build (a plugin install does not repoint that symlink). this MUTATES the install — never run it unprompted. on a linked working-tree build it refuses without `--force`, because installing a release would replace that checkout.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,5 +285,8 @@ The **`herdr`** skill covers CLI usage; these are the hap-specific protocol fact
 | `internal/mcpserver` | stdio MCP server (`get_context`, `submit_decision`) |
 | `internal/herdr` | herdr CLI + events-socket adapters |
 | `internal/store` | SQLite persistence (WAL; `context_json` is an opaque blob) |
+| `internal/taskfile` | advisory file lock behind every checklist read-modify-write |
+| `internal/selfpath` | resolves a live `hap` binary (an upgrade unlinks the running one) |
+| `internal/updatecheck` | GitHub release check — the ONLY `net/http` importer (NFR-007 allowlist) |
 | `internal/fakeherdr`, `e2e_harness/` | test fakes and the e2e driver |
 | `docs/architect/herd-auto-prompter-architecture.md` | consolidated architecture doc (FR-xxx / NFR-xxx ids used in comments) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,14 +36,17 @@ gofmt -l . | grep -v submodule ; go vet -tags "vectors cpu" ./...
 golangci-lint run --build-tags "vectors,cpu" # lint (CI runs this too)
 ```
 
+Both tags are always required — a build without them fails to link, so there is
+no tag-free shortcut for a quick check.
+
 Golden classifier fixtures live in `internal/classify/testdata/`; regenerate
-expectations with `UPDATE_GOLDEN=1 go test ./internal/classify/` and review
-the diff carefully.
+expectations with `UPDATE_GOLDEN=1 go test -tags "vectors cpu" ./internal/classify/`
+and review the diff carefully.
 
 To exercise your working tree inside Herdr:
 
 ```sh
-go build -o bin/hap ./cmd/hap
+go build -tags "vectors cpu" -o bin/hap ./cmd/hap
 herdr plugin link .
 ```
 
@@ -51,19 +54,46 @@ herdr plugin link .
 
 1. Fork/branch from `main`.
 2. Keep PRs focused; include tests for behavior changes.
-3. Make sure `go test ./...`, `gofmt`, `go vet`, and `golangci-lint` pass —
-   CI gates on all of them plus the never-auto patterns-corpus regression.
+3. Make sure the tagged commands above pass — `go test -tags "vectors cpu" ./...`,
+   `gofmt`, `go vet`, and `golangci-lint`. CI gates on all of them, plus:
+   - the never-auto patterns-corpus regression (`corpus-gate`);
+   - a **race-detector** job over `internal/{store,domain,control,embedder,match,daemon}`,
+     retried up to 3 times because the detector is flaky under CI load;
+   - a **macOS** matrix leg, where test binaries need `-ldflags "-r /usr/local/lib"`
+     to reach the FAISS dylibs.
 4. Describe *what* and *why* in the PR body; link related issues.
+
+Never put `[skip ci]`, `[ci skip]`, or `[no ci]` anywhere in the squash-merge
+message (title or body) of a PR that should release. GitHub suppresses *all*
+workflows for a ref whose head commit carries one — including the release tag
+push onto that commit — so the release silently never builds.
 
 ## Release flow (maintainers)
 
-1. Update `version` in `herdr-plugin.toml` to `X.Y.Z`.
-2. Tag the same commit: `git tag vX.Y.Z && git push origin main vX.Y.Z`.
-3. The Release workflow runs the full CI gate, builds Linux/macOS binaries,
-   and publishes a GitHub Release.
+Releases are **automated on merge to `main`** (`.github/workflows/auto-release.yml`).
+`version` in `herdr-plugin.toml` is the single source of truth, and it always
+names a version whose GitHub release already exists — it *trails* releases,
+never leads them.
+
+- **Patch (the default): do nothing.** Merge the feature PR. The workflow sees
+  the manifest version already tagged, computes the next patch, squash-merges a
+  bump PR (`release/bump-vX.Y.Z+1`, commit marked `[skip release]`), and tags
+  that bump commit — which fires the tag-driven `release.yml`. Do not bump the
+  manifest by hand for patch work.
+- **Minor/major (the reserved manual path):** overwrite `version` in
+  `herdr-plugin.toml` *inside* your feature PR (e.g. `0.6.0`). On merge the
+  workflow finds that version untagged, skips the bump, and tags the merge
+  commit directly.
+
+`release.yml` then runs the full CI gate and builds on three native runners
+(CGO cannot cross-compile), publishing the platform binaries, the per-platform
+native tarballs, the embedding model, and `SHA256SUMS`.
 
 The manifest version and the tag MUST match: `herdr plugin install` runs
 `scripts/install.sh`, which downloads the release asset for the version
 declared in `herdr-plugin.toml` (that's what removes the Go-toolchain
-dependency for users). Pushing a manifest version before its release exists
-briefly breaks fresh installs, so push the tag immediately after the bump.
+dependency for users). The automation preserves this by construction. Between
+the bump merge and the release publishing (~15 min), installs from `main` can
+404 — a self-resolving window; pinned `--ref vX.Y.Z` installs are never
+affected. If the release *build* fails after the tag exists, re-run that
+`release.yml` run — never re-run auto-release, which would advance versions.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ and correctable.
 Requires: Herdr ≥ 0.7.0 and `curl`. **No Go toolchain needed** — the install
 step downloads the prebuilt binary for your platform (Linux/macOS,
 amd64/arm64) from the matching GitHub Release and verifies it against the
-published SHA256SUMS. (Building from source instead needs Go ≥ 1.24; see
+published SHA256SUMS. (Building from source instead needs Go ≥ 1.25; see
 Development.)
 
 ```sh
@@ -56,14 +56,14 @@ Pin a release (recommended for reproducible installs), or install
 non-interactively:
 
 ```sh
-herdr plugin install 0xGosu/herdr-auto-pilot --ref v0.4.0
+herdr plugin install 0xGosu/herdr-auto-pilot --ref v0.5.3
 herdr plugin install 0xGosu/herdr-auto-pilot --yes
 ```
 
 ### Update to the latest version
 
 The TUI header flags a newer release next to the version
-(`Herd Auto Prompter v0.5.1 ↑ v0.5.2 available`). It learns that from a GitHub
+(`Herd Auto Prompter v0.5.3 ↑ v0.5.4 available`). It learns that from a GitHub
 release check that runs at most every 6 hours while the TUI is open — the
 plugin's only outbound call, and off with
 `hap config set tui.disable_check_for_update true`. A locally built (`herdr
@@ -108,6 +108,12 @@ herdr plugin uninstall herd-auto-prompter            # optional: only for a clea
 herdr plugin install 0xGosu/herdr-auto-pilot --yes
 hap daemon --ensure
 ```
+
+`--ensure` starts a daemon only if none is running, and replaces one left by an
+older binary (or a binary at a different path) — it is what herdr's event hook
+runs, and how you pick up a rebuild. Adding `--replace-only` replaces a running
+daemon but never starts one when none is running; the plugin's install step uses
+it so installing hap does not bring a daemon up as a side effect.
 
 The monitoring daemon starts automatically when an agent appears in the herd.
 Use the following recommended setup to make the **Auto Prompter** pane (TUI)
@@ -196,7 +202,9 @@ shell instead of opening the Herdr pane with the hotkey:
 hap tui
 ```
 
-Everything the TUI does is also a CLI verb on the same binary:
+Nearly everything the TUI does is also a CLI verb on the same binary — the
+exceptions are two interactive-only conveniences, the `/usr/local/bin/hap`
+symlink shortcut on the Config tab and the daemon-stderr viewer (`!`):
 
 ```sh
 hap status         # from any shell after creating the symlink above
@@ -238,6 +246,18 @@ hap state-dir            # state dir (DB, logs, socket, lock, match-index)
 hap config path          # the config.toml path (printed even before it exists)
 hap paths                # both, labeled
 cd "$(hap state-dir)"    # e.g. jump into the state dir
+```
+
+To read and change settings without opening the file:
+
+```sh
+hap version                        # the running build
+hap config show                    # the effective config, defaults filled in
+hap config fields                  # the authoritative key list `config set` takes
+hap config set <key> <value>
+hap config set-threshold approval 0.80   # minimum|idle|approval|choice|error
+hap capture <agent>                # re-run the capture pipeline for one agent now
+hap kill-history                   # past kill-switch (pause/resume) activity
 ```
 
 ## Architecture
@@ -380,7 +400,8 @@ gates and remain visible in the same audit trail.
    "none yet" for a first sighting) when the list line is truncated; it
    works on the *Agents*, *Audit*, and *Rules* tabs too, and pressing
    `tab`/`shift+tab` inside the detail view switches tabs directly (no
-   `esc` needed). Escalation and audit list rows carry compact `rule=` and
+   `esc` needed). `t` jumps straight to that matched rule on the *Rules*
+   tab. Escalation and audit list rows carry compact `rule=` and
    agent-type columns; the CLI `escalations`/`audit` listings show the
    same. From the CLI: `confirm <id> --send` or
    `resolve <id> --action TEXT --send`. Escalations you don't want to
@@ -461,6 +482,17 @@ hap signatures                      # list (--type, --mode, --agent-type, --min-
 hap signatures show approval:9f2c   # full detail by unique prefix
 hap signatures reset approval:9f2c --yes # shadow + fresh streak/confidence; history kept
 hap signatures delete approval:9f2c --yes
+
+# Find a rule without knowing its id — substring by default, or by MEANING
+# with --semantic (embeds the query with the same model the matcher uses):
+hap signatures search "force push"
+hap signatures search "asking to overwrite the branch" --semantic \
+    --limit 20 --min-score 0.3
+
+# Re-compute stored embeddings, e.g. after switching embedding model.
+# `hap status` reports model drift when a re-embed is due; the TUI offers it
+# on `R`.
+hap signatures reembed [--force]
 ```
 
 ## Configuration
@@ -519,7 +551,10 @@ warm_timeout_ms = 0         # 0 = 30000ms for the first call (model load; max 60
 [tui]
 max_content_width = 0       # cap variable-width list columns; 0 = full width
 max_content_height = 0      # expanded long-field lines; 0 = unlimited (collapsed previews use short tails)
-theme = "high-contrast"
+theme = "high-contrast"     # illustrative; the DEFAULT is "" (= the default palette)
+terminal_bell = true        # ring the bell on a new escalation, and on a pause
+                            # caused by a different process
+disable_check_for_update = false  # true turns off the GitHub release check
 
 # Optional per-role color overrides, layered on top of the theme; unset
 # roles inherit the theme's value. Values are terminal color strings
@@ -596,6 +631,19 @@ through the normal pipeline, so the kill switch, never-auto patterns, rate
 limits and per-agent disable all still apply, and every send is audited
 (trigger `auto-idle-send`).
 
+Every option a source takes can be set at creation time, in any combination:
+
+```sh
+hap task-source add --agent brave-otter --workspace 'codex-*' \
+    --template 'Your next task is {next_task_content} (cwd {cwd})' \
+    --auto-send-when-idle --enable-llm-review-before-auto-send \
+    --max-tasks 40 ./docs/tasks.md
+```
+
+Flags must come **before** the path — Go stops parsing flags at the first
+positional argument, so one written after it would be silently ignored (hap
+detects that and refuses instead).
+
 This **composes** with the pre-delivery LLM review
 (`enable_llm_review_before_auto_send`): the hand-out decides *that* a task
 goes, the review decides *which* task and in what shape. The two were once
@@ -604,7 +652,7 @@ pending escalation stops the idle poll for that agent, so a reviewed auto-send
 source silently switched itself off. The review never escalates now, so the
 restriction is gone.
 
-Two rules keep unattended hand-out safe:
+Three rules keep unattended hand-out safe:
 
 - **One task, one agent.** Agents matched by the same source in one poll are
   paired with *different* pending items, and the delivered item is marked
@@ -613,7 +661,19 @@ Two rules keep unattended hand-out safe:
   the *source*, so ordinary event-driven sends from it are marked `[-]` too;
   the agent's own `hap task <name> start <n>` then simply becomes a no-op.
 - **Nothing jumps the queue.** An agent that is disabled, rate-paused,
-  blocked, or has an escalation still waiting on you is skipped.
+  blocked, or has an escalation still waiting on you is skipped. *Any* open
+  escalation parks that agent's poll, which is the first thing to check when
+  auto-send appears to do nothing: `hap escalations`.
+- **Every sweep decides from current state, not from the last send.** A
+  successful `agent send` only proves herdr accepted the keystrokes — text
+  typed into a CLI that is restarting or unfocused is silently lost, and the
+  item would sit `[-]` forever. So each hand-out is recorded in a durable
+  ledger and confirmed only when herdr reports that agent *working*. An
+  unconfirmed hand-out whose agent is parked again after ~2 minutes is
+  returned to `[ ]` (audit trigger `auto-send-reclaim`) and re-offered in the
+  same sweep, to that agent or any other idle one. After **3** hand-outs that
+  were never started, hap escalates instead of resending forever. A `[-]` hap
+  did not write itself — yours, or one an agent marked — is never touched.
 
 The former `[thresholds]` table is accepted for compatibility. Loading it
 preserves its values, and the next config save rewrites it as
@@ -691,8 +751,28 @@ Manage items without leaving the pane:
   source (see below)
 - `space` — mark a run of tasks, so `d`/`x` act on all of them at once
   (with nothing marked, they act on the row under the cursor)
+- `K` / `J` (or `shift+↑` / `shift+↓`) — move the task under the cursor up or
+  down among its siblings; its nested detail lines and sub-tasks travel with it
 - `f` — focus the live agent this source feeds, in herdr
 - `/` — incremental search over the visible columns
+
+The same CRUD is available from the CLI, addressed either by the agent whose
+source it is or by `--path <file>` for any checklist:
+
+```sh
+hap task backend-dev list [--status pending|done|all]
+hap task backend-dev get 3.4          # <n> is a task REFERENCE (id), '#3' is a position
+hap task backend-dev add "wire up retries"
+hap task backend-dev start 2          # [-] in progress
+hap task backend-dev done 2 / undone 2
+hap task backend-dev update 2 "new text"
+hap task backend-dev remove 2
+hap task backend-dev move 5 2         # or: up | down — reorders among siblings
+hap task --path ./docs/tasks.md list  # any checklist file, no source needed
+```
+
+Aliases mirror the obvious spellings: `ls`, `show`, `create`, `wip`, `check`,
+`uncheck`/`reopen`, `edit`, `rm`/`delete`, `mv`/`reorder`.
 
 The add and edit prompts accept multi-line task text: **Shift+Enter inserts
 a line break** (Ctrl+J works on terminals that can't report Shift+Enter) and
@@ -960,11 +1040,25 @@ agents working" above.
 Irreversible operations are **never** automated, regardless of confidence.
 The shipped seed covers force-pushes, destructive filesystem/database ops,
 deploys/publishes, credential changes, and broader suspected-irreversible
-language. The strict and heuristic seed rules are both controlled by
-`safety.disable_never_auto_seed_patterns` and are regression-tested in
+language. The strict and heuristic seed rules are regression-tested in
 CI against a maintained corpus of irreversible-operation prompts
-(`internal/domain/testdata/irreversible_corpus.txt`). Extend it with your own
-regex patterns:
+(`internal/domain/testdata/irreversible_corpus.txt`).
+
+Turn the whole shipped set off with `safety.disable_never_auto_seed_patterns`,
+or — when just one seed rule is too aggressive for a repo — silence that one by
+id and keep the rest of the safety net:
+
+```sh
+hap rules list                # each shipped rule carries a stable `seed <id>`
+hap rules disable-seed <id>   # writes safety.disabled_seed_patterns
+hap rules enable-seed <id>    # restore it
+```
+
+The id is a hash of the pattern, so it names the same rule across upgrades (and
+is rejected if that pattern no longer ships). One seed rule is a single regex
+that may cover several phrasings — disabling it silences all of them.
+
+Extend the set with your own regex patterns:
 
 ```toml
 [safety]
@@ -990,7 +1084,7 @@ Simple fields — numbers, booleans, and the `tui.theme` enum, including
 kill switch is paused by a *different* process than the TUI you're in), and
 `tui.disable_check_for_update` (off by default — see *Update to the latest
 version*) — edit
-inline (`enter`) or via `hap config set <key> <value>`. Free-text fields (`llm.command`,
+inline (`enter`, or `e`) or via `hap config set <key> <value>`. Free-text fields (`llm.command`,
 `llm.command_start`, `llm.rewrite_action_fallback_template`,
 `llm.task_generate_command`,
 `llm.task_generate_command_start`, `embedding.model_path`) show read-only in
@@ -1050,7 +1144,7 @@ The fallback idle/unclassified signature window defaults to 500 characters.
 
 **Larger models need larger budgets.** Each embed call is bounded by a stall
 guard — 2s once the model is warm, 30s for the first call including the model
-load — and three back-to-back failures latch semantic matching onto text
+load — and five back-to-back failures latch semantic matching onto text
 matching for the rest of the daemon's life. A model bigger than the bundled
 MiniLM can exceed those defaults on every call, which looks exactly like a
 broken embedder. `hap status` distinguishes the two: a degrade whose failures

--- a/docs/architect/herd-auto-prompter-architecture.md
+++ b/docs/architect/herd-auto-prompter-architecture.md
@@ -3,7 +3,7 @@
 > **Single source of truth** for the Herd Auto Prompter Herdr plugin's design.
 > Consolidated from the original constitution, requirements, and solution specs
 > (now removed) and **reconciled against the shipped code** (module
-> `github.com/0xGosu/herdr-auto-pilot`, manifest `herd-auto-prompter` v0.4.24,
+> `github.com/0xGosu/herdr-auto-pilot`, manifest `herd-auto-prompter` v0.5.3,
 > `min_herdr_version` 0.7.0). This document is the authoritative single-page view
 > of *what the system is and why it is built this way*, current to the code, and
 > still carries the requirement ids (FR/NFR/DR/IR) that code comments reference.
@@ -50,8 +50,10 @@ These principles are load-bearing — every design decision below traces to one.
    action it cannot explain. *Every optional subsystem (semantic matching, LLM
    fallback, task generation) degrades rather than blocks.*
 6. **Local and private by default.** Learning data, history, and audit logs stay
-   on the operator's machine. No telemetry. Data leaves only through the local
-   LLM CLI the operator explicitly configures.
+   on the operator's machine. No telemetry. Operator data leaves only through the
+   local LLM CLI the operator explicitly configures. The one other outbound call
+   is the opt-out GitHub release check (NFR-007, §13), which sends no data and
+   only reads the latest release tag.
 7. **Reversible and interruptible.** A global pause/kill switch halts all
    automation instantly; irreversible operations are never automated.
 8. **Host-respecting integration.** Herdr owns the host surface; the plugin uses
@@ -77,7 +79,7 @@ Single **Operator** role; multi-user access is explicitly out of scope.
 |---|---|---|
 | Language / distribution | **Go**, single static binary; subcommands `daemon` / `tui` / `mcp` / `embed-worker` / CLI verbs | No runtime dependency; strong concurrency for the monitor loop |
 | Herdr events | **Raw socket** `events.subscribe` (JSON) | Long-lived agent-status subscription |
-| Herdr actions | **CLI via `HERDR_BIN_PATH`** (`agent send`, `pane read`, `pane send-keys`, `pane get`, `pane zoom`, `agent list`, `notification show`) | Portable across Unix socket / Windows named pipe |
+| Herdr actions | **CLI via `HERDR_BIN_PATH`** (`agent send`, `pane read`, `pane send-keys`, `pane get`, `pane zoom`, `agent list`, `notification show`, plus `tab focus`, `workspace list`, `tab list` behind the optional `FocusPort`/`LocatorPort`) | Portable across Unix socket / Windows named pipe |
 | History / audit | **Embedded SQLite (WAL)** | Transactional, corruption-safe concurrent access, queryable |
 | Operator config / rules | **TOML** in the plugin config dir | Hand-editable thresholds, never-auto patterns, classifier manifests, task sources, embedding tuning |
 | Daemon coordination | **Unix-domain control socket** (named pipe on Windows) | Sub-second reload propagation, no idle polling |
@@ -217,7 +219,19 @@ sequenceDiagram
 ## 6. System Modules
 
 Layered as `cmd → domain (pure) → adapters`, with `internal/daemon` the pipeline
-spine (`daemon.go`, `semantic.go`, `sweep.go`).
+spine (`daemon.go`, `semantic.go`, `sweep.go`, `autosendidle.go` — the idle poll,
+hand-out ledger and reclaim — and `tasklistreview.go` — the FR-011 pre-delivery
+review).
+
+Supporting packages not otherwise called out below: `internal/config` (TOML load
+/ save, defaults, clamps, and the deprecated-key migrations); `internal/logging`
+(`logging.Guard`, the panic fence NFR-004 depends on); `internal/taskfile` (the
+cross-platform advisory file lock behind the *locked read-modify-write* FR-011
+promises for checklist edits + `[-]` reservation); `internal/selfpath` (resolves a
+live `hap` binary for `{self}`, the embed worker, and daemon re-exec across plugin
+upgrades — an upgrade unlinks the running binary, so `os.Executable()` alone names
+a dead path); `internal/buildinfo` (ldflags-stamped version); `internal/updatecheck`
+(§13); and `internal/testutil`.
 
 ### Ports (adapter boundary — `internal/ports`)
 
@@ -263,8 +277,9 @@ The domain depends only on interfaces. **Core ports:** `HerdrPort` (send/read),
   didn't commit), because a digit commits on plain option lists but only moves
   the caret on preview forms. Never acts without a durably-committed audit record.
 - **Verify-unblock** *(`internal/verifyunblock`)* — after delivering a reply to a
-  blocked agent, re-queries status a moment later (`verify_unblock_ms`); if still
-  blocked, appends a `delivery_failed` diagnostic audit row.
+  blocked agent, re-queries status after a fixed 1s (`unblockCheckDelay`; the old
+  `limits.verify_unblock_ms` key is warned-and-ignored); if still blocked, appends
+  a `delivery_failed` diagnostic audit row.
 - **Escalation** *(daemon)* — routes uncertain paths to escalate + audit + notify,
   with a **dedup window** (fixed internal constants `escalationDedupWindow` +
   `escalationDedupJitterPercent` = 5% in the daemon package — not
@@ -372,7 +387,20 @@ TUI and CLI have identical functionality (FR-022): monitored agents, pending
 escalations, audit log + corrections, tasks, threshold/rule editing, pause/kill
 and its history. Operator-owned mutations are written directly to the DB/TOML in
 a transaction, then the daemon is nudged to reload. Front-ends never write
-daemon-owned hot-path rows.
+daemon-owned hot-path rows (with the two narrow exceptions listed in §11).
+
+Two conveniences are deliberately interactive-only and have no CLI twin: the
+Config tab's `/usr/local/bin/hap` symlink shortcut and the daemon-stderr viewer.
+
+**Self-update surface.** `internal/frontend/updatestatus.go` exposes the cached
+release check to both front-ends: the TUI header renders the running version and,
+when a newer release exists, `↑ vX.Y.Z available`; `hap update` performs the
+upgrade by shelling out to `herdr plugin install <repo> --yes`, then prints the
+`daemon --ensure` hand-over step naming the NEWLY installed binary by absolute
+path (an install does not repoint `hap` on `PATH`, so a bare `hap daemon --ensure`
+could hand the daemon back to the build just replaced). It refuses on a non-release
+(`plugin link`) build without `--force`, which would otherwise overwrite the
+developer's checkout. See §13 for the privacy carve-out the check needs.
 
 ## 7. Situation Signatures, Guards & Semantic Resolution
 
@@ -499,8 +527,13 @@ automated action.
   (`internal/domain/testdata/irreversible_corpus.txt`); CI fails if any entry
   goes unmatched.
 - **Suspected-irreversible heuristic.** A prompt showing destructive indicators
-  (`safety.indicator_rules`) but matching no allowlist pattern biases toward
-  escalation.
+  but matching no explicit never-auto pattern biases toward escalation. The
+  heuristic set is seed-only (`domain.SeedHeuristicNeverAutoRules`, kind
+  `NeverAutoHeuristic`) and is not operator-extensible: the old
+  `[[safety.indicator_rules]]` / `safety.irreversible_indicators` keys are
+  deprecated and, on load, merge into `never_auto_rules` / `never_auto_patterns`
+  as STRICT rules. Individual seed rules can be silenced by id via
+  `safety.disabled_seed_patterns` (`hap rules disable-seed`).
 - **Global pause/kill switch.** Instantly halts all automated prompting across the
   herd, from either the TUI or CLI. Implemented as an **append-only event table**
   — the daemon reads the *latest row every pipeline tick*, so a kill takes effect
@@ -510,7 +543,7 @@ automated action.
   prompts without intervening human interaction, and no more than **5 per
   minute** (`limits.max_consecutive_auto_prompts` default 30,
   `max_auto_prompts_per_minute` default 5). On either ceiling, automation for
-  that agent pauses and escalates. Unattended `auto_send_when_idle` task
+  that agent pauses and escalates. Unattended `enable_auto_send_task_when_idle` task
   hand-outs are exempt from the consecutive counter and never pause on the
   per-minute ceiling (they defer to a later sweep), since the operator opted
   into unattended repeated sending for that source.
@@ -557,6 +590,8 @@ erDiagram
     DECISIONS {
         int id PK
         text signature FK
+        text situation_type
+        text agent_type
         text chosen_action
         text source
         real confidence_at_decision
@@ -566,14 +601,23 @@ erDiagram
     AUDIT_LOG {
         int id PK
         int decision_id FK
+        text agent_id
+        text agent_type
+        text signature
+        text situation_type
         text trigger
+        text input
         text action_or_escalation
+        text status
+        text suggestion
         real confidence
         text rationale
         text match_method
         real match_score
         text embed_error
         text llm_output
+        int llm_confidence
+        text pane_excerpt
         int corrects_audit_id FK
         int created_at
     }
@@ -589,6 +633,10 @@ erDiagram
     }
     LLM_REQUESTS {
         text request_id PK
+        text signature
+        text situation_type
+        text agent_type
+        text agent_id
         text context_json
         text status
         int created_at
@@ -596,9 +644,15 @@ erDiagram
     LLM_DECISIONS {
         int id PK
         text request_id FK
+        text signature
+        text situation_type
+        text agent_type
         text action
         text option_id
+        text task_actions_json
+        text send_task
         int confident_score
+        text rationale
         text captured_output
         text status
         int created_at
@@ -628,18 +682,29 @@ erDiagram
 | **llm_retries** | Queue of audit rows to re-ask the LLM about |
 | **signature_embeddings** | **Semantic source of truth** — vector + salient per signature, scoped by situation/agent type |
 | **signature_snapshots** | Pane-excerpt provenance per signature (inspection/debugging) |
+| **task_reservations** | The `[-]` a daemon hand-out wrote, with the `terminal_id` that owns it — only a reservation hap itself holds may be released |
+| **task_handouts** | Durable ledger of unattended hand-outs (FR-011): confirms on a `working` transition, drives the ~2-min reclaim, and enforces the 3-hand-out ceiling |
 | **agent_names** | Friendly short-name mapping + per-agent disabled flag + terminal id |
 | **operator** | Single operator identity row anchoring correction/kill authorship |
 
 TOML config (not in SQLite): per-situation `confidence_thresholds` (+ the
 minimum-agreement floor is `confidence_thresholds.minimum`), `learning`
-(graduation N, confirmation
-weight), `limits` (error-retry ceiling, rate ceilings, escalation-dedup window +
-jitter), `safety` (never-auto + indicator rules, seed toggles), classifier
-manifests, `capture_delay`, `verify_unblock_ms`, `task_sources` (+ generate
-command), `embedding` (model_path, similarity/BM25 thresholds, gpu_layers,
-context window, disabled), `llm` (argv template + timeout, optional
-rewrite-action review), and `tui` palette.
+(graduation N, confirmation weight), `limits` (error-retry ceiling, rate
+ceilings — the escalation-dedup window and jitter are NOT configurable; they are
+fixed daemon constants), `safety` (never-auto patterns + rules, the global seed
+toggle, and `disabled_seed_patterns` for silencing one seed rule by id),
+classifier manifests, `capture_delay`, `task_sources` (+ generate command),
+`embedding` (model_path, similarity/BM25 thresholds, context window, stall
+guards, `pane_salient_chars`, disabled — embedding is CPU-only; `gpu_layers` is
+warned-and-ignored), `llm` (argv templates + timeouts, per-command env/env_file,
+optional rewrite-action review), `cli` (`ai_agent_friendly_output`), and `tui`
+(theme, palette, `max_content_width`/`height`, `terminal_bell`,
+`disable_check_for_update`).
+
+Removed keys still decoded only to warn and ignore: `limits.verify_unblock_ms`,
+`limits.escalation_dedup_window_seconds` / `escalation_dedup_jitter_percent`,
+`embedding.gpu_layers`, `embedding.max_consecutive_failures`,
+`confidence_thresholds.inferred_task_bar`, `llm.auto_act`.
 
 ## 11. Concurrency & Durability
 
@@ -653,10 +718,17 @@ Two concerns are kept separate:
 2. **Logical correctness** (no lost updates on hot rows) is solved by
    **write-ownership partitioning**:
    - **Daemon-exclusive (hot path):** `signatures` counters/mode, `agent_rate`,
-     `error_retries`, `signature_embeddings`, daemon-emitted `audit_log` /
-     `decisions`, and consumed-then-promoted `llm_requests`/`llm_decisions`. No
-     other process writes these, so the daemon's read-modify-write is race-free.
-   - **Front-end direct (operator-owned):** TOML config/rules, `corrections`,
+     `error_retries`, `signature_embeddings`, `task_reservations`/`task_handouts`,
+     daemon-emitted `audit_log` / `decisions`, and consumed-then-promoted
+     `llm_requests`/`llm_decisions`. The daemon is the only writer of the *hot
+     path* — the counters and state its read-modify-write depends on — so that
+     cycle is race-free. Two narrow, deliberate exceptions exist, and neither
+     touches a counter the daemon increments: a front-end may `UpsertSignature` /
+     `DeleteSignature` (the operator resetting or deleting a learned rule), and
+     may flip an existing `audit_log` row's escalation status via
+     `DismissEscalation` / `ResolveEscalation` / `DismissEscalationsBefore`.
+   - **Front-end direct (operator-owned):** TOML config/rules, `corrections`
+     (including the `sent` flip once an answer is delivered), `llm_retries`,
      `kill_events` — append-only inserts or independent rows.
    - **`mcp` staged:** `llm_decisions` inserts only; the daemon consumes these and
      derives any hot-path effect itself.
@@ -664,7 +736,7 @@ Two concerns are kept separate:
      daemon and front-ends (concurrent inserts converge; renames front-end-owned).
 
 **Propagation without polling.** After a direct/staged write, the writer sends a
-payload-free **nudge** over the daemon's control socket (`internal/control`); the
+**nudge** over the daemon's control socket (`internal/control`); the
 daemon reloads TOML and re-reads operator/staged rows — sub-second, no idle poll.
 The pause/kill switch is the exception that is *not* nudge-dependent: the daemon
 reads the latest `kill_events` row every tick, so a kill halts automation
@@ -677,12 +749,17 @@ immediately even if the nudge is delayed.
 - Actions (CLI via `HERDR_BIN_PATH`): `agent send` (writes text without Enter —
   follow with `pane send-keys <pane> enter`), `pane read` (`--source
   visible|recent`), `pane get` (cwd/ids), `pane zoom`, `agent list`,
-  `notification show`. *(Agent status is driven off the events socket, not a
-  `wait agent-status` CLI call.)*
+  `notification show`; plus `tab focus`, `workspace list` and `tab list` behind
+  the optional `FocusPort`/`LocatorPort`. *(Agent status is driven off the events
+  socket, not a `wait agent-status` CLI call.)*
 
 **Daemon control socket (internal).** Unix-domain socket (named pipe on Windows)
-in the plugin state dir. Messages: `{ "kind": "reload" | "wake" }` — no domain
-payload, idempotent and debounced.
+in the plugin state dir. Messages: `{ "kind": ... }` — idempotent and debounced.
+Four kinds: `reload`, `wake`, `reembed` (rebuild a fresh embedder, clearing the
+degraded-failure latch, and re-embed stored signatures), and `capture:<target>`
+(re-run the capture pipeline for one agent — the only kind carrying a payload,
+encoded in the kind so the one-field protocol stayed backward compatible).
+A daemon predating a kind logs and ignores it.
 
 **MCP tool surface (internal, exposed to the LLM agent — `internal/mcpserver`).**
 Exactly two tools:
@@ -690,7 +767,8 @@ Exactly two tools:
   `agent_type`, options / permission verb, history summary, and (for pre-send
   reviews) an optional `proposed_task` / `proposed_action`.
 - `submit_decision(request_id?, recommend_action?, select_options?,
-  confident_score, rationale)` — writes a `pending` `llm_decision` row and nudges
+  task_actions?, send_task?, confident_score, rationale)` — writes a `pending`
+  `llm_decision` row and nudges
   the daemon, which re-gates it before promoting/acting. **`confident_score`
   (0–100) is required** — the daemon auto-acts only when it meets the operator's
   threshold, else it surfaces the decision for confirmation. Per-situation
@@ -709,11 +787,14 @@ Exactly two tools:
   itself); a length mismatch between the answer series and `tab_count` is rejected
   rather than partially delivered.
 
-**Escalation error codes** — every rejected/failed path resolves to
-**escalate + audit**, never a silent drop: `unclassifiable`, `below_threshold`,
-`variance_guard`, `over_masked`, `never_auto_match`, `suspected_irreversible`,
-`rate_limited`, `retry_exhausted`, `daemon_paused`, `llm_timeout`,
-`llm_no_submit`, `herdr_unreachable`, `persistence_failed`.
+**Escalation reason codes** — every rejected/failed path resolves to
+**escalate + audit**, never a silent drop. The full set (`domain.EscalateReason`):
+`unclassifiable`, `below_threshold`, `variance_guard`, `over_masked`,
+`never_auto_match`, `suspected_irreversible`, `rate_limited`, `retry_exhausted`,
+`daemon_paused`, `llm_timeout`, `llm_no_submit`, `llm_low_confidence`,
+`herdr_unreachable`, `persistence_failed`, `shadow_mode`, `no_task_source`,
+`task_source_exhausted`, `noop_vs_pending_tasks`, `unfamiliar_options`,
+`no_history`, `graduation_pending`, `task_gen_failed`, `llm_retry`.
 
 ## 13. Security & Privacy
 
@@ -729,11 +810,14 @@ Exactly two tools:
   index live in the plugin's config/state dir with normal user permissions; the
   control socket is owner-only; the operator can clear/reset learned and audit
   data (`hap clear-data`). A dedicated no-egress test (`internal/privacy`) asserts
-  NFR-007. It allows exactly ONE outbound call, by name: the TUI's release check
+  NFR-007. It allows exactly ONE outbound call, by name: the release check
   (`internal/updatecheck/fetch.go`), which asks GitHub for the newest published
-  version at most every 6h, sends nothing about the operator or their panes, and
-  is switched off by `[tui] disable_check_for_update`. Every other file importing
-  `net/http` still fails the test.
+  version, sends nothing about the operator or their panes, and is switched off by
+  `[tui] disable_check_for_update`. The TUI drives it in the background at most
+  every 6h (a dev/`plugin link` build never checks at all); `hap update` performs
+  it on demand, since the operator asked for the upgrade. Every other file
+  importing `net/http` still fails the test, and a second test pins the allowlist
+  at that single entry.
 
 ## 14. Key Design Decisions
 
@@ -833,7 +917,7 @@ the sections they gate.
 | **FR-016** | Allowlist seeding, extension & coverage safety | Ship a corpus-validated seed allowlist, allow operator extension via TOML regex/keyword patterns, and bias toward escalation on destructive-looking prompts that match no pattern (suspected-irreversible heuristic). |
 | **FR-017** | Global pause / kill switch | Provide a global pause/kill switch (TUI + CLI) that instantly halts all automated prompting across the herd within a small bounded delay. |
 | **FR-018** | Escalation on uncertainty | Take no action and notify the operator whenever a situation is unclassifiable, below threshold, guard-tripped, suspected-irreversible, or otherwise ineligible for autonomous action. |
-| **FR-019** | Runaway-loop guard | Bound automated prompting per agent to ≤ `max_consecutive_auto_prompts` consecutive auto-prompts without intervening human interaction AND ≤ `max_auto_prompts_per_minute` per minute (defaults 30 and 5); on either ceiling, pause automation for that agent and escalate. Unattended `auto_send_when_idle` hand-outs are exempt from the consecutive counter and defer (never pause) on the per-minute ceiling. |
+| **FR-019** | Runaway-loop guard | Bound automated prompting per agent to ≤ `max_consecutive_auto_prompts` consecutive auto-prompts without intervening human interaction AND ≤ `max_auto_prompts_per_minute` per minute (defaults 30 and 5); on either ceiling, pause automation for that agent and escalate. Unattended `enable_auto_send_task_when_idle` hand-outs are exempt from the consecutive counter and defer (never pause) on the per-minute ceiling. |
 | **FR-020** | Full audit log | Record every automated decision and escalation with its trigger, situation type, chosen action (or escalation), confidence, rationale (rule/LLM), and timestamp. |
 | **FR-021** | Post-hoc correction | Let the operator review the audit log and correct any past automated decision, feeding the correction back into learning (per FR-007) and recording it in the audit trail. |
 | **FR-022** | Equivalent TUI and CLI | Expose a TUI (Herdr pane) and a CLI with identical functionality; mutations from either surface propagate promptly to the running daemon. |
@@ -870,7 +954,7 @@ the sections they gate.
 | Id | Title | Requirement (the plugin SHALL…) |
 |---|---|---|
 | **IR-001** | Herdr event subscription | Subscribe to Herdr agent-status transition events (raw socket `events.subscribe`) to drive monitoring without polling. |
-| **IR-002** | Herdr control actions | Send prompts/responses to agents and read pane content via Herdr's documented CLI commands (`agent send`, `pane read`, `pane get`, `pane send-keys`, `agent list`, `notification show`). |
+| **IR-002** | Herdr control actions | Send prompts/responses to agents and read pane content via Herdr's documented CLI commands (`agent send`, `pane read`, `pane get`, `pane send-keys`, `pane zoom`, `agent list`, `notification show`, and — behind optional ports — `tab focus`, `workspace list`, `tab list`). |
 | **IR-003** | Herdr notifications | Surface escalations and critical failures via Herdr notifications in addition to the TUI. |
 | **IR-004** | Herdr plugin manifest | Package as a Herdr plugin declaring id/version, pinned `min_herdr_version`, the TUI pane command, event hooks, and build steps in `herdr-plugin.toml`. |
 | **IR-005** | Local LLM CLI | Integrate an optional, operator-configured local LLM/agent CLI for the hybrid decision fallback, treating its absence or failure as an escalation trigger. |

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1351,7 +1351,7 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 	fs := flag.NewFlagSet("task-source", flag.ContinueOnError)
 	agent := fs.String("agent", "", "agent short name, id, or type this source applies to")
 	workspace := fs.String("workspace", "", "workspace name this source applies to (\"*\" wildcards, e.g. \"codex-*\")")
-	template := fs.String("template", "", "next-task prompt template ({next_task_content}, {task_list_path}, {task_list_path_quoted}, {agent_name} placeholders)")
+	template := fs.String("template", "", "next-task prompt template ({next_task_content}, {task_list_path}, {task_list_path_quoted}, {agent_name}, {cwd} placeholders)")
 	autoSend := fs.Bool("auto-send-when-idle", false, "also hand out tasks on the periodic idle poll, not only on a herdr attention event")
 	llmReview := fs.Bool("enable-llm-review-before-auto-send", false, "let the configured [llm].command revise the task list and pick the task, immediately before the daemon auto-sends one (never applies to a manual `task send`)")
 	maxTasks := fs.Int("max-tasks", config.DefaultMaxTasks, "cap on how many checklist items this source may hold before task generation stops refilling it")
@@ -1388,13 +1388,28 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 	// Unprompted hand-out is the one setting that makes hap act without a herdr
 	// event, so say so plainly instead of leaving it to `task-source list`.
 	if *autoSend {
-		fmt.Fprintln(out, "auto-send when idle is ON: matching idle agents are handed their next pending task without an attention event")
+		fmt.Fprintln(out, autoSendOnMessage)
 	}
 	if *llmReview {
-		fmt.Fprintln(out, "LLM review before sending is ON: each determined task is reviewed by the configured [llm].command, and a decline is escalated to you")
+		fmt.Fprintln(out, llmReviewOnMessage)
 	}
 	return nil
 }
+
+// autoSendOnMessage and llmReviewOnMessage explain a delivery-gate flag the
+// moment it is switched on. `task-source add` and `task-source set` both print
+// them, so they are shared rather than duplicated: the add path went on
+// promising "a decline is escalated to you" for two releases after #255 made
+// the review a pre-delivery filter that never escalates, purely because the two
+// copies could drift.
+const (
+	autoSendOnMessage = "auto-send when idle is ON: matching idle agents are handed their next pending task without an attention event"
+
+	llmReviewOnMessage = "LLM review before auto-send is ON: immediately before the daemon sends a task, " +
+		"the configured [llm].command may revise the list and pick which task goes. A review that fails " +
+		"or scores below auto_act_confidence_threshold sends the original task unchanged — it never " +
+		"escalates. A task you send by hand is never reviewed."
+)
 
 // taskSourceSet edits one setting of an existing task source — the CLI twin of
 // the TUI Config tab's enter on a task-source row. Only the settings that are
@@ -1402,7 +1417,7 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 // and the cap; path/agent/workspace are remove-and-re-add, since changing them
 // silently re-points an agent's work.
 func taskSourceSet(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
-	const usage = "usage: task-source set <index> <auto-send-when-idle|enable-llm-review|max-tasks> <value> (see: task-source list, hap help task-source)"
+	const usage = "usage: task-source set <index> <auto-send-when-idle|enable-llm-review-before-auto-send|max-tasks> <value> (see: task-source list, hap help task-source)"
 	if len(args) != 3 {
 		return fmt.Errorf("%s", usage)
 	}
@@ -1432,7 +1447,7 @@ func taskSourceSet(ctx context.Context, app *frontend.App, out io.Writer, args [
 		}
 		fmt.Fprintf(out, "task source #%d: auto_send_when_idle=%v\n", idx, on)
 		if on {
-			fmt.Fprintln(out, "auto-send when idle is ON: matching idle agents are handed their next pending task without an attention event")
+			fmt.Fprintln(out, autoSendOnMessage)
 		}
 		return nil
 	case "enable-llm-review-before-auto-send", "enable_llm_review_before_auto_send":
@@ -1445,7 +1460,7 @@ func taskSourceSet(ctx context.Context, app *frontend.App, out io.Writer, args [
 		}
 		fmt.Fprintf(out, "task source #%d: enable_llm_review_before_auto_send=%v\n", idx, on)
 		if on {
-			fmt.Fprintln(out, "LLM review before auto-send is ON: immediately before the daemon sends a task, the configured [llm].command may revise the list and pick which task goes. A review that fails or scores below auto_act_confidence_threshold sends the original task unchanged — it never escalates. A task you send by hand is never reviewed.")
+			fmt.Fprintln(out, llmReviewOnMessage)
 		}
 		return nil
 	case "enable-llm-review", "enable_llm_review", "llm-review", "llm_review":

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2395,8 +2395,15 @@ func TestTaskSourceAddLLMReview(t *testing.T) {
 			if got := saved.TaskSources[0].ReviewBeforeAutoSendEnabled(); got != tc.want {
 				t.Errorf("enable_llm_review_before_auto_send = %v, want %v", got, tc.want)
 			}
-			if said := strings.Contains(out, "LLM review before sending is ON"); said != tc.want {
+			if said := strings.Contains(out, "LLM review before auto-send is ON"); said != tc.want {
 				t.Errorf("success output announced the review = %v, want %v; got:\n%s", said, tc.want, out)
+			}
+			// The add path told operators "a decline is escalated to you" long
+			// after #255 made the review a pre-delivery filter that never
+			// escalates — the very behaviour that used to force this flag to be
+			// exclusive with auto-send. It must now agree with `task-source set`.
+			if tc.want && !strings.Contains(out, "never escalates") {
+				t.Errorf("turning the review ON must say it never escalates, got:\n%s", out)
 			}
 		})
 	}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -110,11 +110,14 @@ func buildCommands() {
 			},
 		},
 		{
-			Name:     "tui",
-			Group:    groupCore,
-			Summary:  "run the interactive TUI control pane",
-			Usage:    []string{"hap tui"},
-			Details:  "Tabs mirror the CLI: agents, escalations, signatures, tasks, config.\nEverything the TUI does is also available as a CLI verb, which is what scripts and AI agents should use.",
+			Name:    "tui",
+			Group:   groupCore,
+			Summary: "run the interactive TUI control pane",
+			Usage:   []string{"hap tui"},
+			Details: "Tabs: Agents, Tasks, Escalations, Audit, Rules, Config, Pause/Kill.\n" +
+				"Nearly everything the TUI does is also a CLI verb, which is what scripts and AI\n" +
+				"agents should use. The exceptions are interactive-only conveniences: the Config\n" +
+				"tab's `/usr/local/bin/hap` symlink shortcut, and the daemon-stderr viewer (`!`).",
 			Examples: []string{"hap tui"},
 			Next: []Hint{
 				{Cmd: "hap status", Why: "the same overview, non-interactive"},
@@ -597,9 +600,9 @@ func buildCommands() {
 			Group:   groupConfigure,
 			Summary: "declare which checklist file feeds which agent (the config, not the items)",
 			Usage: []string{
-				"hap task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] [--enable-llm-review] [--max-tasks N] <checklist.md>",
+				"hap task-source [add] [--agent A] [--workspace W] [--template T] [--auto-send-when-idle] [--enable-llm-review-before-auto-send] [--max-tasks N] <checklist.md>",
 				"hap task-source list",
-				"hap task-source set <index> <auto-send-when-idle|enable-llm-review|max-tasks> <value>",
+				"hap task-source set <index> <auto-send-when-idle|enable-llm-review-before-auto-send|max-tasks> <value>",
 				"hap task-source remove <index>",
 			},
 			Flags: []FlagDoc{

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -3,13 +3,17 @@ package cli_test
 import (
 	"bytes"
 	"context"
+	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/cli"
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
 )
 
 // TestRegistryEntriesAreDocumented pins the invariant that makes the registry
@@ -233,5 +237,105 @@ func TestTaskSourceHelpDocumentsTheReview(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("`hap help task-source` must mention %q, got:\n%s", want, out)
 		}
+	}
+}
+
+// setKeysFrom pulls the "<a|b|c>" alternation of settable keys out of a
+// `task-source set` usage line, in whichever text it appears.
+func setKeysFrom(t *testing.T, usage string) []string {
+	t.Helper()
+	start := strings.Index(usage, "> <")
+	if start < 0 {
+		t.Fatalf("cannot parse the set usage line: %q", usage)
+	}
+	end := strings.Index(usage[start+1:], ">")
+	if end < 0 {
+		t.Fatalf("cannot parse the set usage line: %q", usage)
+	}
+	var keys []string
+	for _, k := range strings.Split(usage[start+3:start+1+end], "|") {
+		if k = strings.TrimSpace(k); k != "" {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// TestTaskSourceUsageKeysAreAccepted closes the gap TestCommandHelpPages leaves:
+// it verifies each documented FLAG appears in the help page, but nothing checked
+// that the settings named inside a Usage line are spellings the CLI still takes.
+// They drifted — both usage texts advertised `enable-llm-review`, a key `set`
+// refuses outright because it was renamed. The runtime one was appended to the
+// rename error itself, so hap named the correct spelling and then printed a
+// usage line advertising the wrong one.
+//
+// hap states those keys in TWO places, so both are checked here: the registry
+// Usage in help.go (what `hap help task-source` prints) and the usage const in
+// cli.go (what a malformed `set` prints). They must agree with each other AND
+// with what the command actually accepts.
+func TestTaskSourceUsageKeysAreAccepted(t *testing.T) {
+	cmd, ok := cli.Lookup("task-source")
+	if !ok {
+		t.Fatal("task-source is not in the registry")
+	}
+	var keys []string
+	for _, u := range cmd.Usage {
+		if strings.Contains(u, "task-source set ") {
+			keys = append(keys, setKeysFrom(t, u)...)
+		}
+	}
+	if len(keys) == 0 {
+		t.Fatal("no `task-source set` usage line in the registry to check")
+	}
+
+	// The runtime usage string is unreachable from the registry, so provoke it:
+	// a wrong key prints it alongside the error.
+	app, _ := testApp(t)
+	seedTaskSource(t, app)
+	_, err := run(t, app, "task-source", "set", "0", "definitely-not-a-key", "1")
+	if err == nil {
+		t.Fatal("an unknown task-source key must be refused")
+	}
+	runtimeKeys := setKeysFrom(t, err.Error())
+	if !slices.Equal(runtimeKeys, keys) {
+		t.Errorf("the two usage texts disagree:\n  help.go: %v\n   cli.go: %v", keys, runtimeKeys)
+	}
+
+	values := map[string]string{"max-tasks": "7"}
+	for _, key := range append(keys, runtimeKeys...) {
+		t.Run(key, func(t *testing.T) {
+			app, _ := testApp(t)
+			seedTaskSource(t, app)
+			value, ok := values[key]
+			if !ok {
+				value = "true"
+			}
+			if _, err := run(t, app, "task-source", "set", "0", key, value); err != nil {
+				t.Fatalf("a usage line advertises %q but `set` rejects it: %v", key, err)
+			}
+			// A key wired to a no-op branch would pass on err==nil alone.
+			saved, err := config.Load(app.ConfigPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if reflect.DeepEqual(saved.TaskSources[0], seededTaskSource) {
+				t.Errorf("setting %q=%q changed nothing on disk: %+v", key, value, saved.TaskSources[0])
+			}
+		})
+	}
+}
+
+// seededTaskSource is the row every subtest starts from; a `set` that leaves it
+// untouched did nothing.
+var seededTaskSource = config.TaskSource{
+	Agent: "quiet-fox", Path: "/tmp/quiet.md", MaxTasks: config.DefaultMaxTasks,
+}
+
+func seedTaskSource(t *testing.T, app *frontend.App) {
+	t.Helper()
+	cfg := config.Default()
+	cfg.TaskSources = []config.TaskSource{seededTaskSource}
+	if err := config.Save(app.ConfigPath, cfg); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -20,12 +20,17 @@ error = 0.75
 # ── Shadow-mode learning ────────────────────────────────────────────
 [learning]
 graduation_n = 2           # consecutive consistent confirmations to graduate a rule (1-10)
+confirmation_weight = 3.0  # how much more an operator confirm/send counts toward
+                           # confidence than a passive observation
 
 # ── Safety (never-auto) ─────────────────────────────────────────────
 [safety]
 never_auto_patterns = []         # extra regexes that ALWAYS escalate (e.g. "rm -rf")
 # allowlist_patterns = []        # DEPRECATED alias for never_auto_patterns (merged on load)
 disable_never_auto_seed_patterns = false  # keep all shipped strict + heuristic rules (recommended)
+disabled_seed_patterns = []      # silence individual shipped rules by id instead of all of
+                                 # them: take the `seed <id>` from `hap rules list`, then
+                                 # `hap rules disable-seed <id>` / `enable-seed <id>`
 
 # Agent-scoped never-auto rule (repeatable):
 # [[safety.never_auto_rules]]


### PR DESCRIPTION
Started as a documentation refresh and a check that `enable_auto_send_task_when_idle`
and `enable_llm_review_before_auto_send` are no longer mutually exclusive. The
exclusivity is already gone (#255) and needed no code change — but verifying it
turned up two user-facing bugs that still described the *old* behaviour.

## The exclusivity question: already fixed, verified end to end

The exclusion was added by `73f6b7b` (#254) and removed by `2e601d3` (#255).
Nothing rejects the pair anywhere:

- `config.ValidateTaskSource` is a deliberate no-op, and `updateTaskSource` is the
  single write funnel that calls it, so every setter is ungated.
- All four write surfaces accept both, in either order: `AddTaskSource`, CLI
  `task-source set`, the TUI `t` prompt, and the TUI picker (which no longer marks
  a row `blocked while <other>=true`).
- It composes at runtime, not just in config: `TestAutoSendIdleReviewsItsHandouts`
  proves an unattended hand-out is reviewed, its checklist edits land, and the task
  the review chose is delivered and reserved.

The reason it works is structural. The review used to fork *upstream* of
`domain.Decide`, and its only failure mode was an escalation — and one pending
escalation bars an agent from the idle poll entirely, so a reviewed auto-send
source silently switched itself off. It is now a pre-DELIVERY filter
(`internal/daemon/tasklistreview.go`) that never escalates.

## Two bugs found while checking (commit 1)

1. **`hap help task-source` advertised a key the CLI refuses.** Both the registry
   Usage in `help.go` and the runtime `usage` const in `cli.go` named
   `enable-llm-review`, which `set` refuses because it was renamed. The runtime
   copy is appended to the rename error itself, so hap named the correct spelling
   and then printed a usage line advertising the wrong one.
2. **`task-source add --enable-llm-review-before-auto-send` still promised
   pre-#255 behaviour** — *"a decline is escalated to you"*. That is precisely the
   claim that forced the two flags apart. Both success messages are now shared
   constants (`autoSendOnMessage`, `llmReviewOnMessage`) so they cannot drift again.

Also: `hap help tui` listed the wrong tabs and claimed complete TUI/CLI parity
(the symlink shortcut and stderr viewer have no CLI verb), and `--template` help
omitted the `{cwd}` placeholder.

**New test.** `TestTaskSourceUsageKeysAreAccepted` parses the `<a|b|c>` alternation
out of BOTH usage texts, asserts they agree with each other, and drives every key
through the real command — then re-loads the config so a key wired to a no-op
branch cannot pass. It fails on the pre-fix code.

## Documentation (commit 2)

Corrected facts, each verified against source. Most consequential first:

| Claim | Was | Is | Source |
|---|---|---|---|
| `llm.auto_act_confidence_threshold` default | 999 (never) | **99** | `config.go:553` |
| capture delay after first event | 500ms | **2000ms** | `config.go:1054` |
| `embedding.pane_salient_chars` | 800 | **500** | `signature.go:69` |
| strict never-auto seed patterns | 38 | **40** | `safety.go` |
| embedder degrade latch | 3 failures | **5** | `embedder.go:48` |
| build-from-source Go version | 1.24 | **1.25** | `go.mod` |

The threshold one matters most: the skill told operators hap never auto-acts on an
LLM suggestion out of the box. It does, at a score >= 99. The latch count
contradicted the README's own sample `hap status` output three lines below it.

Also corrected: the TUI picker's removed "blocked while" note; `safety.indicator_rules`
(deprecated, migrates to STRICT rules — the heuristic set is seed-only);
`limits.verify_unblock_ms`, the escalation-dedup keys and `embedding.gpu_layers`
(all removed, warned-and-ignored); FR-019's key name; and CONTRIBUTING's release
flow, which still described the manual bump-and-tag and whose build commands
dropped the `vectors cpu` tags the build will not link without.

Filled gaps: the hand-out ledger / reclaim / 3-attempt ceiling; per-seed-rule
disable; `hap update`, `capture`, `kill-history`, `config show|fields|set-threshold`,
`signatures search|reembed`, `task move`, `daemon --replace-only`; the Tasks-tab
`K`/`J` and escalation `t` keys; `tui.max_content_height`,
`safety.disabled_seed_patterns`, `learning.confirmation_weight`;
`task_reservations`/`task_handouts` and the missing ER columns; the four
control-socket kinds; `submit_decision`'s `task_actions`/`send_task`; and the full
escalation reason-code set. Every `internal/` package now appears in the
architecture doc.

Guiding principle 6 no longer claims data never leaves the machine — it names the
opt-out release check, matching NFR-007 and section 13.

**Left alone deliberately:** `docs/analyst/embedding-model-upgrade-and-gpu.md` is an
explicitly dated *"research only, nothing implemented"* analysis, not living
documentation.

## Verification

- `go test -tags "vectors cpu" ./... -count=1` — green, all 27 packages with tests
- `golangci-lint run --build-tags "vectors,cpu"` — 0 issues
- `gofmt`, `go vet -tags "vectors cpu" ./...` — clean
- `hap help task-source` and `hap help tui` smoke-tested from a real build

Manifest version untouched, so this releases as a patch on merge.
