### PR TITLE
#1 feat: raise daemon herdr notifications over the socket API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ section in `CLAUDE.md`. Entries go under the version that will carry them: mergi
 to main auto-releases the next patch, so a PR adds its lines under that number
 (or under the minor/major version it bumps the manifest to).
 
+## 0.5.14
+
+- Changed the daemon to raise its herdr notifications over the socket API instead of the `herdr notification show` CLI, so it now learns whether a toast was actually displayed. The CLI exits 0 even when herdr paints nothing, which meant an escalation could be dropped — notifications turned off, rate limited, no foreground client — with the daemon assuming the operator had been told
+- Added the delivery outcome to the daemon's `escalated` log line: `notified=true`, or `notified=false` with the reason herdr gave. Absent when nothing reported it, so the log never turns "we don't know" into a claim
+- Kept the CLI as the fallback for when the socket itself is unreachable. A request herdr answered and refused is never re-fired through it — same herdr, same verdict — and neither is one already refused locally or cancelled by shutdown
+- Changed the notification timeout to bound the whole socket-then-CLI attempt rather than each hop, so adding the socket cannot make a wedged herdr stall the daemon longer than the CLI alone did
+
 ## 0.5.13
 
 - Fixed long text being invisible past the right edge of the TUI while typing it. Every text input — add task, edit a task, correct a suggestion, the `/` filter, every config value — now wraps to the pane width, so the whole entry is readable without breaking the sentence with `shift+enter` to see it

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -388,11 +388,16 @@ func runDaemon(ctx context.Context, paths config.Paths, args []string) error {
 		Store:             st,
 		Herdr:             cliAdapter,
 		Events:            herdr.NewSubscriber(socketPath),
-		Notify:            cliAdapter,
-		LLMFactory:        llmFactory,
-		EmbedderFactory:   embedderFactory,
-		MatchIndexDir:     filepath.Join(paths.StateDir, "match-index"),
-		StateDir:          paths.StateDir,
+		// Socket first, CLI as the transport backstop: `notification.show`
+		// answers whether the toast was actually painted, which is the
+		// difference between "the operator was told about this escalation" and
+		// "nothing reached anyone" (IR-003). The CLI exits 0 either way, so it
+		// can only ever be the fallback.
+		Notify:          herdr.NewFallbackNotifier(socketPath, cliAdapter),
+		LLMFactory:      llmFactory,
+		EmbedderFactory: embedderFactory,
+		MatchIndexDir:   filepath.Join(paths.StateDir, "match-index"),
+		StateDir:        paths.StateDir,
 		// Hand the herd to the binary that replaced ours (plugin upgrade)
 		// instead of soldiering on with children we can no longer spawn.
 		//

--- a/docs/architect/herd-auto-prompter-architecture.md
+++ b/docs/architect/herd-auto-prompter-architecture.md
@@ -79,8 +79,8 @@ Single **Operator** role; multi-user access is explicitly out of scope.
 |---|---|---|
 | Language / distribution | **Go**, single static binary; subcommands `daemon` / `tui` / `mcp` / `embed-worker` / CLI verbs | No runtime dependency; strong concurrency for the monitor loop |
 | Herdr events | **Raw socket** `events.subscribe` (JSON) | Long-lived agent-status subscription |
-| Herdr notifications (TUI) | **Raw socket** `notification.show` (JSON) | Reports whether the toast was displayed, so the TUI can fall back to the terminal bell |
-| Herdr actions | **CLI via `HERDR_BIN_PATH`** (`agent send`, `pane read`, `pane send-keys`, `pane get`, `pane zoom`, `agent list`, `notification show`, plus `tab focus`, `workspace list`, `tab list` behind the optional `FocusPort`/`LocatorPort`) | Portable across Unix socket / Windows named pipe |
+| Herdr notifications (TUI + daemon) | **Raw socket** `notification.show` (JSON), CLI as transport fallback | Reports whether the toast was displayed, so the TUI can fall back to the terminal bell and the daemon can record that an escalation reached nobody |
+| Herdr actions | **CLI via `HERDR_BIN_PATH`** (`agent send`, `pane read`, `pane send-keys`, `pane get`, `pane zoom`, `agent list`, plus `tab focus`, `workspace list`, `tab list` behind the optional `FocusPort`/`LocatorPort`) | Portable across Unix socket / Windows named pipe |
 | History / audit | **Embedded SQLite (WAL)** | Transactional, corruption-safe concurrent access, queryable |
 | Operator config / rules | **TOML** in the plugin config dir | Hand-editable thresholds, never-auto patterns, classifier manifests, task sources, embedding tuning |
 | Daemon coordination | **Unix-domain control socket** (named pipe on Windows) | Sub-second reload propagation, no idle polling |
@@ -963,7 +963,7 @@ the sections they gate.
 |---|---|---|
 | **IR-001** | Herdr event subscription | Subscribe to Herdr agent-status transition events (raw socket `events.subscribe`) to drive monitoring without polling. |
 | **IR-002** | Herdr control actions | Send prompts/responses to agents and read pane content via Herdr's documented CLI commands (`agent send`, `pane read`, `pane get`, `pane send-keys`, `pane zoom`, `agent list`, `notification show`, and — behind optional ports — `tab focus`, `workspace list`, `tab list`). |
-| **IR-003** | Herdr notifications | Surface escalations and critical failures via Herdr notifications in addition to the TUI. The daemon uses the CLI (`notification show`); the TUI uses the socket method (`notification.show`), which reports whether the toast was actually displayed so it can fall back to the terminal bell when Herdr drops it. |
+| **IR-003** | Herdr notifications | Surface escalations and critical failures via Herdr notifications in addition to the TUI. Both front-ends prefer the socket method (`notification.show`), which reports whether the toast was actually displayed; the CLI (`notification show`) is the transport-failure fallback only, because it exits 0 whether or not a toast was painted. The TUI acts on the report by falling back to the terminal bell; the daemon, having no second channel, records it — an escalation Herdr declined to paint means the operator was never interrupted, and the log says so. A toast Herdr *answered and declined* is never retried through the CLI (same Herdr, same verdict); an unreported delivery is recorded as unknown rather than claimed. |
 | **IR-004** | Herdr plugin manifest | Package as a Herdr plugin declaring id/version, pinned `min_herdr_version`, the TUI pane command, event hooks, and build steps in `herdr-plugin.toml`. |
 | **IR-005** | Local LLM CLI | Integrate an optional, operator-configured local LLM/agent CLI for the hybrid decision fallback, treating its absence or failure as an escalation trigger. |
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2430,10 +2430,31 @@ func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.Si
 	if dec.Suggestion != "" {
 		body += " Suggestion: " + dec.Suggestion
 	}
-	d.notify(ctx, title, body)
-	slog.Info("escalated", "agent", s.AgentID, "situation", s.Type,
+	res := d.notify(ctx, title, body)
+	slog.Info("escalated", escalationLogAttrs(s, dec, res)...)
+}
+
+// escalationLogAttrs builds the "escalated" log line's key/value pairs.
+//
+// Split out as a pure function so the one thing an escalation log could never
+// say before — whether the operator was actually interrupted — is directly
+// testable. The CLI notification path exits 0 even when herdr paints nothing,
+// so the delivery keys are emitted ONLY when herdr reported the outcome; an
+// unknown must never be logged as a claim either way.
+func escalationLogAttrs(s domain.Situation, dec domain.Decision, res ports.NotifyResult) []any {
+	attrs := []any{"agent", s.AgentID, "situation", s.Type,
 		"reason", dec.Reason, "suggestion", dec.Suggestion,
-		"version", buildinfo.Version)
+		"version", buildinfo.Version}
+	if !res.Known {
+		return attrs
+	}
+	attrs = append(attrs, "notified", res.Shown)
+	if !res.Shown {
+		// Only meaningful when herdr declined: naming a reason next to
+		// notified=true would read as a caveat on a delivered toast.
+		attrs = append(attrs, "notify_reason", res.Reason)
+	}
+	return attrs
 }
 
 const (
@@ -4641,13 +4662,40 @@ func (d *Daemon) audit(ctx context.Context, rec domain.AuditRecord) {
 	}
 }
 
