### PR TITLE
feat: notify the operator through herdr when the TUI needs attention

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -415,7 +415,8 @@ per-command env notes: layering is daemon env → `env_file` → `env` → the c
 | `tui.max_content_height` | 0 (full height) | cap the rows a list body may use; 0 = full height |
 | `tui.theme` | default | TUI color theme: default, dark, light, high-contrast (in the TUI Config tab, `e` on this row opens a ↑/↓ picker of the available themes) |
 | `cli.ai_agent_friendly_output` | true | append the "Next steps" footer to command output (for AI agents driving the CLI); never affects `hap help` / `--help`, which always show theirs |
-| `tui.terminal_bell` | true | ring the terminal bell (\a) on new escalations and on pauses caused by a different process |
+| `tui.terminal_bell` | true | ring the terminal bell (\a) on new escalations and on pauses caused by a different process; also the fallback when a herdr notification is not displayed |
+| `tui.herdr_notification` | true | raise a herdr desktop notification on those same two events, when the TUI runs as a herdr-managed pane |
 | `tui.disable_check_for_update` | false | turn off the GitHub release check (at most every 6h, TUI only) that puts `↑ vX.Y.Z available` in the header. it is the plugin's ONLY outbound network call; a locally built (`plugin link`) binary never checks |
 
 TUI palette colors (`tui.palette.*`) are config.toml-only — roles: `title`, `section`, `error`, `ok`, `paused`, `running`, `warn`, `help`. values are 256-color codes (`"205"`) or hex (`"#ff5faf"`).

--- a/.claude/skills/herdr/SKILL.md
+++ b/.claude/skills/herdr/SKILL.md
@@ -181,6 +181,32 @@ herdr pane send-keys 1-1 Enter
 herdr pane run 1-1 "echo hello"
 ```
 
+## notify the user
+
+raise a desktop/in-app notification when you need the user's attention and they
+may be looking at a different tab or another app:
+
+```bash
+herdr notification show "build failed" --body "api workspace" --sound request
+```
+
+- `--sound` is `none` (default), `done`, or `request`. use `request` when you
+  are asking for something and `done` when work finished.
+- `--position` is `top-left` | `top-right` | `bottom-left` | `bottom-right`;
+  omit it to use the user's configured default.
+- the title must contain visible text. herdr collapses whitespace and trims the
+  title to 80 characters and the body to 240.
+
+the cli exits 0 whether or not the toast was actually displayed. the socket
+method answers `{"shown":…,"reason":…}` — `shown`, `disabled`, `rate_limited`,
+`no_foreground_client`, or `busy` — so use the socket directly when you must
+know whether it landed:
+
+```bash
+printf '{"id":"n1","method":"notification.show","params":{"title":"needs you","sound":"request"}}\n' \
+  | nc -U "$HERDR_SOCKET_PATH"
+```
+
 ## workspace management
 
 create a new workspace:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ carries them is tagged, then that heading becomes the version number.
 
 ## Unreleased
 
+- Added a herdr desktop notification when a new escalation appears while the TUI is open, or when automation is paused by another process — the TUI detects that herdr launched it and raises the toast over herdr's socket API, so an escalation reaches you from another tab or another app instead of only beeping the pane you are not looking at
+- The terminal bell is now the fallback rather than the only channel: it rings when there is no herdr to talk to, and also when herdr answers that it did NOT display the toast (notifications turned off, rate limited, no foreground window, or a toast already standing) — an undelivered toast never counts as having alerted you
+- Added `tui.herdr_notification` (default on) to turn the toast off independently of `tui.terminal_bell`; with both off the TUI is silent
+- Outside herdr nothing changes: no socket is opened and the bell behaves exactly as before
 - Fixed the builtin-rule attribution behind `b` and the `hap escalations` hint being spoofable by agent-influenced text: it searched the whole rationale for a shipped rule's `(source=seed …)` marker, so a fabricated diagnostic in a pane excerpt or in appended LLM/error text could claim a rule that never fired — and because the search ran in seed-list order, a forgery naming an earlier rule could even outrank the genuine hit. You would be offered "disable this builtin rule" for an unrelated safety control while the rule that actually blocked you kept blocking. Attribution is now bound to the first diagnostic in the rationale, which is always the genuine one
 
 ## 0.5.7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,11 @@ go test -tags "integration vectors cpu" ./test/integration/ -v      # include th
   plain menu and got a bare digit that only toggled its checkbox — and asserts the answer
   toggles, advances to Submit, and commits. It FAILS (does not skip) when a form is on screen
   but `MultiTabForm` misses it, so the detection regression can never pass silently.
+  `TestRealHerdrNotification*` / `TestRealInHerdrDetection` (`notification_test.go`) drive the
+  socket notifier the TUI alerts through: the `notification.show` result shape (`shown` must
+  agree with a `reason` the TUI knows), that two calls in a row both land (herdr closes the
+  connection after each answer, so a pooled connection would EPIPE), and that an empty
+  normalized title is refused locally AND still refused by herdr. They raise real toasts.
 
 **Recommended: run the integration suite once after finishing any feature**, before the
 PR — the unit suite fakes herdr, so only this catches real CLI-shape drift (e.g.

--- a/README.md
+++ b/README.md
@@ -562,7 +562,10 @@ max_content_width = 0       # cap variable-width list columns; 0 = full width
 max_content_height = 0      # expanded long-field lines; 0 = unlimited (collapsed previews use short tails)
 theme = "high-contrast"     # illustrative; the DEFAULT is "" (= the default palette)
 terminal_bell = true        # ring the bell on a new escalation, and on a pause
-                            # caused by a different process
+                            # caused by a different process. Also the fallback
+                            # when a herdr notification is not displayed
+herdr_notification = true   # raise a herdr desktop notification on those same
+                            # two events, when the TUI runs inside herdr
 disable_check_for_update = false  # true turns off the GitHub release check
 
 # Optional per-role color overrides, layered on top of the theme; unset
@@ -1097,7 +1100,10 @@ Simple fields — numbers, booleans, and the `tui.theme` enum, including
 `embedding.model_context_window`, `safety.disable_never_auto_seed_patterns`,
 `tui.max_content_width` / `tui.max_content_height`, `tui.terminal_bell`
 (on by default — rings the terminal bell on a new escalation, and when the
-kill switch is paused by a *different* process than the TUI you're in), and
+kill switch is paused by a *different* process than the TUI you're in),
+`tui.herdr_notification` (on by default — raises a herdr desktop notification
+for those same two events when the TUI is running as a herdr pane; the bell
+still rings if herdr reports it did not display the toast), and
 `tui.disable_check_for_update` (off by default — see *Update to the latest
 version*) — edit
 inline (`enter`, or `e`) or via `hap config set <key> <value>`. Free-text fields (`llm.command`,

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -164,6 +164,12 @@ func buildApp(paths config.Paths) (*frontend.App, func(), error) {
 			return daemonlock.Info(paths)
 		},
 	}
+	// Desktop notifications only exist when herdr launched us as a managed
+	// pane — it injects HERDR_ENV=1 and the control socket there. Outside
+	// herdr the field stays nil and consumers fall back (the TUI beeps).
+	if herdr.InHerdr() {
+		app.Notifier = herdr.NewSocketNotifier(herdr.SocketPath())
+	}
 	return app, func() { st.Close() }, nil
 }
 
@@ -318,11 +324,7 @@ func runDaemon(ctx context.Context, paths config.Paths, args []string) error {
 		return embedder.New(cfg.Embedding)
 	}
 
-	socketPath := os.Getenv("HERDR_SOCKET_PATH")
-	if socketPath == "" {
-		home, _ := os.UserHomeDir()
-		socketPath = home + "/.config/herdr/herdr.sock"
-	}
+	socketPath := herdr.SocketPath()
 
 	d, err := daemon.New(daemon.Options{
 		ConfigPath:        paths.File(),

--- a/docs/architect/herd-auto-prompter-architecture.md
+++ b/docs/architect/herd-auto-prompter-architecture.md
@@ -79,6 +79,7 @@ Single **Operator** role; multi-user access is explicitly out of scope.
 |---|---|---|
 | Language / distribution | **Go**, single static binary; subcommands `daemon` / `tui` / `mcp` / `embed-worker` / CLI verbs | No runtime dependency; strong concurrency for the monitor loop |
 | Herdr events | **Raw socket** `events.subscribe` (JSON) | Long-lived agent-status subscription |
+| Herdr notifications (TUI) | **Raw socket** `notification.show` (JSON) | Reports whether the toast was displayed, so the TUI can fall back to the terminal bell |
 | Herdr actions | **CLI via `HERDR_BIN_PATH`** (`agent send`, `pane read`, `pane send-keys`, `pane get`, `pane zoom`, `agent list`, `notification show`, plus `tab focus`, `workspace list`, `tab list` behind the optional `FocusPort`/`LocatorPort`) | Portable across Unix socket / Windows named pipe |
 | History / audit | **Embedded SQLite (WAL)** | Transactional, corruption-safe concurrent access, queryable |
 | Operator config / rules | **TOML** in the plugin config dir | Hand-editable thresholds, never-auto patterns, classifier manifests, task sources, embedding tuning |
@@ -699,7 +700,7 @@ guards, `pane_salient_chars`, disabled — embedding is CPU-only; `gpu_layers` i
 warned-and-ignored), `llm` (argv templates + timeouts, per-command env/env_file,
 optional rewrite-action review), `cli` (`ai_agent_friendly_output`), and `tui`
 (theme, palette, `max_content_width`/`height`, `terminal_bell`,
-`disable_check_for_update`).
+`herdr_notification`, `disable_check_for_update`).
 
 Removed keys still decoded only to warn and ignore: `limits.verify_unblock_ms`,
 `limits.escalation_dedup_window_seconds` / `escalation_dedup_jitter_percent`,
@@ -746,6 +747,12 @@ immediately even if the nudge is delayed.
 
 **Herdr (external, consumed).**
 - Events (raw socket): `events.subscribe` for agent-status transitions.
+- Request/response (raw socket): `pane.list`, and `notification.show` from the
+  TUI. Unlike the CLI's fire-and-forget `notification show`, the socket method
+  answers `{shown, reason}`, so a toast Herdr declined to paint (`disabled`,
+  `rate_limited`, `no_foreground_client`, `busy`) is distinguishable from a
+  delivered one and the TUI falls back to the terminal bell. Detected at
+  runtime via `HERDR_ENV=1` + `HERDR_SOCKET_PATH`; absent outside Herdr.
 - Actions (CLI via `HERDR_BIN_PATH`): `agent send` (writes text without Enter —
   follow with `pane send-keys <pane> enter`), `pane read` (`--source
   visible|recent`), `pane get` (cwd/ids), `pane zoom`, `agent list`,
@@ -956,7 +963,7 @@ the sections they gate.
 |---|---|---|
 | **IR-001** | Herdr event subscription | Subscribe to Herdr agent-status transition events (raw socket `events.subscribe`) to drive monitoring without polling. |
 | **IR-002** | Herdr control actions | Send prompts/responses to agents and read pane content via Herdr's documented CLI commands (`agent send`, `pane read`, `pane get`, `pane send-keys`, `pane zoom`, `agent list`, `notification show`, and — behind optional ports — `tab focus`, `workspace list`, `tab list`). |
-| **IR-003** | Herdr notifications | Surface escalations and critical failures via Herdr notifications in addition to the TUI. |
+| **IR-003** | Herdr notifications | Surface escalations and critical failures via Herdr notifications in addition to the TUI. The daemon uses the CLI (`notification show`); the TUI uses the socket method (`notification.show`), which reports whether the toast was actually displayed so it can fall back to the terminal bell when Herdr drops it. |
 | **IR-004** | Herdr plugin manifest | Package as a Herdr plugin declaring id/version, pinned `min_herdr_version`, the TUI pane command, event hooks, and build steps in `herdr-plugin.toml`. |
 | **IR-005** | Local LLM CLI | Integrate an optional, operator-configured local LLM/agent CLI for the hybrid decision fallback, treating its absence or failure as an escalation trigger. |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -594,7 +594,16 @@ type TUI struct {
 	// last poll, and (2) the global pause/kill switch becoming active
 	// because of a DIFFERENT process (another TUI instance, or `hap
 	// pause`) — not when this instance's own operator pressed "p".
