### PR TITLE
#1 feat: wrap long input to the pane width in the TUI

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -724,7 +724,11 @@ marked items win over it. the add/edit prompts take
 multi-line task text: **shift+enter inserts a line break** (ctrl+j on
 terminals that can't report it), the box expands one line per break, **enter
 submits** — stored as the literal `\n` encoding above, decoded back when the
-prompt pre-fills. the input is a full line editor, so a typo in the middle of
+prompt pre-fills. **long text wraps to the pane width** on its own (breaking
+after a word, never mid-word), so a line break is only for text you actually
+want on its own line — never to make a long sentence visible. an entry taller
+than the box scrolls with the caret and the label says which rows are showing.
+the input is a full line editor, so a typo in the middle of
 a long task is fixed in place: **←/→ move the caret** (ctrl+←/→ by word,
 home/end or ctrl+a/ctrl+e to the ends), typing and backspace/delete act at the
 caret, and the block cursor shows where the next keystroke lands. a prompt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ section in `CLAUDE.md`. Entries go under the version that will carry them: mergi
 to main auto-releases the next patch, so a PR adds its lines under that number
 (or under the minor/major version it bumps the manifest to).
 
+## 0.5.13
+
+- Fixed long text being invisible past the right edge of the TUI while typing it. Every text input — add task, edit a task, correct a suggestion, the `/` filter, every config value — now wraps to the pane width, so the whole entry is readable without breaking the sentence with `shift+enter` to see it
+- Changed: wrapping breaks after a word rather than mid-word. A short entry still sits on its label's line as before; a label too long to share that line, or a box that has scrolled, gives the text the full pane width instead
+- Added a scrolling input box: the box takes only the rows the pane can spare (at most 8, and never the last few list rows), and an entry taller than that scrolls with the caret and says which rows are showing — instead of pushing the list and the help line off the bottom
+- Unchanged: what gets submitted. Wrapping is a rendering decision only — no line break enters the stored task, filter or config value
+
 ## 0.5.12
 
 - Fixed `enable_auto_send_task_when_idle` still not delivering anything unattended: the task went out only once its situation signature had graduated, which took two operator confirmations — the exact human attention the flag exists to remove. Because every idle screen mints its own signature, in practice it escalated `shadow_mode` with the task as a suggestion and waited, forever

--- a/internal/tui/input_wrap_test.go
+++ b/internal/tui/input_wrap_test.go
@@ -1,0 +1,440 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-runewidth"
+)
+
+// viewLines splits a rendered frame into the rows a terminal would paint.
+func viewLines(m Model) []string { return strings.Split(m.View(), "\n") }
+
+// promptRows returns the rows the input box drew, with the caret block and the
+// continuation indent stripped, so a test can reassemble what the operator can
+// actually read on screen.
+func promptRows(t *testing.T, m Model) []string {
+	t.Helper()
+	var out []string
+	for _, l := range m.promptBox().render(plainStyle) {
+		out = append(out, strings.ReplaceAll(strings.TrimPrefix(l, promptIndent), promptCaret, ""))
+	}
+	return out
+}
+
+// caretRow reports which of a box's rows holds the caret, or -1.
+func caretRow(rows []string) int {
+	for i, r := range rows {
+		if strings.Contains(r, promptCaretMark) {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestWrapInputTextIsLossless pins the property the caret depends on: every row
+// is a contiguous slice of the input, so joining the rows of one logical line
+// reproduces it exactly. If wrapping dropped the space it broke at (what a
+// prose wrapper normally does), the caret block riding inside the text would
+// land a column off from where the next keystroke actually goes.
+func TestWrapInputTextIsLossless(t *testing.T) {
+	cases := []struct {
+		name        string
+		text        string
+		first, rest int
+	}{
+		{"plain prose", "the quick brown fox jumps over the lazy dog", 12, 12},
+		{"trailing space", "alpha beta ", 7, 7},
+		{"runs of spaces", "a     b     c", 4, 4},
+		{"unbreakable token", strings.Repeat("x", 40), 9, 9},
+		{"embedded breaks", "one\ntwo three four\nfive", 8, 8},
+		{"narrower first row", "the quick brown fox", 5, 12},
+		{"empty", "", 10, 10},
+		{"single wide rune", "漢", 1, 1},
+		{"wide runes", "漢字漢字漢字漢字", 5, 5},
+		{"caret at the end", "hello world" + promptCaretMark, 6, 6},
+		{"caret mid-word", "hello" + promptCaretMark + " world", 6, 6},
+		{"a block glyph in the text", "bar " + promptCaret + promptCaret + " done", 5, 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := wrapInputText(tc.text, tc.first, tc.rest)
+			// A row is a contiguous slice of ONE logical line, so joining every
+			// row reproduces the text minus its line breaks...
+			if got := strings.Join(rows, ""); got != strings.ReplaceAll(tc.text, "\n", "") {
+				t.Errorf("wrapping lost text:\n got %q\nwant %q", got, tc.text)
+			}
+			// ...and each break must still cost a row of its own, or a
+			// hand-typed line break silently merges into its neighbour.
+			if breaks := strings.Count(tc.text, "\n"); len(rows) < breaks+1 {
+				t.Errorf("rows = %d, too few to keep %d line break(s) apart", len(rows), breaks)
+			}
+			for i, r := range rows {
+				limit := tc.rest
+				if i == 0 {
+					limit = tc.first
+				}
+				// A single rune wider than the row has nowhere to go; every
+				// other row must fit.
+				if w := runewidth.StringWidth(r); w > limit && len([]rune(r)) > 1 {
+					t.Errorf("row %d is %d cells, over the %d-cell limit: %q", i, w, limit, r)
+				}
+			}
+		})
+	}
+}
+
+// TestWrapInputTextBreaksAtWordBoundaries pins the readable half: a break lands
+// after the last space that fit, not mid-word. Splitting words is exactly the
+// unreadable rendering the operator was working around by typing newlines.
+func TestWrapInputTextBreaksAtWordBoundaries(t *testing.T) {
+	rows := wrapInputText("the quick brown fox jumps", 12, 12)
+	for _, r := range rows {
+		if strings.HasPrefix(r, " ") {
+			t.Errorf("a row must not open on the space it broke at: %q in %q", r, rows)
+		}
+	}
+	want := []string{"the quick ", "brown fox ", "jumps"}
+	if strings.Join(rows, "|") != strings.Join(want, "|") {
+		t.Errorf("rows = %q, want %q", rows, want)
+	}
+}
+
+// TestWrapInputTextHardBreaksAnOverlongToken pins the fallback: a token with no
+// space in it (a URL, a path) has nowhere to break, so it is cut at the width
+// rather than allowed to overflow the pane.
+func TestWrapInputTextHardBreaksAnOverlongToken(t *testing.T) {
+	rows := wrapInputText("see https://example.com/a/very/long/path/indeed", 10, 10)
+	for _, r := range rows {
+		if w := runewidth.StringWidth(r); w > 10 {
+			t.Errorf("row %q is %d cells, over the 10-cell limit (rows=%q)", r, w, rows)
+		}
+	}
+	if len(rows) < 4 {
+		t.Errorf("an unbreakable 40-cell token should span several rows, got %q", rows)
+	}
+}
+
+// TestWrapInputTextExpandsTabs pins the one rewrite wrapping is allowed: a
+// pasted tab counts as zero cells to runewidth but paints several columns, so
+// leaving it in would let a row overflow the pane despite the accounting saying
+// it fits.
+func TestWrapInputTextExpandsTabs(t *testing.T) {
+	rows := wrapInputText("a\tb", 20, 20)
+	if got, want := strings.Join(rows, ""), "a    b"; got != want {
+		t.Errorf("tab expansion = %q, want %q", got, want)
+	}
+}
+
+// TestPromptWrapsLongInputToPaneWidth is the headline behavior: a long entry is
+// readable in full instead of being clipped at the right margin. Before this,
+// bubbletea truncated the row at the pane width and everything past it was
+// invisible — which is why operators broke sentences with newlines by hand.
+func TestPromptWrapsLongInputToPaneWidth(t *testing.T) {
+	text := "wrap this whole sentence so the operator can read every single word " +
+		"of it without ever pressing shift enter in the middle of a thought"
+	m := promptModel(t, text)
+
+	rows := promptRows(t, m)
+	if len(rows) < 2 {
+		t.Fatalf("a %d-cell entry must wrap in a %d-cell pane, got %q",
+			runewidth.StringWidth(text), m.contentWidth(), rows)
+	}
+	// The rows must reassemble into exactly what was typed, label aside.
+	if got := strings.TrimPrefix(strings.Join(rows, ""), "edit> "); got != text {
+		t.Errorf("the wrapped box does not show the whole entry:\n got %q\nwant %q", got, text)
+	}
+	for _, l := range viewLines(m) {
+		if w := runewidth.StringWidth(l); w > m.width {
+			t.Errorf("rendered line overflows the pane (%d > %d): %q", w, m.width, l)
+		}
+	}
+}
+
+// TestPromptShortInputStaysOnTheLabelLine pins the unchanged look for the
+// common case: a short entry must not suddenly cost a second row.
+func TestPromptShortInputStaysOnTheLabelLine(t *testing.T) {
+	m := promptModel(t, "short")
+	box := m.promptBox()
+	if !box.inline {
+		t.Fatalf("a short entry must stay inline, got %q", box.render(plainStyle))
+	}
+	if got, want := box.render(plainStyle), []string{"edit> short" + promptCaret}; strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("rendered %q, want %q", got, want)
+	}
+}
+
+// TestPromptWrappingLeavesTheStoredTextAlone pins the boundary between display
+// and data: wrapping is a rendering decision, so no line break may leak into
+// the value that gets submitted. A wrapped-in newline would be written straight
+// into the checklist item.
+func TestPromptWrappingLeavesTheStoredTextAlone(t *testing.T) {
+	// No leading/trailing space: submit trims the value, which is separate
+	// behavior this test is not about.
+	text := strings.TrimSpace(strings.Repeat("alpha beta gamma delta ", 12))
+	var got string
+	m := testModel(t)
+	m.openPrompt(&prompt{label: "add task", input: text,
+		onSubmit: func(in string) tea.Cmd { got = in; return nil }})
+
+	_ = m.View() // render before submitting, as the operator would
+	upd, _ := m.Update(editKey("enter"))
+	_ = upd.(Model)
+	if got != text {
+		t.Errorf("submitted %q, want the unwrapped original %q", got, text)
+	}
+	if strings.Contains(got, "\n") {
+		t.Error("wrapping must not push a line break into the submitted value")
+	}
+}
+
+// TestPromptWrapFollowsTheCaretWhenScrolled pins the windowing: an entry too
+// tall for its budget scrolls inside the box, and the row holding the caret is
+// always one of the rows on screen. Otherwise a long paste would hide the very
+// position the next keystroke lands at.
+func TestPromptWrapFollowsTheCaretWhenScrolled(t *testing.T) {
+	m := promptModel(t, "start "+strings.Repeat("filler words to burn rows ", 60)+" finish")
+
+	box := m.promptBox()
+	if len(box.rows) != m.promptRowBudget() {
+		t.Fatalf("box should be capped at %d rows, got %d", m.promptRowBudget(), len(box.rows))
+	}
+	// The exact counter, not just "some numbers": the bounds come straight from
+	// the window's start index and are the likeliest off-by-one here. The caret
+	// parks at the end of pre-filled text, so the window sits on the last rows.
+	total := len(wrapInputText(m.prompt.edit().withCaret(),
+		m.contentWidth()-promptIndentWidth, m.contentWidth()-promptIndentWidth))
+	want := fmt.Sprintf("edit>  (lines %d-%d of %d)", total-len(box.rows)+1, total, total)
+	if box.head[0] != want {
+		t.Errorf("scroll counter = %q, want %q", box.head[0], want)
+	}
+	if got := caretRow(box.rows); got != len(box.rows)-1 {
+		t.Errorf("appending at the end must show the tail, caret on row %d of %d", got, len(box.rows))
+	}
+	if !strings.Contains(strings.Join(box.rows, ""), "finish") {
+		t.Errorf("the end of the entry must be visible, got %q", box.rows)
+	}
+
+	// Jump to the front: the window must follow the caret back up.
+	m = pressEdit(t, m, "home")
+	box = m.promptBox()
+	if got := caretRow(box.rows); got != 0 {
+		t.Errorf("home must scroll the box back to the caret, caret on row %d", got)
+	}
+	if !strings.Contains(box.rows[0], "start") {
+		t.Errorf("the front of the entry must be visible, got %q", box.rows[0])
+	}
+}
+
+// TestScrollFollowsTheRealCaretNotABlockInTheText is the reason the caret is
+// marked with a private-use rune rather than the block glyph it draws as. The
+// text an operator edits can itself contain "█" — a "correct this suggestion"
+// prompt pre-fills from pane output, which is full of progress bars — and
+// searching for the drawn glyph would lock the window onto THEIR block and
+// scroll the real caret off screen, leaving them typing blind.
+func TestScrollFollowsTheRealCaretNotABlockInTheText(t *testing.T) {
+	m := promptModel(t, promptCaret+" "+strings.Repeat("filler words to burn rows ", 60)+"end")
+
+	box := m.promptBox()
+	if len(box.rows) >= len(wrapInputText(m.prompt.input, 98, 98)) {
+		t.Fatalf("the entry must be long enough to scroll, got %d rows", len(box.rows))
+	}
+	if got := caretRow(box.rows); got != len(box.rows)-1 {
+		t.Errorf("the window must follow the real caret to the tail, caret on row %d of %d:\n%q",
+			got, len(box.rows), box.rows)
+	}
+	if !strings.Contains(strings.Join(box.rows, ""), "end") {
+		t.Errorf("the tail must be on screen, got %q", box.rows)
+	}
+	// The operator's own block still draws, and only the caret is added.
+	if got := strings.Count(strings.Join(m.promptBox().render(plainStyle), ""), promptCaret); got != 1 {
+		t.Errorf("the tail rows should carry exactly the caret's block, got %d", got)
+	}
+}
+
+// TestWindowRows pins the scrolling window on its own, at the boundaries the
+// box only ever reaches indirectly.
+func TestWindowRows(t *testing.T) {
+	rows := func(n, caret int) []string {
+		out := make([]string, n)
+		for i := range out {
+			out[i] = fmt.Sprintf("row%d", i)
+			if i == caret {
+				out[i] += promptCaretMark
+			}
+		}
+		return out
+	}
+	cases := []struct {
+		name             string
+		n, caret, budget int
+		wantLen, wantAt  int
+	}{
+		{"fits exactly", 5, 4, 5, 5, 0},
+		{"one over", 6, 5, 5, 5, 1},
+		{"caret at the top", 20, 0, 6, 6, 0},
+		{"caret at the bottom", 20, 19, 6, 6, 14},
+		{"caret in the middle", 20, 10, 6, 6, 7},
+		{"budget of one", 20, 10, 1, 1, 10},
+		{"budget below one is still a cap", 20, 10, 0, 1, 10},
+		{"no caret at all", 20, -1, 6, 6, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, at := windowRows(rows(tc.n, tc.caret), tc.budget)
+			if len(got) != tc.wantLen || at != tc.wantAt {
+				t.Errorf("windowRows = %d rows at %d, want %d at %d", len(got), at, tc.wantLen, tc.wantAt)
+			}
+			if tc.caret >= 0 && caretRow(got) < 0 {
+				t.Errorf("the caret row must stay in the window, got %q", got)
+			}
+		})
+	}
+}
+
+// TestPromptBoxNeverOutgrowsThePane pins AR-010 end to end: the height the
+// chrome accounting reserves must be the height the box actually draws, or a
+// long entry pushes the help line off the bottom and the frame scrolls.
+func TestPromptBoxNeverOutgrowsThePane(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		text string
+	}{
+		{"short", "hi"},
+		{"one wrap", strings.Repeat("word ", 40)},
+		{"far past the budget", strings.Repeat("word ", 500)},
+		{"hand-typed newlines", strings.Repeat("a line of text\n", 40)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := testModel(t)
+			m.openPrompt(&prompt{label: "add task", input: tc.text, multiline: true,
+				onSubmit: func(string) tea.Cmd { return nil }})
+			if n := len(viewLines(m)); n > m.height {
+				t.Errorf("frame is %d rows in a %d-row pane", n, m.height)
+			}
+		})
+	}
+}
+
+// TestInputBoxFitsEveryPaneSize sweeps the layout across pane sizes, label
+// lengths and entry shapes. The box budgets its rows from what the rest of the
+// chrome leaves, so a short pane and a long label are exactly where a flat cap
+// would overflow — this pins that it does not, and that no row is ever wider
+// than the width the box wraps to.
+//
+// Rows are measured against contentWidth, not m.width: contentWidth floors at
+// 40, so on a pane narrower than that the box (like every list row) is drawn
+// wider than the pane and the terminal deals with it.
+func TestInputBoxFitsEveryPaneSize(t *testing.T) {
+	texts := map[string]string{
+		"tiny":        "x",
+		"many words":  strings.Repeat("word ", 200),
+		"no spaces":   strings.Repeat("a", 900),
+		"many breaks": strings.Repeat("line\n", 50),
+	}
+	labels := map[string]string{
+		"terse": "e",
+		"usual": "add task",
+		"huge":  strings.Repeat("very long label ", 12),
+	}
+	for _, w := range []int{20, 40, 80, 200} {
+		for _, h := range []int{12, 24, 30, 60} {
+			for ln, lb := range labels {
+				for tn, tx := range texts {
+					name := fmt.Sprintf("%dx%d/%s/%s", w, h, ln, tn)
+					t.Run(name, func(t *testing.T) {
+						m := testModel(t)
+						m.width, m.height = w, h
+						m.openPrompt(&prompt{label: lb, input: tx, multiline: true,
+							onSubmit: func(string) tea.Cmd { return nil }})
+						for _, l := range m.promptBox().render(plainStyle) {
+							if cw := runewidth.StringWidth(l); cw > m.contentWidth() {
+								t.Errorf("box row is %d cells, over the %d-cell pane: %q",
+									cw, m.contentWidth(), l)
+							}
+						}
+						if n := len(viewLines(m)); n > h {
+							t.Errorf("frame is %d rows in a %d-row pane", n, h)
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+// TestSearchQueryWrapsToPaneWidth pins the other live input. The filter box is
+// edited with the same textEdit, so a long query must wrap the same way instead
+// of running off the right margin.
+func TestSearchQueryWrapsToPaneWidth(t *testing.T) {
+	query := strings.Repeat("a long filter phrase ", 12)
+	m := testModel(t)
+	m.searching = true
+	m.setQuery(m.tab, query)
+
+	rows := m.searchBox().render(plainStyle)
+	if len(rows) < 3 {
+		t.Fatalf("a long query must wrap, got %q", rows)
+	}
+	var shown string
+	for i, r := range rows {
+		if i == 0 {
+			shown += strings.TrimPrefix(r, "search> ")
+			continue
+		}
+		shown += strings.TrimPrefix(r, promptIndent)
+	}
+	if want := query + promptCaret; shown != want {
+		t.Errorf("the wrapped box does not show the whole query:\n got %q\nwant %q", shown, want)
+	}
+	for _, l := range rows {
+		if w := runewidth.StringWidth(l); w > m.width {
+			t.Errorf("search row overflows the pane (%d > %d): %q", w, m.width, l)
+		}
+	}
+	if n := len(viewLines(m)); n > m.height {
+		t.Errorf("frame is %d rows in a %d-row pane", n, m.height)
+	}
+}
+
+// TestPickerOptionsAreBounded pins the picker's half of the same rule: a choice
+// is selected, not edited, so an over-wide one is truncated rather than wrapped
+// — wrapping would cost rows listPageSize budgets one-per-option.
+func TestPickerOptionsAreBounded(t *testing.T) {
+	m := testModel(t)
+	m.openPrompt(&prompt{label: "theme", options: []string{"ok", strings.Repeat("x", 400)},
+		onSubmit: func(string) tea.Cmd { return nil }})
+	for _, l := range viewLines(m) {
+		if w := runewidth.StringWidth(l); w > m.width {
+			t.Errorf("picker line overflows the pane (%d > %d): %q", w, m.width, l)
+		}
+	}
+	if n := len(viewLines(m)); n > m.height {
+		t.Errorf("frame is %d rows in a %d-row pane", n, m.height)
+	}
+}
+
+// TestTypingALongEntryKeepsTheCaretOnScreen is the operator's actual loop:
+// keystroke after keystroke past the pane width, the caret must stay visible so
+// they can see what they are typing. This is what the whole change is for.
+func TestTypingALongEntryKeepsTheCaretOnScreen(t *testing.T) {
+	m := promptModel(t, "")
+	for i := 0; i < 400; i++ {
+		m = pressEdit(t, m, fmt.Sprintf("w%d", i%10))
+		m = pressEdit(t, m, "space")
+		view := m.View()
+		if !strings.Contains(view, promptCaret) {
+			t.Fatalf("caret vanished after %d keystrokes:\n%s", i, view)
+		}
+		for _, l := range strings.Split(view, "\n") {
+			if w := runewidth.StringWidth(l); w > m.width {
+				t.Fatalf("line overflows after %d keystrokes (%d > %d): %q", i, w, m.width, l)
+			}
+		}
+	}
+	if strings.Contains(m.prompt.input, "\n") {
+		t.Error("typing must never insert a line break of its own")
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -283,12 +283,27 @@ func (e textEdit) wordRight() textEdit {
 	return textEdit{text: e.text, cursor: cur}
 }
 
-// withCaret renders the text with the caret block at its position, ready to be
-// split on "\n" by a multi-line renderer. With the caret at the end this is
-// exactly "text" + the block, which is how the box always used to look.
+// promptCaret is the block drawn at the caret's position. It travels INSIDE
+// the rendered text (see withCaret) rather than being positioned by column, so
+// wrapping the text also carries the caret to the right row.
+const promptCaret = "█"
+
+// promptCaretMark is what withCaret actually inserts; inputBox.render swaps it
+// for promptCaret on the way out. The layout has to FIND the caret's row to
+// scroll to it, and the operator's own text can contain a block glyph — pane
+// output full of progress bars is exactly what pre-fills a "correct this
+// suggestion" prompt — so searching for the drawn glyph would lock the window
+// onto their text and scroll the real caret off screen. A private-use rune
+// cannot be typed or pasted, and measures 1 cell like the block it stands in
+// for, so wrapping is identical either way.
+const promptCaretMark = "\ue000"
+
+// withCaret renders the text with the caret at its position, ready to be split
+// on "\n" by a multi-line renderer. With the caret at the end this is exactly
+// "text" + the marker, which is how the box always used to look.
 func (e textEdit) withCaret() string {
 	r, cur := e.runes()
-	return string(r[:cur]) + "█" + string(r[cur:])
+	return string(r[:cur]) + promptCaretMark + string(r[cur:])
 }
 
 // applyTextKey applies one editing or caret-motion keystroke and returns the
@@ -381,6 +396,234 @@ func isPromptSpace(r rune) bool { return unicode.IsSpace(r) }
 // terminal bracketed paste) to \n so the prompt renders one input line per
 // break and the height accounting can count them.
 var promptNewlines = strings.NewReplacer("\r\n", "\n", "\r", "\n")
+
+// promptIndent prefixes every text row of a wrapped input box so the block
+// reads as one unit under its label.
+const promptIndent = "  "
+
+// promptIndentWidth is promptIndent's width in display cells.
+var promptIndentWidth = runewidth.StringWidth(promptIndent)
+
+// wrapInputText breaks s into the rows an input box renders, wrapping at
+// `first` display cells on the first row and `rest` on every row after it, and
+// giving each line break already in s a row of its own.
+//
+// Unlike wrapText it never drops or rewrites a rune WITHIN a line: every row is
+// a contiguous slice of one logical line (after \r\n normalization and tab
+// expansion), so joining the rows of a line reproduces it exactly. That is what
+// lets the caret marker ride inside the text — the row it lands on and the
+// column it sits at both come out right without tracking an index separately.
+//
+// A break prefers the position just after the last space that fit, so a word is
+// not split mid-way; a token longer than the row is hard-broken because there is
+// nowhere else to cut. Tabs are expanded first: runewidth counts a tab as zero
+// cells but a terminal paints several, and a paste can carry one.
+func wrapInputText(s string, first, rest int) []string {
+	first, rest = max(first, 1), max(rest, 1)
+	s = strings.ReplaceAll(promptNewlines.Replace(s), "\t", "    ")
+	var out []string
+	limit := first
+	for _, ln := range strings.Split(s, "\n") {
+		r := []rune(ln)
+		// start is the first rune of the row being built and cells its width so
+		// far; brk is the index just past the last space seen on it, with
+		// brkCells the width of what follows that space — the width the next row
+		// would open with, tracked as we go so a break never has to rescan.
+		start, cells := 0, 0
+		brk, brkCells := -1, 0
+		for i := 0; i < len(r); i++ {
+			w := runewidth.RuneWidth(r[i])
+			if cells+w > limit && i > start {
+				if brk > start && brk < i {
+					out, start, cells = append(out, string(r[start:brk])), brk, brkCells
+				} else {
+					out, start, cells = append(out, string(r[start:i])), i, 0
+				}
+				limit, brk, brkCells = rest, -1, 0
+			}
+			cells, brkCells = cells+w, brkCells+w
+			if r[i] == ' ' {
+				brk, brkCells = i+1, 0
+			}
+		}
+		out = append(out, string(r[start:]))
+		limit = rest
+	}
+	return out
+}
+
+// windowRows trims rows to at most budget entries, keeping the row that holds
+// the caret visible, and reports the index the window starts at. A long entry
+// therefore scrolls inside its box instead of pushing the list off the pane.
+// The window centers on the caret, which parks it at the tail while text is
+// being appended (the common case) and follows the caret when it is moved.
+func windowRows(rows []string, budget int) ([]string, int) {
+	budget = max(budget, 1)
+	if len(rows) <= budget {
+		return rows, 0
+	}
+	caret := 0
+	for i, r := range rows {
+		if strings.Contains(r, promptCaretMark) {
+			caret = i
+			break
+		}
+	}
+	start := max(0, min(caret-budget/2, len(rows)-budget))
+	return rows[start : start+budget], start
+}
+
+// inputBox is one text input laid out for the pane. head is the label, wrapped
+// and kept separate so the caller can style it; rows are the wrapped text rows.
+// When inline is true the single text row sits on the label's line — the
+// historical one-line look; otherwise the label keeps its own line(s) and every
+// text row is indented under it, which is what gives long text the full width.
+type inputBox struct {
+	head   []string
+	inline bool
+	rows   []string
+}
+
+// plainStyle is the identity styler, for callers (and the height accounting)
+// that want inputBox.render's output without escape codes.
+func plainStyle(s string) string { return s }
+
+// render returns the exact lines the box occupies, the label styled by style
+// and the caret marker swapped for the block that gets drawn. View prints these
+// lines and listPageSize counts them, so the pane-height budget can never
+// disagree with what is drawn (AR-010).
+func (b inputBox) render(style func(string) string) []string {
+	out := make([]string, 0, len(b.head)+len(b.rows))
+	for _, h := range b.head {
+		out = append(out, style(h))
+	}
+	rows := b.rows
+	if b.inline && len(out) > 0 && len(rows) > 0 {
+		out[len(out)-1] += drawCaret(rows[0])
+		rows = rows[1:]
+	}
+	for _, r := range rows {
+		out = append(out, promptIndent+drawCaret(r))
+	}
+	return out
+}
+
+// drawCaret swaps the internal caret marker for the block the operator sees.
+func drawCaret(s string) string {
+	return strings.ReplaceAll(s, promptCaretMark, promptCaret)
+}
+
+// promptInlineFloor is the width the first row must keep for the label to share
+// it. Below that the text would trickle down a sliver beside a wall of label,
+// which reads worse than giving the label its own line.
+const promptInlineFloor = 20
+
+// promptLabelRows bounds a wrapped label. Labels carry instructions worth
+// reading, so they wrap rather than clip; but they are also chrome, and an
+// unbounded one would eat the list, so the overflow is flattened into the last
+// row instead.
+const promptLabelRows = 2
+
+// promptMaxRows caps the input box even on a tall pane: past a few hundred
+// characters on screen at once, more rows stop helping and just bury the list.
+// minListRows is what the list keeps whatever the box does — a list showing
+// nothing is not a list.
+const (
+	promptMaxRows = 8
+	minListRows   = 3
+	// searchRowCap bounds the search box. It is a FIXED cap, not the derived
+	// promptRowBudget: chromeRows counts the search box, and deriving its
+	// budget from chromeRows would recurse.
+	searchRowCap = 3
+)
+
+// promptRowBudget bounds how many text rows the prompt box may draw: whatever
+// the pane can spare once the rest of the chrome, the box's own blank and label
+// lines, and the list's floor are paid for. Deriving it (rather than taking a
+// flat fraction of the height) is what keeps a long entry on a short pane from
+// pushing the help line off the bottom.
+func (m Model) promptRowBudget() int {
+	if m.height <= 0 || m.prompt == nil {
+		return promptMaxRows
+	}
+	// The blank line plus the most the label can cost. Taking the bound rather
+	// than measuring this label keeps the figure independent of the layout it is
+	// being used to decide (an inline box spends fewer rows, and a scrolled one
+	// lengthens the label with its "(lines x-y of z)" note) — erring high only
+	// ever leaves a text row on the table, and only on a pane too short to spare
+	// it anyway.
+	overhead := 1 + promptLabelRows
+	spare := m.height - m.chromeRows() - overhead - minListRows
+	return max(1, min(promptMaxRows, spare))
+}
+
+// layoutInput lays out one text input: `label> ` followed by text (which already
+// carries its caret block), wrapped to the pane so the operator can read
+// everything they typed. Before this the row was drawn in full and bubbletea
+// clipped it at the pane edge, so anything past the right margin was invisible
+// and operators broke sentences with newlines to work around it.
+func (m Model) layoutInput(label, text string, budget int) inputBox {
+	width := m.contentWidth()
+	prefix := label + "> "
+	rest := max(1, width-promptIndentWidth)
+	// The label shares the first row, so that row is the narrower one — unless
+	// the label is so long that sharing would leave a sliver, or the box is
+	// scrolled and the first row is not the one on screen. Then the label takes
+	// its own line and every text row gets the full width.
+	first := width - runewidth.StringWidth(prefix)
+	inline := first >= min(promptInlineFloor, rest)
+	if !inline {
+		first = rest
+	}
+	rows := wrapInputText(text, first, rest)
+	shown, start := windowRows(rows, budget)
+	if len(shown) < len(rows) && inline {
+		// Scrolled: the label can no longer share the first row, so re-wrap at
+		// the full width. Without this the top visible row keeps the narrow
+		// first-row width and reads as a short, ragged line under a label that
+		// is no longer beside it.
+		inline = false
+		rows = wrapInputText(text, rest, rest)
+		shown, start = windowRows(rows, budget)
+	}
+	if inline {
+		return inputBox{head: []string{prefix}, inline: true, rows: shown}
+	}
+	head := label + ">"
+	if len(shown) < len(rows) {
+		head = fmt.Sprintf("%s>  (lines %d-%d of %d)", label, start+1, start+len(shown), len(rows))
+	}
+	return inputBox{head: wrapLabel(head, width), rows: shown}
+}
+
+// wrapLabel wraps an input's label to the pane, bounded by promptLabelRows —
+// the overflow past the last allowed row is flattened into it rather than
+// costing further list rows.
+//
+// The label is flattened to one logical line first. A label is a line of
+// instruction, so a break in one is noise; flattening also makes every wrapped
+// row a contiguous slice of the SAME string, which is what lets the overflow be
+// rejoined without gluing the words either side of a break together.
+func wrapLabel(label string, width int) []string {
+	flat := strings.ReplaceAll(promptNewlines.Replace(label), "\n", " ")
+	rows := wrapInputText(flat, width, width)
+	if len(rows) > promptLabelRows {
+		tail := oneLine(strings.Join(rows[promptLabelRows-1:], ""), width)
+		rows = append(rows[:promptLabelRows-1:promptLabelRows-1], tail)
+	}
+	return rows
+}
+
+// promptBox and searchBox are the two live text inputs. Both View and
+// listPageSize go through these, so the drawn box and the budgeted box are the
+// same box by construction.
+func (m Model) promptBox() inputBox {
+	return m.layoutInput(m.prompt.label, m.prompt.edit().withCaret(), m.promptRowBudget())
+}
+
+func (m Model) searchBox() inputBox {
+	return m.layoutInput("search", m.queryEdit().withCaret(), searchRowCap)
+}
 
 // shiftEnterSeqs are the String() forms bubbletea gives the two standard
 // shift+enter escape sequences — xterm modifyOtherKeys (ESC[27;2;13~, what
@@ -3383,15 +3626,17 @@ func (m Model) detailPageSize() int {
 	return max(1, m.height-chrome)
 }
 
-// listPageSize is how many list rows fit under the current pane chrome,
-// mirroring detailPageSize's accounting (AR-002): header title + tabs +
-// blank (3), the more-rows indicator (1), and blank + help (2) — plus the
-// error line, the daemon health banner, the search/filter lines, and the
-// prompt, hint, and status areas when present.
-func (m Model) listPageSize() int {
-	if m.height <= 0 {
-		return 20
-	}
+// chromeRows is every pane row View spends outside the list rows and the
+// prompt box, mirroring detailPageSize's accounting (AR-002): header title +
+// tabs + blank (3), the more-rows indicator (1), and blank + help (2) — plus
+// the error line, the daemon health banner, the search/filter lines, and the
+// hint and status areas when present.
+//
+// The prompt box is deliberately NOT counted here: promptRowBudget sizes that
+// box from what the rest of the chrome leaves, so counting it would recurse.
+// The search box IS counted, and is safe to count because it takes a fixed row
+// cap rather than the derived budget.
+func (m Model) chromeRows() int {
 	chrome := 6
 	if m.data.err != nil {
 		chrome++
@@ -3399,7 +3644,11 @@ func (m Model) listPageSize() int {
 	if m.data.daemonHealth.Banner() != "" {
 		chrome++
 	}
-	if m.searching || (m.tab.isList() && m.query[m.tab] != "") {
+	if m.searching {
+		// The query wraps like any other input, so budget the rows it draws
+		// rather than a flat one.
+		chrome += len(m.searchBox().render(plainStyle))
+	} else if m.tab.isList() && m.query[m.tab] != "" {
 		chrome++
 	}
 	if m.semanticHintVisible() {
@@ -3411,20 +3660,31 @@ func (m Model) listPageSize() int {
 	if m.tab == tabAgents || m.tab == tabEscalations || m.tab == tabAudit || m.tab == tabSignatures {
 		chrome++ // these list tabs render a column header row
 	}
-	if m.prompt != nil {
-		if len(m.prompt.options) > 0 {
-			// blank + label line + one line per choice.
-			chrome += 2 + len(m.prompt.options)
-		} else {
-			// blank + label line + one line per line break in the expanded input.
-			chrome += 2 + strings.Count(promptNewlines.Replace(m.prompt.input), "\n")
-		}
-	}
 	if m.message != "" {
 		chrome += 2
 	}
 	if m.status != nil {
 		chrome += 2
+	}
+	return chrome
+}
+
+// listPageSize is how many list rows fit under the current pane chrome and the
+// prompt box.
+func (m Model) listPageSize() int {
+	if m.height <= 0 {
+		return 20
+	}
+	chrome := m.chromeRows()
+	if m.prompt != nil {
+		if len(m.prompt.options) > 0 {
+			// blank + label line + one line per choice.
+			chrome += 2 + len(m.prompt.options)
+		} else {
+			// blank + every row the box actually draws (the label's line, plus
+			// one per line break AND per wrap of the expanded input).
+			chrome += 1 + len(m.promptBox().render(plainStyle))
+		}
 	}
 	return max(1, m.height-chrome)
 }
@@ -4877,7 +5137,9 @@ func (m Model) View() string {
 	// Search bar / active-filter line (its height is accounted for in
 	// listPageSize so the body never overflows the pane).
 	if m.searching {
-		fmt.Fprintf(&b, "%s%s\n", st.section.Render("search> "), m.queryEdit().withCaret())
+		for _, l := range m.searchBox().render(func(s string) string { return st.section.Render(s) }) {
+			fmt.Fprintf(&b, "%s\n", l)
+		}
 		if m.semanticHintVisible() {
 			fmt.Fprintf(&b, "%s\n", st.help.Render(
 				"enter: semantic search — embed this query to rank rules by meaning"))
@@ -4909,26 +5171,27 @@ func (m Model) View() string {
 
 	if m.prompt != nil && len(m.prompt.options) > 0 {
 		// Picker mode: label then one row per choice, the highlight marked.
-		fmt.Fprintf(&b, "\n%s\n", m.prompt.label)
+		// A choice is a value the operator picks, not text they edit, so an
+		// over-wide one is truncated rather than wrapped — wrapping it would
+		// cost list rows the height budget does not reserve.
+		fmt.Fprintf(&b, "\n%s\n", oneLine(m.prompt.label, m.contentWidth()))
 		for i, opt := range m.prompt.options {
 			marker := "  "
 			if i == m.prompt.optIdx {
 				marker = "❯ "
 			}
-			fmt.Fprintf(&b, "%s%s\n", marker, opt)
+			fmt.Fprintf(&b, "%s%s\n", marker, oneLine(opt, max(1, m.contentWidth()-promptIndentWidth)))
 		}
 	} else if m.prompt != nil {
-		// A multiline input expands the box: one rendered line per line break,
-		// continuation lines indented under the label. The caret is drawn AT
-		// its rune index rather than always at the end, so the operator can
-		// see where the next keystroke lands; with the caret at the end this
-		// renders exactly as it always did.
-		lines := strings.Split(m.prompt.edit().withCaret(), "\n")
-		fmt.Fprintf(&b, "\n%s> %s", m.prompt.label, lines[0])
-		for _, l := range lines[1:] {
-			fmt.Fprintf(&b, "\n  %s", l)
-		}
+		// The input expands the box: one rendered row per line break AND per
+		// wrap at the pane width, rows indented under the label. The caret is
+		// drawn AT its rune index rather than always at the end, so the
+		// operator can see where the next keystroke lands; a short entry still
+		// renders on the label's line exactly as it always did.
 		fmt.Fprint(&b, "\n")
+		for _, l := range m.promptBox().render(plainStyle) {
+			fmt.Fprintf(&b, "%s\n", l)
+		}
 	}
 	if m.confirm != nil {
 		fmt.Fprintf(&b, "\n%s\n", m.confirm.label)
@@ -5001,8 +5264,8 @@ func (m Model) helpLine() string {
 		return "type to filter  ←/→: move (ctrl: by word)  home/end: line ends  backspace/delete: erase  esc/enter: apply & close"
 	}
 	// The caret bindings are advertised here rather than in the prompt label:
-	// the label is inside the prompt box, whose height listPageSize budgets as
-	// one row, so a longer label would silently wrap and cost a list row.
+	// the label shares the box's first row with short input, so a longer label
+	// would push that text onto its own row for no reason.
 	if m.prompt != nil {
 		if len(m.prompt.options) > 0 {
 			return "↑/↓: choose  enter: select  esc: cancel"


### PR DESCRIPTION
## Problem

Every text input in the TUI drew its row in full and let bubbletea clip it at the pane edge, so anything past the right margin was **invisible while you typed it**. The workaround was to break the sentence with `shift+enter` purely to make it visible — putting a line break in the stored task that was never wanted.

This affects every input surface: add task, edit a task, correct a suggestion, the `/` filter, and every config value.

## What changed

The prompt box and the `/` search filter now wrap to the pane width.

- **`wrapInputText`** breaks *after a word* rather than mid-word, and is lossless within a logical line — every row is a contiguous slice of the input. That is what lets the caret marker ride inside the text and land on the right row and column without tracking an index separately.
- **The caret travels as a private-use rune**, not the block it draws as. The text being edited can itself contain `█` — a "correct this suggestion" prompt pre-fills from pane output, which is full of progress bars — and searching for the drawn glyph would lock the scroll window onto *the operator's* block and scroll the real caret off screen. Regression test included; verified by mutation.
- **Layout**: a short entry still sits on its label's line exactly as before. A label too long to share that line, or a box that has scrolled, gives the text the full pane width instead.
- **The box takes only the rows the pane can spare** (at most 8, never the last few list rows), and a taller entry scrolls with the caret and reports `(lines 9-16 of 16)`. `View` and `listPageSize` render and count through the *same* call, so the drawn height and the budgeted height cannot drift (AR-010).
- Picker options are truncated rather than wrapped — a choice is selected, not edited, and wrapping would cost rows the height budget reserves one-per-option.

**Wrapping is display-only.** No line break enters the submitted value — pinned by a test that renders and then submits.

## How it looks

```
add task> short one█

add task> Enhance TUI when input a long text so that the input wraps by
  the TUI width and the user can see the entire text being typed
  without adding a newline in the middle of the sentence█

add task>  (lines 8-15 of 15)
  scroll me please scroll me please scroll me please scroll me please
  ...
  scroll me please scroll me please scroll me please scroll me please █
```

## Tests

New `internal/tui/input_wrap_test.go`: losslessness (incl. CJK, wide runes, embedded breaks, a literal `█` in the text), word-boundary breaks, hard break of an unbreakable token, tab expansion, `TestWindowRows` over the scroll boundaries, the caret-hijack regression, stored-text purity, a 400-keystroke typing loop, and a sweep across pane sizes × label lengths × entry shapes asserting the frame never outgrows the pane.

`go test -tags "vectors cpu" ./...` passes; the only failures on this machine are load artifacts in `internal/embedder` (2s stall guard under load ~20 on 4 cores) and the documented `internal/daemon` flakiness — both in packages this PR does not touch, and both pass in isolation.