-func (d *Daemon) notify(ctx context.Context, title, body string) {
+// notify surfaces an operator toast and REPORTS what herdr did with it.
+//
+// The daemon has no second channel to fall back to (the TUI rings the terminal
+// bell; a background process has no terminal), so the value of the result is
+// evidential, not corrective: an escalation herdr declined to paint means the
+// operator was never interrupted, and the log must be able to say so. Callers
+// that only fire-and-forget ignore the return.
+//
+// A NotifyPort that cannot report delivery yields a !Known result rather than
+// a false claim of one — see ports.NotifyResult.
+func (d *Daemon) notify(ctx context.Context, title, body string) ports.NotifyResult {
 	if d.opt.Notify == nil {
-		return
+		return ports.NotifyResult{}
 	}
-	if err := d.opt.Notify.Notify(ctx, title, body); err != nil {
+	shower, ok := d.opt.Notify.(ports.NotifyShower)
+	if !ok {
+		if err := d.opt.Notify.Notify(ctx, title, body); err != nil {
+			slog.Warn("notification failed", "error", err)
+		}
+		return ports.NotifyResult{}
+	}
+	res, err := shower.ShowNotification(ctx, title, body)
+	if err != nil {
 		slog.Warn("notification failed", "error", err)
+		return ports.NotifyResult{}
 	}
+	if res.Known && !res.Shown {
+		// Info, not Warn: herdr routinely declines toasts the operator turned
+		// off or rate limited. It is normal traffic — but traffic that means
+		// nobody was told, so it is never silent.
+		slog.Info("herdr did not display notification",
+			"reason", res.Reason, "title", title)
+	}
+	return res
 }
 
 // neverAutoRules maps agent-scoped operator configuration into the unified

--- a/internal/daemon/notify_test.go
+++ b/internal/daemon/notify_test.go
@@ -1,0 +1,207 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+)
+
+// showerNotifier is a NotifyShower — the socket-backed shape, which reports
+// what herdr did with the toast.
+type showerNotifier struct {
+	res    ports.NotifyResult
+	err    error
+	titles []string
+}
+
+func (s *showerNotifier) ShowNotification(_ context.Context, title, _ string) (ports.NotifyResult, error) {
+	s.titles = append(s.titles, title)
+	return s.res, s.err
+}
+
+func (s *showerNotifier) Notify(ctx context.Context, title, body string) error {
+	_, err := s.ShowNotification(ctx, title, body)
+	return err
+}
+
+// plainNotifier is a bare NotifyPort — the CLI-backed shape, which cannot
+// report delivery.
+type plainNotifier struct {
+	titles []string
+	err    error
+}
+
+func (p *plainNotifier) Notify(_ context.Context, title, _ string) error {
+	p.titles = append(p.titles, title)
+	return p.err
+}
+
+func TestNotifyReportsDeliveryFromAShower(t *testing.T) {
+	n := &showerNotifier{res: ports.NotifyResult{Shown: true, Reason: "shown", Known: true}}
+	d := &Daemon{opt: Options{Notify: n}}
+
+	res := d.notify(context.Background(), "Agent needs attention", "blocked")
+	if !res.Shown || !res.Known {
+		t.Fatalf("want a reported, displayed toast, got %+v", res)
+	}
+	if len(n.titles) != 1 {
+		t.Fatalf("want 1 notification, got %v", n.titles)
+	}
+}
+
+// TestNotifyReportsADroppedToast is the gap this closes: herdr answering
+// "no_foreground_client" means the operator was never interrupted, and the
+// daemon must be able to tell that apart from a delivered toast. Before the
+// socket path it could not — the CLI exits 0 either way.
+func TestNotifyReportsADroppedToast(t *testing.T) {
+	n := &showerNotifier{res: ports.NotifyResult{Shown: false, Reason: "no_foreground_client", Known: true}}
+	d := &Daemon{opt: Options{Notify: n}}
+
+	res := d.notify(context.Background(), "Agent needs attention", "blocked")
+	if res.Shown {
+		t.Error("Shown must be false — herdr declined it")
+	}
+	if !res.Known {
+		t.Error("herdr answered, so the outcome is Known")
+	}
+	if res.Reason != "no_foreground_client" {
+		t.Errorf("Reason = %q, want the reason herdr gave", res.Reason)
+	}
+}
+
+// TestNotifyFromAPlainPortClaimsNothing: a NotifyPort with no delivery report
+// must yield !Known, never a Shown=false that reads as "herdr dropped it".
+// Conflating the two would make every CLI-notified escalation look dropped.
+func TestNotifyFromAPlainPortClaimsNothing(t *testing.T) {
+	n := &plainNotifier{}
+	d := &Daemon{opt: Options{Notify: n}}
+
+	res := d.notify(context.Background(), "Agent needs attention", "blocked")
+	if res.Known {
+		t.Errorf("a plain NotifyPort cannot report delivery, got %+v", res)
+	}
+	if res.Shown {
+		t.Error("must never claim delivery it has no evidence for")
+	}
+	if len(n.titles) != 1 {
+		t.Fatalf("the toast must still be sent, got %v", n.titles)
+	}
+}
+
+// A failed round trip is not a dropped toast: it is no evidence at all.
+func TestNotifyFailureIsUnknownNotDropped(t *testing.T) {
+	n := &showerNotifier{err: errors.New("dial unix: no such file")}
+	d := &Daemon{opt: Options{Notify: n}}
+
+	res := d.notify(context.Background(), "Agent needs attention", "blocked")
+	if res.Known || res.Shown {
+		t.Fatalf("a failed call reports nothing, got %+v", res)
+	}
+}
+
+func TestNotifyWithNoNotifierIsASafeNoop(t *testing.T) {
+	d := &Daemon{opt: Options{}}
+	if res := d.notify(context.Background(), "t", "b"); res.Known || res.Shown {
+		t.Fatalf("want a zero result, got %+v", res)
+	}
+}
+
+// A plain NotifyPort that FAILS still reports nothing rather than a dropped
+// toast — the degrade path must not manufacture evidence either.
+func TestNotifyPlainPortErrorIsStillUnknown(t *testing.T) {
+	n := &plainNotifier{err: errors.New("herdr notification show: exit 1")}
+	d := &Daemon{opt: Options{Notify: n}}
+
+	res := d.notify(context.Background(), "Agent needs attention", "blocked")
+	if res.Known || res.Shown {
+		t.Fatalf("a failed CLI notify reports nothing, got %+v", res)
+	}
+	if len(n.titles) != 1 {
+		t.Fatalf("the toast must still have been attempted, got %v", n.titles)
+	}
+}
+
+// TestEscalationLogAttrs pins the invariant the changelog promises: the
+// delivery keys appear ONLY when herdr reported the outcome, so an unknown is
+// never logged as either a delivery or a drop.
+func TestEscalationLogAttrs(t *testing.T) {
+	s := domain.Situation{AgentID: "agent-1", Type: "approval"}
+	dec := domain.Decision{Reason: "low_confidence", Suggestion: "1"}
+
+	has := func(attrs []any, key string) (any, bool) {
+		for i := 0; i+1 < len(attrs); i += 2 {
+			if k, ok := attrs[i].(string); ok && k == key {
+				return attrs[i+1], true
+			}
+		}
+		return nil, false
+	}
+
+	tests := []struct {
+		name           string
+		res            ports.NotifyResult
+		wantNotified   any
+		wantNoNotified bool
+		wantReason     string
+		wantNoReason   bool
+	}{
+		{
+			name:         "herdr displayed it",
+			res:          ports.NotifyResult{Shown: true, Reason: "shown", Known: true},
+			wantNotified: true,
+			// A delivered toast carries no reason: it would read as a caveat.
+			wantNoReason: true,
+		},
+		{
+			name:         "herdr declined it",
+			res:          ports.NotifyResult{Shown: false, Reason: "no_foreground_client", Known: true},
+			wantNotified: false,
+			wantReason:   "no_foreground_client",
+		},
+		{
+			name:           "nothing reported it",
+			res:            ports.NotifyResult{},
+			wantNoNotified: true,
+			wantNoReason:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs := escalationLogAttrs(s, dec, tt.res)
+			if len(attrs)%2 != 0 {
+				t.Fatalf("slog attrs must be key/value pairs, got %d items", len(attrs))
+			}
+			// The pre-existing keys must survive in every case.
+			if v, ok := has(attrs, "agent"); !ok || v != "agent-1" {
+				t.Errorf("agent key lost: %v", attrs)
+			}
+			if _, ok := has(attrs, "reason"); !ok {
+				t.Errorf("reason key lost: %v", attrs)
+			}
+
+			v, ok := has(attrs, "notified")
+			switch {
+			case tt.wantNoNotified && ok:
+				t.Errorf("notified must be absent when nothing reported, got %v", v)
+			case !tt.wantNoNotified && !ok:
+				t.Error("notified missing")
+			case !tt.wantNoNotified && v != tt.wantNotified:
+				t.Errorf("notified = %v, want %v", v, tt.wantNotified)
+			}
+
+			r, ok := has(attrs, "notify_reason")
+			switch {
+			case tt.wantNoReason && ok:
+				t.Errorf("notify_reason must be absent, got %v", r)
+			case !tt.wantNoReason && !ok:
+				t.Error("notify_reason missing")
+			case !tt.wantNoReason && r != tt.wantReason:
+				t.Errorf("notify_reason = %v, want %q", r, tt.wantReason)
+			}
+		})
+	}
+}