+	//
+	// It is also the FALLBACK for HerdrNotification: a toast herdr declined
+	// to display still rings the bell, because the operator asked to be
+	// alerted and an undelivered toast has not alerted them.
 	TerminalBell bool `toml:"terminal_bell"`
+	// HerdrNotification raises a herdr desktop notification (the socket API's
+	// notification.show) on those same two events, when the TUI is running as
+	// a herdr-managed pane. Outside herdr there is no socket to talk to and
+	// this does nothing. Default true.
+	HerdrNotification bool `toml:"herdr_notification"`
 	// DisableCheckForUpdate turns off the TUI's periodic release check — the
 	// plugin's only outbound network call (NFR-007). It is named negatively so
 	// the zero value keeps the check on, the way Embedding.Disabled does.
@@ -678,7 +687,7 @@ func Default() Config {
 			SimilarityThreshold: 0.90,
 			BM25MinScore:        0.35,
 		},
-		TUI: TUI{TerminalBell: true},
+		TUI: TUI{TerminalBell: true, HerdrNotification: true},
 		CLI: CLI{AIAgentFriendlyOutput: true},
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1651,6 +1651,49 @@ func TestSampleConfigParsesWithDocumentedDefaults(t *testing.T) {
 		t.Errorf("sample tui.terminal_bell = %v, default is %v",
 			cfg.TUI.TerminalBell, def.TUI.TerminalBell)
 	}
