### PR TITLE
#1 feat: declutter the TUI Config tab and handle SIGHUP on a closed pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,23 @@
 # Changelog
 
 Every change gets a line here, including patch releases — see the Changelog
-section in `CLAUDE.md`. Entries sit under **Unreleased** until the release that
-carries them is tagged, then that heading becomes the version number.
+section in `CLAUDE.md`. Entries go under the version that will carry them: merging
+to main auto-releases the next patch, so a PR adds its lines under that number
+(or under the minor/major version it bumps the manifest to).
 
-## Unreleased
+## 0.5.10
+
+- Fixed the changelog leaving the 0.5.8 and 0.5.9 entries stranded under `Unreleased` after both releases shipped; they now sit under their own version headings, and the file no longer uses an `Unreleased` heading at all
+
+## 0.5.9
 
 - Added a herdr desktop notification when a new escalation appears while the TUI is open, or when automation is paused by another process — the TUI detects that herdr launched it and raises the toast over herdr's socket API, so an escalation reaches you from another tab or another app instead of only beeping the pane you are not looking at
 - The terminal bell is now the fallback rather than the only channel: it rings when there is no herdr to talk to, and also when herdr answers that it did NOT display the toast (notifications turned off, rate limited, no foreground window, or a toast already standing) — an undelivered toast never counts as having alerted you
 - Added `tui.herdr_notification` (default on) to turn the toast off independently of `tui.terminal_bell`; with both off the TUI is silent
 - Outside herdr nothing changes: no socket is opened and the bell behaves exactly as before
+
+## 0.5.8
+
 - Fixed the builtin-rule attribution behind `b` and the `hap escalations` hint being spoofable by agent-influenced text: it searched the whole rationale for a shipped rule's `(source=seed …)` marker, so a fabricated diagnostic in a pane excerpt or in appended LLM/error text could claim a rule that never fired — and because the search ran in seed-list order, a forgery naming an earlier rule could even outrank the genuine hit. You would be offered "disable this builtin rule" for an unrelated safety control while the rule that actually blocked you kept blocking. Attribution is now bound to the first diagnostic in the rationale, which is always the genuine one
 
 ## 0.5.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to main auto-releases the next patch, so a PR adds its lines under that number
 ## 0.5.10
 
 - Fixed the changelog leaving the 0.5.8 and 0.5.9 entries stranded under `Unreleased` after both releases shipped; they now sit under their own version headings, and the file no longer uses an `Unreleased` heading at all
+- Changed the TUI Config tab to hide ten advanced fields that crowded out the settings people actually change: `llm.pane_excerpt_chars`, `llm.enable_rewrite_action`, `llm.rewrite_action_fallback_template`, the five `llm.*env_file` paths, `embedding.pane_salient_chars`, and `embedding.warm_timeout_ms`. They are unchanged everywhere else — still listed by `hap config fields`, still settable with `hap config set`, still read from `config.toml`
 
 ## 0.5.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to main auto-releases the next patch, so a PR adds its lines under that number
 ## 0.5.10
 
 - Fixed the changelog leaving the 0.5.8 and 0.5.9 entries stranded under `Unreleased` after both releases shipped; they now sit under their own version headings, and the file no longer uses an `Unreleased` heading at all
+- Fixed `hap` being killed outright by SIGHUP — the signal raised whenever the terminal hosting it goes away, so closing a herdr pane or dropping an ssh session while the TUI was open ended it mid-flight, with the store never closed and the terminal left in raw mode with the alt screen still on. SIGHUP now cancels the run context like SIGINT and SIGTERM, and the TUI unwinds through it. A second signal still terminates immediately, so a process that ignores the cancellation can never become unkillable
 - Changed the TUI Config tab to hide ten advanced fields that crowded out the settings people actually change: `llm.pane_excerpt_chars`, `llm.enable_rewrite_action`, `llm.rewrite_action_fallback_template`, the five `llm.*env_file` paths, `embedding.pane_salient_chars`, and `embedding.warm_timeout_ms`. They are unchanged everywhere else — still listed by `hap config fields`, still settable with `hap config set`, still read from `config.toml`
 
 ## 0.5.9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,9 +112,22 @@ ticket/issue id**. Examples:
 patch releases.** No exceptions for "small", "internal", or "just a fix": if it
 merges, it is in the changelog. A PR without one is incomplete.
 
-- Add the line(s) under `## Unreleased`, in the same commit as the change. The
-  heading becomes the version number when that release is tagged (the manifest
-  version TRAILS releases, so the number is not known at merge time).
+- **Never use an `Unreleased` heading.** Merging to main auto-releases, so the
+  version a PR ships in is knowable at write time — write that number as the
+  heading, in the same commit as the change:
+  1. Read `CHANGELOG.md` on the latest **remote** `main`
+     (`git fetch origin main && git show origin/main:CHANGELOG.md | head -20`) —
+     not your branch, which may be behind. The topmost `## X.Y.Z` is the latest
+     entry.
+  2. If that version is already released (`git tag -l vX.Y.Z` finds it, i.e. it
+     matches `version` in `herdr-plugin.toml`), your section is the **next patch**:
+     `## X.Y.(Z+1)`. If it is NOT yet released, another unmerged PR already opened
+     that section — add your lines to it instead of starting a new one.
+  3. Exception: when the user explicitly asks for a minor/major bump, the version
+     is not a guess — you overwrite `version` in `herdr-plugin.toml` inside the PR
+     (see *Version bump & release*), so use exactly that number as the heading.
+- The guess can be wrong if a race merges another PR first; that is fine and
+  self-correcting — fix the heading in a follow-up rather than reverting.
 - Style: a flat list of verb-first one-liners — `Added …`, `Fixed …`,
   `Changed …`, `Removed …`. No sub-sections.
 - Write what it MEANS for the reader, not what the diff did. GitHub already

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,8 +73,13 @@ herdr plugin link .
    - a **macOS** matrix leg, where test binaries need `-ldflags "-r /usr/local/lib"`
      to reach the FAISS dylibs.
 4. Describe *what* and *why* in the PR body; link related issues.