--- a/internal/herdr/notify.go
+++ b/internal/herdr/notify.go
@@ -2,6 +2,7 @@ package herdr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -35,6 +36,12 @@ const (
 // its update loop's goroutine pool), so this is far shorter than the CLI
 // adapter's 15s command timeout.
 const defaultNotifyTimeout = 3 * time.Second
+
+// ErrEmptyNotificationTitle is the local refusal of a title herdr would reject
+// with invalid_params. It is a caller bug, not a transport fault, so a chain
+// must recognize it and decline to spend a second channel on the same
+// invalid request (see FallbackNotifier).
+var ErrEmptyNotificationTitle = errors.New("notification title is empty")
 
 // SocketPath resolves herdr's control socket the way herdr itself documents:
 // HERDR_SOCKET_PATH when herdr injected it (every managed pane gets one),
@@ -121,7 +128,7 @@ func (n *SocketNotifier) Show(ctx context.Context, msg Notification) (ports.Noti
 		// herdr rejects an empty normalized title with invalid_params; catch
 		// it here so a caller's bug surfaces as its own error rather than a
 		// protocol one, and so we never open a connection for nothing.
-		return ports.NotifyResult{}, fmt.Errorf("notification title is empty")
+		return ports.NotifyResult{}, ErrEmptyNotificationTitle
 	}
 	params := map[string]any{"title": title}
 	if body := clampNotifyText(msg.Body, maxNotifyBody); body != "" {
@@ -145,7 +152,8 @@ func (n *SocketNotifier) Show(ctx context.Context, msg Notification) (ports.Noti
 	if err := call(ctx, n.dial, id, "notification.show", params, &result); err != nil {
 		return ports.NotifyResult{}, err
 	}
-	return ports.NotifyResult{Shown: result.Shown, Reason: result.Reason}, nil
+	// Known: herdr answered this one, so Shown is evidence rather than a guess.
+	return ports.NotifyResult{Shown: result.Shown, Reason: result.Reason, Known: true}, nil
 }
 
 // ShowNotification satisfies ports.NotifyShower — the title/body form the

--- a/internal/herdr/notify_fallback.go
+++ b/internal/herdr/notify_fallback.go
@@ -1,0 +1,133 @@
+package herdr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+)
+
+// fallbackNotifyBudget bounds the whole socket-then-CLI chain. It matches the
+// CLI adapter's own command timeout so adding the socket hop can never make
+// the worst case slower than the CLI path was before this chain existed.
+const fallbackNotifyBudget = 15 * time.Second
+
+// FallbackNotifier prefers herdr's socket `notification.show` — the only path
+// that reports whether the toast was actually painted (IR-003) — and drops to
+// the CLI `notification show` when the socket round trip fails outright.
+//
+// The fallback covers TRANSPORT failure only: no socket path, herdr restarted
+// under us, a dial that timed out. A toast herdr ANSWERED and declined
+// (disabled, rate_limited, no_foreground_client, busy) is never retried
+// through the CLI — that reaches the same herdr and is declined the same way,
+// and re-firing would turn one dropped toast into two dropped toasts while
+// throwing away the very fact the socket path exists to report.
+//
+// After a CLI fallback the outcome is unknowable, so the result is left
+// !Known rather than claimed as delivered.
+type FallbackNotifier struct {
+	// Socket is the preferred, delivery-reporting path. Nil disables it.
+	Socket ports.NotifyShower
+	// CLI is the transport-failure backstop. Nil disables it.
+	CLI ports.NotifyPort
+}
+
+// Compile-time conformance: the chain is usable anywhere either port is.
+var (
+	_ ports.NotifyPort   = (*FallbackNotifier)(nil)
+	_ ports.NotifyShower = (*FallbackNotifier)(nil)
+)
+
+// NewFallbackNotifier chains a socket notifier for the given path ahead of an
+// existing CLI notifier. An empty socketPath yields a chain that is CLI-only,
+// which is exactly the degraded behavior wanted when herdr never told us where
+// its socket lives.
+func NewFallbackNotifier(socketPath string, cli ports.NotifyPort) *FallbackNotifier {
+	f := &FallbackNotifier{CLI: cli}
+	if socketPath != "" {
+		f.Socket = NewSocketNotifier(socketPath)
+	}
+	return f
+}
+
+// ShowNotification satisfies ports.NotifyShower.
+func (f *FallbackNotifier) ShowNotification(ctx context.Context, title, body string) (ports.NotifyResult, error) {
+	// One budget for the WHOLE chain, not one per hop. Without this a herdr
+	// that accepts the connection and never answers costs the socket's 3s and
+	// THEN the CLI adapter's 15s, and escalate runs on the daemon's main
+	// select loop (CLAUDE.md: don't stall the main loop) — so the fallback
+	// would make the worst case worse than the CLI alone ever was.
+	ctx, cancel := context.WithTimeout(ctx, fallbackNotifyBudget)
+	defer cancel()
+
+	var socketErr error
+	if f.Socket != nil {
+		res, err := f.Socket.ShowNotification(ctx, title, body)
+		if err == nil {
+			return res, nil
+		}
+		if f.CLI == nil || !worthRetryingOnCLI(ctx, err) {
+			return ports.NotifyResult{}, err
+		}
+		socketErr = err
+		// Warn, not Debug: a permanently wrong socket path silently costs the
+		// operator every delivery report from here on, and the CLI's exit-0
+		// success would otherwise hide that completely.
+		slog.Warn("herdr notification socket failed, falling back to CLI",
+			"error", err, "title", title)
+	}
+	if f.CLI == nil {
+		return ports.NotifyResult{}, fmt.Errorf("no notifier configured")
+	}
+	if err := f.CLI.Notify(ctx, title, body); err != nil {
+		// Join so the Warn the caller logs names the transport cause too;
+		// without it a failed chain reports only the subprocess failure and
+		// the reason the socket was abandoned is lost.
+		return ports.NotifyResult{}, errors.Join(socketErr, err)
+	}
+	// Delivered to herdr, but `notification show` exits 0 either way: we have
+	// no evidence a toast was painted. The ZERO result is the unknown one, so
+	// returning it keeps `res == ports.NotifyResult{}` meaning "no idea" and
+	// never puts a Reason herdr did not give in front of a caller.
+	return ports.NotifyResult{}, nil
+}
+
+// worthRetryingOnCLI decides whether a failed socket attempt deserves a second
+// channel. Only a request that never got an answer does.
+//
+// A herdr-ANSWERED refusal (*SocketError) means herdr was reached and said no;
+// re-firing the identical request through `herdr notification show` reaches the
+// same herdr, is refused the same way, and costs a subprocess plus its timeout
+// while burying the real code behind a Warn. The one exception is a method the
+// server does not know: an older herdr without `notification.show` is exactly
+// the capability gap the CLI backstop exists for.
+//
+// A cancelled caller ctx (daemon shutting down) is not a herdr fault either —
+// the CLI would inherit the same dead ctx and fail too, so it buys two
+// failures and an extra Warn on the way out.
+func worthRetryingOnCLI(ctx context.Context, err error) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	// A local refusal never reached herdr, but it is a caller bug: the CLI
+	// would send the same invalid request and herdr would reject it again.
+	if errors.Is(err, ErrEmptyNotificationTitle) {
+		return false
+	}
+	var se *SocketError
+	if errors.As(err, &se) {
+		return se.Code == "method_not_found"
+	}
+	return true
+}
+
+// Notify satisfies ports.NotifyPort. As with SocketNotifier, a toast herdr
+// declined to paint is not an error — only a failure to complete the request
+// is.
+func (f *FallbackNotifier) Notify(ctx context.Context, title, body string) error {
+	_, err := f.ShowNotification(ctx, title, body)
+	return err
+}