+	if !strings.Contains(string(raw), "herdr_notification") {
+		t.Error("sample config does not document [tui].herdr_notification")
+	}
+	if cfg.TUI.HerdrNotification != def.TUI.HerdrNotification {
+		t.Errorf("sample tui.herdr_notification = %v, default is %v",
+			cfg.TUI.HerdrNotification, def.TUI.HerdrNotification)
+	}
+}
+
+// TestHerdrNotificationDefaultsOnAndCanBeDisabled pins the Load-over-Default
+// idiom for a bool that defaults TRUE: an absent key must keep the default,
+// and only an explicit false may turn it off.
+func TestHerdrNotificationDefaultsOnAndCanBeDisabled(t *testing.T) {
+	if !Default().TUI.HerdrNotification {
+		t.Fatal("herdr notifications should be on by default")
+	}
+
+	dir := t.TempDir()
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"absent key keeps the default", "[tui]\nterminal_bell = true\n", true},
+		{"no [tui] table at all", "", true},
+		{"explicit false disables", "[tui]\nherdr_notification = false\n", false},
+		{"explicit true", "[tui]\nherdr_notification = true\n", true},
+	}
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, fmt.Sprintf("config%d.toml", i))
+			if err := os.WriteFile(path, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.TUI.HerdrNotification != tc.want {
+				t.Errorf("HerdrNotification = %v, want %v", cfg.TUI.HerdrNotification, tc.want)
+			}
+		})
+	}
 }
 
 func TestLLMCommandEnvRoundTrip(t *testing.T) {

--- a/internal/fakeherdr/fakeherdr.go
+++ b/internal/fakeherdr/fakeherdr.go
@@ -27,6 +27,15 @@ type clientConn struct {
 	subs []subscription
 }
 
+// SocketNotification is one notification.show request the fake received.
+type SocketNotification struct {
+	ID       string
+	Title    string
+	Body     string
+	Position string
+	Sound    string
+}
+
 // Server is a fake Herdr events socket.
 type Server struct {
 	SocketPath string
@@ -35,6 +44,16 @@ type Server struct {
 	mu    sync.Mutex
 	conns map[net.Conn]*clientConn
 	panes map[string]string // paneID → workspaceID (replayed on subscribe)
+
+	// notifications records every notification.show request; notifyShown /
+	// notifyReason are the canned result, defaulting to a displayed toast.
+	notifications []SocketNotification
+	notifyShown   bool
+	notifyReason  string
+	// notifyErrCode, when set, makes notification.show answer with a
+	// protocol error instead of a result.
+	notifyErrCode string
+	notifyErrMsg  string
 }
 
 // NewServer starts a fake events socket in dir.
@@ -46,8 +65,10 @@ func NewServer(dir string) (*Server, error) {
 	}
 	s := &Server{
 		SocketPath: path, ln: ln,
-		conns: map[net.Conn]*clientConn{},
-		panes: map[string]string{},
+		conns:        map[net.Conn]*clientConn{},
+		panes:        map[string]string{},
+		notifyShown:  true,
+		notifyReason: "shown",
 	}
 	go s.accept()
 	return s, nil
@@ -71,9 +92,37 @@ func (s *Server) serve(conn net.Conn) {
 			Method string `json:"method"`
 			Params struct {
 				Subscriptions []subscription `json:"subscriptions"`
+				Title         string         `json:"title"`
+				Body          string         `json:"body"`
+				Position      string         `json:"position"`
+				Sound         string         `json:"sound"`
 			} `json:"params"`
 		}
 		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+			continue
+		}
+		if req.Method == "notification.show" {
+			s.mu.Lock()
+			s.notifications = append(s.notifications, SocketNotification{
+				ID: req.ID, Title: req.Params.Title, Body: req.Params.Body,
+				Position: req.Params.Position, Sound: req.Params.Sound,
+			})
+			shown, reason := s.notifyShown, s.notifyReason
+			errCode, errMsg := s.notifyErrCode, s.notifyErrMsg
+			s.mu.Unlock()
+			var resp []byte
+			if errCode != "" {
+				resp, _ = json.Marshal(map[string]any{
+					"id": req.ID, "error": map[string]any{"code": errCode, "message": errMsg},
+				})
+			} else {
+				resp, _ = json.Marshal(map[string]any{
+					"id": req.ID, "result": map[string]any{
+						"type": "notification_show", "shown": shown, "reason": reason,
+					},
+				})
+			}
+			conn.Write(append(resp, '\n'))
 			continue
 		}
 		if req.Method == "pane.list" {
@@ -149,6 +198,33 @@ func (s *Server) serve(conn net.Conn) {
 func wrap(event string, data map[string]any) []byte {
 	msg, _ := json.Marshal(map[string]any{"event": event, "data": data})
 	return append(msg, '\n')
+}
+
+// SetNotificationResult sets the canned notification.show result. Real herdr
+// answers shown=false with a reason ("disabled", "rate_limited",
+// "no_foreground_client", "busy") when it drops a toast.
+func (s *Server) SetNotificationResult(shown bool, reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.notifyShown, s.notifyReason = shown, reason
+	s.notifyErrCode, s.notifyErrMsg = "", ""
+}
+
+// SetNotificationError makes notification.show answer with a protocol error
+// instead of a result. An empty code restores the canned result.
+func (s *Server) SetNotificationError(code, message string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.notifyErrCode, s.notifyErrMsg = code, message
+}
+
+// SocketNotifications returns every notification.show request received so
+// far, in order. Named apart from FakeCLI.Notifications, which records the
+// `herdr notification show` COMMAND rather than the socket method.
+func (s *Server) SocketNotifications() []SocketNotification {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]SocketNotification(nil), s.notifications...)
 }
 
 // AddPane registers a pane (replayed to future pane.created subscribers and

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -42,6 +42,11 @@ type App struct {
 	// DaemonInfo reports the running daemon's identity from the lock file
 	// (daemonlock.Info in prod); nil hides the daemon line in status.
 	DaemonInfo func() (running bool, pid int, version string)
+	// Notifier raises herdr desktop notifications and reports whether they
+	// were actually displayed. nil when hap is not running inside herdr (a
+	// plain terminal), which is why every consumer must degrade rather than
+	// depend on it. Read only by the TUI today.
+	Notifier ports.NotifyShower
 	// StateDir is the daemon state directory; front-ends read the daemon's
 	// heartbeat/health record (daemonhealth) and reference the captured
 	// stderr log from here. Empty skips the health-derived status lines.
@@ -1548,6 +1553,7 @@ var ConfigFields = []ConfigFieldDef{
 	{Key: "tui.max_content_height", TUIEditable: true},
 	{Key: "tui.theme", TUIEditable: true},
 	{Key: "tui.terminal_bell", TUIEditable: true},
+	{Key: "tui.herdr_notification", TUIEditable: true},
 	{Key: "tui.disable_check_for_update", TUIEditable: true},
 	{Key: "cli.ai_agent_friendly_output", TUIEditable: true},
 }
@@ -1719,6 +1725,8 @@ func FieldValue(cfg config.Config, key string) string {
 		return cfg.TUI.Theme
 	case "tui.terminal_bell":
 		return strconv.FormatBool(cfg.TUI.TerminalBell)
+	case "tui.herdr_notification":
+		return strconv.FormatBool(cfg.TUI.HerdrNotification)
 	case "tui.disable_check_for_update":
 		return strconv.FormatBool(cfg.TUI.DisableCheckForUpdate)
 	case "cli.ai_agent_friendly_output":
@@ -1977,6 +1985,13 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 				return fmt.Errorf("tui.terminal_bell must be true or false, got %q", value)
 			}
 			cfg.TUI.TerminalBell = v
+			return nil
+		case "tui.herdr_notification":
+			v, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("tui.herdr_notification must be true or false, got %q", value)
+			}
+			cfg.TUI.HerdrNotification = v
 			return nil
 		case "tui.disable_check_for_update":
 			v, err := strconv.ParseBool(value)

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -2334,6 +2334,7 @@ func TestConfigFieldRegistryParity(t *testing.T) {
 		"tui.max_content_height":                   "12",
 		"tui.theme":                                "dark",
 		"tui.terminal_bell":                        "true",
+		"tui.herdr_notification":                   "false",
 		"tui.disable_check_for_update":             "true",
 		"cli.ai_agent_friendly_output":             "false",
 	}
@@ -2488,6 +2489,9 @@ func TestSetFieldNewKeysValidation(t *testing.T) {
 		{"safety.disable_never_auto_seed_patterns", "true", false},
 		{"safety.disable_never_auto_seed_patterns", "false", false},
 		{"safety.disable_never_auto_seed_patterns", "yes", true},
+		{"tui.herdr_notification", "true", false},
+		{"tui.herdr_notification", "false", false},
+		{"tui.herdr_notification", "sometimes", true},
 		{"llm.pane_excerpt_chars", "0", false}, // 0 = restore-default sentinel (fillZeroes)
 		{"llm.pane_excerpt_chars", "-5", true},
 		{"llm.pane_excerpt_chars", "abc", true},
@@ -2552,6 +2556,11 @@ func TestSetFieldNewKeysValidation(t *testing.T) {
 	if err := app.SetField(ctx, "llm.task_generate_timeout_seconds", "30"); err != nil {
 		t.Fatal(err)
 	}
+	// Ends on false — the non-default value, so a validator that forgot the
+	// assignment cannot pass by inheriting the true default.
+	if err := app.SetField(ctx, "tui.herdr_notification", "false"); err != nil {
+		t.Fatal(err)
+	}
 	if cfg, err = app.Config(); err != nil {
 		t.Fatal(err)
 	}
@@ -2569,6 +2578,9 @@ func TestSetFieldNewKeysValidation(t *testing.T) {
 	}
 	if cfg.LLM.GenerateTaskTimeoutSeconds != 30 {
 		t.Errorf("llm.task_generate_timeout_seconds = %d, want 30 (assignment not persisted)", cfg.LLM.GenerateTaskTimeoutSeconds)
+	}
+	if cfg.TUI.HerdrNotification {
+		t.Error("tui.herdr_notification = true, want false (assignment not persisted)")
 	}
 }
 

--- a/internal/herdr/events.go
+++ b/internal/herdr/events.go
@@ -212,7 +212,8 @@ func (s *Subscriber) runDiscovery(ctx context.Context, out chan<- domain.AgentTr
 func (s *Subscriber) runStatus(ctx context.Context, out chan<- domain.AgentTransition) error {
 	paneIDs, err := s.listPanes(ctx)
 	if err != nil {
-		return fmt.Errorf("pane.list: %w", err)
+		// Not wrapped with the method name: call()'s errors already carry it.
+		return err
 	}
 	if len(paneIDs) == 0 {
 		// Nothing to watch yet: wait for discovery to find panes.
@@ -388,52 +389,107 @@ func (s *Subscriber) signalDirty() {
 	}
 }
 
-// listPanes queries the live pane set over a short-lived connection.
-func (s *Subscriber) listPanes(ctx context.Context) ([]string, error) {
-	conn, err := s.Dial(ctx)
+// SocketError is a protocol-level error herdr returned in place of a result.
+// It is distinct from a transport failure so callers can tell "herdr answered,
+// and said no" from "we never reached herdr".
+type SocketError struct {
+	Method  string
+	Code    string
+	Message string
+}
+
+func (e *SocketError) Error() string {
+	return fmt.Sprintf("herdr %s: %s: %s", e.Method, e.Code, e.Message)
+}
+
+// call performs one request/response round trip over a SHORT-LIVED connection
+// and decodes the single response line's `result` into out (nil discards it).
+// herdr's protocol is newline-delimited JSON with no handshake, so one write
+// plus one read is the whole exchange.
+//
+// This is the request/response counterpart to stream(), which keeps its
+// connection open as an event feed instead.
+//
+// EVERY error it returns names the method, so callers must not wrap with the
+// method again — that is what produced "pane.list: herdr pane.list: …".
+func call(ctx context.Context, dial func(context.Context) (net.Conn, error),
+	id, method string, params any, out any) error {
+
+	conn, err := dial(ctx)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("dial herdr socket for %s: %w", method, err)
 	}
 	defer conn.Close()
+	// Closing the conn is what unblocks the read below; ctx alone cannot
+	// interrupt a Scan already in flight.
 	stop := context.AfterFunc(ctx, func() { conn.Close() })
 	defer stop()
 
-	req, _ := json.Marshal(socketRequest{ID: "hap_pane_list", Method: "pane.list", Params: map[string]any{}})
+	req, err := json.Marshal(socketRequest{ID: id, Method: method, Params: params})
+	if err != nil {
+		return fmt.Errorf("encode %s request: %w", method, err)
+	}
 	if _, err := conn.Write(append(req, '\n')); err != nil {
-		return nil, err
+		return fmt.Errorf("write %s request: %w", method, err)
 	}
 	scanner := bufio.NewScanner(conn)
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	if !scanner.Scan() {
 		if err := scanner.Err(); err != nil {
-			return nil, err
+			return fmt.Errorf("read %s response: %w", method, err)
 		}
-		return nil, fmt.Errorf("connection closed before pane.list response")
+		return fmt.Errorf("connection closed before %s response", method)
 	}
-	var resp struct {
+	var envelope struct {
+		ID    string `json:"id"`
 		Error *struct {
 			Code    string `json:"code"`
 			Message string `json:"message"`
 		} `json:"error"`
-		Result struct {
-			Panes []struct {
-				PaneID      string `json:"pane_id"`
-				TabID       string `json:"tab_id"`
-				WorkspaceID string `json:"workspace_id"`
-				Agent       string `json:"agent"`
-			} `json:"panes"`
-		} `json:"result"`
+		Result json.RawMessage `json:"result"`
 	}
-	if err := json.Unmarshal(scanner.Bytes(), &resp); err != nil {
+	if err := json.Unmarshal(scanner.Bytes(), &envelope); err != nil {
+		return fmt.Errorf("decode %s response: %w", method, err)
+	}
+	// herdr echoes the request id. A mismatch means we are reading someone
+	// else's answer — decoding it as ours would be worse than failing. Only
+	// checked when the server actually sent one, so an id-less reply still
+	// works.
+	if envelope.ID != "" && envelope.ID != id {
+		return fmt.Errorf("%s response id %q does not match request %q", method, envelope.ID, id)
+	}
+	if envelope.Error != nil {
+		return &SocketError{Method: method, Code: envelope.Error.Code, Message: envelope.Error.Message}
+	}
+	// An absent result is not an error: the pre-extraction code decoded a
+	// missing `result` into a zero struct and carried on, so this preserves
+	// that. A malformed one still errors, one Unmarshal later.
+	if out == nil || len(envelope.Result) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(envelope.Result, out); err != nil {
+		return fmt.Errorf("decode %s result: %w", method, err)
+	}
+	return nil
+}
+
+// listPanes queries the live pane set over a short-lived connection.
+func (s *Subscriber) listPanes(ctx context.Context) ([]string, error) {
+	var result struct {
+		Panes []struct {
+			PaneID      string `json:"pane_id"`
+			TabID       string `json:"tab_id"`
+			WorkspaceID string `json:"workspace_id"`
+			Agent       string `json:"agent"`
+		} `json:"panes"`
+	}
+	if err := call(ctx, s.Dial, "hap_pane_list", "pane.list", map[string]any{}, &result); err != nil {
 		return nil, err
 	}
-	if resp.Error != nil {
-		return nil, fmt.Errorf("%s: %s", resp.Error.Code, resp.Error.Message)
-	}
-	ids := make([]string, 0, len(resp.Result.Panes))
+	ids := make([]string, 0, len(result.Panes))
 	s.mu.Lock()
 	live := map[string]bool{}
-	for _, p := range resp.Result.Panes {
+	for _, p := range result.Panes {
 		ids = append(ids, p.PaneID)
 		live[p.PaneID] = true
 		info := s.panes[p.PaneID]

--- a/internal/herdr/notify.go
+++ b/internal/herdr/notify.go
@@ -1,0 +1,193 @@
+package herdr
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+)
+
+// Sound values `notification.show` accepts. Anything else is rejected by
+// herdr, so callers pick from these.
+const (
+	SoundNone    = "none"
+	SoundDone    = "done"
+	SoundRequest = "request"
+)
+
+// Herdr's own text normalization trims a notification's title to 80 display
+// characters and its body to 240. We clamp locally to the same bounds so what
+// we log and what herdr paints are the same string, and so a huge pane
+// excerpt is never written to the socket in the first place.
+const (
+	maxNotifyTitle = 80
+	maxNotifyBody  = 240
+)
+
+// defaultNotifyTimeout bounds one notification round trip. A toast is a
+// courtesy: it must never hold up the caller (the TUI dispatches these from
+// its update loop's goroutine pool), so this is far shorter than the CLI
+// adapter's 15s command timeout.
+const defaultNotifyTimeout = 3 * time.Second
+
+// SocketPath resolves herdr's control socket the way herdr itself documents:
+// HERDR_SOCKET_PATH when herdr injected it (every managed pane gets one),
+// else the default session socket under the user's config dir.
+func SocketPath() string {
+	if p := os.Getenv("HERDR_SOCKET_PATH"); p != "" {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "herdr", "herdr.sock")
+}
+
+// InHerdr reports whether this process is running as a herdr-managed pane.
+// Herdr injects HERDR_ENV=1 into every process it launches, which is the
+// signal to use its socket API rather than plain-terminal fallbacks; a socket
+// we cannot even name means there is nothing to talk to.
+func InHerdr() bool {
+	return os.Getenv("HERDR_ENV") == "1" && SocketPath() != ""
+}
+
+// Notification is one `notification.show` request. Only Title is required.
+type Notification struct {
+	Title string
+	Body  string
+	// Position is the desktop placement ("top-left", …); empty uses herdr's
+	// configured default.
+	Position string
+	// Sound is one of SoundNone / SoundDone / SoundRequest; empty means
+	// herdr's default (none).
+	Sound string
+}
+
+// SocketNotifier raises operator notifications over herdr's control socket
+// (`notification.show`). Unlike the CLI adapter's Notify it reports whether
+// herdr actually PAINTED the toast, so a caller can fall back to another
+// channel when herdr drops it (toasts disabled, rate limited, no foreground
+// client, or an in-app toast already standing).
+//
+// Every call opens its own connection. That is not just simplicity: verified
+// against herdr 0.7.3, the server CLOSES the connection right after answering
+// a notification.show — on the error path and the success path alike — so a
+// second request written to the same connection dies with EPIPE. Do not
+// "optimize" this into a persistent connection.
+type SocketNotifier struct {
+	SocketPath string
+	// Timeout bounds one round trip; zero means defaultNotifyTimeout.
+	Timeout time.Duration
+	// Dial allows tests to substitute the transport, mirroring Subscriber.
+	Dial func(ctx context.Context) (net.Conn, error)
+
+	seq atomic.Uint64
+}
+
+// Compile-time conformance: the socket notifier satisfies both the plain and
+// the result-reporting notification ports.
+var (
+	_ ports.NotifyPort   = (*SocketNotifier)(nil)
+	_ ports.NotifyShower = (*SocketNotifier)(nil)
+)
+
+// NewSocketNotifier creates a notifier for the given herdr socket path.
+// Dial is deliberately left nil: the zero value already dials the real
+// socket (see dial), so a literal-constructed notifier behaves identically.
+func NewSocketNotifier(socketPath string) *SocketNotifier {
+	return &SocketNotifier{SocketPath: socketPath, Timeout: defaultNotifyTimeout}
+}
+
+func (n *SocketNotifier) timeout() time.Duration {
+	if n.Timeout <= 0 {
+		return defaultNotifyTimeout
+	}
+	return n.Timeout
+}
+
+// Show sends one notification and reports what herdr did with it. A non-nil
+// error means the request never completed; a nil error with Shown == false
+// means herdr answered and declined to display it (see NotifyResult.Reason).
+func (n *SocketNotifier) Show(ctx context.Context, msg Notification) (ports.NotifyResult, error) {
+	title := clampNotifyText(msg.Title, maxNotifyTitle)
+	if title == "" {
+		// herdr rejects an empty normalized title with invalid_params; catch
+		// it here so a caller's bug surfaces as its own error rather than a
+		// protocol one, and so we never open a connection for nothing.
+		return ports.NotifyResult{}, fmt.Errorf("notification title is empty")
+	}
+	params := map[string]any{"title": title}
+	if body := clampNotifyText(msg.Body, maxNotifyBody); body != "" {
+		params["body"] = body
+	}
+	if msg.Position != "" {
+		params["position"] = msg.Position
+	}
+	if msg.Sound != "" {
+		params["sound"] = msg.Sound
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, n.timeout())
+	defer cancel()
+
+	var result struct {
+		Shown  bool   `json:"shown"`
+		Reason string `json:"reason"`
+	}
+	id := fmt.Sprintf("hap_notify_%d", n.seq.Add(1))
+	if err := call(ctx, n.dial, id, "notification.show", params, &result); err != nil {
+		return ports.NotifyResult{}, err
+	}
+	return ports.NotifyResult{Shown: result.Shown, Reason: result.Reason}, nil
+}
+
+// ShowNotification satisfies ports.NotifyShower — the title/body form the
+// front-ends use, with the "request" sound that marks an operator action.
+func (n *SocketNotifier) ShowNotification(ctx context.Context, title, body string) (ports.NotifyResult, error) {
+	return n.Show(ctx, Notification{Title: title, Body: body, Sound: SoundRequest})
+}
+
+// Notify satisfies ports.NotifyPort. A toast herdr declined to display is NOT
+// an error here — that distinction is exactly what ShowNotification exists
+// for, and reporting it as a failure would make every rate-limited toast look
+// like a broken socket.
+func (n *SocketNotifier) Notify(ctx context.Context, title, body string) error {
+	_, err := n.ShowNotification(ctx, title, body)
+	return err
+}
+
+// dial routes through the overridable field, defaulting when it is nil so a
+// zero-valued SocketNotifier (constructed as a literal, as tests do) still
+// works.
+func (n *SocketNotifier) dial(ctx context.Context) (net.Conn, error) {
+	if n.Dial != nil {
+		return n.Dial(ctx)
+	}
+	d := net.Dialer{Timeout: n.timeout()}
+	return d.DialContext(ctx, "unix", n.SocketPath)
+}
+
+// clampNotifyText applies herdr's own normalization — collapse every run of
+// whitespace (newlines and tabs included) to a single space, trim, then cut
+// to max RUNES — so the caller sees the same text herdr will.
+func clampNotifyText(s string, max int) string {
+	s = strings.TrimSpace(strings.Join(strings.Fields(s), " "))
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	if max <= 0 {
+		return ""
+	}
+	if max == 1 {
+		return "…"
+	}
+	return string(r[:max-1]) + "…"
+}

--- a/internal/herdr/notify_test.go
+++ b/internal/herdr/notify_test.go
@@ -1,0 +1,283 @@
+package herdr
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/fakeherdr"
+	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
+)
+
+func newTestNotifier(t *testing.T) (*SocketNotifier, *fakeherdr.Server) {
+	t.Helper()
+	srv, err := fakeherdr.NewServer(testutil.SocketDir(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { srv.Close() })
+	return NewSocketNotifier(srv.SocketPath), srv
+}
+
+func TestSocketNotifierShowsNotification(t *testing.T) {
+	n, srv := newTestNotifier(t)
+
+	res, err := n.ShowNotification(context.Background(), "build failed", "api workspace")
+	if err != nil {
+		t.Fatalf("ShowNotification: %v", err)
+	}
+	if !res.Shown || res.Reason != "shown" {
+		t.Fatalf("want a displayed toast, got %+v", res)
+	}
+
+	got := srv.SocketNotifications()
+	if len(got) != 1 {
+		t.Fatalf("want 1 notification recorded, got %d", len(got))
+	}
+	if got[0].Title != "build failed" || got[0].Body != "api workspace" {
+		t.Errorf("title/body not delivered: %+v", got[0])
+	}
+	// The operator-attention sound is what distinguishes an escalation toast
+	// from an informational one.
+	if got[0].Sound != SoundRequest {
+		t.Errorf("sound = %q, want %q", got[0].Sound, SoundRequest)
+	}
+}
+
+// TestSocketNotifierNotShownIsNotAnError pins the contract the TUI's bell
+// fallback depends on: herdr answering "I dropped it" is a successful call
+// reporting Shown=false, never an error. Collapsing the two would make a
+// rate-limited toast indistinguishable from a broken socket.
+func TestSocketNotifierNotShownIsNotAnError(t *testing.T) {
+	n, srv := newTestNotifier(t)
+	srv.SetNotificationResult(false, "rate_limited")
+
+	res, err := n.ShowNotification(context.Background(), "escalation", "agent blocked")
+	if err != nil {
+		t.Fatalf("a declined toast must not be an error, got %v", err)
+	}
+	if res.Shown {
+		t.Error("Shown should be false")
+	}
+	if res.Reason != "rate_limited" {
+		t.Errorf("Reason = %q, want %q", res.Reason, "rate_limited")
+	}
+}
+
+func TestSocketNotifierProtocolError(t *testing.T) {
+	n, srv := newTestNotifier(t)
+	srv.SetNotificationError("invalid_params", "title must contain visible text")
+
+	res, err := n.ShowNotification(context.Background(), "x", "y")
+	if err == nil {
+		t.Fatal("want an error for a protocol-level failure")
+	}
+	if res.Shown {
+		t.Error("a failed call must not report Shown")
+	}
+	var se *SocketError
+	if !errors.As(err, &se) {
+		t.Fatalf("want a *SocketError, got %T: %v", err, err)
+	}
+	if se.Code != "invalid_params" || se.Method != "notification.show" {
+		t.Errorf("unexpected SocketError: %+v", se)
+	}
+	if !strings.Contains(err.Error(), "title must contain visible text") {
+		t.Errorf("error should name herdr's message, got %q", err.Error())
+	}
+}
+
+func TestSocketNotifierUnreachableSocket(t *testing.T) {
+	n := NewSocketNotifier(filepath.Join(testutil.SocketDir(t), "no-such.sock"))
+	n.Timeout = 200 * time.Millisecond
+
+	start := time.Now()
+	res, err := n.ShowNotification(context.Background(), "title", "body")
+	if err == nil {
+		t.Fatal("want an error when the socket does not exist")
+	}
+	if res.Shown {
+		t.Error("a failed call must not report Shown")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("dial should fail fast, took %v", elapsed)
+	}
+}
+
+// TestSocketNotifierEmptyTitleRejectedLocally: herdr rejects an empty
+// normalized title with invalid_params, so we catch it before opening a
+// connection — and a whitespace-only title normalizes to empty.
+func TestSocketNotifierEmptyTitleRejectedLocally(t *testing.T) {
+	n, srv := newTestNotifier(t)
+
+	for _, title := range []string{"", "   ", "\n\t "} {
+		if _, err := n.ShowNotification(context.Background(), title, "body"); err == nil {
+			t.Errorf("title %q should be rejected", title)
+		}
+	}
+	if got := srv.SocketNotifications(); len(got) != 0 {
+		t.Errorf("no request should have been sent, got %d", len(got))
+	}
+}
+
+func TestSocketNotifierClampsText(t *testing.T) {
+	n, srv := newTestNotifier(t)
+
+	longTitle := strings.Repeat("a", 200)
+	longBody := strings.Repeat("b", 500)
+	if _, err := n.ShowNotification(context.Background(), longTitle, longBody); err != nil {
+		t.Fatal(err)
+	}
+	got := srv.SocketNotifications()
+	if len(got) != 1 {
+		t.Fatalf("want 1 notification, got %d", len(got))
+	}
+	if n := len([]rune(got[0].Title)); n != maxNotifyTitle {
+		t.Errorf("title length = %d, want %d", n, maxNotifyTitle)
+	}
+	if n := len([]rune(got[0].Body)); n != maxNotifyBody {
+		t.Errorf("body length = %d, want %d", n, maxNotifyBody)
+	}
+}
+
+// TestSocketNotifierCollapsesWhitespace: a pane excerpt or a multi-line
+// suggestion must reach herdr as the single line it will paint, so what we
+// clamp is what it shows.
+func TestSocketNotifierCollapsesWhitespace(t *testing.T) {
+	n, srv := newTestNotifier(t)
+
+	if _, err := n.ShowNotification(context.Background(),
+		" agent  blocked \n", "line one\nline two\t\ttabbed  "); err != nil {
+		t.Fatal(err)
+	}
+	got := srv.SocketNotifications()[0]
+	if got.Title != "agent blocked" {
+		t.Errorf("title = %q, want %q", got.Title, "agent blocked")
+	}
+	if got.Body != "line one line two tabbed" {
+		t.Errorf("body = %q, want %q", got.Body, "line one line two tabbed")
+	}
+}
+
+// TestSocketNotifierOmitsEmptyOptionalParams: herdr validates `sound` and
+// `position` against a fixed set, so an empty string must be left out of the
+// request rather than sent as "".
+func TestSocketNotifierOmitsEmptyOptionalParams(t *testing.T) {
+	n, srv := newTestNotifier(t)
+
+	if _, err := n.Show(context.Background(), Notification{Title: "bare"}); err != nil {
+		t.Fatal(err)
+	}
+	got := srv.SocketNotifications()[0]
+	if got.Body != "" || got.Sound != "" || got.Position != "" {
+		t.Errorf("optional params should be omitted when empty, got %+v", got)
+	}
+}
+
+// TestSocketNotifierRequestIDsAreUnique: herdr echoes the request id back,
+// so reusing one across calls would make two responses indistinguishable.
+func TestSocketNotifierRequestIDsAreUnique(t *testing.T) {
+	n, srv := newTestNotifier(t)
+
+	for i := 0; i < 3; i++ {
+		if _, err := n.ShowNotification(context.Background(), "t", "b"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seen := map[string]bool{}
+	for _, got := range srv.SocketNotifications() {
+		if got.ID == "" {
+			t.Fatal("request carried no id")
+		}
+		if seen[got.ID] {
+			t.Fatalf("request id %q was reused", got.ID)
+		}
+		seen[got.ID] = true
+	}
+	if len(seen) != 3 {
+		t.Errorf("want 3 distinct ids, got %d", len(seen))
+	}
+}
+
+// TestSocketNotifierConcurrentCalls: the TUI can dispatch an escalation toast
+// and a pause toast from the same refresh, on separate goroutines.
+func TestSocketNotifierConcurrentCalls(t *testing.T) {
+	n, srv := newTestNotifier(t)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := n.ShowNotification(context.Background(), "t", "b"); err != nil {
+				t.Errorf("ShowNotification: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	seen := map[string]bool{}
+	for _, got := range srv.SocketNotifications() {
+		if seen[got.ID] {
+			t.Fatalf("concurrent calls reused request id %q", got.ID)
+		}
+		seen[got.ID] = true
+	}
+	if len(seen) != 8 {
+		t.Errorf("want 8 distinct ids, got %d", len(seen))
+	}
+}
+
+func TestSocketNotifierNotifyIgnoresNotShown(t *testing.T) {
+	n, srv := newTestNotifier(t)
+	srv.SetNotificationResult(false, "disabled")
+
+	// The plain NotifyPort form has no channel for "shown"; a dropped toast
+	// must not surface as a transport error there either.
+	if err := n.Notify(context.Background(), "title", "body"); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+}
+
+func TestSocketPath(t *testing.T) {
+	t.Setenv("HERDR_SOCKET_PATH", "/run/herdr/custom.sock")
+	if got := SocketPath(); got != "/run/herdr/custom.sock" {
+		t.Errorf("SocketPath() = %q, want the injected value", got)
+	}
+
+	t.Setenv("HERDR_SOCKET_PATH", "")
+	got := SocketPath()
+	if got == "" || !strings.HasSuffix(got, filepath.Join(".config", "herdr", "herdr.sock")) {
+		t.Errorf("SocketPath() = %q, want the default session socket", got)
+	}
+}
+
+func TestInHerdr(t *testing.T) {
+	tests := []struct {
+		name       string
+		herdrEnv   string
+		socketPath string
+		want       bool
+	}{
+		{"managed pane", "1", "/run/herdr/herdr.sock", true},
+		{"no HERDR_ENV", "", "/run/herdr/herdr.sock", false},
+		{"HERDR_ENV not 1", "0", "/run/herdr/herdr.sock", false},
+		// An empty socket path still resolves to the default under $HOME, so
+		// it stays "in herdr" — the dial is what finally fails, and callers
+		// degrade on that.
+		{"default socket path", "1", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HERDR_ENV", tc.herdrEnv)
+			t.Setenv("HERDR_SOCKET_PATH", tc.socketPath)
+			if got := InHerdr(); got != tc.want {
+				t.Errorf("InHerdr() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -106,6 +106,23 @@ type NotifyPort interface {
 	Notify(ctx context.Context, title, body string) error
 }
 
+// NotifyResult reports what herdr did with a notification. Shown == false is
+// not a failure: herdr answered and declined to paint the toast, naming why
+// in Reason ("disabled", "rate_limited", "no_foreground_client", "busy").
+type NotifyResult struct {
+	Shown  bool
+	Reason string
+}
+
+// NotifyShower is the optional richer form of NotifyPort: it reports whether
+// the notification was actually displayed, so a caller that must reach the
+// operator can fall back to another channel (the TUI falls back to the
+// terminal bell) instead of assuming a silently-dropped toast landed.
+// Type-assert it off a NotifyPort at the call site and degrade when absent.
+type NotifyShower interface {
+	ShowNotification(ctx context.Context, title, body string) (NotifyResult, error)
+}
+
 // EmbedderPort turns masked salient text into a semantic vector for
 // signature matching. Implementations must be safe for concurrent use and
 // must return errors — never panic — when the model is unavailable, so the

--- a/internal/tui/bell_test.go
+++ b/internal/tui/bell_test.go
@@ -2,16 +2,19 @@ package tui
 
 import (
 	"bytes"
+	"context"
+	"sync"
 	"testing"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
 )
 
 func bellModel() (Model, *bytes.Buffer) {
 	var buf bytes.Buffer
-	return Model{width: 100, height: 30, bellOut: &buf}, &buf
+	return Model{width: 100, height: 30, bellOut: &buf, inflight: &sync.WaitGroup{}}, &buf
 }
 
 func TestBellNoRingOnFirstRefresh(t *testing.T) {
@@ -198,3 +201,405 @@ type boomError struct{}
 func (boomError) Error() string { return "boom" }
 
 var errBoom = boomError{}
+
+// fakeNotifier records the toasts the TUI raises and replays a canned herdr
+// answer, standing in for the socket adapter.
+type fakeNotifier struct {
+	mu    sync.Mutex
+	calls []struct{ title, body string }
+	res   ports.NotifyResult
+	err   error
+}
+
+func (f *fakeNotifier) ShowNotification(_ context.Context, title, body string) (ports.NotifyResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, struct{ title, body string }{title, body})
+	return f.res, f.err
+}
+
+func (f *fakeNotifier) Calls() []struct{ title, body string } {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]struct{ title, body string }(nil), f.calls...)
+}
+
+// notifyModel builds a model wired to a fake notifier. shown/err are the
+// canned answer; ctx is real because alert() passes m.ctx to the notifier.
+func notifyModel(shown bool, err error) (Model, *bytes.Buffer, *fakeNotifier) {
+	var buf bytes.Buffer
+	f := &fakeNotifier{res: ports.NotifyResult{Shown: shown, Reason: "shown"}, err: err}
+	if !shown {
+		f.res.Reason = "rate_limited"
+	}
+	m := Model{
+		width: 100, height: 30,
+		bellOut:  &buf,
+		inflight: &sync.WaitGroup{},
+		ctx:      context.Background(),
+		notifier: f,
+	}
+	return m, &buf, f
+}
+
+// bothOn enables the toast and keeps the bell as its fallback.
+func bothOn() config.Config {
+	return config.Config{TUI: config.TUI{TerminalBell: true, HerdrNotification: true}}
+}
+
+// settle waits for alert()'s goroutine, which delivers the toast off the
+// update loop so a socket round trip cannot freeze the UI.
+func settle(m Model) { m.inflight.Wait() }
+
+func TestNotifyShownSuppressesBell(t *testing.T) {
+	m, buf, f := notifyModel(true, nil)
+	cfg := bothOn()
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}}})
+	m = upd.(Model)
+	upd, _ = m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{
+		{ID: 1},
+		{ID: 2, AgentID: "w1:p3", SituationType: domain.SituationApproval, Suggestion: "Yes"},
+	}})
+	m = upd.(Model)
+	settle(m)
+
+	calls := f.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("want exactly 1 notification, got %d", len(calls))
+	}
+	if calls[0].title != "Auto Prompter: w1:p3 needs attention" {
+		t.Errorf("title = %q", calls[0].title)
+	}
+	if calls[0].body != "approval escalated. Suggestion: Yes" {
+		t.Errorf("body = %q", calls[0].body)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("a delivered toast must not also ring the bell, got %v", buf.Bytes())
+	}
+}
+
+// TestNotifyNotShownFallsBackToBell is the core of the feature: herdr saying
+// "I dropped it" (disabled, rate limited, no foreground client, busy) must
+// still reach the operator.
+func TestNotifyNotShownFallsBackToBell(t *testing.T) {
+	m, buf, f := notifyModel(false, nil)
+	cfg := bothOn()
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}}})
+	m = upd.(Model)
+	upd, _ = m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}, {ID: 2}}})
+	m = upd.(Model)
+	settle(m)
+
+	if len(f.Calls()) != 1 {
+		t.Fatalf("want 1 notification attempt, got %d", len(f.Calls()))
+	}
+	if got := buf.Bytes(); len(got) != 1 || got[0] != 0x07 {
+		t.Fatalf("an undelivered toast should ring exactly one BEL, got %v", got)
+	}
+}
+
+func TestNotifyErrorFallsBackToBell(t *testing.T) {
+	m, buf, _ := notifyModel(true, errBoom)
+	cfg := bothOn()
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}}})
+	m = upd.(Model)
+	upd, _ = m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}, {ID: 2}}})
+	m = upd.(Model)
+	settle(m)
+
+	if got := buf.Bytes(); len(got) != 1 || got[0] != 0x07 {
+		t.Fatalf("a failed notification should ring exactly one BEL, got %v", got)
+	}
+}
+
+// TestNotifyWithBellOffStaysSilent: the bell is only ever a fallback for an
+// operator who asked for it. Turning it off must not resurrect it.
+func TestNotifyWithBellOffStaysSilent(t *testing.T) {
+	m, buf, f := notifyModel(false, nil)
+	cfg := config.Config{TUI: config.TUI{TerminalBell: false, HerdrNotification: true}}
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}}})
+	m = upd.(Model)
+	upd, _ = m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}, {ID: 2}}})
+	m = upd.(Model)
+	settle(m)
+
+	if len(f.Calls()) != 1 {
+		t.Fatalf("the toast should still be attempted, got %d calls", len(f.Calls()))
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("bell is off; nothing should be written, got %v", buf.Bytes())
+	}
+}
+
+// TestNotifyToggleOffNeverCallsNotifier: with herdr_notification off the
+// behavior is exactly what it was before the feature — bell only, socket
+// untouched.
+func TestNotifyToggleOffNeverCallsNotifier(t *testing.T) {
+	m, buf, f := notifyModel(true, nil)
+	cfg := config.Config{TUI: config.TUI{TerminalBell: true, HerdrNotification: false}}
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}}})
+	m = upd.(Model)
+	upd, _ = m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}, {ID: 2}}})
+	m = upd.(Model)
+	settle(m)
+
+	if len(f.Calls()) != 0 {
+		t.Fatalf("notifier must not be called when the option is off, got %d", len(f.Calls()))
+	}
+	if got := buf.Bytes(); len(got) != 1 || got[0] != 0x07 {
+		t.Fatalf("bell should still ring, got %v", got)
+	}
+}
+
+// TestNewPropagatesNotifierFromApp guards the single line that connects the
+// wiring to the behavior. Every other test here injects the notifier into a
+// Model literal, so dropping `notifier: app.Notifier` from New would leave the
+// whole feature dead in production with a fully green suite.
+func TestNewPropagatesNotifierFromApp(t *testing.T) {
+	f := &fakeNotifier{res: ports.NotifyResult{Shown: true}}
+	m := New(context.Background(), &frontend.App{Notifier: f})
+	if m.notifier == nil {
+		t.Fatal("New must carry App.Notifier onto the model")
+	}
+
+	// And a plain terminal (no herdr, so App.Notifier is nil) must leave it nil
+	// rather than a non-nil interface holding a nil pointer, which would make
+	// alert()'s `m.notifier != nil` check pass and then panic.
+	if plain := New(context.Background(), &frontend.App{}); plain.notifier != nil {
+		t.Errorf("notifier should be nil without an App.Notifier, got %#v", plain.notifier)
+	}
+}
+
+// TestPausePendingConsumedWhileAlertsOff: pausePending records who caused a
+// pause, so it must be cleared by the transition itself. Leaving it set
+// because alerts happened to be off would latch it, and the NEXT pause — an
+// external one, with alerts back on — would read as self-caused and be
+// silently swallowed.
+func TestPausePendingConsumedWhileAlertsOff(t *testing.T) {
+	m, buf, f := notifyModel(true, nil)
+	off := config.Config{TUI: config.TUI{TerminalBell: false, HerdrNotification: false}}
+
+	upd, _ := m.Update(refreshMsg{cfg: off, status: frontend.Status{Paused: false}})
+	m = upd.(Model)
+	m.pausePending = true // this instance pressed "p"
+	upd, _ = m.Update(refreshMsg{cfg: off, status: frontend.Status{Paused: true}})
+	m = upd.(Model)
+	settle(m)
+	if m.pausePending {
+		t.Fatal("pausePending must be consumed by the transition even with alerts off")
+	}
+
+	// Unpause, turn alerting back on, and take an EXTERNAL pause: it must alert.
+	upd, _ = m.Update(refreshMsg{cfg: bothOn(), status: frontend.Status{Paused: false}})
+	m = upd.(Model)
+	upd, _ = m.Update(refreshMsg{cfg: bothOn(), status: frontend.Status{Paused: true}})
+	m = upd.(Model)
+	settle(m)
+
+	if len(f.Calls()) != 1 {
+		t.Fatalf("the later external pause must alert, got %d calls", len(f.Calls()))
+	}
+	if buf.Len() != 0 {
+		t.Errorf("the toast was shown; the bell should stay quiet, got %v", buf.Bytes())
+	}
+}
+
+// TestNotifyBothOffIsFullySilent covers the fourth corner of the matrix; the
+// trigger block must not even evaluate when neither channel is enabled.
+func TestNotifyBothOffIsFullySilent(t *testing.T) {
+	m, buf, f := notifyModel(true, nil)
+	cfg := config.Config{TUI: config.TUI{TerminalBell: false, HerdrNotification: false}}
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}}})
+	m = upd.(Model)
+	upd, _ = m.Update(refreshMsg{cfg: cfg,
+		escalations: []domain.AuditRecord{{ID: 1}, {ID: 2}},
+		status:      frontend.Status{Paused: true}})
+	m = upd.(Model)
+	settle(m)
+
+	if len(f.Calls()) != 0 || buf.Len() != 0 {
+		t.Fatalf("both channels off must be silent; %d calls, %v bytes", len(f.Calls()), buf.Bytes())
+	}
+}
+
+func TestNotifyNoneOnFirstRefresh(t *testing.T) {
+	m, _, f := notifyModel(true, nil)
+
+	upd, _ := m.Update(refreshMsg{
+		cfg:         bothOn(),
+		status:      frontend.Status{Paused: true},
+		escalations: []domain.AuditRecord{{ID: 5}},
+	})
+	m = upd.(Model)
+	settle(m)
+
+	if len(f.Calls()) != 0 {
+		t.Fatalf("the first refresh must never notify, got %d", len(f.Calls()))
+	}
+}
+
+func TestNotifyOnExternallyCausedPause(t *testing.T) {
+	m, _, f := notifyModel(true, nil)
+	cfg := bothOn()
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, status: frontend.Status{Paused: false}})
+	m = upd.(Model)
+	upd, _ = m.Update(refreshMsg{cfg: cfg, status: frontend.Status{Paused: true}})
+	m = upd.(Model)
+	settle(m)
+
+	calls := f.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("want 1 notification, got %d", len(calls))
+	}
+	if calls[0].title != "Auto Prompter: automation paused" {
+		t.Errorf("title = %q", calls[0].title)
+	}
+}
+
+func TestNotifyNotOnSelfCausedPause(t *testing.T) {
+	m, buf, f := notifyModel(true, nil)
+	cfg := bothOn()
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, status: frontend.Status{Paused: false}})
+	m = upd.(Model)
+	m.pausePending = true
+	upd, _ = m.Update(refreshMsg{cfg: cfg, status: frontend.Status{Paused: true}})
+	m = upd.(Model)
+	settle(m)
+
+	if len(f.Calls()) != 0 || buf.Len() != 0 {
+		t.Fatalf("a self-caused pause must alert through neither channel")
+	}
+}
+
+// TestNotifyNilNotifierFallsBackToBell is the non-herdr case: hap launched
+// from a plain terminal has no socket, so App.Notifier is nil.
+func TestNotifyNilNotifierFallsBackToBell(t *testing.T) {
+	m, buf := bellModel()
+	cfg := bothOn()
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}}})
+	m = upd.(Model)
+	m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}, {ID: 2}}})
+
+	if got := buf.Bytes(); len(got) != 1 || got[0] != 0x07 {
+		t.Fatalf("without a notifier the bell must still ring, got %v", got)
+	}
+}
+
+// TestNotifyNilNotifierAndNilOutputNeverPanics guards the fully-unwired model
+// the way TestBellNilOutputNeverPanics does for the bell alone.
+func TestNotifyNilNotifierAndNilOutputNeverPanics(t *testing.T) {
+	m := Model{width: 100, height: 30, inflight: &sync.WaitGroup{}} // no bellOut, no notifier
+	cfg := bothOn()
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, status: frontend.Status{Paused: false}})
+	m = upd.(Model)
+	upd, _ = m.Update(refreshMsg{cfg: cfg, status: frontend.Status{Paused: true}})
+	m = upd.(Model)
+	settle(m)
+}
+
+// TestNotifyOneAlertPerPollForABurst: several escalations landing in one poll
+// is still one toast — the same rule the bell always followed.
+func TestNotifyOneAlertPerPollForABurst(t *testing.T) {
+	m, _, f := notifyModel(true, nil)
+	cfg := bothOn()
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}}})
+	m = upd.(Model)
+	upd, _ = m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{
+		{ID: 1}, {ID: 2, AgentID: "a"}, {ID: 3, AgentID: "b"}, {ID: 4, AgentID: "c"},
+	}})
+	m = upd.(Model)
+	settle(m)
+
+	calls := f.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("a burst should raise exactly 1 toast, got %d", len(calls))
+	}
+	// The newest row is the one described.
+	if calls[0].title != "Auto Prompter: c needs attention" {
+		t.Errorf("the highest-id escalation should be named, got %q", calls[0].title)
+	}
+}
+
+// TestNotifyUsesAgentDisplayName: the toast and the Agents tab must name the
+// same agent, so it resolves the short name herdr/hap knows it by.
+func TestNotifyUsesAgentDisplayName(t *testing.T) {
+	m, _, f := notifyModel(true, nil)
+	cfg := bothOn()
+	status := frontend.Status{AgentNames: map[string]string{"w1:p3": "backend"}}
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, status: status,
+		escalations: []domain.AuditRecord{{ID: 1}}})
+	m = upd.(Model)
+	upd, _ = m.Update(refreshMsg{cfg: cfg, status: status, escalations: []domain.AuditRecord{
+		{ID: 1}, {ID: 2, AgentID: "w1:p3", SituationType: domain.SituationError},
+	}})
+	m = upd.(Model)
+	settle(m)
+
+	calls := f.Calls()
+	if len(calls) != 1 || calls[0].title != "Auto Prompter: backend needs attention" {
+		t.Fatalf("want the agent's short name in the title, got %+v", calls)
+	}
+	if calls[0].body != "error escalated." {
+		t.Errorf("body = %q", calls[0].body)
+	}
+}
+
+// TestNotifyWithNoEscalationRow: a max-id bump with no matching row (a pruned
+// or filtered list) must still alert, just without specifics — never panic on
+// an empty record and never send an empty title, which herdr rejects.
+func TestNotifyWithNoEscalationRow(t *testing.T) {
+	m, _, f := notifyModel(true, nil)
+	cfg := bothOn()
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 1}}})
+	m = upd.(Model)
+	// ID 2 with no AgentID at all — the degenerate shape.
+	upd, _ = m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 2}}})
+	m = upd.(Model)
+	settle(m)
+
+	calls := f.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("want 1 notification, got %d", len(calls))
+	}
+	if calls[0].title == "" {
+		t.Error("title must never be empty — herdr rejects it with invalid_params")
+	}
+}
+
+// TestNotifyFailedRefreshDoesNotAlert: a failed poll carries a zero config
+// and empty escalations; it must not look like "everything resolved" and then
+// re-alert on the next good poll.
+func TestNotifyFailedRefreshDoesNotAlert(t *testing.T) {
+	m, buf, f := notifyModel(true, nil)
+	cfg := bothOn()
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 7}}})
+	m = upd.(Model)
+	upd, _ = m.Update(refreshMsg{err: errBoom})
+	m = upd.(Model)
+	settle(m)
+	if len(f.Calls()) != 0 || buf.Len() != 0 {
+		t.Fatalf("a failed refresh must not alert")
+	}
+
+	// The baseline survived the failure, so the unchanged set is still quiet.
+	upd, _ = m.Update(refreshMsg{cfg: cfg, escalations: []domain.AuditRecord{{ID: 7}}})
+	m = upd.(Model)
+	settle(m)
+	if len(f.Calls()) != 0 || buf.Len() != 0 {
+		t.Fatalf("the baseline must survive a failed refresh; %d calls", len(f.Calls()))
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -29,6 +30,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
 	"github.com/0xGosu/herdr-auto-pilot/internal/updatecheck"
 )
 