-5. **Add an entry under `## Unreleased` in `CHANGELOG.md`** — required for every
-   change, including patch-level fixes, in the same commit as the change itself.
+5. **Add an entry to `CHANGELOG.md`** — required for every change, including
+   patch-level fixes, in the same commit as the change itself. There is no
+   `Unreleased` heading: merging auto-releases the next patch, so head your
+   section with that number. Read the file on the latest remote `main`, take the
+   topmost `## X.Y.Z`, and use `X.Y.(Z+1)` if that version is already tagged —
+   or append to it if it is not (another unmerged PR opened it). A deliberate
+   minor/major bump uses the version you set in `herdr-plugin.toml` instead.
    Verb-first one-liners (`Added …`, `Fixed …`); write what it means for the
    reader, not what the diff did. GitHub already generates a list of PR titles
    per release; that file is for what a title cannot convey, like the bounds of

--- a/README.md
+++ b/README.md
@@ -1096,7 +1096,7 @@ or `hap rules add '<regex>'` / `rules remove <index>`, or press `a`/`x` on
 the TUI's *Config* tab — which also lists the supported scalar config fields,
 adds/removes task sources (`t`/`x`), and clears learned data (`X`).
 Simple fields — numbers, booleans, and the `tui.theme` enum, including
-`llm.pane_excerpt_chars`, `llm.task_generate_timeout_seconds`,
+`llm.task_generate_timeout_seconds`,
 `embedding.model_context_window`, `safety.disable_never_auto_seed_patterns`,
 `tui.max_content_width` / `tui.max_content_height`, `tui.terminal_bell`
 (on by default — rings the terminal bell on a new escalation, and when the
@@ -1107,12 +1107,18 @@ still rings if herdr reports it did not display the toast), and
 `tui.disable_check_for_update` (off by default — see *Update to the latest
 version*) — edit
 inline (`enter`, or `e`) or via `hap config set <key> <value>`. Free-text fields (`llm.command`,
-`llm.command_start`, `llm.rewrite_action_fallback_template`,
+`llm.command_start`,
 `llm.task_generate_command`,
 `llm.task_generate_command_start`, `embedding.model_path`) show read-only in
 the TUI, because a one-line
 prompt mangles quoted argv values — edit them in `config.toml` or with
-`config set`, which accepts every listed scalar key. Scoped never-auto rules
+`config set`, which accepts every listed scalar key. Ten advanced fields are
+not listed on the tab at all, so the settings you actually change stay
+findable: `llm.pane_excerpt_chars`, `llm.enable_rewrite_action`,
+`llm.rewrite_action_fallback_template`, the five `llm.*env_file` paths,
+`embedding.pane_salient_chars`, and `embedding.warm_timeout_ms`. They are
+hidden only from the TUI — `hap config fields` still lists them, `hap config
+set` still sets them, and `config.toml` still reads them. Scoped never-auto rules
 and `[[capture_delay]]` rules also display read-only on the tab. The
 `[tui.palette]` overrides are edited directly in `config.toml`. Capture delays show the built-in defaults (10000
 ms first event / 2000 ms after) when none are configured, and long values are

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -81,8 +81,64 @@ func main() {
 	}
 }
 
