### PR TITLE
#1 fix: fail fast when a submodule gitlink is replaced by a symlink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      # Deliberately the first thing after checkout: a submodule gitlink
+      # replaced by a symlink otherwise surfaces as a linker error deep
+      # inside setup-native.sh that names neither git nor submodules. It
+      # broke every job twice in #265; this costs seconds.
+      - name: Submodule gitlinks intact
+        run: bash scripts/check-submodule-gitlink.sh
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -63,6 +69,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Submodule gitlinks intact
+        run: bash scripts/check-submodule-gitlink.sh
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      # First after checkout: a submodule gitlink replaced by a symlink
+      # otherwise surfaces as a linker error deep inside setup-native.sh
+      # that names neither git nor submodules (#265).
+      - name: Submodule gitlinks intact
+        run: bash scripts/check-submodule-gitlink.sh
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -69,6 +74,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Submodule gitlinks intact
+        run: bash scripts/check-submodule-gitlink.sh
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ The semantic matcher links native code (llama.cpp via CGO, FAISS behind bleve's
 always — a build without both fails to link.
 
 ```sh
+bash scripts/check-submodule-gitlink.sh        # seconds: submodule must be a gitlink, not a symlink (#265)
 bash scripts/setup-native.sh                   # one-time: submodules + llama-go libs + FAISS → /usr/local/lib
 go build -tags "vectors cpu" ./...             # CGO; needs a C/C++ toolchain
 go test -tags "vectors cpu" ./... -count=1     # full unit/golden/safety/semantic suite (what CI runs)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,17 @@ golangci-lint run --build-tags "vectors,cpu" # lint (CI runs this too)
 Both tags are always required — a build without them fails to link, so there is
 no tag-free shortcut for a quick check.
 
+Never `git add` the llama-go submodule directory after pointing it at another
+checkout with a symlink (a common local trick for reusing prebuilt native
+archives): that rewrites its tree entry from a gitlink to a symlink, and a
+fresh clone then fails inside `setup-native.sh` with a linker error that names
+neither git nor submodules. `make check` and every CI job that builds native
+deps run `bash scripts/check-submodule-gitlink.sh` first to catch it. In a
+worktree, `git config submodule.<name>.ignore all` (the `<name>` from the
+`[submodule "…"]` header — it equals the path here) keeps `git add -A` off it,
+but an explicit `git add <that path>` still records the symlink, so never run
+one.
+
 Golden classifier fixtures live in `internal/classify/testdata/`; regenerate
 expectations with `UPDATE_GOLDEN=1 go test -tags "vectors cpu" ./internal/classify/`
 and review the diff carefully.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: native-deps build lint test test-race test-corpus check build-hap-and-reload reinstall-hap-from-github
+.PHONY: native-deps build lint test test-race test-corpus check-submodules check build-hap-and-reload reinstall-hap-from-github
 # SHELL := /bin/bash is required for `set -o pipefail` in *-dev targets (tee log files).
 # This affects ALL Make recipes in this file — all recipes must remain bash-compatible.
 SHELL := /bin/bash
@@ -12,7 +12,13 @@ GOLANGCI_BUILD_TAGS ?= vectors,cpu
 GO_TEST_TIMEOUT ?= 15m
 RACE_PACKAGES := ./internal/store/... ./internal/domain/... ./internal/control/... ./internal/embedder/... ./internal/match/... ./internal/daemon/...
 
-native-deps:
+# Seconds long, and it must run BEFORE native-deps: a submodule gitlink
+# replaced by a symlink (the worktree native-build trick, committed) surfaces
+# otherwise as a linker error deep inside setup-native.sh. See #265.
+check-submodules:
+	bash scripts/check-submodule-gitlink.sh
+
+native-deps: check-submodules
 	bash scripts/setup-native.sh
 
 build:
@@ -53,7 +59,7 @@ test-corpus:
 		exit 1; \
 	}
 
-check: lint test test-race test-corpus
+check: check-submodules lint test test-race test-corpus
 
 bin/hap:
 	@$(MAKE) build

--- a/scripts/check-submodule-gitlink.sh
+++ b/scripts/check-submodule-gitlink.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# Guard: this repository's submodules must be recorded as GITLINKS (mode
+# 160000) — never as a symlink (120000), never as their contents committed
+# as ordinary files, and never missing.
+#
+# Why this exists: a worktree that wants the prebuilt native archives
+# symlinks submodule/github.com/seed-hypermedia/llama-go at a sibling
+# checkout. `git add` on that path rewrites the tree entry from a gitlink to
+# a symlink. Everything still builds for whoever made it — their symlink
+# resolves — but a fresh clone gets a dangling link, `git submodule update`
+# has nothing to check out, and every CI job dies deep inside
+# scripts/setup-native.sh with a linker error that names neither git nor
+# submodules. That broke all of CI twice in #265. This check takes seconds
+# and runs first, so the failure names itself.
+#
+# Usage: bash scripts/check-submodule-gitlink.sh [ref]   (ref defaults to HEAD)
+#
+# Checks BOTH the ref's tree and the index. The index leg is what a local
+# `make check` can still catch — before the bad commit exists.
+set -euo pipefail
+
+REF="${1:-HEAD}"
+GITLINK_MODE="160000"
+TAB="$(printf '\t')"
+
+# Submodules the build cannot do without. Hardcoded deliberately: deriving
+# the list from .gitmodules alone would let a commit that DELETES the
+# .gitmodules entry pass with "nothing to check" — the same broken clone,
+# with no warning at all.
+REQUIRED_PATHS="submodule/github.com/seed-hypermedia/llama-go"
+
+# Every tracked entry under these roots must be a gitlink. This catches a
+# submodule this script has never been told about, which is why adding one
+# needs no edit here — the repo keeps them all under
+# submodule/<host>/<org>/<repo>.
+SWEEP_ROOTS="submodule"
+
+root="$(git rev-parse --show-toplevel)" || {
+  echo "check-submodule-gitlink: not inside a git working tree" >&2
+  exit 2
+}
+cd "$root"
+
+# core.quotePath=false keeps a non-ASCII path raw instead of C-quoted, so
+# the prefix tests below still match it.
+ls_tree() { git -c core.quotePath=false ls-tree -r --full-tree "$@"; }
+ls_index() { git -c core.quotePath=false ls-files --stage "$@"; }
+
+# `git ls-tree` and `git ls-files` exit 0 on a pathspec that matches
+# nothing, so an absent entry reads as an empty mode rather than aborting.
+tree_mode() {
+  git -c core.quotePath=false ls-tree --full-tree "${REF}" -- "$1" | awk '{print $1}'
+}
+
+tree_sha() {
+  git -c core.quotePath=false ls-tree --full-tree "${REF}" -- "$1" | awk 'NR==1 {print $3}'
+}
+
+index_mode() {
+  # A submodule whose contents were committed as ordinary files stages many
+  # entries; collapse to the distinct modes so that case is reported too.
+  ls_index -- "$1" | awk '{print $1}' | sort -u | tr '\n' ' ' | sed 's/ *$//'
+}
+
+index_sha() {
+  ls_index -- "$1" | awk 'NR==1 {print $2}'
+}
+
+describe_mode() {
+  case "$1" in
+    160000) echo "a gitlink (submodule)" ;;
+    120000) echo "a symlink" ;;
+    100644 | 100755) echo "a regular file" ;;
+    040000 | 40000) echo "an ordinary directory of files" ;;
+    "") echo "absent" ;;
+    *) echo "mode $1" ;;
+  esac
+}
+
+# `submodule.<KEY>.ignore` is keyed by the submodule NAME, not its path.
+# They coincide in this repo, but the printed advice must be correct even
+# when they don't.
+submodule_name_for_path() {
+  local path="$1" line
+  [ -f .gitmodules ] || { printf '%s' "$path"; return; }
+  line="$(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null |
+    awk -v p="$path" '$2 == p {print $1; exit}')" || true
+  if [ -n "$line" ]; then
+    # submodule.<name>.path -> <name>
+    line="${line#submodule.}"
+    printf '%s' "${line%.path}"
+  else
+    printf '%s' "$path"
+  fi
+}
+
+reported=" "
+
+fail() {
+  local path="$1" where="$2" mode="$3" cause remove name
+
+  case "$mode" in
+    120000)
+      cause="The submodule directory was replaced by a SYMLINK and committed — the
+  local worktree trick for reusing another checkout's prebuilt native archives."
+      remove='git rm --cached -- "PATH" && rm -f -- "PATH"'
+      ;;
+    "")
+      cause="The submodule has no entry here at all, so nothing checks it out."
+      remove='# nothing tracked to remove'
+      ;;
+    *)
+      cause="The submodule's contents were committed as ordinary files instead of a
+  gitlink, so git tracks a stale copy that no submodule update can refresh."
+      remove='git rm -r --cached -- "PATH" && rm -rf -- "PATH"'
+      ;;
+  esac
+  remove="${remove//PATH/${path}}"
+  name="$(submodule_name_for_path "${path}")"
+
+  cat >&2 <<EOF
+
+✖ submodule gitlink is broken: ${path}
+  ${where} records it as $(describe_mode "${mode}"), expected $(describe_mode "${GITLINK_MODE}") (${GITLINK_MODE}).
+
+  ${cause}
+  A fresh clone cannot materialize it, so scripts/setup-native.sh fails to
+  link and every CI job dies with an unrelated-looking error (#265).
+
+  Fix it:
+    1. ${remove}
+    2. Restore the gitlink from a commit that still has one. VERIFY the
+       source first — a ref that carries the bug names a blob, not a commit:
+         git ls-tree <good-commit> -- "${path}"   # must print: ${GITLINK_MODE} commit <sha>
+         git checkout <good-commit> -- "${path}"
+    3. git submodule update --init --recursive -- "${path}"
+
+  Do NOT repair this with 'git update-index --cacheinfo ${GITLINK_MODE},<sha>,<path>':
+  it accepts any object id without checking its type, so a sha copied from a
+  broken ref yields a ${GITLINK_MODE} entry pointing at the symlink blob. The clone
+  stays just as broken (this guard rejects that shape too).
+
+  Verify the repair:
+    git ls-tree ${REF} -- "${path}"   # must start with ${GITLINK_MODE}
+
+  Then stop it recurring in that worktree:
+    git config submodule."${name}".ignore all
+  (that keeps 'git add -A' off it; an explicit 'git add ${path}' still
+  records the symlink, so never run one)
+EOF
+}
+
+# A ${GITLINK_MODE} entry proves nothing about the OBJECT it names: cacheinfo
+# accepts any id without checking its type, so "repairing" a symlink by
+# re-staging the blob sha as a gitlink yields an entry that looks right and
+# still cannot be checked out. This is the one shape the mode comparison
+# cannot see.
+fail_object() {
+  local path="$1" where="$2" sha="$3" type="$4" name
+  name="$(submodule_name_for_path "${path}")"
+  cat >&2 <<EOF
+
+✖ submodule gitlink names the wrong kind of object: ${path}
+  ${where} has mode ${GITLINK_MODE}, but ${sha} is a ${type}, not a commit.
+
+  That is what 'git update-index --cacheinfo ${GITLINK_MODE},<sha>,<path>' produces when
+  the sha came from a broken ref (the symlink's blob). The entry passes a
+  mode check while 'git submodule update' still fails with
+  "reference is not a tree".
+
+  Fix it by taking the gitlink from a commit that has a real one:
+    git ls-tree <good-commit> -- "${path}"   # must print: ${GITLINK_MODE} commit <sha>
+    git checkout <good-commit> -- "${path}"
+    git submodule update --init --recursive -- "${path}"
+
+  Then stop it recurring in that worktree:
+    git config submodule."${name}".ignore all
+EOF
+}
+
+# A gitlink with no .gitmodules mapping cannot be fetched: the checkout
+# leaves an empty directory and setup-native.sh has nothing to build.
+fail_mapping() {
+  local path="$1" name="$2"
+  cat >&2 <<EOF
+
+✖ submodule has no .gitmodules mapping: ${path}
+  The gitlink is intact, but .gitmodules declares no url for it, so
+  'git submodule update --init' cannot fetch it and a fresh clone leaves the
+  directory empty — scripts/setup-native.sh then fails with a linker error.
+
+  Fix it by restoring the block in .gitmodules:
+    [submodule "${name}"]
+        path = ${path}
+        url = <upstream url>
+  then: git submodule update --init --recursive -- "${path}"
+EOF
+}
+
+status=0
+
+# Report each path once PER PLACE: an operator who broke both HEAD and the
+# index should learn about both in one run, but a required path that the
+# sweep also sees must not print twice.
+report() {
+  local path="$1" where="$2"
+  case "${reported}" in
+    *" ${path}|${where} "*) return ;;
+  esac
+  reported="${reported}${path}|${where} "
+  fail "$@"
+  status=1
+}
+
+report_object() {
+  local path="$1" where="$2"
+  case "${reported}" in
+    *" ${path}|${where} "*) return ;;
+  esac
+  reported="${reported}${path}|${where} "
+  fail_object "$@"
+  status=1
+}
+
+have_ref=1
+git rev-parse --verify --quiet "${REF}^{commit}" >/dev/null || have_ref=0
+if [ "${have_ref}" = 0 ]; then
+  echo "check-submodule-gitlink: ${REF} is not a commit — checking the index only" >&2
+fi
+
+# The submodule paths this run knows about: the required ones plus whatever
+# .gitmodules declares. Required paths must EXIST as gitlinks; a merely
+# declared one is only checked if it is tracked, so pointing this script at
+# an older ref does not fail over a submodule added later.
+declared_paths=""
+if [ -f .gitmodules ]; then
+  # `--get-regexp` prints "<key> <value>" space-separated, so a path (or a
+  # submodule name) containing whitespace cannot be parsed here. Rather than
+  # silently skipping it — leaving that submodule unguarded — say so and fail.
+  declared_paths="$(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null |
+    awk 'NF != 2 { print "UNPARSEABLE"; exit } { print $2 }')" || true
+  case "${declared_paths}" in
+    *UNPARSEABLE*)
+      echo "check-submodule-gitlink: .gitmodules has a submodule name or path containing" >&2
+      echo "  whitespace, which this guard cannot parse. Rename it, or add the path to" >&2
+      echo "  REQUIRED_PATHS in $0 so it is still checked." >&2
+      exit 1
+      ;;
+  esac
+fi
+
+# A 160000 entry can still name a blob (see fail_object). Only a KNOWN object
+# of the wrong type is a failure: a healthy submodule commit normally lives in
+# the submodule's own object store, so `cat-file -t` not resolving it here is
+# the expected case and must pass.
+check_gitlink_object() {
+  local path="$1" where="$2" sha="$3" type
+  [ -n "${sha}" ] || return 0
+  type="$(git cat-file -t "${sha}" 2>/dev/null)" || return 0
+  if [ "${type}" != commit ]; then
+    report_object "${path}" "${where}" "${sha}" "${type}"
+  fi
+}
+
+check_path() {
+  local path="$1" required="$2" mode
+  path_ok=1
+  if [ "${have_ref}" = 1 ]; then
+    mode="$(tree_mode "${path}")"
+    if [ -z "${mode}" ] && [ "${required}" = no ]; then
+      : # declared but not tracked at this ref — not this guard's business
+    elif [ "${mode}" != "${GITLINK_MODE}" ]; then
+      report "${path}" "${REF}" "${mode}"
+      path_ok=0
+    else
+      check_gitlink_object "${path}" "${REF}" "$(tree_sha "${path}")"
+    fi
+  fi
+  mode="$(index_mode "${path}")"
+  if [ -z "${mode}" ] && [ "${required}" = no ]; then
+    return
+  fi
+  if [ "${mode}" != "${GITLINK_MODE}" ]; then
+    report "${path}" "the index" "${mode}"
+    path_ok=0
+  else
+    check_gitlink_object "${path}" "the index" "$(index_sha "${path}")"
+  fi
+}
+
+# A required submodule also needs its .gitmodules mapping: without a url,
+# `git submodule update --init` cannot fetch it and the clone is just as
+# unbuildable as one with a broken gitlink.
+check_mapping() {
+  local path="$1" name url
+  name="$(submodule_name_for_path "${path}")"
+  url=""
+  if [ -f .gitmodules ]; then
+    url="$(git config -f .gitmodules --get "submodule.${name}.url" 2>/dev/null)" || true
+  fi
+  if [ -z "${url}" ]; then
+    fail_mapping "${path}" "${name}"
+    status=1
+  fi
+}
+
+# 1. Every known submodule path is a gitlink.
+path_ok=1
+for path in ${REQUIRED_PATHS}; do
+  check_path "${path}" yes
+  if [ "${path_ok}" = 1 ]; then
+    check_mapping "${path}"
+  fi
+done
+for path in ${declared_paths}; do
+  case " ${REQUIRED_PATHS} " in
+    *" ${path} "*) continue ;; # already checked, and required
+  esac
+  check_path "${path}" no
+done
+
+# 2. Sweep the submodule roots for the two shapes rule 1 cannot see:
+#    - a SYMLINK anywhere under them (the #265 shape, including a submodule
+#      nobody declared or that a bad commit dropped from .gitmodules), and
+#    - files tracked strictly INSIDE a known submodule path, which means its
+#      contents were committed instead of the gitlink.
+# Ordinary files that live under the roots but outside any submodule (the
+# submodule/github.com/.gitkeep placeholder) are left alone.
+sweep_entry() {
+  local mode="$1" path="$2" where="$3" known
+  if [ "${mode}" = "120000" ]; then
+    report "${path}" "${where}" "${mode}"
+    return
+  fi
+  for known in ${REQUIRED_PATHS} ${declared_paths}; do
+    case "${path}" in
+      "${known}"/*)
+        report "${known}" "${where}" "${mode}"
+        return
+        ;;
+    esac
+  done
+}
+
+# Capture to a variable first so a git failure aborts (set -e) instead of
+# being swallowed by a pipeline, and feed each loop from a heredoc so
+# `status` survives (a pipe would run the loop in a subshell).
+for sweep_root in ${SWEEP_ROOTS}; do
+  if [ "${have_ref}" = 1 ]; then
+    # `ls-tree -r` does not descend INTO a gitlink, so a healthy tree lists
+    # the gitlink rows themselves and nothing from inside them.
+    entries="$(ls_tree "${REF}" -- "${sweep_root}")"
+    while IFS= read -r line; do
+      [ -n "${line}" ] || continue
+      sweep_entry "${line%% *}" "${line#*"${TAB}"}" "${REF}"
+    done <<EOF
+${entries}
+EOF
+  fi
+
+  entries="$(ls_index -- "${sweep_root}")"
+  while IFS= read -r line; do
+    [ -n "${line}" ] || continue
+    sweep_entry "${line%% *}" "${line#*"${TAB}"}" "the index"
+  done <<EOF
+${entries}
+EOF
+done
+
+if [ "${status}" = 0 ]; then
+  echo "check-submodule-gitlink: OK — submodules are gitlinks (${GITLINK_MODE})"
+fi
+exit "${status}"

--- a/scripts/check_submodule_gitlink_test.go
+++ b/scripts/check_submodule_gitlink_test.go
@@ -1,0 +1,503 @@
+// Package scripts_test covers the shell guards in scripts/ that CI runs
+// before anything expensive. They are shell because they must work on a bare
+// checkout with no toolchain; they are tested from Go so `go test ./...`
+// keeps them honest.
+package scripts_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	gitlinkMode = "160000"
+	symlinkMode = "120000"
+	// Any 40-hex string that is NOT an object in the repo. That is the
+	// healthy shape: a submodule's commit lives in the submodule's own
+	// object store, so the superproject cannot resolve it either.
+	fakeSubmoduleSHA = "1111111111111111111111111111111111111111"
+	// The guard requires this exact path, so the synthetic repos must use
+	// it too.
+	submodulePath = "submodule/github.com/seed-hypermedia/llama-go"
+)
+
+// scriptPath resolves the guard relative to this test file's directory.
+func scriptPath(t *testing.T) string {
+	t.Helper()
+	abs, err := filepath.Abs("check-submodule-gitlink.sh")
+	if err != nil {
+		t.Fatalf("resolve script path: %v", err)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		t.Fatalf("guard script missing: %v", err)
+	}
+	return abs
+}
+
+// gitEnv seals the environment every git in this file runs under.
+//
+// cmd.Dir alone is NOT enough: an ambient GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE
+// outranks the working directory, and git exports those to every hook and to
+// `git rebase --exec` / `git bisect run` children. Inherited, these tests
+// would `git init`, stage a symlinked submodule, and COMMIT it into the
+// developer's real repository — manufacturing the very #265 breakage the
+// guard exists to prevent. The global and system config files are nulled for
+// the same reason: commit.gpgsign, core.hooksPath (this repo installs a
+// commit-msg hook that rejects these messages), init.templateDir and
+// core.autocrlf would each break the synthetic repos for reasons unrelated
+// to the guard.
+func gitEnv() []string {
+	stripped := []string{
+		"GIT_DIR=", "GIT_WORK_TREE=", "GIT_INDEX_FILE=", "GIT_OBJECT_DIRECTORY=",
+		"GIT_COMMON_DIR=", "GIT_ALTERNATE_OBJECT_DIRECTORIES=", "GIT_CEILING_DIRECTORIES=",
+		"GIT_NAMESPACE=", "GIT_CONFIG=", "GIT_CONFIG_GLOBAL=", "GIT_CONFIG_SYSTEM=",
+		// Highest-precedence config injection, which GIT_CONFIG_GLOBAL=/dev/null
+		// does not override, plus the hook-installing template dir.
+		"GIT_CONFIG_COUNT=", "GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_", "GIT_TEMPLATE_DIR=",
+	}
+	env := make([]string, 0, len(os.Environ())+6)
+	for _, kv := range os.Environ() {
+		drop := false
+		for _, prefix := range stripped {
+			if strings.HasPrefix(kv, prefix) {
+				drop = true
+				break
+			}
+		}
+		if !drop {
+			env = append(env, kv)
+		}
+	}
+	return append(env,
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+	)
+}
+
+// git runs a git command in dir and fails the test on error.
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = gitEnv()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+// newRepo creates a repository whose .gitmodules declares submodulePath.
+// The path itself is left untracked so each test can stage the shape it wants.
+func newRepo(t *testing.T) string {
+	t.Helper()
+	requireGit(t)
+	dir := t.TempDir()
+	initRepo(t, dir)
+	writeGitmodules(t, dir)
+	git(t, dir, "add", ".gitmodules")
+	return dir
+}
+
+// initRepo avoids `git init -b main`, which needs git >= 2.28: an older git
+// would hard-fail these tests instead of the suite skipping cleanly.
+func initRepo(t *testing.T, dir string) {
+	t.Helper()
+	git(t, dir, "init", "-q")
+	git(t, dir, "symbolic-ref", "HEAD", "refs/heads/main")
+}
+
+func writeGitmodules(t *testing.T, dir string) {
+	t.Helper()
+	gitmodules := "[submodule \"" + submodulePath + "\"]\n" +
+		"\tpath = " + submodulePath + "\n" +
+		"\turl = https://example.com/llama-go\n"
+	if err := os.WriteFile(filepath.Join(dir, ".gitmodules"), []byte(gitmodules), 0o644); err != nil {
+		t.Fatalf("write .gitmodules: %v", err)
+	}
+}
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+}
+
+// stage records path in the index with an explicit mode, which is the only
+// way to synthesize a gitlink without a real submodule checkout.
+func stage(t *testing.T, dir, mode, sha, path string) {
+	t.Helper()
+	git(t, dir, "update-index", "--add", "--cacheinfo", mode+","+sha+","+path)
+}
+
+// stageSymlink stages path as a symlink pointing at target — exactly the
+// shape a worktree native-build symlink takes once it is `git add`ed.
+func stageSymlink(t *testing.T, dir, path, target string) {
+	t.Helper()
+	stage(t, dir, symlinkMode, hashObject(t, dir, target), path)
+}
+
+func hashObject(t *testing.T, dir, content string) string {
+	t.Helper()
+	cmd := exec.Command("git", "hash-object", "-w", "--stdin")
+	cmd.Dir = dir
+	cmd.Env = gitEnv()
+	cmd.Stdin = strings.NewReader(content)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git hash-object: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// runGuard executes the script inside dir and returns its exit code and
+// combined output.
+func runGuard(t *testing.T, dir string, args ...string) (int, string) {
+	t.Helper()
+	cmd := exec.Command("bash", append([]string{scriptPath(t)}, args...)...)
+	cmd.Dir = dir
+	cmd.Env = gitEnv()
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return 0, string(out)
+	}
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("run guard: %v\n%s", err, out)
+	}
+	return exit.ExitCode(), string(out)
+}
+
+func mustContain(t *testing.T, out string, want ...string) {
+	t.Helper()
+	for _, w := range want {
+		if !strings.Contains(out, w) {
+			t.Errorf("output is missing %q:\n%s", w, out)
+		}
+	}
+}
+
+func TestGuardAcceptsGitlink(t *testing.T) {
+	dir := newRepo(t)
+	stage(t, dir, gitlinkMode, fakeSubmoduleSHA, submodulePath)
+	git(t, dir, "commit", "-q", "-m", "add submodule")
+
+	code, out := runGuard(t, dir)
+	if code != 0 {
+		t.Fatalf("guard rejected a valid gitlink (exit %d):\n%s", code, out)
+	}
+}
+
+// The regression that broke CI twice in #265: the gitlink replaced by a
+// symlink into a sibling checkout.
+func TestGuardRejectsSymlinkedSubmodule(t *testing.T) {
+	dir := newRepo(t)
+	stageSymlink(t, dir, submodulePath, "../../../../worktree-agent-no1/"+submodulePath)
+	git(t, dir, "commit", "-q", "-m", "symlink the submodule")
+
+	code, out := runGuard(t, dir)
+	if code != 1 {
+		t.Fatalf("guard accepted a symlinked submodule (exit %d):\n%s", code, out)
+	}
+	// The whole point is that the message names the problem and the fix,
+	// instead of surfacing as a linker error inside setup-native.sh.
+	mustContain(t, out, submodulePath, "symlink", gitlinkMode, "git submodule update --init")
+}
+
+// A staged-but-uncommitted symlink must fail too — that is the moment a
+// local `make check` can still prevent the bad commit.
+func TestGuardRejectsStagedSymlinkBeforeCommit(t *testing.T) {
+	dir := newRepo(t)
+	stage(t, dir, gitlinkMode, fakeSubmoduleSHA, submodulePath)
+	git(t, dir, "commit", "-q", "-m", "add submodule")
+	stageSymlink(t, dir, submodulePath, "/elsewhere/llama-go")
+
+	code, out := runGuard(t, dir)
+	if code != 1 {
+		t.Fatalf("guard accepted a staged symlink (exit %d):\n%s", code, out)
+	}
+	mustContain(t, out, "the index", submodulePath)
+}
+
+// A plain file staged AT the submodule path is the one broken shape the
+// root sweep cannot see — it is not a symlink, and it is not *inside* a
+// known submodule path, it IS one. Only the direct per-path index check
+// catches it.
+func TestGuardRejectsRegularFileStagedAtSubmodulePath(t *testing.T) {
+	dir := newRepo(t)
+	stage(t, dir, gitlinkMode, fakeSubmoduleSHA, submodulePath)
+	git(t, dir, "commit", "-q", "-m", "add submodule")
+	git(t, dir, "rm", "-q", "--cached", "--", submodulePath)
+	stage(t, dir, "100644", hashObject(t, dir, "not a submodule\n"), submodulePath)
+
+	code, out := runGuard(t, dir)
+	if code != 1 {
+		t.Fatalf("guard accepted a regular file at the submodule path (exit %d):\n%s", code, out)
+	}
+	mustContain(t, out, "the index records it", "a regular file", submodulePath)
+}
+
+// A staged deletion of the gitlink leaves nothing for the sweep to iterate,
+// so again only the per-path check sees it. This is the shape a botched
+// `git rm --cached` takes, and catching it before the commit is the whole
+// point of the index leg.
+func TestGuardRejectsStagedDeletionOfGitlink(t *testing.T) {
+	dir := newRepo(t)
+	stage(t, dir, gitlinkMode, fakeSubmoduleSHA, submodulePath)
+	git(t, dir, "commit", "-q", "-m", "add submodule")
+	git(t, dir, "rm", "-q", "--cached", "--", submodulePath)
+
+	code, out := runGuard(t, dir)
+	if code != 1 {
+		t.Fatalf("guard accepted a staged deletion of the gitlink (exit %d):\n%s", code, out)
+	}
+	mustContain(t, out, "the index records it", "absent", submodulePath)
+}
+
+// The mirror image, and the leg nothing else covers: the committed tree is
+// broken while the index has already been repaired. Without this, deleting
+// the guard's whole ref check leaves every other test in this file green.
+func TestGuardRejectsBrokenTreeWithCleanIndex(t *testing.T) {
+	dir := newRepo(t)
+	stageSymlink(t, dir, submodulePath, "/elsewhere/llama-go")
+	git(t, dir, "commit", "-q", "-m", "symlink the submodule")
+	// Repair only the index; HEAD still carries the symlink.
+	git(t, dir, "rm", "-q", "--cached", "--", submodulePath)
+	stage(t, dir, gitlinkMode, fakeSubmoduleSHA, submodulePath)
+
+	code, out := runGuard(t, dir)
+	if code != 1 {
+		t.Fatalf("guard accepted a broken HEAD with a clean index (exit %d):\n%s", code, out)
+	}
+	mustContain(t, out, "HEAD records it", "symlink")
+	// Both legs report independently, so this would fire if the "repair"
+	// above had not actually cleaned the index.
+	if strings.Contains(out, "the index records it") {
+		t.Errorf("the index is clean but was blamed:\n%s", out)
+	}
+}
+
+// The shape a mode comparison alone cannot see, and the one the guard's own
+// remediation text used to hand people: mode 160000 pointing at a blob.
+// `git update-index --cacheinfo` takes any object id without checking its
+// type, so re-staging the symlink's blob as a gitlink looks repaired and
+// still fails `git submodule update` with "reference is not a tree".
+func TestGuardRejectsGitlinkNamingANonCommit(t *testing.T) {
+	dir := newRepo(t)
+	blob := hashObject(t, dir, "/elsewhere/llama-go")
+	stage(t, dir, gitlinkMode, blob, submodulePath)
+	git(t, dir, "commit", "-q", "-m", "gitlink pointing at a blob")
+
+	code, out := runGuard(t, dir)
+	if code != 1 {
+		t.Fatalf("guard accepted a gitlink naming a blob (exit %d):\n%s", code, out)
+	}
+	mustContain(t, out, submodulePath, "is a blob, not a commit")
+}
+
+// A submodule commit that simply is not in the superproject's object store
+// is the NORMAL case (it lives in the submodule's own store), so an
+// unresolvable sha must pass — otherwise the guard would fail every clone
+// that has not fetched the submodule yet.
+func TestGuardAcceptsGitlinkWhoseCommitIsNotFetched(t *testing.T) {
+	dir := newRepo(t)
+	stage(t, dir, gitlinkMode, fakeSubmoduleSHA, submodulePath)
+	git(t, dir, "commit", "-q", "-m", "unfetched submodule commit")
+
+	if code, out := runGuard(t, dir); code != 0 {
+		t.Fatalf("guard rejected an unfetched submodule commit (exit %d):\n%s", code, out)
+	}
+}
+
+// A .gitmodules the guard cannot parse must fail loudly. Silently skipping
+// the entry would leave that submodule unguarded while the run still
+// reported OK.
+func TestGuardRejectsUnparseableGitmodules(t *testing.T) {
+	dir := newRepo(t)
+	stage(t, dir, gitlinkMode, fakeSubmoduleSHA, submodulePath)
+	gitmodules := "[submodule \"" + submodulePath + "\"]\n" +
+		"\tpath = " + submodulePath + "\n" +
+		"\turl = https://example.com/llama-go\n" +
+		"[submodule \"submodule/github.com/acme/my repo\"]\n" +
+		"\tpath = submodule/github.com/acme/my repo\n" +
+		"\turl = https://example.com/other\n"
+	if err := os.WriteFile(filepath.Join(dir, ".gitmodules"), []byte(gitmodules), 0o644); err != nil {
+		t.Fatalf("write .gitmodules: %v", err)
+	}
+	git(t, dir, "add", ".gitmodules")
+	git(t, dir, "commit", "-q", "-m", "submodule path with a space")
+
+	code, out := runGuard(t, dir)
+	if code != 1 {
+		t.Fatalf("guard accepted an unparseable .gitmodules (exit %d):\n%s", code, out)
+	}
+	mustContain(t, out, "whitespace")
+}
+
+// Submodule contents committed as ordinary files is the other way the
+// gitlink disappears (a `git add -f` over a materialized checkout).
+func TestGuardRejectsSubmoduleCommittedAsFiles(t *testing.T) {
+	dir := newRepo(t)
+	inner := filepath.Join(dir, submodulePath)
+	if err := os.MkdirAll(inner, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inner, "README.md"), []byte("vendored\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	git(t, dir, "add", submodulePath)
+	git(t, dir, "commit", "-q", "-m", "vendor the submodule")
+
+	code, out := runGuard(t, dir)
+	if code != 1 {
+		t.Fatalf("guard accepted vendored submodule files (exit %d):\n%s", code, out)
+	}
+	// Assert on the message, not just the exit code: exit 1 alone would
+	// also be produced by the guard failing for an unrelated reason.
+	mustContain(t, out, submodulePath, "expected a gitlink")
+}
+
+// A .gitmodules entry with no tree entry at all is broken the same way.
+func TestGuardRejectsMissingSubmoduleEntry(t *testing.T) {
+	dir := newRepo(t)
+	git(t, dir, "commit", "-q", "-m", "gitmodules only")
+
+	code, out := runGuard(t, dir)
+	if code != 1 {
+		t.Fatalf("guard accepted a missing submodule entry (exit %d):\n%s", code, out)
+	}
+	mustContain(t, out, submodulePath, "absent")
+}
+
+// The guard must not take .gitmodules as its only source of truth: a commit
+// that drops the entry (a botched deinit, a merge that deleted the file)
+// leaves the same unbuildable clone, so it must still fail when the gitlink
+// is gone — and still pass when the gitlink is intact.
+func TestGuardIsIndependentOfGitmodules(t *testing.T) {
+	requireGit(t)
+
+	t.Run("gitlink intact, no .gitmodules", func(t *testing.T) {
+		dir := t.TempDir()
+		initRepo(t, dir)
+		stage(t, dir, gitlinkMode, fakeSubmoduleSHA, submodulePath)
+		git(t, dir, "commit", "-q", "-m", "gitlink without .gitmodules")
+
+		// An intact gitlink is not enough on its own: without a url,
+		// `git submodule update --init` fatals and the clone is just as
+		// unbuildable, so this must fail — for the mapping, not the mode.
+		code, out := runGuard(t, dir)
+		if code != 1 {
+			t.Fatalf("guard passed a gitlink with no .gitmodules mapping (exit %d):\n%s", code, out)
+		}
+		mustContain(t, out, "no .gitmodules mapping", submodulePath)
+	})
+
+	t.Run("gitlink gone, no .gitmodules", func(t *testing.T) {
+		dir := t.TempDir()
+		initRepo(t, dir)
+		if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("x\n"), 0o644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		git(t, dir, "add", "README.md")
+		git(t, dir, "commit", "-q", "-m", "no submodule at all")
+
+		code, out := runGuard(t, dir)
+		if code != 1 {
+			t.Fatalf("guard passed with the required submodule gone (exit %d):\n%s", code, out)
+		}
+		mustContain(t, out, submodulePath, "absent")
+	})
+}
+
+// A symlink under the submodule root that no .gitmodules declares is the
+// same breakage wearing a different name; the sweep must catch it.
+func TestGuardRejectsUndeclaredSymlinkUnderSubmoduleRoot(t *testing.T) {
+	dir := newRepo(t)
+	stage(t, dir, gitlinkMode, fakeSubmoduleSHA, submodulePath)
+	stageSymlink(t, dir, "submodule/github.com/example/other", "/elsewhere/other")
+	git(t, dir, "commit", "-q", "-m", "undeclared symlink")
+
+	code, out := runGuard(t, dir)
+	if code != 1 {
+		t.Fatalf("guard accepted an undeclared symlink (exit %d):\n%s", code, out)
+	}
+	mustContain(t, out, "submodule/github.com/example/other", "symlink")
+}
+
+// Ordinary tracked files that live under the submodule root but outside any
+// submodule (this repo's submodule/github.com/.gitkeep) are legitimate and
+// must not trip the sweep.
+func TestGuardAllowsPlainFilesUnderSubmoduleRoot(t *testing.T) {
+	dir := newRepo(t)
+	stage(t, dir, gitlinkMode, fakeSubmoduleSHA, submodulePath)
+	keep := filepath.Join(dir, "submodule", "github.com")
+	if err := os.MkdirAll(keep, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(keep, ".gitkeep"), nil, 0o644); err != nil {
+		t.Fatalf("write .gitkeep: %v", err)
+	}
+	git(t, dir, "add", "submodule/github.com/.gitkeep")
+	git(t, dir, "commit", "-q", "-m", "placeholder")
+
+	if code, out := runGuard(t, dir); code != 0 {
+		t.Fatalf("guard rejected a legitimate placeholder file (exit %d):\n%s", code, out)
+	}
+}
+
+// An explicit ref argument must be honoured, and the index must still be
+// checked alongside it.
+func TestGuardChecksTheGivenRef(t *testing.T) {
+	dir := newRepo(t)
+	stage(t, dir, gitlinkMode, fakeSubmoduleSHA, submodulePath)
+	git(t, dir, "commit", "-q", "-m", "good")
+	git(t, dir, "branch", "good")
+	stageSymlink(t, dir, submodulePath, "/elsewhere/llama-go")
+	git(t, dir, "commit", "-q", "-m", "bad")
+
+	// HEAD is broken.
+	code, out := runGuard(t, dir, "HEAD")
+	if code != 1 {
+		t.Fatalf("guard accepted broken HEAD (exit %d):\n%s", code, out)
+	}
+	mustContain(t, out, "HEAD records it", submodulePath)
+
+	// The good branch's tree is fine, but the index still carries the
+	// symlink, so the guard must still fail — and blame the index.
+	code, out = runGuard(t, dir, "good")
+	if code != 1 {
+		t.Fatalf("guard ignored the broken index (exit %d):\n%s", code, out)
+	}
+	mustContain(t, out, "the index records it")
+	if strings.Contains(out, "good records it") {
+		t.Errorf("ref 'good' was reported broken but its tree is fine:\n%s", out)
+	}
+}
+
+// The repository this test runs in must itself be clean — the guard is only
+// useful if it is true here, and this is the assertion that fails the PR
+// that reintroduces the symlink.
+func TestThisRepositoryHasIntactGitlinks(t *testing.T) {
+	requireGit(t)
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	code, out := runGuard(t, root)
+	// Exit 2 is "not a git repository at all" — an unpacked source archive
+	// or a checkout git refuses over dubious ownership. Nothing to assert
+	// there, and accusing it of a broken gitlink would be wrong.
+	if code == 2 {
+		t.Skipf("source tree is not a usable git checkout:\n%s", out)
+	}
+	if code != 0 {
+		t.Fatalf("submodule gitlinks are broken in this checkout (exit %d):\n%s", code, out)
+	}
+}


### PR DESCRIPTION
## Why

A worktree that symlinks `submodule/github.com/seed-hypermedia/llama-go` at a sibling checkout (to reuse its prebuilt native archives) rewrites the tree entry from a gitlink (`160000`) to a symlink (`120000`) the moment that path is `git add`ed. It still builds for whoever made it — their symlink resolves — but a fresh clone gets a dangling link and **every CI job dies deep inside `scripts/setup-native.sh`** with a linker error that names neither git nor submodules.

That broke all of CI twice in #265, and only surfaced after the whole native-dependency build had run.

## What

`scripts/check-submodule-gitlink.sh` — seconds long, no toolchain needed. It checks the ref's tree **and** the index (the index leg is what a local `make check` can still catch, before the bad commit exists) and rejects every shape that produces an unbuildable clone:

| shape | how it happens |
|---|---|
| symlink at the submodule path | the worktree native-build trick, `git add`ed |
| contents committed as ordinary files | `git add -f` over a materialized checkout |
| entry missing / staged deletion | a botched `git rm --cached` |
| `160000` naming a **blob**, not a commit | a `git update-index --cacheinfo` "repair" using a sha from the broken ref |
| gitlink intact but no `.gitmodules` mapping | a merge or deinit that dropped the entry — `submodule update --init` has no url |

The required path is **hardcoded**, not read from `.gitmodules`, so a commit that deletes that file cannot make the guard pass vacuously. A sweep of `submodule/` additionally catches a symlink for a submodule nobody declared. Legitimate plain files under the root (`submodule/github.com/.gitkeep`) are left alone.

Failures print the cause for the observed mode plus the recovery steps, and explicitly warn against the `--cacheinfo` repair that would otherwise fool a mode-only check.

## Where it runs

- first step after checkout in the **four** `ci.yml` / `release.yml` jobs that build native deps (`corpus-gate` and `publish` need no submodules);
- `make check-submodules`, wired into `make check` and as a prerequisite of `native-deps`.

## Tests

`scripts/check_submodule_gitlink_test.go` — 16 tests driving the script against synthetic git repos. The git environment is sealed (`GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/config-injection vars stripped, global+system config nulled) so the tests can never stage or commit into the developer's real repository.

Mutation testing confirms the suite catches disabling the tree check, the index check, the symlink sweep, the object-type check, the mapping check, or forcing `exit 0` — no blind spots.

Also verified: full `go test -tags "vectors cpu" ./...` green, `shellcheck` clean, `gofmt`/`go vet`/`golangci-lint` clean.