@@ -558,6 +560,11 @@ type Model struct {
 	// bellOut is where the terminal bell (ASCII BEL) is written; nil is a
 	// safe no-op so tests never touch real IO. Run() wires it to os.Stdout.
 	bellOut io.Writer
+	// notifier raises a herdr desktop notification for the same two events
+	// the bell covers. nil whenever hap is not running as a herdr-managed
+	// pane (a plain terminal, and every test that does not inject one), in
+	// which case alert() falls straight through to the bell.
+	notifier ports.NotifyShower
 	// initialized is false until the first successful (err == nil)
 	// refreshMsg has been processed. It gates all bell logic: without it,
 	// the very first refresh would look like a 0-to-N transition against
@@ -965,7 +972,7 @@ func (m Model) visibleSignatures() []frontend.SignatureRow {
 
 // New creates the TUI model.
 func New(ctx context.Context, app *frontend.App) Model {
-	return Model{app: app, ctx: ctx, inflight: &sync.WaitGroup{}}
+	return Model{app: app, ctx: ctx, inflight: &sync.WaitGroup{}, notifier: app.Notifier}
 }
 
 // Init starts the refresh loop.
@@ -1177,21 +1184,32 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case refreshMsg:
 		if msg.err == nil {
-			if m.initialized && msg.cfg.TUI.TerminalBell {
+			if m.initialized {
+				// Either channel being on is enough to evaluate the triggers;
+				// alert() itself picks the channel and honors both switches.
+				alerting := msg.cfg.TUI.HerdrNotification || msg.cfg.TUI.TerminalBell
 				// Trigger 1: any escalation newer than the last successful
-				// poll. One bell per poll cycle even if several appeared at
-				// once — beeping N times for a burst is worse UX.
-				if maxEscalationID(msg.escalations) > m.lastMaxEscalationID {
-					m.ringBell()
+				// poll. One alert per poll cycle even if several appeared at
+				// once — beeping (or toasting) N times for a burst is worse UX.
+				if alerting && maxEscalationID(msg.escalations) > m.lastMaxEscalationID {
+					title, body := escalationAlertText(msg)
+					m.alert(msg.cfg.TUI, title, body)
 				}
 				// Trigger 2: pause just became active, and NOT because this
 				// instance's own "p" press caused it (pausePending, set
 				// synchronously at keypress time — see its doc comment).
+				//
+				// pausePending is consumed on the TRANSITION, never inside the
+				// alerting branch: it is a fact about who caused THIS pause, so
+				// leaving it set while alerts happen to be off would latch it
+				// and make the next externally-caused pause read as self-caused
+				// — silently swallowing a real alert.
 				if !m.lastPaused && msg.status.Paused {
-					if m.pausePending {
-						m.pausePending = false
-					} else {
-						m.ringBell()
+					selfCaused := m.pausePending
+					m.pausePending = false
+					if alerting && !selfCaused {
+						m.alert(msg.cfg.TUI, "Auto Prompter: automation paused",
+							"The kill switch was activated by another process.")
 					}
 				}
 			}
@@ -1885,10 +1903,99 @@ func maxEscalationID(rows []domain.AuditRecord) int64 {
 	return highest
 }
 
-// ringBell emits a single ASCII BEL (0x07). A nil bellOut (the default in
+// alert raises the operator's attention through the best channel available:
+// a herdr desktop notification when hap runs as a herdr-managed pane, else
+// (or when herdr declines to display it) the terminal bell.
+//
+// The notification is dispatched on a goroutine, NOT inline: a socket round
+// trip takes up to SocketNotifier.Timeout, and Update runs on Bubble Tea's
+// single update loop where any wait freezes the whole UI. The goroutine joins
+// m.inflight — the same WaitGroup do() uses and Run drains before returning —
+// so quitting right after an escalation still lets the toast finish. The
+// Add(1) happens here, on the update loop, for the reason documented on do():
+// adding inside the goroutine can race Run's drain.
+//
+// Falling back on a not-shown toast is deliberate. herdr answers with
+// shown=false and a reason (disabled, rate_limited, no_foreground_client,
+// busy) when it drops one; treating that as delivered would silently swallow
+// the alert the operator configured.
+func (m Model) alert(cfg config.TUI, title, body string) {
+	if cfg.HerdrNotification && m.notifier != nil {
+		// Capture only what the goroutine needs — a Model copy would pin the
+		// whole refresh payload for the life of the call.
+		wg, ctx, notifier, out, bell := m.inflight, m.ctx, m.notifier, m.bellOut, cfg.TerminalBell
+		if ctx == nil { // Model literals in tests may leave it unset
+			ctx = context.Background()
+		}
+		// Guarded like every other inflight user here (see do/semanticSearchCmd):
+		// Model is built by literal in dozens of tests, so a nil WaitGroup must
+		// degrade rather than panic on the update loop.
+		if wg != nil {
+			wg.Add(1)
+		}
+		go func() {
+			if wg != nil {
+				defer wg.Done()
+			}
+			res, err := notifier.ShowNotification(ctx, title, body)
+			if err == nil && res.Shown {
+				return
+			}
+			if err != nil {
+				// Warn, not Debug: the TUI logs at Info, and a permanently
+				// broken socket (herdr restarted, wrong HERDR_SOCKET_PATH)
+				// would otherwise leave the operator with an unexplained bell
+				// and nothing to find in the log.
+				slog.Warn("herdr notification failed", "error", err)
+			} else {
+				// Expected traffic, not a fault — herdr routinely declines.
+				slog.Debug("herdr notification not shown", "reason", res.Reason)
+			}
+			// On shutdown the dial fails instantly because ctx is already
+			// cancelled; beeping the terminal on the way out is noise, not an
+			// alert.
+			if bell && ctx.Err() == nil {
+				ringBellTo(out)
+			}
+		}()
+		return
+	}
+	if cfg.TerminalBell {
+		ringBellTo(m.bellOut)
+	}
+}
+
+// escalationAlertText renders the notification for the newest escalation in a
+// refresh. It names the agent the way the lists do (short name, falling back
+// to the pane id) so the toast and the TUI row agree.
+func escalationAlertText(msg refreshMsg) (title, body string) {
+	newest := domain.AuditRecord{}
+	for _, r := range msg.escalations {
+		if r.ID > newest.ID {
+			newest = r
+		}
+	}
+	agent := msg.status.AgentName(newest.AgentID)
+	if agent == "" {
+		agent = newest.AgentID
+	}
+	if agent == "" {
+		// No escalation row to describe (an id-only diff, or a pruned list):
+		// still alert, just without the specifics.
+		return "Auto Prompter: an agent needs attention", "A new escalation is waiting."
+	}
+	title = fmt.Sprintf("Auto Prompter: %s needs attention", agent)
+	body = fmt.Sprintf("%s escalated.", orDash(string(newest.SituationType)))
+	if newest.Suggestion != "" {
+		body += " Suggestion: " + newest.Suggestion
+	}
+	return title, body
+}
+
+// ringBellTo emits a single ASCII BEL (0x07). A nil writer (the default in
 // tests and unless Run() wires it) makes this a safe no-op.
 //
-// This writes directly to bellOut (os.Stdout in Run()) rather than through
+// This writes directly to the writer (os.Stdout in Run()) rather than through
 // Bubble Tea's own output helpers: tea.Println/tea.Printf are silently
 // dropped whenever the alt screen is active (see bubbletea's
 // standardRenderer's printLineMessage handling) — verified against the
@@ -1897,12 +2004,13 @@ func maxEscalationID(rows []domain.AuditRecord) int64 {
 // flush writes to the same fd from its own goroutine, but a lone BEL is a
 // single byte — a single Write() of one byte cannot be torn by a
 // concurrent Write() of another buffer, so the worst case is a one-frame-
-// late beep, never output corruption.
-func (m Model) ringBell() {
-	if m.bellOut == nil {
+// late beep, never output corruption. That same single-byte argument is what
+// lets alert()'s goroutine call this off the update loop.
+func ringBellTo(w io.Writer) {
+	if w == nil {
 		return
 	}
-	_, _ = m.bellOut.Write([]byte{0x07})
+	_, _ = w.Write([]byte{0x07})
 }
 
 // pauseCmd activates the pause/kill switch, tagging its result as

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -282,7 +282,12 @@ max_content_height = 0     # expanded long-field lines; 0 = unlimited; collapsed
 theme = ""                 # named palette: default | dark | light | high-contrast;
                            # empty/unknown = default (the original look)
 terminal_bell = true       # ring the terminal bell (\a) on new escalations and on
-                           # pauses caused by a different process; default on
+                           # pauses caused by a different process; default on.
+                           # Also the fallback when herdr_notification is on but
+                           # herdr does not display the toast
+herdr_notification = true  # raise a herdr desktop notification on those same two
+                           # events when the TUI runs as a herdr-managed pane;
+                           # outside herdr there is no socket and this does nothing
 disable_check_for_update = false  # turn off the periodic GitHub release check — the
                            # plugin's only outbound call; the header flags a newer
                            # release, install it with `hap update`

--- a/test/integration/notification_test.go
+++ b/test/integration/notification_test.go
@@ -1,0 +1,133 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/herdr"
+)
+
+// requireHerdrSocket skips unless herdr injected its control socket, i.e. we
+// are running inside a herdr-managed pane.
+func requireHerdrSocket(t *testing.T) {
+	t.Helper()
+	requireHerdr(t)
+	if os.Getenv("HERDR_SOCKET_PATH") == "" {
+		t.Skip("HERDR_SOCKET_PATH not set; run this from inside a herdr-managed pane")
+	}
+}
+
+// TestRealHerdrNotification drives the SocketNotifier against a LIVE herdr.
+// The unit suite fakes the socket, so only this catches drift in the
+// notification.show contract the TUI's bell fallback is built on: the result
+// must carry a `reason` the TUI knows, and `shown` must agree with it.
+//
+// It raises a real toast on the operator's screen — that is the point.
+func TestRealHerdrNotification(t *testing.T) {
+	requireHerdrSocket(t)
+	n := herdr.NewSocketNotifier(herdr.SocketPath())
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	res, err := n.ShowNotification(ctx,
+		"hap integration test", "TestRealHerdrNotification — safe to dismiss")
+	if err != nil {
+		t.Fatalf("ShowNotification against real herdr: %v", err)
+	}
+	if res.Reason == "" {
+		t.Error("herdr returned no reason — the result shape changed")
+	}
+	// shown can legitimately be false (toasts disabled, rate limited, no
+	// foreground client, a toast already standing) — that is the fallback
+	// path, not a failure. Only an unrecognized reason means real drift.
+	switch res.Reason {
+	case "shown", "disabled", "rate_limited", "no_foreground_client", "busy":
+	default:
+		t.Errorf("unrecognized reason %q — herdr added a case the TUI does not know", res.Reason)
+	}
+	if res.Shown != (res.Reason == "shown") {
+		t.Errorf("shown=%v disagrees with reason=%q", res.Shown, res.Reason)
+	}
+	t.Logf("notification.show -> shown=%v reason=%q", res.Shown, res.Reason)
+}
+
+// TestRealHerdrNotificationSecondCallSucceeds pins the reason every call opens
+// its own connection: herdr 0.7.3 CLOSES the connection after answering a
+// notification.show, so a pooled or reused connection would fail with EPIPE on
+// the second toast — and the TUI can raise two from one refresh (a new
+// escalation and an externally-caused pause).
+func TestRealHerdrNotificationSecondCallSucceeds(t *testing.T) {
+	requireHerdrSocket(t)
+	n := herdr.NewSocketNotifier(herdr.SocketPath())
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	for i, title := range []string{"hap integration test 1/2", "hap integration test 2/2"} {
+		if _, err := n.ShowNotification(ctx, title, "safe to dismiss"); err != nil {
+			t.Fatalf("call %d failed — connections are not being reopened per call: %v", i+1, err)
+		}
+	}
+}
+
+// TestRealHerdrNotificationRejectsEmptyTitle: real herdr answers
+// invalid_params for a title with no visible text. The adapter refuses such a
+// title locally, before dialling — this asserts BOTH halves still agree, so
+// the local guard can never drift away from the contract it stands in for.
+func TestRealHerdrNotificationRejectsEmptyTitle(t *testing.T) {
+	requireHerdrSocket(t)
+	n := herdr.NewSocketNotifier(herdr.SocketPath())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, err := n.ShowNotification(ctx, "   ", "body"); err == nil {
+		t.Fatal("a whitespace-only title must be rejected locally")
+	}
+
+	// Now prove herdr itself still enforces the rule, with a title our local
+	// clamp CANNOT catch: control characters are not unicode space, so
+	// strings.Fields keeps them, but herdr normalizes them away and is left
+	// with nothing. A successful call here means the contract relaxed.
+	_, err := n.Show(ctx, herdr.Notification{Title: "\x01\x02"})
+	if err == nil {
+		t.Skip("herdr accepted a control-character-only title; the contract relaxed")
+	}
+	var se *herdr.SocketError
+	if !errors.As(err, &se) {
+		t.Fatalf("want a *herdr.SocketError from herdr, got %T: %v", err, err)
+	}
+	if se.Code != "invalid_params" {
+		t.Errorf("herdr rejected an empty title with %q, want invalid_params", se.Code)
+	}
+}
+
+// TestRealInHerdrDetection asserts the runtime detection the whole feature
+// hangs off: inside a herdr-managed pane HERDR_ENV=1 and HERDR_SOCKET_PATH
+// both exist, and the resolved socket is a real file.
+func TestRealInHerdrDetection(t *testing.T) {
+	if os.Getenv("HERDR_ENV") != "1" {
+		t.Skip("not running inside a herdr-managed pane")
+	}
+	if !herdr.InHerdr() {
+		t.Fatal("InHerdr() is false inside a herdr-managed pane")
+	}
+	path := herdr.SocketPath()
+	if path == "" {
+		t.Fatal("SocketPath() is empty inside herdr")
+	}
+	if !strings.HasSuffix(path, ".sock") {
+		t.Errorf("socket path %q does not look like a socket", path)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("resolved socket %q does not exist: %v", path, err)
+	}
+	if got := filepath.Clean(path); got != path {
+		t.Errorf("socket path %q is not clean", path)
+	}
+}


### PR DESCRIPTION
## Why

The TUI alerted only with a terminal bell. A bell does nothing in many terminals, and nothing at all when you are looking at a different herdr tab or another app — so an escalation could sit unnoticed.

herdr 0.7 exposes `notification.show` over its control socket and injects `HERDR_ENV=1` + `HERDR_SOCKET_PATH` into every managed pane — and the TUI *is* a managed pane. So it can detect that it is running inside herdr and raise a real notification instead.

## What changed

When herdr launched hap as a managed pane, the TUI raises a herdr desktop notification for the same two events the bell always covered:

1. a new escalation appearing since the last 2s poll
2. the pause/kill switch becoming active because of a **different** process

**The bell becomes the fallback rather than the only channel.** Unlike the CLI's fire-and-forget `herdr notification show` (which exits 0 whether or not the toast appeared), the socket method answers `{shown, reason}` — so a toast herdr declined to paint (`disabled`, `rate_limited`, `no_foreground_client`, `busy`) rings the bell instead of being silently counted as delivered.

Outside herdr nothing changes: no socket is opened and the bell behaves exactly as before.

### Config

New `tui.herdr_notification` (default **on**), independent of the existing `tui.terminal_bell` (default on):

| `herdr_notification` | `terminal_bell` | behavior |
|---|---|---|
| true | true | toast; bell only if the toast was not shown |
| true | false | toast only |
| false | true | bell (today's behavior) |
| false | false | silent |

## Notes for the reviewer

- **The daemon already toasts on escalation** via the CLI (`daemon.escalate`), and it is deliberately left alone — so both can fire for the same escalation. herdr's in-app `busy` de-dup usually swallows the second. This overlap was an explicit decision, not an oversight.
- **Every call opens its own connection.** Verified live against herdr 0.7.3: the server *closes the connection right after answering* `notification.show`, on the success path as well as the error path, so a reused connection dies with EPIPE. This contradicts the socket-API docs' "multiple methods work on one connection", and there is an integration test pinning it so nobody optimizes it into a pooled connection.
- `ports.NotifyShower` is a new **optional** interface alongside the unchanged `NotifyPort`, type-asserted at the call site — the repo's standard optional-capability pattern.
- The notification is dispatched **off the bubbletea update loop**, on a goroutine joined to the `inflight` WaitGroup `Run` already drains, so a socket round trip can never freeze the UI.
- The one-shot request/response helper is **extracted out of `listPanes`** and shared. The rewritten `listPanes` is behavior-preserving (same scanner buffers, same conn-close ordering, same error precedence).

### Two fixes beyond the original scope

Both came out of code review and both have tests:

- `pausePending` was consumed only *inside* the alerting branch. With alerts off it latched, and the next externally-caused pause would read as self-caused and be **silently swallowed**. It is now consumed by the pause transition itself.
- A failed toast now logs at `Warn`, not `Debug` — the TUI logs at Info, so a permanently broken socket previously left the operator with an unexplained bell and nothing in the log.

## Testing

- Full suite `go test -tags "vectors cpu" ./... -count=1` — green
- `golangci-lint run --build-tags "vectors,cpu"` — 0 issues; `go vet` + `gofmt` clean
- `-race` on `internal/tui` and `internal/herdr` — clean
- New unit tests: the socket notifier against the fake herdr socket (result shape, not-shown-is-not-an-error, protocol error, unreachable socket, text clamping, unique request ids, concurrency), and the full four-corner config matrix in the TUI
- New **live** integration tests (`test/integration/notification_test.go`, build tag `integration`) driving a real herdr — they raise real toasts and assert the result shape, that two consecutive calls both land, and that an empty title is refused both locally and by herdr

> One earlier suite run reported 4 daemon failures; those were CPU contention from a concurrent race run, not regressions. Confirmed by re-running this branch and `main` serially — both green.