+// shutdownSignals are the signals that cancel the run context instead of
+// killing the process where it stands.
+//
+// SIGHUP is the one that is easy to miss: it arrives when the terminal hosting
+// us goes away — the herdr pane is closed, an ssh session drops — which is a
+// routine way for `hap tui` to end, not an exceptional one. Unhandled, Go's
+// default for it is immediate termination, so nothing deferred runs: the store
+// is never closed and the TUI never restores the terminal, leaving it in raw
+// mode with the alt screen still on.
+//
+// What this does NOT rescue is the submit-retry drain. Those workers run on
+// the same context the signal just cancelled (herdr.CLI.spawnSubmitRetry), so
+// they return without pressing Enter no matter how orderly the exit is; the
+// drain only does its job on the ordinary quit path, where nothing is
+// cancelled. Making retries survive a signal would mean detaching their
+// context from shutdown, which is a delivery-path decision, not a
+// signal-handling one.
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGHUP}
+
+// shutdownContext returns the run context and its release function. It is
+// separate from run() so tests can exercise the real wiring — both halves of
+// it, including the release below, which no assertion could otherwise reach.
+//
+// Catching a signal means it no longer kills us, so a process wedged in a call
+// that does not observe ctx (a blocking flock, a stuck subprocess read) would
+// become unkillable by anything short of SIGKILL. The graceful path therefore
+// gets exactly one chance: the handler is released the moment the first signal
+// arrives, so a second one terminates immediately. Without that, adding SIGHUP
+// would turn an orphaned-and-wedged process — which the hangup used to reap —
+// into one that lingers forever.
+//
+// The release happens BEFORE the cancellation, not in a goroutine watching
+// ctx.Done(): that ordering is what makes the guarantee real rather than
+// probabilistic. Watching for cancellation leaves the release racing every
+// consumer of ctx, so a second signal arriving promptly — the operator hitting
+// it again because nothing seemed to happen — could still find the handler
+// installed and be swallowed.
+func shutdownContext() (context.Context, func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, shutdownSignals...)
+	release := func() { signal.Stop(ch) }
+	go func() {
+		select {
+		case <-ch:
+			release()
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, func() {
+		release()
+		cancel()
+	}
+}
+
 func run(verb string, args []string) error {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, stop := shutdownContext()
 	defer stop()
 
 	// Path-printing verbs are pure diagnostics: they resolve paths WITHOUT

--- a/cmd/hap/signal_test.go
+++ b/cmd/hap/signal_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestShutdownSignalsCancelInsteadOfKilling delivers each shutdown signal to
+// this very test process, through the production wiring, and asserts the run
+// context cancels.
+//
+// The assertion is deliberately self-enforcing: if a signal is dropped from
+// shutdownSignals, this test does not report a failure — the test BINARY dies
+// on the spot with Go's default disposition for it, which is exactly the
+// production bug (`hap tui` killed mid-flight, no deferred store close,
+// terminal left in raw mode). SIGHUP is the one that matters in practice: it
+// arrives whenever the terminal hosting the TUI goes away — a closed herdr
+// pane, a dropped ssh session.
+func TestShutdownSignalsCancelInsteadOfKilling(t *testing.T) {
+	for _, sig := range []syscall.Signal{syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT} {
+		t.Run(sig.String(), func(t *testing.T) {
+			ctx, stop := shutdownContext()
+			defer stop()
+
+			if err := syscall.Kill(syscall.Getpid(), sig); err != nil {
+				t.Fatalf("raise %v: %v", sig, err)
+			}
+			select {
+			case <-ctx.Done():
+			case <-time.After(5 * time.Second):
+				t.Fatalf("%v did not cancel the run context", sig)
+			}
+		})
+	}
+}
+
+// signalChildEnv makes a re-executed test binary run the helper below instead
+// of the suite. Signal DISPOSITION is process-wide and one-way here (the
+// helper deliberately lets a signal kill it), so it cannot be asserted
+// in-process — it needs a child.
+const signalChildEnv = "HAP_TEST_SIGNAL_CHILD"
+
+// TestSignalChildHelper is not a test: re-executed with signalChildEnv set, it
+// installs the production wiring, reports readiness on stdout, and then waits.
+// The parent signals it and inspects how it died.
+func TestSignalChildHelper(t *testing.T) {
+	if os.Getenv(signalChildEnv) == "" {
+		t.Skip("helper process for TestSecondSignalStillTerminates")
+	}
+	ctx, stop := shutdownContext()
+	defer stop()
+
+	os.Stdout.WriteString("ready\n")
+	<-ctx.Done()
+	// First signal handled. Report that, then block: the parent's second
+	// signal must now kill us, because shutdownContext released the handler.
+	os.Stdout.WriteString("cancelled\n")
+	select {}
+}
+
+// TestSecondSignalStillTerminates pins the escape hatch. Catching a signal
+// means it no longer kills, so a process wedged somewhere that does not
+// observe ctx would survive every signal short of SIGKILL — for an orphaned
+// process whose terminal is already gone, that is a leak the operator cannot
+// even see. The first signal must cancel gracefully; the second must kill.
+//
+// Both halves are load-bearing in opposite directions: release the handler too
+// early and SIGHUP goes back to killing us instantly (the original bug), never
+// release it and a wedged process lingers forever.
+func TestSecondSignalStillTerminates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("re-executes the test binary")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skipf("cannot locate the test binary: %v", err)
+	}
+
+	cmd := exec.Command(exe, "-test.run=TestSignalChildHelper", "-test.v")
+	cmd.Env = append(os.Environ(), signalChildEnv+"=1")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	// Exactly one Wait: a second concurrent call races the first and reports
+	// nothing useful. It starts now, so the child is reaped however the test
+	// ends, and closing the channel (rather than sending) lets both the
+	// assertion and the cleanup read it.
+	var waitErr error
+	waited := make(chan struct{})
+	go func() { waitErr = cmd.Wait(); close(waited) }()
+	defer func() {
+		_ = cmd.Process.Kill()
+		<-waited
+	}()
+
+	// Read until the helper says it is armed, so the signal cannot land before
+	// the handler is installed.
+	sc := bufio.NewScanner(stdout)
+	if !waitForLine(t, sc, "ready") {
+		t.Fatal("helper never reported readiness")
+	}
+
+	if err := cmd.Process.Signal(syscall.SIGHUP); err != nil {
+		t.Fatalf("first SIGHUP: %v", err)
+	}
+	if !waitForLine(t, sc, "cancelled") {
+		t.Fatal("first SIGHUP did not cancel the child's run context gracefully")
+	}
+
+	if err := cmd.Process.Signal(syscall.SIGHUP); err != nil {
+		t.Fatalf("second SIGHUP: %v", err)
+	}
+
+	select {
+	case <-waited:
+		exitErr, ok := waitErr.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("child exited with %v, want death by signal", waitErr)
+		}
+		ws, ok := exitErr.Sys().(syscall.WaitStatus)
+		if !ok || !ws.Signaled() || ws.Signal() != syscall.SIGHUP {
+			t.Errorf("child exit = %v, want killed by SIGHUP — the handler was not released after the first signal", exitErr.ProcessState)
+		}
+	case <-time.After(20 * time.Second):
+		t.Error("child survived a second SIGHUP — a wedged process would be unkillable")
+	}
+}
+
+// waitForLine reads scanner output until it sees want, so the parent never
+// signals a child that is not listening yet. The scanner is shared across
+// calls: each one resumes where the last stopped.
+func waitForLine(t *testing.T, sc *bufio.Scanner, want string) bool {
+	t.Helper()
+	found := make(chan bool, 1)
+	go func() {
+		for sc.Scan() {
+			if strings.TrimSpace(sc.Text()) == want {
+				found <- true
+				return
+			}
+		}
+		found <- false
+	}()
+	select {
+	case ok := <-found:
+		return ok
+	case <-time.After(30 * time.Second):
+		return false
+	}
+}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -1491,9 +1491,16 @@ func (a *App) UpdateConfig(ctx context.Context, fn func(*config.Config) error) e
 // templates, template strings, paths — are TUI-read-only as a standing
 // rule (CR-036): the one-line prompt round-trip mangles them. `config set`
 // accepts every key regardless of the flag.
+//
+// TUIHidden goes one step further: the field is not listed on the TUI Config
+// tab at all. It is for advanced knobs an operator tunes once (if ever) —
+// showing them buries the settings people actually change. Hidden is a
+// display choice only: config.toml, `hap config fields`, and
+// `hap config set` all keep working on the key.
 type ConfigFieldDef struct {
 	Key         string
 	TUIEditable bool
+	TUIHidden   bool
 }
 
 // ConfigFields is the single source of truth for the scalar config field
