### PR TITLE
#1 feat: disable the builtin rule that forced an escalation, from the TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+Every change gets a line here, including patch releases — see the Changelog
+section in `CLAUDE.md`. Entries sit under **Unreleased** until the release that
+carries them is tagged, then that heading becomes the version number.
+
+## Unreleased
+
+- Added `b` on the Escalations tab (and in an escalation's `v` detail): disables the one builtin never-auto rule that forced the selected escalation, after a `[y/N]` confirmation naming the rule, its id, and the escalation it blocked — previously this meant leaving the TUI to match a regex by eye in `hap rules list` and run `hap rules disable-seed <id>`
+- Added a `Builtin rule` line to the escalation and audit detail views, showing the rule's stable id so it can be acted on from either surface
+- `b` disables only the rule that forced that escalation; it never sets the wholesale `safety.disable_never_auto_seed_patterns` switch, never resolves to a builtin when your own `never_auto_patterns` entry has the same text as a shipped rule, and does nothing on the read-only Audit tab. Undo with `hap rules enable-seed <id>`
+- Fixed a rule merely *named* in a rationale counting as its cause: a `variance_guard` escalation quotes the suspected-irreversible diagnostic without having been blocked by it, so `b` is not offered there and the detail line marks the rule `noted, not what forced this`. The same gate now guards the `hap escalations` disable-seed hint, which had the identical gap
+
+## 0.5.6
+
+- Fixed a submodule gitlink replaced by a symlink taking down every CI job with a linker error deep inside `scripts/setup-native.sh` that named neither git nor submodules; `scripts/check-submodule-gitlink.sh` now runs first in every job that builds native dependencies, and as `make check-submodules`
+- The guard checks the ref's tree and the index — the index leg is what a local `make check` catches before the bad commit exists — and rejects a symlink, contents committed as ordinary files, a missing entry, a `160000` entry naming a blob instead of a commit, and a gitlink whose `.gitmodules` mapping was deleted, printing the recovery steps
+- Contributor-facing only; no runtime behavior changed
+
+## 0.5.5
+
+- Added `[escalations.auto_accept]`: escalations that have waited past a configured threshold can be delivered automatically instead of sitting forever. Default OFF, and fail-closed — an escalation is only eligible if it has a persisted signature baseline, and every unknown condition resolves to ineligible
+- An auto-accept is a distinct claim status (`auto-accepting` while in flight, `auto-sent` once delivered) and is deliberately never rendered as `resolved`: nothing is learned from it, so it must not read like an operator decision
+- Four escalation reasons can never be auto-accepted, excluded in code and not exposed to configuration: `never_auto_match` and `suspected_irreversible` (the hard-safety verdicts), plus `retry_exhausted` and `rate_limited` — auto-accepting a ceiling verdict re-sends the very thing the ceiling exists to stop, and because an auto-accept writes no correction the counter never advances, so it would loop forever unattended
+- A `@noop` decision is never delivered by the pass
+- Refactored the reply-delivery pipeline into `internal/deliver` so the daemon and the frontend share one fail-closed implementation (pane re-read, multi-tab answer series, Claude's remote-environment picker, menu-digit mapping) instead of drifting apart across the write partition. Operator-visible refusal strings are byte-identical
+
+## 0.5.4
+
+- Fixed `hap help task-source` and the runtime `task-source set` usage advertising `enable-llm-review`, a key `set` refuses — it was renamed to `enable-llm-review-before-auto-send` in 0.5.2. The runtime copy was appended to the rename error itself, so hap named the correct spelling and then printed usage with the wrong one
+- Fixed `task-source add --enable-llm-review-before-auto-send` still announcing "a decline is escalated to you", which stopped being true in 0.5.2; both success messages are now shared constants so they cannot drift apart again
+- Fixed `hap help tui` listing the wrong tabs and claiming complete TUI/CLI parity — the symlink shortcut and the stderr viewer have no CLI verb
+- Fixed `--template` help omitting the `{cwd}` placeholder
+
+## 0.5.3
+
+- Added the running version to the TUI header, with a newer-release hint: `Herd Auto Prompter v0.5.1 ↑ v0.5.2 available`. Both are dropped rather than wrapped on a narrow pane (hint first), because a wrapped header would push the body past the bottom
+- The release check is the plugin's only outbound network call: at most every 6h, TUI only, result cached to `<state>/update.check.json`, failures cached like successes so an offline host backs off. A `dev` build never claims an upgrade, so a linked working tree does not nag its developer
+- Added `tui.disable_check_for_update` to turn it off
+
+## 0.5.2
+
+- **Breaking.** Rebuilt the LLM task review as a pre-**delivery** filter (`internal/daemon/tasklistreview.go`). It used to fork before `domain.Decide`, which preempted the decision — a signature graduated to autonomous on `@next_task:declared` could never act — and its only failure mode was an escalation, which bars an agent from the idle poll forever, so a reviewed auto-send source silently switched itself off
+- `Decide` now decides *that* a task goes; the review decides *which* task and in what shape, and it never escalates. The mutual exclusion with `enable_auto_send_task_when_idle` is removed — the two compose
+- The LLM answers in one `submit_decision`: `task_actions`, an ordered series of checklist edits (done/delete/edit/move/add), plus `send_task`, the *reference* of the task to deliver. `send_task` is an id, never text — the daemon renders the prompt from the list itself, which removes the paraphrase-drift failure mode of the old text-based design
+- Edits, re-resolution and the `[-]` reservation share one locked read-modify-write (`taskfile.ApplyReview`)
+- The config key `enable_llm_review` is renamed `enable_llm_review_before_auto_send`
+
+## 0.5.1
+
+- Added detection for two more blocking Claude API banners: `api-server-error` ("API Error: Server error mid-response…") and `api-overloaded` ("API Error: NNN Overloaded…", generalized beyond code 529)
+
+Releases 0.5.0 and earlier are documented on the
+[Releases page](https://github.com/0xGosu/herdr-auto-pilot/releases) only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,24 @@ ticket/issue id**. Examples:
   new worktree from `main` that includes those staged changes, and continue there without
   disturbing the other work in progress.
 
+## Changelog (MANDATORY)
+
+**Every change gets an entry in `CHANGELOG.md` at the repo root — including
+patch releases.** No exceptions for "small", "internal", or "just a fix": if it
+merges, it is in the changelog. A PR without one is incomplete.
+
+- Add the line(s) under `## Unreleased`, in the same commit as the change. The
+  heading becomes the version number when that release is tagged (the manifest
+  version TRAILS releases, so the number is not known at merge time).
+- Style: a flat list of verb-first one-liners — `Added …`, `Fixed …`,
+  `Changed …`, `Removed …`. No sub-sections.
+- Write what it MEANS for the reader, not what the diff did. GitHub already
+  generates a per-release list of PR titles; this file exists for what a title
+  cannot carry — the bounds of a new action, what a changed default now does,
+  what a fix stops happening.
+- Mark a breaking change **Breaking.** at the start of its line, matching the
+  `feat!:` commit type.
+
 ## Version bump & release
 
 Releases are **automated on merge to main** with a bump-then-tag model

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,12 @@ herdr plugin link .
    - a **macOS** matrix leg, where test binaries need `-ldflags "-r /usr/local/lib"`
      to reach the FAISS dylibs.
 4. Describe *what* and *why* in the PR body; link related issues.
+5. **Add an entry under `## Unreleased` in `CHANGELOG.md`** — required for every
+   change, including patch-level fixes, in the same commit as the change itself.
+   Verb-first one-liners (`Added …`, `Fixed …`); write what it means for the
+   reader, not what the diff did. GitHub already generates a list of PR titles
+   per release; that file is for what a title cannot convey, like the bounds of
+   a new action. See the Changelog section in `CLAUDE.md`.
 
 Never put `[skip ci]`, `[ci skip]`, or `[no ci]` anywhere in the squash-merge
 message (title or body) of a PR that should release. GitHub suppresses *all*

--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,13 @@ The id is a hash of the pattern, so it names the same rule across upgrades (and
 is rejected if that pattern no longer ships). One seed rule is a single regex
 that may cover several phrasings — disabling it silences all of them.
 
+In the TUI you can do the same without leaving the escalation it blocked: on the
+Escalations tab (or inside an escalation's `v` detail), **`b` disables the one
+builtin rule that forced the selected escalation**, after a confirmation naming
+the rule and its id. It is offered only while that escalation was actually
+raised by a builtin rule, and it never touches any other rule — the detail view
+shows the id under `Builtin rule` either way.
+
 Extend the set with your own regex patterns:
 
 ```toml

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -868,7 +868,11 @@ func escalations(ctx context.Context, app *frontend.App, out io.Writer, args []s
 	// exact command to silence just that one rule. Gated on esc[0] — the SAME row
 	// as the confirm/dismiss ids above — so the hint always refers to the
 	// escalation being acted on, never an unrelated older row in a mixed queue.
-	if rule, ok := domain.SeedRuleForRationale(esc[0].Rationale); ok {
+	// Gated on the rule having FORCED this escalation, not merely being named
+	// in its rationale: the variance guard appends the same diagnostic to its
+	// own, so a [variance_guard] row would otherwise get a hint offering to
+	// disable a rule that is not why it escalated.
+	if rule, ok := domain.SeedRuleForcedEscalation(esc[0].Rationale); ok {
 		hints = append(hints, Hint{
 			Cmd: fmt.Sprintf("hap rules disable-seed %s", domain.SeedRuleID(rule.Pattern)),
 			Why: fmt.Sprintf("a builtin safety rule blocked escalation #%d — silence it if it is too aggressive for this repo", id),

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -885,9 +885,16 @@ func TestEscalationsAndAuditShowMatchedRule(t *testing.T) {
 	}
 }
 
-// seedHeuristicDiagnostic returns a real builtin-heuristic hit's rationale plus
-// the durable id and pattern of the seed rule that produced it.
-func seedHeuristicDiagnostic(t *testing.T) (rationale, id, pattern string) {
+// seedHeuristicRationale returns the rationale a real builtin-heuristic hit
+// produces AS THE DAEMON PERSISTS IT — the machine-readable "[reason]" tag it
+// prefixes (daemon.escalate) followed by the hit's diagnostic — plus the
+// durable id and pattern of the seed rule behind it.
+//
+// The tag is not cosmetic: it is what says the rule is the CAUSE, and the
+// disable-seed hint is gated on it (a [variance_guard] row carries the same
+// diagnostic for a rule that did not force it). A fixture without the tag
+// would test a record shape that never reaches the database.
+func seedHeuristicRationale(t *testing.T) (rationale, id, pattern string) {
 	t.Helper()
 	list, errs := domain.NewNeverAutoList(true, nil, nil, nil)
 	if len(errs) > 0 {
@@ -901,7 +908,8 @@ func seedHeuristicDiagnostic(t *testing.T) (rationale, id, pattern string) {
 	if !ok {
 		t.Fatal("seed rationale must resolve to a rule")
 	}
-	return hit.Diagnostic(), domain.SeedRuleID(rule.Pattern), rule.Pattern
+	return "[" + string(domain.ReasonSuspectedIrrevers) + "] " + hit.Diagnostic(),
+		domain.SeedRuleID(rule.Pattern), rule.Pattern
 }
 
 func TestRulesListShowsSeedIDsAndDisables(t *testing.T) {
@@ -953,7 +961,7 @@ func TestRulesListShowsSeedIDsAndDisables(t *testing.T) {
 
 func TestEscalationsHintsDisableSeedForBuiltinRule(t *testing.T) {
 	app, st := testApp(t)
-	rationale, wantID, _ := seedHeuristicDiagnostic(t)
+	rationale, wantID, _ := seedHeuristicRationale(t)
 
 	st.AppendAudit(context.Background(), domain.AuditRecord{Signature: "approval:seedhit0001",
 		Trigger: "purge?", SituationType: domain.SituationApproval, Action: "escalated",
@@ -991,7 +999,7 @@ func TestEscalationsOmitsDisableSeedForNonSeedEscalation(t *testing.T) {
 func TestEscalationsDisableSeedHintTracksNewestRow(t *testing.T) {
 	app, st := testApp(t)
 	ctx := context.Background()
-	rationale, wantID, _ := seedHeuristicDiagnostic(t)
+	rationale, wantID, _ := seedHeuristicRationale(t)
 
 	// Older row is the seed-caused one; a newer non-seed row sits on top.
 	st.AppendAudit(ctx, domain.AuditRecord{Signature: "approval:oldseed0001",
@@ -1016,6 +1024,32 @@ func TestEscalationsDisableSeedHintTracksNewestRow(t *testing.T) {
 	out, _ = run(t, app, "escalations")
 	if !strings.Contains(out, "hap rules disable-seed "+wantID) {
 		t.Errorf("a seed-caused newest row should surface the hint, got:\n%s", out)
+	}
+}
+
+// TestEscalationsOmitsDisableSeedWhenAnotherReasonNamedTheRule is the
+// regression for the variance guard naming a rule it was not blocked by: it
+// appends the suspected-irreversible diagnostic to its OWN rationale, so the
+// row names a seed rule while a different control forced the escalation.
+// Hinting disable-seed there would tell the operator to weaken the safety net
+// on a false premise — and leave them blocked, since the guard keeps escalating.
+func TestEscalationsOmitsDisableSeedWhenAnotherReasonNamedTheRule(t *testing.T) {
+	app, st := testApp(t)
+	rationale, _, _ := seedHeuristicRationale(t)
+	// Same diagnostic, different (and truthful) reason tag.
+	_, diagnostic, _ := strings.Cut(rationale, "] ")
+	varianceGuard := "[" + string(domain.ReasonVarianceGuard) + "] contradictory history; " + diagnostic
+
+	st.AppendAudit(context.Background(), domain.AuditRecord{Signature: "approval:variance001",
+		Trigger: "purge?", SituationType: domain.SituationApproval, Action: "escalated",
+		Rationale: varianceGuard, Status: "escalated", CreatedAt: time.Now()})
+
+	out, err := run(t, app, "escalations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "disable-seed") {
+		t.Errorf("a rule the variance guard merely named must not be hinted for disabling, got:\n%s", out)
 	}
 }
 

--- a/internal/domain/safety.go
+++ b/internal/domain/safety.go
@@ -214,6 +214,36 @@ func SeedRuleForRationale(rationale string) (NeverAutoRule, bool) {
 	return NeverAutoRule{}, false
 }
 
+// SeedRuleForcedEscalation resolves the shipped never-auto rule that FORCED an
+// escalation. It is the gate every "silence this rule" affordance must use —
+// SeedRuleForRationale alone is not enough.
+//
+// Two conditions, both required:
+//
+//   - the rationale carries a source=seed diagnostic (SeedRuleForRationale),
+//     which rules out an operator rule whose pattern text equals a shipped
+//     one; and
+//   - the escalation's REASON is one whose rationale IS that hit.
+//
+// The second is not redundant. The variance guard appends the
+// suspected-irreversible diagnostic to its OWN rationale, so a confirmable line
+// still names why the action looked destructive — which means a
+// [variance_guard] row names a seed rule that did not force it. Offering to
+// disable that rule would weaken the safety net on a false premise AND leave
+// the operator still blocked, because the guard keeps escalating the same
+// situation.
+func SeedRuleForcedEscalation(rationale string) (NeverAutoRule, bool) {
+	reason, ok := EscalationReason(rationale)
+	if !ok {
+		return NeverAutoRule{}, false
+	}
+	switch reason {
+	case ReasonNeverAutoMatch, ReasonSuspectedIrrevers:
+		return SeedRuleForRationale(rationale)
+	}
+	return NeverAutoRule{}, false
+}
+
 // compiledNeverAutoRule is one unified rule ready for matching.
 type compiledNeverAutoRule struct {
 	rule NeverAutoRule

--- a/internal/domain/safety_test.go
+++ b/internal/domain/safety_test.go
@@ -773,3 +773,52 @@ func TestSeedRuleIDIsDurableAcrossOrdering(t *testing.T) {
 		t.Error("an operator pattern must not be recognized as a seed pattern")
 	}
 }
+
+// TestSeedRuleForcedEscalationRequiresTheReasonToBeTheHit guards the gate every
+// "silence this rule" affordance uses. The variance guard APPENDS the
+// suspected-irreversible diagnostic to its own rationale (see Decide), so a
+// [variance_guard] escalation names a seed rule that did not force it.
+// Resolving it there would offer to weaken the safety net on a false premise —
+// and leave the operator still blocked, since the guard keeps escalating.
+func TestSeedRuleForcedEscalationRequiresTheReasonToBeTheHit(t *testing.T) {
+	a := newSeedNeverAuto(t)
+	hit, ok := a.SuspectedIrreversible("claude", "This action cannot be undone")
+	if !ok {
+		t.Fatal("expected the no-undo heuristic to fire")
+	}
+
+	// The two reasons whose rationale IS the hit resolve.
+	for _, reason := range []EscalateReason{ReasonNeverAutoMatch, ReasonSuspectedIrrevers} {
+		rationale := "[" + string(reason) + "] " + hit.Diagnostic()
+		rule, ok := SeedRuleForcedEscalation(rationale)
+		if !ok {
+			t.Fatalf("%s must resolve its own hit: %q", reason, rationale)
+		}
+		if rule.Pattern != hit.Pattern {
+			t.Errorf("%s resolved pattern=%q want %q", reason, rule.Pattern, hit.Pattern)
+		}
+	}
+
+	// The variance guard's own rationale carries the same diagnostic and must
+	// NOT resolve — this is the regression.
+	varianceGuard := "[" + string(ReasonVarianceGuard) + "] contradictory history; " + hit.Diagnostic()
+	if _, ok := SeedRuleForcedEscalation(varianceGuard); ok {
+		t.Errorf("a rule the variance guard merely named must not resolve: %q", varianceGuard)
+	}
+	// SeedRuleForRationale alone still resolves it — which is exactly why the
+	// reason gate is not redundant.
+	if _, ok := SeedRuleForRationale(varianceGuard); !ok {
+		t.Error("SeedRuleForRationale should still name the rule; the reason gate is what adds causation")
+	}
+
+	// An untagged rationale cannot prove causation, so it fails closed.
+	if _, ok := SeedRuleForcedEscalation(hit.Diagnostic()); ok {
+		t.Error("an untagged rationale must not resolve")
+	}
+	// An operator rule whose pattern text equals a shipped one stays excluded
+	// through the new gate too: the source check still runs underneath it.
+	if _, ok := SeedRuleForcedEscalation("[" + string(ReasonNeverAutoMatch) + "] pattern " +
+		hit.Pattern + ` matched "x" (source=operator kind=strict)`); ok {
+		t.Error("an operator-sourced hit must not resolve through the reason gate")
+	}
+}

--- a/internal/tui/seedrule_test.go
+++ b/internal/tui/seedrule_test.go
@@ -1,0 +1,532 @@
+package tui
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+)
+
+// aSeedRule returns a shipped rule to build fixtures from. Taken from the live
+// seed list rather than hardcoded, so these tests keep testing a REAL rule
+// after the seed set changes (a hardcoded pattern would silently stop
+// resolving and the tests would assert on nothing).
+//
+// Deliberately NOT index 0: an implementation that resolved "the first seed
+// rule" instead of the matched one would pass every assertion here if the
+// fixtures were built from rules[0].
+func aSeedRule(t *testing.T) domain.NeverAutoRule {
+	t.Helper()
+	rules := domain.SeedNeverAutoRules()
+	if len(rules) < 2 {
+		t.Fatal("need at least two shipped seed rules to tell the matched one apart")
+	}
+	return rules[len(rules)/2]
+}
+
+// firstSeedRule is the decoy: the rule a "resolves the wrong one" bug would
+// reach for. No fixture ever matches it, so it must never be disabled.
+func firstSeedRule(t *testing.T) domain.NeverAutoRule {
+	t.Helper()
+	rules := domain.SeedNeverAutoRules()
+	if len(rules) == 0 {
+		t.Fatal("no seed never-auto rules ship")
+	}
+	return rules[0]
+}
+
+// seedRationale renders the rationale the daemon actually persists: the
+// machine-readable "[reason]" tag it prefixes (daemon.escalate) followed by
+// the hit's diagnostic. Both halves matter — the tag is what says the rule is
+// the CAUSE, and the diagnostic is what names the rule.
+func seedRationale(reason domain.EscalateReason, rule domain.NeverAutoRule, source domain.NeverAutoRuleSource) string {
+	hit := domain.NeverAutoHit{
+		Pattern: rule.Pattern,
+		Excerpt: "rm -rf /var/data",
+		Source:  source,
+		Kind:    rule.Kind,
+	}
+	return "[" + string(reason) + "] " + hit.Diagnostic()
+}
+
+// escModelWith builds a Model on the Escalations tab showing rows.
+func escModelWith(t *testing.T, cfg config.Config, rows []domain.AuditRecord) Model {
+	t.Helper()
+	m := Model{width: 200, height: 40}
+	msg := refreshMsg{cfg: cfg}
+	msg.escalations = rows
+	upd, _ := m.Update(msg)
+	m = upd.(Model)
+	m.tab = tabEscalations
+	return m
+}
+
+func seedRuleEscalation(id int64, rule domain.NeverAutoRule, source domain.NeverAutoRuleSource) domain.AuditRecord {
+	return escalationWithRationale(id, seedRationale(domain.ReasonNeverAutoMatch, rule, source))
+}
+
+func escalationWithRationale(id int64, rationale string) domain.AuditRecord {
+	return domain.AuditRecord{
+		ID: id, AgentID: "w1:p1", SituationType: domain.SituationApproval,
+		Action: "escalated", Status: "escalated",
+		Rationale: rationale,
+		CreatedAt: time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+// The rationale names a regex; it does not say which of the ~90 shipped rules
+// that is, nor how to silence it. The detail must resolve it to its stable id.
+func TestEscalationDetailNamesTheBuiltinRule(t *testing.T) {
+	rule := aSeedRule(t)
+	m := escModelWith(t, config.Default(), []domain.AuditRecord{seedRuleEscalation(1, rule, domain.NeverAutoSeed)})
+
+	m = press(t, m, "v")
+	if m.detail == nil {
+		t.Fatal("v should open the escalation detail")
+	}
+	if m.detail.seedRule == nil {
+		t.Fatal("detail should snapshot the builtin rule that forced this escalation")
+	}
+	if m.detail.seedRule.Pattern != rule.Pattern {
+		t.Errorf("detail snapshotted %q, want %q", m.detail.seedRule.Pattern, rule.Pattern)
+	}
+	lines := strings.Join(m.detail.lines, "\n")
+	for _, want := range []string{"Builtin rule", domain.SeedRuleID(rule.Pattern)} {
+		if !strings.Contains(lines, want) {
+			t.Errorf("detail missing %q:\n%s", want, lines)
+		}
+	}
+	if !strings.Contains(m.helpLine(), "b: disable builtin rule") {
+		t.Errorf("detail help should advertise b, got %q", m.helpLine())
+	}
+}
+
+// The key must be advertised only where it does something: on an escalation
+// nothing builtin blocked, `b` has no target.
+func TestEscalationsHelpAdvertisesBuiltinKeyOnlyWhenOneMatched(t *testing.T) {
+	rule := aSeedRule(t)
+	withRule := escModelWith(t, config.Default(), []domain.AuditRecord{seedRuleEscalation(1, rule, domain.NeverAutoSeed)})
+	if !strings.Contains(withRule.helpLine(), "b: disable builtin rule") {
+		t.Errorf("help should advertise b when a builtin rule matched, got %q", withRule.helpLine())
+	}
+
+	plain := escModelWith(t, config.Default(), []domain.AuditRecord{{
+		ID: 1, AgentID: "w1:p1", SituationType: domain.SituationApproval,
+		Action: "escalated", Status: "escalated", Rationale: "low confidence",
+		CreatedAt: time.Now(),
+	}})
+	if strings.Contains(plain.helpLine(), "b: disable builtin rule") {
+		t.Errorf("help should not advertise b with no builtin match, got %q", plain.helpLine())
+	}
+}
+
+// The end-to-end path: b asks, y writes, and ONLY the matched rule is written.
+func TestDisableMatchedSeedRuleWritesOnlyThatRule(t *testing.T) {
+	rule := aSeedRule(t)
+	dir := t.TempDir()
+	app := &frontend.App{ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	m := escModelWith(t, config.Default(), []domain.AuditRecord{seedRuleEscalation(7, rule, domain.NeverAutoSeed)})
+	m.ctx = context.Background()
+	m.app = app
+
+	upd, cmd := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if cmd != nil {
+		t.Fatal("b must ask before weakening a safety control, not act")
+	}
+	if m.confirm == nil {
+		t.Fatal("b should open a confirmation")
+	}
+	// The question has to name what is being turned off, and tie it to the
+	// escalation the operator is looking at.
+	for _, want := range []string{domain.SeedRuleID(rule.Pattern), rule.Pattern, "#7"} {
+		if !strings.Contains(m.confirm.label, want) {
+			t.Errorf("confirm label missing %q: %q", want, m.confirm.label)
+		}
+	}
+
+	upd, cmd = m.Update(pressKeyMsg("y"))
+	m = upd.(Model)
+	if cmd == nil {
+		t.Fatal("confirming should issue the disable command")
+	}
+	res, ok := cmd().(actionResultMsg)
+	if !ok || res.err != nil {
+		t.Fatalf("disable should succeed, got %+v", res)
+	}
+	if !strings.Contains(res.message, domain.SeedRuleID(rule.Pattern)) {
+		t.Errorf("result should name the rule id, got %q", res.message)
+	}
+
+	cfg, err := config.Load(app.ConfigPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if len(cfg.Safety.DisabledSeedPatterns) != 1 || cfg.Safety.DisabledSeedPatterns[0] != rule.Pattern {
+		t.Fatalf("exactly the matched rule should be disabled, got %q", cfg.Safety.DisabledSeedPatterns)
+	}
+	// An implementation that resolved "a" seed rule instead of THE matched one
+	// would most likely land on the first; nothing here ever matches it.
+	if decoy := firstSeedRule(t).Pattern; decoy != rule.Pattern {
+		for _, p := range cfg.Safety.DisabledSeedPatterns {
+			if p == decoy {
+				t.Errorf("disabled the first seed rule, not the matched one: %q", p)
+			}
+		}
+	}
+	// The blunt instrument beside it must stay untouched: this action silences
+	// one rule, never the whole safety net.
+	if cfg.Safety.DisableNeverAutoSeedPatterns {
+		t.Error("disabling one rule must not flip the master seed switch")
+	}
+}
+
+// An escalation nobody's builtin rule forced must refuse — and say so, rather
+// than silently doing nothing.
+func TestDisableMatchedSeedRuleRefusesWithoutABuiltinMatch(t *testing.T) {
+	m := escModelWith(t, config.Default(), []domain.AuditRecord{{
+		ID: 1, AgentID: "w1:p1", SituationType: domain.SituationApproval,
+		Action: "escalated", Status: "escalated",
+		Rationale: "confidence 0.42 below threshold", CreatedAt: time.Now(),
+	}})
+
+	upd, cmd := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if cmd != nil || m.confirm != nil {
+		t.Fatal("b should do nothing when no builtin rule matched")
+	}
+	if !strings.Contains(m.message, "no builtin safety rule") {
+		t.Errorf("should explain why, got %q", m.message)
+	}
+}
+
+// An OPERATOR rule whose pattern text happens to equal a shipped one must not
+// disable the builtin: they are different rules, and disabling the seed would
+// leave the operator's own rule still blocking — the escalation would repeat
+// while the safety net was quietly weakened.
+func TestDisableMatchedSeedRuleIgnoresAnOperatorRuleWithTheSamePattern(t *testing.T) {
+	rule := aSeedRule(t)
+	m := escModelWith(t, config.Default(), []domain.AuditRecord{seedRuleEscalation(1, rule, domain.NeverAutoOperator)})
+
+	if m.detail != nil {
+		t.Fatal("no detail expected yet")
+	}
+	upd, cmd := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if cmd != nil || m.confirm != nil {
+		t.Fatal("an operator-sourced hit must not offer to disable a builtin rule")
+	}
+	if strings.Contains(m.helpLine(), "b: disable builtin rule") {
+		t.Errorf("help must not advertise b for an operator-sourced hit, got %q", m.helpLine())
+	}
+}
+
+// Re-pressing b on a rule that is already off must report that, not ask a
+// question whose answer changes nothing.
+func TestDisableMatchedSeedRuleReportsAlreadyDisabled(t *testing.T) {
+	rule := aSeedRule(t)
+	cfg := config.Default()
+	cfg.Safety.DisabledSeedPatterns = []string{rule.Pattern}
+	m := escModelWith(t, cfg, []domain.AuditRecord{seedRuleEscalation(1, rule, domain.NeverAutoSeed)})
+
+	upd, cmd := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if cmd != nil || m.confirm != nil {
+		t.Fatal("an already-disabled rule should not prompt")
+	}
+	if !strings.Contains(m.message, "already disabled") {
+		t.Errorf("should say it is already disabled, got %q", m.message)
+	}
+	// The detail must say so too: an old escalation raised while the rule was
+	// live otherwise reads as a block still waiting to be cleared.
+	m = press(t, m, "v")
+	if lines := strings.Join(m.detail.lines, "\n"); !strings.Contains(lines, "already disabled") {
+		t.Errorf("detail should mark the rule inactive:\n%s", lines)
+	}
+}
+
+// The master switch is a different truth from a per-rule disable: re-enabling
+// one rule does nothing while it is on, so the refusal must name it.
+func TestDisableMatchedSeedRuleReportsTheMasterSwitch(t *testing.T) {
+	rule := aSeedRule(t)
+	cfg := config.Default()
+	cfg.Safety.DisableNeverAutoSeedPatterns = true
+	m := escModelWith(t, cfg, []domain.AuditRecord{seedRuleEscalation(1, rule, domain.NeverAutoSeed)})
+
+	upd, cmd := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if cmd != nil || m.confirm != nil {
+		t.Fatal("no prompt while every builtin rule is already off")
+	}
+	if !strings.Contains(m.message, "disable_never_auto_seed_patterns") {
+		t.Errorf("should name the master switch, got %q", m.message)
+	}
+}
+
+// A refresh can land between the question and the answer. Confirming then must
+// not report a disable that did nothing.
+func TestDisableMatchedSeedRuleRevalidatesBeforeWriting(t *testing.T) {
+	rule := aSeedRule(t)
+	m := escModelWith(t, config.Default(), []domain.AuditRecord{seedRuleEscalation(1, rule, domain.NeverAutoSeed)})
+
+	upd, _ := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if m.confirm == nil {
+		t.Fatal("b should open a confirmation")
+	}
+	// Someone else (Config tab, another hap) disabled it meanwhile.
+	m.data.cfg.Safety.DisabledSeedPatterns = []string{rule.Pattern}
+
+	upd, cmd := m.Update(pressKeyMsg("y"))
+	m = upd.(Model)
+	if cmd != nil {
+		t.Fatal("confirming a rule disabled meanwhile must not run the write")
+	}
+	if !strings.Contains(m.message, "already disabled") {
+		t.Errorf("should report the re-check result, got %q", m.message)
+	}
+}
+
+// The overlay's b acts on the record ON SCREEN. A background refresh that
+// reorders the list under it must not retarget the action — the same rule the
+// other per-entry overlay actions follow.
+func TestDisableSeedRuleFromDetailUsesTheSnapshotNotTheCursor(t *testing.T) {
+	rules := domain.SeedNeverAutoRules()
+	if len(rules) < 3 {
+		t.Skip("needs three distinct seed rules")
+	}
+	// Neither is index 0, so "resolved the first rule" cannot pass this.
+	first, second := rules[len(rules)/2], rules[len(rules)-1]
+	if first.Pattern == second.Pattern {
+		t.Skip("needs two distinct seed patterns")
+	}
+	m := escModelWith(t, config.Default(), []domain.AuditRecord{
+		seedRuleEscalation(1, first, domain.NeverAutoSeed),
+	})
+	m = press(t, m, "v")
+	if m.detail == nil || m.detail.seedRule == nil {
+		t.Fatal("detail should snapshot the rule")
+	}
+
+	// A refresh replaces the row under the cursor with a different escalation
+	// forced by a DIFFERENT builtin rule.
+	m.data.escalations = []domain.AuditRecord{seedRuleEscalation(2, second, domain.NeverAutoSeed)}
+
+	upd, cmd := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if cmd != nil {
+		t.Fatal("b in the overlay must ask, not act")
+	}
+	if m.confirm == nil {
+		t.Fatal("b in the overlay should open a confirmation")
+	}
+	if !strings.Contains(m.confirm.label, domain.SeedRuleID(first.Pattern)) {
+		t.Errorf("should target the snapshotted rule %s, label %q",
+			domain.SeedRuleID(first.Pattern), m.confirm.label)
+	}
+	if strings.Contains(m.confirm.label, domain.SeedRuleID(second.Pattern)) {
+		t.Errorf("must not target the rule that scrolled under the cursor: %q", m.confirm.label)
+	}
+	if !strings.Contains(m.confirm.label, "#1") {
+		t.Errorf("should name the snapshotted escalation #1, got %q", m.confirm.label)
+	}
+}
+
+// The Audit tab is a read-only history; b there must not weaken anything.
+func TestDisableMatchedSeedRuleIsEscalationsOnly(t *testing.T) {
+	rule := aSeedRule(t)
+	m := Model{width: 200, height: 40}
+	msg := refreshMsg{cfg: config.Default()}
+	msg.audit = []domain.AuditRecord{seedRuleEscalation(1, rule, domain.NeverAutoSeed)}
+	upd, _ := m.Update(msg)
+	m = upd.(Model)
+	m.tab = tabAudit
+
+	upd, cmd := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if cmd != nil || m.confirm != nil {
+		t.Fatal("b must do nothing on the Audit tab")
+	}
+	// The record still names the rule there — reading which rule decided a
+	// past record is exactly the Audit tab's job.
+	m = press(t, m, "v")
+	if lines := strings.Join(m.detail.lines, "\n"); !strings.Contains(lines, "Builtin rule") {
+		t.Errorf("audit detail should still name the builtin rule:\n%s", lines)
+	}
+	if m.detail.seedRule != nil {
+		t.Error("audit detail must not arm the disable action")
+	}
+	if strings.Contains(m.helpLine(), "b: disable builtin rule") {
+		t.Errorf("audit detail help must not advertise b, got %q", m.helpLine())
+	}
+}
+
+// Cancelling must leave the safety net exactly as it was.
+func TestDisableMatchedSeedRuleCancelChangesNothing(t *testing.T) {
+	rule := aSeedRule(t)
+	dir := t.TempDir()
+	app := &frontend.App{ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	m := escModelWith(t, config.Default(), []domain.AuditRecord{seedRuleEscalation(1, rule, domain.NeverAutoSeed)})
+	m.ctx = context.Background()
+	m.app = app
+
+	upd, _ := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if m.confirm == nil {
+		t.Fatal("b should open a confirmation — without one there is nothing to cancel")
+	}
+	upd, cmd := m.Update(pressKeyMsg("n"))
+	m = upd.(Model)
+	if cmd != nil {
+		t.Fatal("cancelling must not run the write")
+	}
+	if m.confirm != nil {
+		t.Error("cancelling should close the confirmation")
+	}
+	cfg, err := config.Load(app.ConfigPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if len(cfg.Safety.DisabledSeedPatterns) != 0 {
+		t.Errorf("cancel must disable nothing, got %q", cfg.Safety.DisabledSeedPatterns)
+	}
+}
+
+// Guard the id the operator acts on: it is a content hash, so the rule named
+// in the prompt is the rule `hap rules list` shows and `enable-seed` restores.
+func TestDisableMatchedSeedRulePromptIdMatchesTheCLIId(t *testing.T) {
+	rule := aSeedRule(t)
+	m := escModelWith(t, config.Default(), []domain.AuditRecord{seedRuleEscalation(1, rule, domain.NeverAutoSeed)})
+
+	upd, _ := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if m.confirm == nil {
+		t.Fatal("b should open a confirmation")
+	}
+	resolved, ok := domain.SeedRuleByID(domain.SeedRuleID(rule.Pattern))
+	if !ok {
+		t.Fatal("the id in the prompt must resolve back to a shipped rule")
+	}
+	if resolved.Pattern != rule.Pattern {
+		t.Errorf("id resolves to %q, want %q", resolved.Pattern, rule.Pattern)
+	}
+	if !strings.Contains(m.confirm.label, domain.SeedRuleID(rule.Pattern)) {
+		t.Errorf("prompt should carry that id: %q", m.confirm.label)
+	}
+}
+
+// The regression the reason gate exists for. The variance guard appends the
+// suspected-irreversible diagnostic to its OWN rationale, so a
+// [variance_guard] escalation names a seed rule it was not forced by.
+// Offering `b` there would weaken the safety net on a false premise AND leave
+// the operator blocked, because the guard keeps escalating the same situation.
+func TestBuiltinRuleNamedByAnotherReasonIsNotOfferedForDisabling(t *testing.T) {
+	rule := aSeedRule(t)
+	hit := domain.NeverAutoHit{
+		Pattern: rule.Pattern, Excerpt: "rm -rf /var/data",
+		Source: domain.NeverAutoSeed, Kind: rule.Kind,
+	}
+	rec := escalationWithRationale(1,
+		"[variance_guard] contradictory history; "+hit.Diagnostic())
+	m := escModelWith(t, config.Default(), []domain.AuditRecord{rec})
+
+	upd, cmd := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if cmd != nil || m.confirm != nil {
+		t.Fatal("a rule the variance guard merely NAMED must not be offered for disabling")
+	}
+	if strings.Contains(m.helpLine(), "b: disable builtin rule") {
+		t.Errorf("help must not advertise b on a [variance_guard] row, got %q", m.helpLine())
+	}
+
+	m = press(t, m, "v")
+	if m.detail == nil {
+		t.Fatal("v should open the detail")
+	}
+	if m.detail.seedRule != nil {
+		t.Error("the overlay must not arm the disable action for a rule that did not force this")
+	}
+	lines := strings.Join(m.detail.lines, "\n")
+	// The rule is still WORTH naming — it says why the action looked
+	// destructive — but the line must not imply it caused the escalation.
+	if !strings.Contains(lines, "Builtin rule") {
+		t.Errorf("detail should still name the rule:\n%s", lines)
+	}
+	if !strings.Contains(lines, "not what forced this") {
+		t.Errorf("detail must say the rule is not the cause:\n%s", lines)
+	}
+	if strings.Contains(m.helpLine(), "b: disable builtin rule") {
+		t.Errorf("overlay help must not advertise b, got %q", m.helpLine())
+	}
+}
+
+// An untagged rationale (a legacy row written before the daemon prefixed the
+// reason) cannot prove the rule was the cause, so it must fail closed.
+func TestUntaggedRationaleDoesNotArmTheDisableAction(t *testing.T) {
+	rule := aSeedRule(t)
+	hit := domain.NeverAutoHit{
+		Pattern: rule.Pattern, Excerpt: "rm -rf /var/data",
+		Source: domain.NeverAutoSeed, Kind: rule.Kind,
+	}
+	m := escModelWith(t, config.Default(),
+		[]domain.AuditRecord{escalationWithRationale(1, hit.Diagnostic())})
+
+	upd, cmd := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if cmd != nil || m.confirm != nil {
+		t.Fatal("an untagged rationale must not arm the disable action")
+	}
+	if !strings.Contains(m.message, "no builtin safety rule") {
+		t.Errorf("should explain why, got %q", m.message)
+	}
+}
+
+// The other reason whose rationale IS the hit must be offered: a
+// suspected-irreversible escalation is the same judgement reached by
+// inference, and its rule is exactly what an operator wants to silence.
+func TestSuspectedIrreversibleEscalationOffersTheRule(t *testing.T) {
+	rule := aSeedRule(t)
+	rec := escalationWithRationale(1,
+		seedRationale(domain.ReasonSuspectedIrrevers, rule, domain.NeverAutoSeed))
+	m := escModelWith(t, config.Default(), []domain.AuditRecord{rec})
+
+	if !strings.Contains(m.helpLine(), "b: disable builtin rule") {
+		t.Errorf("help should advertise b for a suspected-irreversible hit, got %q", m.helpLine())
+	}
+	upd, _ := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if m.confirm == nil {
+		t.Fatal("b should open a confirmation")
+	}
+	if !strings.Contains(m.confirm.label, domain.SeedRuleID(rule.Pattern)) {
+		t.Errorf("should target the matched rule, got %q", m.confirm.label)
+	}
+}
+
+// The prompt must state its accept keys: enter accepts, and enter is this
+// tab's most-used key (confirm+send).
+func TestDisableSeedRulePromptStatesItsAcceptKeys(t *testing.T) {
+	rule := aSeedRule(t)
+	m := escModelWith(t, config.Default(), []domain.AuditRecord{seedRuleEscalation(1, rule, domain.NeverAutoSeed)})
+
+	upd, _ := m.Update(pressKeyMsg("b"))
+	m = upd.(Model)
+	if m.confirm == nil {
+		t.Fatal("b should open a confirmation")
+	}
+	if !strings.Contains(m.confirm.label, "[y/N]") {
+		t.Errorf("prompt should state the accept keys: %q", m.confirm.label)
+	}
+	// The consequence must precede the (possibly 100-char) pattern, or it
+	// wraps past the fold on a narrow pane.
+	consequence := strings.Index(m.confirm.label, "stop being held for a human")
+	pattern := strings.Index(m.confirm.label, rule.Pattern)
+	if consequence < 0 || pattern < 0 || consequence > pattern {
+		t.Errorf("consequence should come before the pattern: %q", m.confirm.label)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -473,6 +473,12 @@ type detailView struct {
 	// `agent` nil) must do nothing at all.
 	ruleDetail    bool
 	ruleSignature string
+	// seedRule snapshots the builtin (seed) never-auto rule that forced THIS
+	// escalation, resolved from its rationale at open time, so `b` disables the
+	// rule named on screen even if a refresh moved the list cursor (same reason
+	// as confirmID). nil when no builtin rule produced the record — which is
+	// the common case, and is why the binding is advertised conditionally.
+	seedRule *domain.NeverAutoRule
 	// agent snapshots the agent an agents-tab detail was opened for, so the
 	// clock tick can rebuild its lines against the current clock (the live Age
 	// would otherwise freeze at open time — the build closure captures m by
@@ -1475,6 +1481,16 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if r := m.detail.task; r != nil {
 				return m.focusTaskGroupAgent(r.group)
 			}
+		case "b":
+			// Acts on the rule snapshotted at open, not the live cursor —
+			// same rule as confirmID. The overlay closes as soon as there is
+			// something to act on (the house convention the other per-entry
+			// keys follow), and stays open when nothing is armed.
+			if rule := m.detail.seedRule; rule != nil {
+				id := m.detail.confirmID
+				m.detail = nil
+				return m.disableSeedRulePrompt(*rule, id)
+			}
 		case "t":
 			if m.detail.agent != nil {
 				return m.showAgentTasks(*m.detail.agent)
@@ -1708,6 +1724,12 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "c":
 		if m.tab == tabEscalations || m.tab == tabAudit {
 			return m.correctSelected()
+		}
+	case "b":
+		// Escalations only: disabling a builtin rule answers "this rule
+		// blocked me", which the read-only Audit history cannot pose.
+		if m.tab == tabEscalations {
+			return m.disableMatchedSeedRulePrompt()
 		}
 	case "n":
 		if m.tab == tabAgents {
@@ -3221,6 +3243,13 @@ func (m Model) viewSelected() (tea.Model, tea.Cmd) {
 				d.confirmID = r.ID
 				d.escRetryable = m.canRetry(r)
 				d.focusAgentID = r.AgentID
+				// Only the Escalations detail offers `b`: disabling a builtin
+				// rule is a response to being blocked by it, and the Audit tab
+				// is a read-only history. The line naming the rule still
+				// renders on both.
+				if rule, ok := domain.SeedRuleForcedEscalation(r.Rationale); ok {
+					d.seedRule = &rule
+				}
 			}
 			m.detail = d
 		}
@@ -3696,6 +3725,22 @@ func (m Model) auditDetailLines(r domain.AuditRecord, snapshot string, w int, op
 	lines = m.detailField(lines, w, "Action", r.Action)
 	lines = m.detailField(lines, w, "Input", r.Input)
 	lines = m.detailField(lines, w, "Rationale", r.Rationale)
+	// The rationale names the pattern, but not which of the ~90 shipped rules
+	// it is or how to silence it. Resolve it to its stable id here so the
+	// operator can act without hand-matching regex text against `rules list`.
+	if rule, ok := domain.SeedRuleForRationale(r.Rationale); ok {
+		// Named, but say whether it is the CAUSE. The variance guard appends
+		// this diagnostic to its own rationale, so a record can name a builtin
+		// rule that did not force it — and disabling that one would weaken the
+		// safety net while the guard kept escalating the same situation.
+		role := ""
+		if _, forced := domain.SeedRuleForcedEscalation(r.Rationale); !forced {
+			role = "  (noted, not what forced this)"
+		}
+		lines = m.detailField(lines, w, "Builtin rule",
+			fmt.Sprintf("%s  %s%s%s", domain.SeedRuleID(rule.Pattern), rule.Pattern,
+				m.seedRuleStateSuffix(rule.Pattern), role))
+	}
 	if opts.collapseLLMOutput {
 		lines = m.detailPreviewField(lines, w, "LLM output", r.LLMOutput, opts.expanded, 3)
 	} else {
@@ -4421,6 +4466,94 @@ func (m Model) showSelectedRule() (tea.Model, tea.Cmd) {
 	return m.showRuleFor(rec.Signature)
 }
 
+// --- Builtin (seed) never-auto rules ---
+
+// seedRuleDisabled reports whether a shipped seed pattern is currently
+// silenced, and why. Two different switches can silence it: the per-rule
+// safety.disabled_seed_patterns list, and the wholesale
+// safety.disable_never_auto_seed_patterns. They need different messages —
+// re-enabling one rule does nothing while the master switch is on.
+func (m Model) seedRuleDisabled(pattern string) (reason string, disabled bool) {
+	if m.data.cfg.Safety.DisableNeverAutoSeedPatterns {
+		return "every builtin rule is already off (safety.disable_never_auto_seed_patterns)", true
+	}
+	for _, p := range m.data.cfg.Safety.DisabledSeedPatterns {
+		if p == pattern {
+			return "already disabled", true
+		}
+	}
+	return "", false
+}
+
+// seedRuleStateSuffix annotates a rule's detail line when it is no longer
+// active, so an OLD escalation — raised while the rule still applied — does
+// not read as a live block the operator still has to clear.
+func (m Model) seedRuleStateSuffix(pattern string) string {
+	if reason, off := m.seedRuleDisabled(pattern); off {
+		return "  (" + reason + ")"
+	}
+	return ""
+}
+
+// disableMatchedSeedRulePrompt silences the ONE builtin never-auto rule that
+// forced the selected escalation (`b`). Being blocked by a shipped rule that
+// is too aggressive for this repo is otherwise a trip to `hap rules list` and
+// an eyeball match of regex text; the rationale already names the pattern, so
+// resolve it here instead.
+//
+// Only the rule that matched THIS escalation is offered — never the whole seed
+// set. Weakening a safety control wholesale is a config decision, not an
+// answer to one blocked agent.
+func (m Model) disableMatchedSeedRulePrompt() (tea.Model, tea.Cmd) {
+	rec := m.selectedAudit()
+	if rec == nil {
+		return m, nil
+	}
+	rule, ok := domain.SeedRuleForcedEscalation(rec.Rationale)
+	if !ok {
+		m.message = "no builtin safety rule forced this escalation — nothing to disable (v: details shows why it escalated)"
+		m.scrollCursorIntoView() // the hint line shrinks the page
+		return m, nil
+	}
+	return m.disableSeedRulePrompt(rule, rec.ID)
+}
+
+// disableSeedRulePrompt asks before silencing one shipped rule. It is a
+// guarded action deliberately: the rule exists to force a human decision, and
+// after this every situation matching it is answerable by the machine.
+func (m Model) disableSeedRulePrompt(rule domain.NeverAutoRule, escID int64) (tea.Model, tea.Cmd) {
+	id, pattern := domain.SeedRuleID(rule.Pattern), rule.Pattern
+	if reason, off := m.seedRuleDisabled(pattern); off {
+		m.message = fmt.Sprintf("builtin rule %s: %s", id, reason)
+		m.scrollCursorIntoView()
+		return m, nil
+	}
+	app := m.app
+	m.confirm = &confirmation{
+		// The consequence comes BEFORE the pattern: a seed regex can run past
+		// 100 characters, and this label is rendered untruncated — on a narrow
+		// pane a trailing warning wraps past the fold. The [y/N] is not
+		// decoration either: enter accepts, and enter is this tab's most-used
+		// key (confirm+send), so the accept keys have to be stated.
+		label: fmt.Sprintf("disable builtin safety rule %s? situations matching it stop being held for a human (it forced escalation #%d) — pattern: %s [y/N]",
+			id, escID, pattern),
+		// The 2s poll can land between the question and the answer, and the
+		// same rule can be disabled from the Config tab or another hap
+		// process. Re-check rather than report a disable that did nothing.
+		revalidate: func(cur Model) (string, bool) {
+			if reason, off := cur.seedRuleDisabled(pattern); off {
+				return fmt.Sprintf("builtin rule %s: %s", id, reason), false
+			}
+			return "", true
+		},
+		onConfirm: func() tea.Cmd {
+			return m.do(fmt.Sprintf("builtin rule %s disabled: %s (re-enable: hap rules enable-seed %s)", id, pattern, id),
+				func(ctx context.Context) error { return app.DisableSeedRule(ctx, pattern) })
+		},
+	}
+	return m, nil
+}
+
 // showRuleFor jumps to the Rules tab with the rule a record is keyed to already
 // selected (AR-039) — shared by the Escalations/Audit lists and their detail
 // overlays, since a record and its rule share the signature string (see
@@ -4738,7 +4871,14 @@ func (m Model) helpLine() string {
 			if m.detail.escRetryable {
 				retry = "  l: retry LLM"
 			}
-			return "enter: confirm+send  y: confirm only  c: correct (+send?)  x: delete  f: focus in herdr" + rule + retry +
+			// Advertised only when a builtin rule actually produced this
+			// record: on most escalations the key does nothing, and the line
+			// is already at the width budget.
+			seed := ""
+			if m.detail.seedRule != nil {
+				seed = "  b: disable builtin rule"
+			}
+			return "enter: confirm+send  y: confirm only  c: correct (+send?)  x: delete  f: focus in herdr" + rule + retry + seed +
 				preview + "  ↑/↓: scroll  tab: switch tab  " + closeKeys
 		}
 		if m.detail.agent != nil {
@@ -4779,7 +4919,16 @@ func (m Model) helpLine() string {
 	case tabTasks:
 		return "enter/y: send to agent  v: details  a: add  e: edit  d: done/undone  K/J: move up/down  x: delete (source on a header)  space: mark  f: focus in herdr  /: search  " + common
 	case tabEscalations:
-		return "enter: confirm+send  y: confirm only (marked)  c: correct (+send?)  l: retry LLM  f: focus in herdr  t: see rule  space: mark  x: delete  X: prune old  v: details  /: search  " + common
+		// `b` is offered only while the selected row was actually forced by a
+		// builtin rule — on every other escalation the key has nothing to act
+		// on, and this line is already the longest one here.
+		seed := ""
+		if rec := m.selectedAudit(); rec != nil {
+			if _, ok := domain.SeedRuleForcedEscalation(rec.Rationale); ok {
+				seed = "  b: disable builtin rule"
+			}
+		}
+		return "enter: confirm+send  y: confirm only (marked)  c: correct (+send?)  l: retry LLM  f: focus in herdr  t: see rule" + seed + "  space: mark  x: delete  X: prune old  v: details  /: search  " + common
 	case tabAudit:
 		return "c: correct decision  v: details  t: see rule  /: search  " + common
 	case tabSignatures:


### PR DESCRIPTION
## Why

When a shipped never-auto rule is too aggressive for a repo, clearing the escalation it caused meant leaving the TUI: read the regex out of the rationale, find it in `hap rules list` by eye, then `hap rules disable-seed <id>`. The rationale already names the pattern — resolve it in place.

## What

On the **Escalations** tab, and inside an escalation's `v` detail, **`b` disables the one builtin rule that forced the selected escalation**, after a confirmation naming the rule, its id, the escalation it blocked, and what stops being held for a human:

```
disable builtin safety rule 3f2a91c4? situations matching it stop being held for
a human (it forced escalation #7) — pattern: (?i)\bforce[- ]push\b [y/N]
```

The detail view gains a `Builtin rule` line showing the id — on the Audit tab too, where "which rule decided this?" is the likeliest question.

Backend plumbing already existed (`domain.SeedRuleForRationale`, `domain.SeedRuleID`, `frontend.App.DisableSeedRule`); this is the TUI surface for it.

## The gate: named ≠ caused

`domain.SeedRuleForcedEscalation` is new here, and **the CLI's existing `disable-seed` hint now uses it too — it had the same gap**.

A rule being named in a rationale does not mean it caused the escalation. The variance guard deliberately appends the suspected-irreversible diagnostic to its *own* rationale (`domain.Decide`), so a `[variance_guard]` row names a seed rule it was not blocked by. Offering to disable that one would weaken the safety net on a false premise **and leave the operator still blocked**, because the guard keeps escalating the same situation.

So the affordance now requires both:
- a `source=seed` diagnostic (already excluded an operator rule whose pattern text equals a shipped one), **and**
- an escalation reason whose rationale *is* that hit — `never_auto_match` or `suspected_irreversible`.

Anything else fails closed, including an untagged legacy rationale, and the detail line marks such a rule `(noted, not what forced this)`.

This was caught in review; without it, `b` was offered on `[variance_guard]` rows with a confirmation that claimed "it forced escalation #N".

## Bounds

- only the matched rule is disabled — the wholesale `safety.disable_never_auto_seed_patterns` switch is never touched;
- the overlay acts on the rule snapshotted at open, never the live cursor (a refresh lands every 2s), like the other per-entry actions;
- the confirmation revalidates before writing, so a rule disabled meanwhile reports that instead of a no-op "disabled";
- `b` is inert on the read-only Audit tab, and is advertised only when the selected row actually carries a builtin match.

## Tests

16 new tests in `internal/tui/seedrule_test.go`, plus `TestSeedRuleForcedEscalationRequiresTheReasonToBeTheHit` (domain) and `TestEscalationsOmitsDisableSeedWhenAnotherReasonNamedTheRule` (CLI). Fixtures use the **real persisted rationale shape** (`[reason] diagnostic`) and a **non-index-0** seed rule, so an implementation that resolved "the first seed rule" instead of the matched one cannot pass; the write test also asserts the first rule is *not* disabled.

Two existing CLI tests were built on a bare-diagnostic rationale the daemon never writes; their helper (`seedHeuristicDiagnostic` → `seedHeuristicRationale`) now produces the tagged form.

Full `go test -tags "vectors cpu" ./...` green (28 packages); `gofmt`, `go vet`, `golangci-lint` clean.