--- a/internal/herdr/notify_fallback_test.go
+++ b/internal/herdr/notify_fallback_test.go
@@ -1,0 +1,297 @@
+package herdr
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+)
+
+// recordingCLI stands in for the CLI adapter's Notify — the transport
+// backstop. Guarded because the chain is exercised concurrently under -race.
+type recordingCLI struct {
+	mu    sync.Mutex
+	calls [][2]string
+	err   error
+}
+
+func (r *recordingCLI) Notify(_ context.Context, title, body string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, [2]string{title, body})
+	return r.err
+}
+
+func (r *recordingCLI) seen() [][2]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([][2]string(nil), r.calls...)
+}
+
+func TestFallbackNotifierPrefersSocketAndReportsDelivery(t *testing.T) {
+	n, srv := newTestNotifier(t)
+	cli := &recordingCLI{}
+	f := &FallbackNotifier{Socket: n, CLI: cli}
+
+	res, err := f.ShowNotification(context.Background(), "build failed", "api workspace")
+	if err != nil {
+		t.Fatalf("ShowNotification: %v", err)
+	}
+	if !res.Shown || !res.Known {
+		t.Fatalf("want a reported, displayed toast, got %+v", res)
+	}
+	if len(srv.SocketNotifications()) != 1 {
+		t.Errorf("socket should have carried the toast, got %d", len(srv.SocketNotifications()))
+	}
+	if len(cli.seen()) != 0 {
+		t.Errorf("CLI must not run when the socket succeeded, got %v", cli.seen())
+	}
+}
+
+// TestFallbackNotifierDeclinedToastIsNotRetriedOnCLI is the invariant that
+// keeps this a FALLBACK and not a retry loop. herdr answering "I dropped it"
+// is a completed round trip; re-firing through the CLI reaches the same herdr,
+// is declined the same way, and throws away the delivery report that is the
+// entire reason for preferring the socket.
+func TestFallbackNotifierDeclinedToastIsNotRetriedOnCLI(t *testing.T) {
+	n, srv := newTestNotifier(t)
+	srv.SetNotificationResult(false, "no_foreground_client")
+	cli := &recordingCLI{}
+	f := &FallbackNotifier{Socket: n, CLI: cli}
+
+	res, err := f.ShowNotification(context.Background(), "escalation", "agent blocked")
+	if err != nil {
+		t.Fatalf("a declined toast must not be an error, got %v", err)
+	}
+	if res.Shown {
+		t.Error("Shown should be false")
+	}
+	if !res.Known {
+		t.Error("herdr answered, so the outcome is Known")
+	}
+	if res.Reason != "no_foreground_client" {
+		t.Errorf("Reason = %q, want the reason herdr gave", res.Reason)
+	}
+	if len(cli.seen()) != 0 {
+		t.Fatalf("a declined toast must not fall back to the CLI, got %v", cli.seen())
+	}
+}
+
+// TestFallbackNotifierTransportFailureFallsBackUnreported covers the case the
+// fallback exists for: the socket never completed, so the CLI carries the
+// toast — and because `notification show` exits 0 either way, the result must
+// NOT claim delivery.
+func TestFallbackNotifierTransportFailureFallsBackUnreported(t *testing.T) {
+	dead := NewSocketNotifier(filepath.Join(t.TempDir(), "nonexistent.sock"))
+	cli := &recordingCLI{}
+	f := &FallbackNotifier{Socket: dead, CLI: cli}
+
+	res, err := f.ShowNotification(context.Background(), "escalation", "agent blocked")
+	if err != nil {
+		t.Fatalf("the CLI carried it, so this is not an error: %v", err)
+	}
+	if res.Known {
+		t.Errorf("the CLI cannot report delivery; Known must stay false, got %+v", res)
+	}
+	if res.Shown {
+		t.Error("a result we have no evidence for must never claim Shown")
+	}
+	if len(cli.seen()) != 1 || cli.seen()[0][0] != "escalation" {
+		t.Fatalf("CLI should have carried the toast, got %v", cli.seen())
+	}
+}
+
+func TestFallbackNotifierTransportFailureWithNoCLIIsAnError(t *testing.T) {
+	dead := NewSocketNotifier(filepath.Join(t.TempDir(), "nonexistent.sock"))
+	f := &FallbackNotifier{Socket: dead}
+
+	if _, err := f.ShowNotification(context.Background(), "x", "y"); err == nil {
+		t.Fatal("want an error when neither path can carry the toast")
+	}
+}
+
+func TestFallbackNotifierCLIErrorSurfaces(t *testing.T) {
+	dead := NewSocketNotifier(filepath.Join(t.TempDir(), "nonexistent.sock"))
+	want := errors.New("herdr notification show: exit 1")
+	f := &FallbackNotifier{Socket: dead, CLI: &recordingCLI{err: want}}
+
+	_, err := f.ShowNotification(context.Background(), "x", "y")
+	if !errors.Is(err, want) {
+		t.Fatalf("want the CLI's error, got %v", err)
+	}
+}
+
+// TestNewFallbackNotifierEmptySocketPathIsCLIOnly: herdr never told us where
+// its socket is, which must degrade to the historical CLI behavior rather than
+// failing every toast on a dial to "".
+func TestNewFallbackNotifierEmptySocketPathIsCLIOnly(t *testing.T) {
+	cli := &recordingCLI{}
+	f := NewFallbackNotifier("", cli)
+
+	if f.Socket != nil {
+		t.Fatal("no socket path must mean no socket notifier")
+	}
+	res, err := f.ShowNotification(context.Background(), "escalation", "agent blocked")
+	if err != nil {
+		t.Fatalf("ShowNotification: %v", err)
+	}
+	if res.Known {
+		t.Error("CLI-only can never report delivery")
+	}
+	if len(cli.seen()) != 1 {
+		t.Fatalf("CLI should have carried the toast, got %v", cli.seen())
+	}
+}
+
+// TestFallbackNotifierHerdrAnsweredErrorIsNotRetried: a *SocketError means
+// herdr was REACHED and refused. The CLI reaches the same herdr and is refused
+// the same way, so spending a subprocess (and burying the real code behind a
+// Warn) buys nothing. Only an unknown method — an older herdr genuinely
+// lacking `notification.show` — is the capability gap the backstop is for.
+func TestFallbackNotifierHerdrAnsweredErrorIsNotRetried(t *testing.T) {
+	tests := []struct {
+		name    string
+		code    string
+		wantCLI int
+		wantErr bool
+	}{
+		{name: "invalid params is herdr's verdict", code: "invalid_params", wantCLI: 0, wantErr: true},
+		{name: "unknown method falls back", code: "method_not_found", wantCLI: 1, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n, srv := newTestNotifier(t)
+			srv.SetNotificationError(tt.code, "nope")
+			cli := &recordingCLI{}
+			f := &FallbackNotifier{Socket: n, CLI: cli}
+
+			_, err := f.ShowNotification(context.Background(), "escalation", "agent blocked")
+			if tt.wantErr && err == nil {
+				t.Fatal("want herdr's own error surfaced, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("want the CLI to have carried it, got %v", err)
+			}
+			if len(cli.seen()) != tt.wantCLI {
+				t.Fatalf("CLI calls = %d, want %d", len(cli.seen()), tt.wantCLI)
+			}
+		})
+	}
+}
+
+// A cancelled caller (daemon shutting down) must not spend a subprocess on a
+// ctx the CLI would inherit and fail on too.
+func TestFallbackNotifierCancelledContextDoesNotFallBack(t *testing.T) {
+	n, _ := newTestNotifier(t)
+	cli := &recordingCLI{}
+	f := &FallbackNotifier{Socket: n, CLI: cli}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := f.ShowNotification(ctx, "escalation", "agent blocked"); err == nil {
+		t.Fatal("want the cancellation surfaced")
+	}
+	if len(cli.seen()) != 0 {
+		t.Fatalf("a cancelled ctx must not reach the CLI, got %v", cli.seen())
+	}
+}
+
+// An empty title is a caller bug caught locally; the CLI would send the same
+// invalid request for herdr to reject again.
+func TestFallbackNotifierEmptyTitleDoesNotFallBack(t *testing.T) {
+	n, _ := newTestNotifier(t)
+	cli := &recordingCLI{}
+	f := &FallbackNotifier{Socket: n, CLI: cli}
+
+	_, err := f.ShowNotification(context.Background(), "   ", "body")
+	if !errors.Is(err, ErrEmptyNotificationTitle) {
+		t.Fatalf("want ErrEmptyNotificationTitle, got %v", err)
+	}
+	if len(cli.seen()) != 0 {
+		t.Fatalf("an invalid request must not reach the CLI, got %v", cli.seen())
+	}
+}
+
+// When BOTH paths fail the caller must still learn why the socket was
+// abandoned — otherwise the daemon's Warn names only the subprocess failure.
+func TestFallbackNotifierJoinsBothErrors(t *testing.T) {
+	dead := NewSocketNotifier(filepath.Join(t.TempDir(), "nonexistent.sock"))
+	cliErr := errors.New("herdr notification show: exit 1")
+	f := &FallbackNotifier{Socket: dead, CLI: &recordingCLI{err: cliErr}}
+
+	_, err := f.ShowNotification(context.Background(), "x", "y")
+	if !errors.Is(err, cliErr) {
+		t.Fatalf("want the CLI error preserved, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "dial") && !strings.Contains(err.Error(), "socket") {
+		t.Errorf("want the transport cause joined in too, got %q", err)
+	}
+}
+
+func TestFallbackNotifierWithNoPathsConfigured(t *testing.T) {
+	f := &FallbackNotifier{}
+	if _, err := f.ShowNotification(context.Background(), "x", "y"); err == nil {
+		t.Fatal("want an error when nothing can carry the toast")
+	}
+}
+
+func TestNewFallbackNotifierBuildsASocketPath(t *testing.T) {
+	_, srv := newTestNotifier(t)
+	f := NewFallbackNotifier(srv.SocketPath, &recordingCLI{})
+	if f.Socket == nil {
+		t.Fatal("a non-empty socket path must build a socket notifier")
+	}
+	res, err := f.ShowNotification(context.Background(), "build failed", "api")
+	if err != nil {
+		t.Fatalf("ShowNotification: %v", err)
+	}
+	if !res.Known || !res.Shown {
+		t.Fatalf("want the socket's reported delivery, got %+v", res)
+	}
+}
+
+// Concurrency is an explicit design claim (no locking, fresh connection per
+// call, atomic request ids). Run under -race to mean anything.
+func TestFallbackNotifierConcurrentCalls(t *testing.T) {
+	n, srv := newTestNotifier(t)
+	f := &FallbackNotifier{Socket: n, CLI: &recordingCLI{}}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := f.ShowNotification(context.Background(), "escalation", "blocked"); err != nil {
+				t.Errorf("concurrent ShowNotification: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := len(srv.SocketNotifications()); got != 10 {
+		t.Fatalf("want all 10 toasts delivered, got %d", got)
+	}
+}
+
+// TestFallbackNotifierNotifyIgnoresNotShown mirrors SocketNotifier.Notify: a
+// toast herdr declined is not a broken notifier.
+func TestFallbackNotifierNotifyIgnoresNotShown(t *testing.T) {
+	n, srv := newTestNotifier(t)
+	srv.SetNotificationResult(false, "disabled")
+	f := &FallbackNotifier{Socket: n, CLI: &recordingCLI{}}
+
+	if err := f.Notify(context.Background(), "escalation", "agent blocked"); err != nil {
+		t.Fatalf("a declined toast must not be an error, got %v", err)
+	}
+}
+
+// Conformance: the chain must be usable wherever either port is expected.
+var (
+	_ ports.NotifyPort   = (*FallbackNotifier)(nil)
+	_ ports.NotifyShower = (*FallbackNotifier)(nil)
+)

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -109,9 +109,17 @@ type NotifyPort interface {
 // NotifyResult reports what herdr did with a notification. Shown == false is
 // not a failure: herdr answered and declined to paint the toast, naming why
 // in Reason ("disabled", "rate_limited", "no_foreground_client", "busy").
+//
+// Known separates "herdr answered, and the answer was no" from "we never
+// found out". Only the socket method reports delivery; the CLI
+// (`notification show`) exits 0 whether or not a toast was painted, so a
+// caller that fell back to it holds no evidence either way. The zero value is
+// therefore the unknown one — a result nobody filled in never claims delivery
+// — and !Known must be read as "assume the operator was not reached".
 type NotifyResult struct {
 	Shown  bool
 	Reason string
+	Known  bool
 }
 
 // NotifyShower is the optional richer form of NotifyPort: it reports whether


### PR DESCRIPTION
## Why

The daemon raised operator toasts by shelling out to `herdr notification show`, which **exits 0 whether or not a toast was actually painted**. So when herdr dropped an escalation — notifications disabled, rate limited, no foreground client, an in-app toast already standing — the daemon assumed the operator had been told. For a tool whose entire job is escalating to a human, that is a real gap.

herdr's socket method `notification.show` answers `{shown, reason}`. The TUI already used it for exactly this reason (IR-003); the daemon now does too.

This is the first step of a deliberately **selective** socket migration. Measured against a live herdr, the socket is *not* meaningfully faster — herdr's own ~120 ms server-side handling dominates both paths and process spawn is ~3 ms — so this moves for **capability**, not speed.

## What changed

- **`ports.NotifyResult` gains `Known`** — separates "herdr answered and said no" from "we never found out". The CLI cannot report delivery, so the zero value is the unknown one: a result nobody filled in never claims delivery.
- **New `herdr.FallbackNotifier`** — prefers the socket, drops to the CLI **only on transport failure**. A request herdr *answered and refused* is never re-fired (same herdr, same verdict, and it would bury the real error code); neither is one refused locally (empty title) or cancelled by shutdown. `method_not_found` still falls back — an older herdr lacking the method is precisely the capability gap a backstop is for.
- **One budget bounds the whole chain**, so adding the socket hop cannot stall the daemon's select loop longer than the CLI alone did (CLAUDE.md: don't stall the main loop).
- **`escalate` logs `notified=` / `notify_reason=`**, emitted only when herdr reported the outcome — the log never turns "we don't know" into a claim. Extracted as the pure `escalationLogAttrs` so the invariant is directly testable.
- IR-003 and the protocol-surfaces table updated to match.

## Testing

- `internal/herdr`: all notification tests pass, including under `-race` (the chain is lock-free by design: fresh connection per call, atomic request ids).
- New coverage: socket-preferred delivery, declined-toast-not-retried, transport-failure-falls-back-unreported, herdr-answered errors (table: `invalid_params` refuses vs `method_not_found` falls back), cancelled ctx, empty title, joined errors, both-nil, and a concurrent case.
- `escalationLogAttrs` table-tested across displayed / declined / unreported.
- Full suite: the `internal/daemon` package has **pre-existing** full-suite flakiness. Verified against a clean `origin/main` worktree — a `./...` run there failed 4 arbitrary daemon tests, including one this branch never hit. Every targeted test here passes.

## Not in this PR

- **`pane.focus`** (would replace the `tab focus` + `pane zoom --on` hack in `CLI.FocusPane`, which mutates the operator's layout) — it is **undocumented on herdr.dev** and confirming it switches the active tab needs a live test that moves the operator's view.
- The polling migrations (the 1-minute `agent list` sweep; `retrySubmitEnter`'s up-to-15 spawns per send) — separate PRs.