@@ -1526,29 +1533,29 @@ var ConfigFields = []ConfigFieldDef{
 	{Key: "llm.command_start"}, // argv template (first consult; inherits command)
 	{Key: "llm.timeout_seconds", TUIEditable: true},
 	{Key: "llm.auto_act_confidence_threshold", TUIEditable: true},
-	{Key: "llm.pane_excerpt_chars", TUIEditable: true},
-	{Key: "llm.enable_rewrite_action", TUIEditable: true},
-	{Key: "llm.rewrite_action_fallback_template"}, // template string
-	{Key: "llm.task_generate_command"},            // argv template (idle task suggestion)
-	{Key: "llm.task_generate_command_start"},      // argv template (first generation; inherits task_generate_command)
+	{Key: "llm.pane_excerpt_chars", TUIEditable: true, TUIHidden: true},
+	{Key: "llm.enable_rewrite_action", TUIEditable: true, TUIHidden: true},
+	{Key: "llm.rewrite_action_fallback_template", TUIHidden: true}, // template string
+	{Key: "llm.task_generate_command"},                             // argv template (idle task suggestion)
+	{Key: "llm.task_generate_command_start"},                       // argv template (first generation; inherits task_generate_command)
 	{Key: "llm.task_generate_timeout_seconds", TUIEditable: true},
 	// Only the `.env` PATHS are registered. The inline `[llm.*_env]` tables
-	// hold API keys, and every key in this registry is rendered by the TUI
-	// and `config fields`, so they stay config.toml-only; `hap config`
+	// hold API keys, and every key in this registry is rendered by
+	// `config fields`, so they stay config.toml-only; `hap config`
 	// summarizes them by name. A path is not a secret.
-	{Key: "llm.env_file", TUIEditable: true},
-	{Key: "llm.command_env_file", TUIEditable: true},
-	{Key: "llm.command_start_env_file", TUIEditable: true},
-	{Key: "llm.task_generate_command_env_file", TUIEditable: true},
-	{Key: "llm.task_generate_command_start_env_file", TUIEditable: true},
+	{Key: "llm.env_file", TUIEditable: true, TUIHidden: true},
+	{Key: "llm.command_env_file", TUIEditable: true, TUIHidden: true},
+	{Key: "llm.command_start_env_file", TUIEditable: true, TUIHidden: true},
+	{Key: "llm.task_generate_command_env_file", TUIEditable: true, TUIHidden: true},
+	{Key: "llm.task_generate_command_start_env_file", TUIEditable: true, TUIHidden: true},
 	{Key: "embedding.disabled", TUIEditable: true},
 	{Key: "embedding.model_path"}, // path
 	{Key: "embedding.similarity_threshold", TUIEditable: true},
 	{Key: "embedding.bm25_min_score", TUIEditable: true},
-	{Key: "embedding.pane_salient_chars", TUIEditable: true},
+	{Key: "embedding.pane_salient_chars", TUIEditable: true, TUIHidden: true},
 	{Key: "embedding.model_context_window", TUIEditable: true},
 	{Key: "embedding.embed_timeout_ms", TUIEditable: true},
-	{Key: "embedding.warm_timeout_ms", TUIEditable: true},
+	{Key: "embedding.warm_timeout_ms", TUIEditable: true, TUIHidden: true},
 	{Key: "tui.max_content_width", TUIEditable: true},
 	{Key: "tui.max_content_height", TUIEditable: true},
 	{Key: "tui.theme", TUIEditable: true},
@@ -1559,7 +1566,8 @@ var ConfigFields = []ConfigFieldDef{
 }
 
 // ConfigFieldKeys lists every scalar config field editable via SetField, in
-// display order (shared by the TUI config editor and `config set`).
+// display order. This is the complete set — `config fields` and `config set`
+// use it. The TUI shows the shorter TUIConfigFieldKeys.
 var ConfigFieldKeys = func() []string {
 	keys := make([]string, len(ConfigFields))
 	for i, f := range ConfigFields {
@@ -1568,16 +1576,43 @@ var ConfigFieldKeys = func() []string {
 	return keys
 }()
 
-// FieldTUIEditable reports whether the TUI inline prompt may edit key;
-// false means the TUI shows it read-only (config.toml and `config set`
-// still work — CR-036).
-func FieldTUIEditable(key string) bool {
+// TUIConfigFieldKeys lists the config fields the TUI Config tab shows, in
+// display order: ConfigFieldKeys minus the advanced ones marked TUIHidden.
+var TUIConfigFieldKeys = func() []string {
+	keys := make([]string, 0, len(ConfigFields))
 	for _, f := range ConfigFields {
-		if f.Key == key {
-			return f.TUIEditable
+		if !f.TUIHidden {
+			keys = append(keys, f.Key)
 		}
 	}
-	return false
+	return keys
+}()
+
+// configFieldDef looks a registry entry up by key. It is the single place the
+// "unknown key" default lives, so every accessor below degrades the same way.
+func configFieldDef(key string) (ConfigFieldDef, bool) {
+	for _, f := range ConfigFields {
+		if f.Key == key {
+			return f, true
+		}
+	}
+	return ConfigFieldDef{}, false
+}
+
+// FieldTUIHidden reports whether the TUI Config tab omits key. Hidden fields
+// stay fully settable through config.toml and `hap config set`.
+func FieldTUIHidden(key string) bool {
+	f, _ := configFieldDef(key)
+	return f.TUIHidden
+}
+
+// FieldTUIEditable reports whether the TUI inline prompt may edit key. False
+// means the TUI will not edit it inline — either it renders read-only because
+// a one-line prompt would mangle the value (CR-036), or it is not rendered at
+// all (TUIHidden). config.toml and `config set` work in both cases.
+func FieldTUIEditable(key string) bool {
+	f, _ := configFieldDef(key)
+	return f.TUIEditable && !f.TUIHidden
 }
 
 // defaultedInt renders an int config field whose 0 means "use the built-in

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -2447,10 +2448,20 @@ func TestFieldTUIEditableClassification(t *testing.T) {
 		"llm.task_generate_command_start":      true,
 		"embedding.model_path":                 true,
 	}
-	for _, key := range frontend.ConfigFieldKeys {
-		want := !readOnly[key]
-		if got := frontend.FieldTUIEditable(key); got != want {
-			t.Errorf("FieldTUIEditable(%s) = %v, want %v", key, got, want)
+	for _, f := range frontend.ConfigFields {
+		// Assert the DECLARED flag, not the accessor's output. A hidden
+		// field's FieldTUIEditable is forced false, so deriving the
+		// expectation from the accessor would leave TUIEditable unpinned
+		// for exactly the fields where it matters — it is the value that
+		// takes effect the day one is un-hidden.
+		if f.TUIEditable == readOnly[f.Key] {
+			t.Errorf("%s: TUIEditable=%v contradicts the CR-036 read-only classification", f.Key, f.TUIEditable)
+		}
+		// The accessor folds in TUIHidden: the TUI cannot edit a row it
+		// does not render.
+		want := f.TUIEditable && !f.TUIHidden
+		if got := frontend.FieldTUIEditable(f.Key); got != want {
+			t.Errorf("FieldTUIEditable(%s) = %v, want %v", f.Key, got, want)
 		}
 	}
 	// Every expected read-only key must actually exist in the registry.
@@ -2465,6 +2476,64 @@ func TestFieldTUIEditableClassification(t *testing.T) {
 	}
 	if frontend.FieldTUIEditable("nonexistent.field") {
 		t.Error("unknown key must not be TUI-editable")
+	}
+}
+
+// TestTUIHiddenConfigFields: the advanced knobs are dropped from the TUI's
+// display list only. They must stay in ConfigFieldKeys so config.toml,
+// `hap config fields`, and `hap config set` keep working on them.
+func TestTUIHiddenConfigFields(t *testing.T) {
+	hidden := map[string]bool{
+		"llm.pane_excerpt_chars":                   true,
+		"llm.enable_rewrite_action":                true,
+		"llm.rewrite_action_fallback_template":     true,
+		"llm.env_file":                             true,
+		"llm.command_env_file":                     true,
+		"llm.command_start_env_file":               true,
+		"llm.task_generate_command_env_file":       true,
+		"llm.task_generate_command_start_env_file": true,
+		"embedding.pane_salient_chars":             true,
+		"embedding.warm_timeout_ms":                true,
+	}
+	all := make(map[string]bool, len(frontend.ConfigFieldKeys))
+	for _, key := range frontend.ConfigFieldKeys {
+		all[key] = true
+		if got := frontend.FieldTUIHidden(key); got != hidden[key] {
+			t.Errorf("FieldTUIHidden(%s) = %v, want %v", key, got, hidden[key])
+		}
+	}
+	for key := range hidden {
+		if !all[key] {
+			t.Errorf("hidden key %q is gone from ConfigFieldKeys — it must stay settable via `hap config set`", key)
+		}
+	}
+	if frontend.FieldTUIHidden("nonexistent.field") {
+		t.Error("unknown key must not report as hidden")
+	}
+
+	// TUIConfigFieldKeys is exactly ConfigFieldKeys minus the hidden ones,
+	// in the same order.
+	var want []string
+	for _, key := range frontend.ConfigFieldKeys {
+		if !hidden[key] {
+			want = append(want, key)
+		}
+	}
+	if !slices.Equal(frontend.TUIConfigFieldKeys, want) {
+		t.Errorf("TUIConfigFieldKeys = %v, want %v", frontend.TUIConfigFieldKeys, want)
+	}
+
+	// Hidden fields still round-trip through SetField.
+	app, _ := testApp(t)
+	if err := app.SetField(context.Background(), "embedding.warm_timeout_ms", "90000"); err != nil {
+		t.Fatalf("SetField on a hidden key must still work: %v", err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Embedding.WarmTimeoutMs != 90000 {
+		t.Errorf("hidden field not persisted: %d", cfg.Embedding.WarmTimeoutMs)
 	}
 }
 
@@ -5095,9 +5164,9 @@ func TestConfirmTaskGenNoopLearnsNoopWithoutTaskSource(t *testing.T) {
 }
 
 // TestConfigFieldsNeverRenderEnvValues guards the secrecy rule for the
-// per-command LLM environment: the field registry is rendered verbatim by the
-// TUI config screen and `hap config fields`, so no inline env VALUE may be
-// reachable through it. Only the `.env` paths are registered.
+// per-command LLM environment: the field registry is rendered verbatim by
+// `hap config fields`, so no inline env VALUE may be reachable through it.
+// Only the `.env` paths are registered.
 func TestConfigFieldsNeverRenderEnvValues(t *testing.T) {
 	cfg := config.Default()
 	const secret = "sk-ant-supersecret"

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -1388,7 +1388,7 @@ func TestConfigReadOnlyRowsRefuseEditAndRemove(t *testing.T) {
 }
 
 func TestConfigTUIReadOnlyFieldsNoPrompt(t *testing.T) {
-	readOnly := []string{"llm.command", "llm.command_start", "llm.rewrite_action_fallback_template", "embedding.model_path"}
+	readOnly := []string{"llm.command", "llm.command_start", "llm.task_generate_command", "embedding.model_path"}
 	for _, key := range readOnly {
 		for _, k := range []string{"enter", "e"} {
 			t.Run(key+"/"+k, func(t *testing.T) {
@@ -1412,6 +1412,53 @@ func TestConfigTUIReadOnlyFieldsNoPrompt(t *testing.T) {
 	m = press(t, m, "enter")
 	if m.prompt == nil || !strings.Contains(m.prompt.label, "set llm.timeout_seconds") {
 		t.Errorf("editable field should open the edit prompt, got %+v", m.prompt)
+	}
+}
+
+// TestConfigTUIHidesAdvancedFields: advanced knobs are kept out of the Config
+// tab so the settings operators actually change stay findable. They must be
+// absent as rows AND as rendered text, while `hap config fields` still lists
+// them — hiding is a TUI display choice, not a removal.
+func TestConfigTUIHidesAdvancedFields(t *testing.T) {
+	hidden := []string{
+		"llm.pane_excerpt_chars",
+		"llm.enable_rewrite_action",
+		"llm.rewrite_action_fallback_template",
+		"llm.env_file",
+		"llm.command_env_file",
+		"llm.command_start_env_file",
+		"llm.task_generate_command_env_file",
+		"llm.task_generate_command_start_env_file",
+		"embedding.pane_salient_chars",
+		"embedding.warm_timeout_ms",
+	}
+	m := configModel(t, config.Default())
+	rows := make(map[string]bool)
+	for _, it := range m.items {
+		if it.kind == "field" {
+			rows[it.key] = true
+		}
+	}
+	view := m.View()
+	for _, key := range hidden {
+		if rows[key] {
+			t.Errorf("advanced field %q must not be a Config tab row", key)
+		}
+		if strings.Contains(view, key) {
+			t.Errorf("advanced field %q must not render on the Config tab", key)
+		}
+		if !slices.Contains(frontend.ConfigFieldKeys, key) {
+			t.Errorf("advanced field %q dropped from the registry — it must stay settable via `hap config set`", key)
+		}
+	}
+	// A neighbouring visible field is untouched.
+	if !rows["llm.timeout_seconds"] {
+		t.Error("llm.timeout_seconds must still render on the Config tab")
+	}
+	// The section header is the operator's only in-app clue that more
+	// fields exist, so absence alone is not enough — it must point somewhere.
+	if !strings.Contains(view, "hap config fields") {
+		t.Errorf("Config header must point at `hap config fields` for the hidden ones:\n%s", view)
 	}
 }
 

--- a/internal/tui/signal_test.go
+++ b/internal/tui/signal_test.go
@@ -1,0 +1,167 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// headless lets a program start where there is no terminal: CI and `go test`
+// have no /dev/tty, and bubbletea opens one unless input is explicitly
+// disabled. The options under test (WithContext, WithoutSignalHandler) still
+// come from run itself.
+//
+// It does narrow what these tests can see: with no input reader and no
+// renderer, cancel-reader teardown and restoreTerminalState() never run, so
+// the terminal-restore half of the shutdown fix is not covered here. That half
+// is only observable against a real pty.
+func headless() []tea.ProgramOption {
+	return []tea.ProgramOption{tea.WithInput(nil), tea.WithoutRenderer()}
+}
+
+// runTestApp builds a store-backed App for driving Run end to end.
+func runTestApp(t *testing.T) *frontend.App {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return &frontend.App{
+		Store:      st,
+		Herdr:      &captureHerdr{},
+		ConfigPath: filepath.Join(dir, "config.toml"),
+		StateDir:   dir,
+		Author:     "operator",
+	}
+}
+
+// TestRunUnwindsOnContextCancel pins the wiring that makes signal handling
+// work at all: Run passes its context to bubbletea, so cancelling it shuts the
+// program down through bubbletea's own teardown — which restores the terminal
+// and lets main's deferred store close and submit-retry drain run.
+//
+// bubbletea installs handlers for SIGINT and SIGTERM only. Every other signal
+// main catches (notably SIGHUP, raised when the pane or ssh session hosting
+// the TUI closes) reaches the TUI ONLY as a cancelled context, so a Run that
+// ignores its context leaves those signals with Go's default disposition:
+// the process dies where it stands and no cleanup runs.
+func TestRunUnwindsOnContextCancel(t *testing.T) {
+	app := runTestApp(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errc := make(chan error, 1)
+	go func() { errc <- run(ctx, app, headless()...) }()
+
+	// Let the program reach its event loop before pulling the context out.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errc:
+		// A cancelled context is a signal-driven exit, not a failure: main
+		// must not print an error and exit non-zero when the operator simply
+		// closes the pane.
+		if err != nil {
+			t.Errorf("Run after context cancel = %v, want a clean exit", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("Run did not return after its context was cancelled — the TUI ignores ctx, so SIGHUP cannot unwind it")
+	}
+}
+
+// TestRunAlreadyCancelledExitsCleanly covers the race where the signal lands
+// before the event loop is up: the context is already dead when the program
+// starts. That still has to be a clean exit, not an error — closing the pane
+// during startup is the same operator action as closing it a minute later.
+func TestRunAlreadyCancelledExitsCleanly(t *testing.T) {
+	app := runTestApp(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	errc := make(chan error, 1)
+	go func() { errc <- run(ctx, app, headless()...) }()
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Errorf("Run with an already-cancelled context = %v, want a clean exit", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("Run never returned for an already-cancelled context")
+	}
+}
+
+// TestRunStillReportsRealFailures is the control for the two tests above: the
+// nil they expect must come from the cancellation path specifically, not from
+// Run having been taught to swallow errors. With a live context, a program
+// that cannot start still reports why.
+func TestRunStillReportsRealFailures(t *testing.T) {
+	app := runTestApp(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errc := make(chan error, 1)
+	// An input reader that only ever errors: bubbletea's cancel-reader setup
+	// fails and Run returns that. Deliberately NOT WithInputTTY — `go test`
+	// keeps its controlling terminal when run from a real shell, so that
+	// variant passes in CI and hangs locally while eating the developer's
+	// keystrokes.
+	go func() { errc <- run(ctx, app, tea.WithoutRenderer(), tea.WithInput(errReader{})) }()
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Error("Run swallowed a genuine startup failure — a real error must still reach main")
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("Run never returned after a startup failure")
+	}
+}
+
+// TestSignalDoesNotWedgeTheProgram pins tea.WithoutSignalHandler.
+//
+// Without it, a signal reaches bubbletea's own handler AND cancels the run
+// context. The handler answers with a blocking send onto an internal channel
+// that has no ctx escape, while bubbletea's shutdown waits on that goroutine
+// unbounded — so whenever the event loop unwinds on ctx.Done() first, nothing
+// is left to receive the message and the program never returns. Measured at
+// roughly half of SIGINTs before the fix, so -count is what makes this
+// deterministic; even a single run catches it often.
+func TestSignalDoesNotWedgeTheProgram(t *testing.T) {
+	app := runTestApp(t)
+	// Catch the signal here as main does, so raising it cannot kill the test
+	// binary — this asserts shutdown behavior, not signal disposition.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	errc := make(chan error, 1)
+	go func() { errc <- run(ctx, app, headless()...) }()
+	time.Sleep(200 * time.Millisecond)
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatalf("raise SIGINT: %v", err)
+	}
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Errorf("Run after SIGINT = %v, want a clean exit", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("Run wedged after a signal — bubbletea's own signal handler is racing the context shutdown")
+	}
+}
+
+// errReader fails every read, so a program using it cannot start.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("no input available") }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -5577,11 +5577,54 @@ func llmConfShort(v *int) string {
 }
 
 // Run starts the TUI program.
+//
+// Signals reach the TUI as a cancelled ctx and nothing else. tea.WithContext
+// makes cancellation tear the program down through bubbletea's own shutdown,
+// which restores the terminal (alt screen off, cursor back, cooked mode) and
+// lets Run's drain and main's deferred cleanup run. That is the only path by
+// which SIGHUP — raised when the pane or ssh session hosting us closes — gets
+// a clean exit rather than Go's default, which kills the process on the spot.
+//
+// tea.WithoutSignalHandler is what keeps that path SINGLE, and it is
+// load-bearing rather than tidiness. bubbletea's own handler answers
+// SIGINT/SIGTERM by pushing a message onto an internal channel with a
+// blocking send that has no ctx escape; its shutdown then waits on that
+// goroutine forever. With both mechanisms live, the same signal cancels the
+// context AND queues that message, so whenever the event loop unwinds on
+// ctx.Done() first, nothing is left to receive it and the process hangs
+// instead of exiting (reproduced on roughly half of SIGINTs). Ctrl+C is
+// unaffected: the terminal is in raw mode, so it arrives as a KeyMsg the
+// model already handles.
 func Run(ctx context.Context, app *frontend.App) error {
+	return run(ctx, app)
+}
+
+// run is Run with room for extra program options. The shutdown-critical
+// options are applied here so tests exercise the real configuration; `extra`
+// is appended last and therefore wins on anything it overlaps, so tests must
+// only add options (a terminal-less input, say), never contradict these.
+func run(ctx context.Context, app *frontend.App, extra ...tea.ProgramOption) error {
 	m := New(ctx, app)
 	m.bellOut = os.Stdout
-	p := tea.NewProgram(m, tea.WithAltScreen())
+	opts := append([]tea.ProgramOption{
+		tea.WithAltScreen(), tea.WithContext(ctx), tea.WithoutSignalHandler(),
+	}, extra...)
+	p := tea.NewProgram(m, opts...)
 	_, err := p.Run()
+	// A cancelled context is how a signal reaches us, not a failure: report it
+	// as a clean exit so `hap tui` does not print "error: program was killed"
+	// and exit 1 every time the operator closes the pane.
+	//
+	// Match ONLY the pure-cancellation shape. bubbletea returns ErrProgramKilled
+	// wrapped around a real cause too — around ErrProgramPanic for a recovered
+	// panic, and around the event loop's own error — and those satisfy a bare
+	// errors.Is(err, tea.ErrProgramKilled) just as well. Swallowing them would
+	// silence a crash at the one moment the report is most wanted: while the
+	// TUI is unwinding. Only the cancel path carries context.Canceled.
+	if errors.Is(err, tea.ErrProgramKilled) &&
+		errors.Is(err, context.Canceled) && !errors.Is(err, tea.ErrProgramPanic) {
+		err = nil
+	}
 	// bubbletea does not wait for in-flight Cmd goroutines on quit; drain
 	// them (bounded, in case a Cmd was somehow never launched) so a send
 	// confirmed right before quitting still lands and registers its submit

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1074,7 +1074,7 @@ func (m Model) updateCheckCmd() tea.Cmd {
 // buildRuleItems lays out the Config tab rows from the current config.
 func buildRuleItems(cfg config.Config) []ruleItem {
 	var items []ruleItem
-	for _, key := range frontend.ConfigFieldKeys {
+	for _, key := range frontend.TUIConfigFieldKeys {
 		items = append(items, ruleItem{
 			kind: "field", key: key,
 			label: fmt.Sprintf("%-38s %s", key, frontend.FieldValue(cfg, key)),
@@ -5458,7 +5458,14 @@ func (m Model) configLines() []configLine {
 			}
 			switch item.kind {
 			case "field":
-				header("Config", false)
+				// Name the omission: advanced fields are hidden here, not
+				// gone, so the operator knows where the rest live. Derived,
+				// so the note disappears if nothing is hidden any more.
+				title := "Config"
+				if len(frontend.TUIConfigFieldKeys) < len(frontend.ConfigFieldKeys) {
+					title += " (advanced fields hidden — see: hap config fields)"
+				}
+				header(title, false)
 			case "pattern":
 				header(fmt.Sprintf("Never-auto patterns (operator; %s)", m.seedLabel()), true)
 			case "source":


### PR DESCRIPTION
Three independent changes, one per commit. The first predates the other two and
is carried here because the working tree held it.

## 1. `docs:` drop the `Unreleased` changelog heading (dc5380b)

Merging to main auto-releases the next patch, so the version a PR ships in is
knowable when the entry is written. An `Unreleased` heading just defers work
that then gets forgotten — which is how the 0.5.8 and 0.5.9 entries ended up
stranded under it after both releases had shipped.

`CLAUDE.md` and `CONTRIBUTING.md` now spell out how to derive the number: read
`CHANGELOG.md` on the latest remote main, take the topmost `## X.Y.Z`, use the
next patch if that one is already tagged, or append to it if it is not (an
unmerged PR already opened that section). A deliberate minor/major bump uses the
version set in `herdr-plugin.toml` instead. A guess that loses a merge race is
self-correcting: fix the heading in a follow-up.

## 2. `feat:` hide ten advanced fields from the TUI Config tab (5fab2d4)

The Config tab listed every scalar config key, so knobs an operator tunes once
(if ever) crowded out the ones they actually change. Ten are now hidden from
that tab: `llm.pane_excerpt_chars`, `llm.enable_rewrite_action`,
`llm.rewrite_action_fallback_template`, the five `llm.*env_file` paths,
`embedding.pane_salient_chars`, and `embedding.warm_timeout_ms`.

**Hiding is a display choice, not a removal.** The registry in
`frontend.ConfigFields` is shared by the TUI, `hap config fields`, and
`hap config set`, so rather than dropping entries the fields carry a new
`TUIHidden` flag and the TUI renders the filtered `TUIConfigFieldKeys`. All ten
remain listed by `hap config fields`, settable with `hap config set`, and read
from `config.toml` — verified by hand as well as by test.

`FieldTUIEditable` now folds in `TUIHidden`: the TUI cannot edit a row it does
not render, so the two flags can never disagree. The section header names the
omission (`Config (advanced fields hidden — see: hap config fields)`) and is
derived from the two list lengths, so it disappears on its own if nothing is
hidden any more.

## 3. `fix:` handle SIGHUP so a closed pane does not kill the TUI mid-flight (f80ecbe)

SIGHUP arrives whenever the terminal hosting a process goes away — a closed
herdr pane, a dropped ssh session — which is a routine way for `hap tui` to end.
It was unhandled: main caught only SIGINT and SIGTERM, and bubbletea's own
handler covers the same two, so SIGHUP fell through to Go's default and killed
the process on the spot. Nothing deferred ran: the store was never closed and
the terminal was left in raw mode with the alt screen still on. Verified under a
real pty — killed by signal 1, zero terminal-restore bytes.

Three parts, each exposed by testing the previous one:

1. `shutdownSignals` includes SIGHUP.
2. That alone did nothing, because `tui.Run` ignored its context entirely —
   cancellation had no path in. `tea.WithContext(ctx)` makes cancellation unwind
   through bubbletea's own shutdown, which restores the terminal.
3. That introduced a worse bug. bubbletea's signal handler answers
   SIGINT/SIGTERM with a blocking send onto an internal channel with no ctx
   escape, while its `shutdown()` waits on that goroutine unbounded — so with
   both shutdown paths live, whenever the event loop unwound on `ctx.Done()`
   first there was nobody left to receive the message and the program hung.
   Reproduced on roughly half of SIGINTs. `tea.WithoutSignalHandler` makes the
   context the single shutdown path. Ctrl+C is unaffected: in raw mode it
   arrives as a `KeyMsg` the model already handles.

Catching a signal means it no longer kills, so a process wedged somewhere that
does not observe ctx would survive everything short of SIGKILL. The handler is
released as the first signal arrives, so a second one terminates immediately.
The release happens **before** the cancellation, not in a goroutine watching
`ctx.Done()` — that ordering is what makes the guarantee real rather than
probabilistic, and the racy version failed its own test.

The `ErrProgramKilled` swallow matches only the pure-cancellation shape.
bubbletea wraps that sentinel around a recovered panic and around the event
loop's own error too; swallowing those would silence a crash at the one moment
the report is most wanted — while the TUI is unwinding.

**Result:** 15/15 pty runs across SIGHUP/SIGTERM/SIGINT exit in 0.12s with the
terminal restored, and a true hangup (closing the pty master) exits cleanly too.

## Testing

- Full suite green (`go test -tags "vectors cpu" ./... -count=1`); `go vet` and
  `golangci-lint run --build-tags "vectors,cpu"` clean.
- Commit 2 was verified as an independently valid state before commit 3 was
  built on top, not just as a checkpoint.
- **Both new regression tests confirmed by mutation:** removing
  `tea.WithoutSignalHandler` makes `TestSignalDoesNotWedgeTheProgram` fail (both
  the 20s wedge and the interrupted-error path); restoring the racy release
  ordering makes `TestSecondSignalStillTerminates` fail.
- `TestShutdownSignalsCancelInsteadOfKilling` is self-enforcing: if a signal is
  dropped from the set, the test *binary* dies rather than reporting a failure —
  which is exactly the production bug.
- `TestFieldTUIEditableClassification` asserts the **declared** flag rather than
  the accessor's output; deriving the expectation from `FieldTUIHidden` made it
  vacuous for exactly the ten fields where `TUIEditable` matters.

## Open items

**1. The submit-retry gap is NOT closed by this PR.** An earlier draft of the
SIGHUP commit claimed the fix rescued the submit-retry drain — the pending Enter
behind a just-confirmed send. That was wrong and is corrected in the committed
message and changelog. Those workers run on the same context the signal cancels
(`herdr.CLI.spawnSubmitRetry`), and `retrySubmitEnter` opens with
`sleepCtx(ctx, …)`, so they return without pressing Enter however orderly the
exit is. The drain only ever did its job on the ordinary quit path.

Closing it means detaching the worker context from shutdown
(`context.WithoutCancel` plus a deadline) and bounding `drainSubmitRetries`,
which is currently an unbounded `WaitGroup.Wait()`. That is a delivery-path
decision with a safety dimension — hap would keep pressing Enter into an agent's
pane for a few seconds after the operator closed the UI — so it is deliberately
left out of a signal-handling PR.

**2. `internal/daemon` is flaky on main, independent of this branch.** A test
run of this branch reported six intermittent daemon failures. Measured against
untouched main (c41d782): two full-suite runs each failed exactly one daemon
test, a *different* one each time — `TestManualCaptureRecognizesIdleCodexPlanApproval`
(daemon logged `ignored duplicate event` instead of capturing), then
`TestAutoAcceptGuard2AdmitsParkedStatuses/blocked`
(`status = "escalated", want "auto_accepted"`). All pass in isolation.

Nothing in this PR touches `internal/daemon`. If CI shows an arbitrary daemon
failure here, re-run before reading it as a regression — but the package's
stability deserves its own issue.
