### PR TITLE
#1 feat: close older TUI processes beyond a configurable instance limit

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -418,6 +418,7 @@ per-command env notes: layering is daemon env → `env_file` → `env` → the c
 | `tui.terminal_bell` | true | ring the terminal bell (\a) on new escalations and on pauses caused by a different process; also the fallback when a herdr notification is not displayed |
 | `tui.herdr_notification` | true | raise a herdr desktop notification on those same two events, when the TUI runs as a herdr-managed pane |
 | `tui.disable_check_for_update` | false | turn off the GitHub release check (at most every 6h, TUI only) that puts `↑ vX.Y.Z available` in the header. it is the plugin's ONLY outbound network call; a locally built (`plugin link`) binary never checks |
+| `tui.max_instances` | 1 | how many `hap tui` processes may run at once. starting one closes the OLDEST past this cap (SIGTERM — a clean exit), because each instance re-polls the whole state every 2s and shells out to herdr per agent. `0` = no limit; a lowered cap applies within 10s without restarting anything |
 
 TUI palette colors (`tui.palette.*`) are config.toml-only — roles: `title`, `section`, `error`, `ok`, `paused`, `running`, `warn`, `help`. values are 256-color codes (`"205"`) or hex (`"#ff5faf"`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ section in `CLAUDE.md`. Entries go under the version that will carry them: mergi
 to main auto-releases the next patch, so a PR adds its lines under that number
 (or under the minor/major version it bumps the manifest to).
 
+## 0.5.15
+
+- Added an instance limit for the TUI: starting `hap tui` now closes the older ones, so only the newest stays open. Every instance re-reads the whole state on a 2s tick and shells out to herdr for each agent's pane, so panes left open in other tabs kept a core busy for a view nobody was reading
+- Added `[tui] max_instances` (default 1) to raise that cap — `hap config set tui.max_instances 2` keeps two; `0` restores the old unlimited behavior. It applies without a restart: lowering it closes the surplus within 10s
+- An older TUI is closed the same way closing its pane is, so it restores the terminal and shuts its database down cleanly — and it is given a full minute to finish doing so before it is ever asked again. The instance that closed it says which pids it asked to close and why. A TUI whose peers cannot be read or signalled is left running: the limit is a performance guard, never a reason for a TUI to fail
+
 ## 0.5.13
 
 - Fixed long text being invisible past the right edge of the TUI while typing it. Every text input — add task, edit a task, correct a suggestion, the `/` filter, every config value — now wraps to the pane width, so the whole entry is readable without breaking the sentence with `shift+enter` to see it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,7 @@ The **`herdr`** skill covers CLI usage; these are the hap-specific protocol fact
 | `internal/store` | SQLite persistence (WAL; `context_json` is an opaque blob) |
 | `internal/taskfile` | advisory file lock behind every checklist read-modify-write |
 | `internal/selfpath` | resolves a live `hap` binary (an upgrade unlinks the running one) |
+| `internal/tuisession` | flock registry of live `hap tui` processes; closes the oldest past `[tui] max_instances` |
 | `internal/updatecheck` | GitHub release check — the ONLY `net/http` importer (NFR-007 allowlist) |
 | `internal/fakeherdr`, `e2e_harness/` | test fakes and the e2e driver |
 | `docs/architect/herd-auto-prompter-architecture.md` | consolidated architecture doc (FR-xxx / NFR-xxx ids used in comments) |

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/selfpath"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store"
 	"github.com/0xGosu/herdr-auto-pilot/internal/tui"
+	"github.com/0xGosu/herdr-auto-pilot/internal/tuisession"
 )
 
 func main() {
@@ -182,6 +183,17 @@ func run(verb string, args []string) error {
 		defer drainSubmitRetries(app)
 		if _, err := logging.Setup(paths.StateDir, false); err != nil {
 			return err
+		}
+		// Join the TUI registry so this instance is counted, and so it can
+		// close the older ones (`[tui] max_instances`; the first refresh
+		// sweeps). Failing to register only costs the limit — never the TUI —
+		// so it is logged, not returned.
+		session, err := tuisession.Register(paths.StateDir)
+		if err != nil {
+			slog.Warn("TUI instance limit disabled for this run", "error", err)
+		} else {
+			defer session.Release()
+			app.TUISessions = session
 		}
 		return tui.Run(ctx, app)
 	default:

--- a/docs/architect/herd-auto-prompter-architecture.md
+++ b/docs/architect/herd-auto-prompter-architecture.md
@@ -393,6 +393,42 @@ daemon-owned hot-path rows (with the two narrow exceptions listed in §11).
 Two conveniences are deliberately interactive-only and have no CLI twin: the
 Config tab's `/usr/local/bin/hap` symlink shortcut and the daemon-stderr viewer.
 
+**TUI instance limit** *(`internal/tuisession`)*. Each TUI re-reads the whole
+state on a 2s tick and shells out to herdr per agent, so instances left open in
+other tabs cost real CPU for a view nobody reads. Every `hap tui` registers in
+`<state>/tui-sessions/`, holding an advisory lock on its record for its whole
+run — liveness is therefore proved by the lock, never by probing a pid, so a
+recycled pid can never be mistaken for a TUI (the same guarantee `daemonlock`
+gives). The refresh path sweeps (throttled to 10s): the oldest sessions past
+`[tui] max_instances` (default 1, `0` = unlimited) get SIGTERM, which is the
+ordinary "pane closed" exit, and the sweeping instance reports the pids it
+asked to close. Only the NEWEST live session signals, and it only ever signals
+peers older than itself: the second half keeps two TUIs starting at the same
+moment from closing each other, and the first keeps the grace below meaningful
+by making signalling single-writer (with three TUIs, a middle session and the
+newest would otherwise each SIGTERM the oldest, neither aware of the other). An
+unreadable registry or an unsignallable peer leaves everything running: the
+limit is a performance guard and never a reason for a TUI to fail.
+
+Three bounds are load-bearing. **A peer already asked to exit is left alone for
+`signalGrace` (60s)**: `cmd/hap` releases its signal handler on the first signal
+so a wedged process stays killable, so a second SIGTERM from the next 10s sweep
+would kill the TUI where it stands — no terminal restore, no store close. (The
+submit-retry drain is not among the stakes; any signalled exit forfeits it, as
+`shutdownSignals` documents.) Past the grace it has plainly ignored the request
+and signalling again is the right escalation. **`claim` truncates the record the
+moment it takes the lock**, so a reused pid can never be read carrying its dead
+predecessor's start time (which would make the newest TUI look like the oldest
+and close it). **A peer whose recorded process identity differs from ours is
+neither counted nor signalled** — a state dir reached from two pid namespaces (a
+container and its host sharing a bind-mounted home) is the one case where flock
+still says "live" while the pid names someone else entirely; an unknown identity
+on either side degrades to trusting the pid.
+
+Closing a plugin pane's process does not restart it: herdr respawns a *shell*
+in the pane when a launch command exits, so the limit cannot oscillate between
+two TUI panes re-closing each other.
+
 **Self-update surface.** `internal/frontend/updatestatus.go` exposes the cached
 release check to both front-ends: the TUI header renders the running version and,
 when a newer release exists, `↑ vX.Y.Z available`; `hap update` performs the

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -117,7 +117,10 @@ func buildCommands() {
 			Details: "Tabs: Agents, Tasks, Escalations, Audit, Rules, Config, Pause/Kill.\n" +
 				"Nearly everything the TUI does is also a CLI verb, which is what scripts and AI\n" +
 				"agents should use. The exceptions are interactive-only conveniences: the Config\n" +
-				"tab's `/usr/local/bin/hap` symlink shortcut, and the daemon-stderr viewer (`!`).",
+				"tab's `/usr/local/bin/hap` symlink shortcut, and the daemon-stderr viewer (`!`).\n" +
+				"Only ONE TUI stays open: each instance re-polls the whole state every 2s, so\n" +
+				"starting one closes the older ones. Raise the cap with `hap config set\n" +
+				"tui.max_instances <n>`, or set 0 for no limit.",
 			Examples: []string{"hap tui"},
 			Next: []Hint{
 				{Cmd: "hap status", Why: "the same overview, non-interactive"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -609,6 +609,17 @@ type TUI struct {
 	// plugin's only outbound network call (NFR-007). It is named negatively so
 	// the zero value keeps the check on, the way Embedding.Disabled does.
 	DisableCheckForUpdate bool `toml:"disable_check_for_update"`
+	// MaxInstances caps how many `hap tui` processes may run at once against
+	// this state dir. Every instance polls the same state on a 2s tick and
+	// shells out to herdr per agent, so forgotten panes cost real CPU while
+	// only one of them is ever being read. When a TUI starts and more than this
+	// many are live, the OLDEST are closed (SIGTERM — a clean exit, same as
+	// closing the pane). Default 1; 0 or less means no limit.
+	//
+	// Unlike the other zero-means-default ints here, 0 is a real setting, so
+	// fillZeroes deliberately leaves it alone: the default only applies when
+	// the key is absent, which config.Load gets from starting at Default().
+	MaxInstances int `toml:"max_instances"`
 }
 
 // CLI configures the `hap` command-line output (as opposed to the TUI).
@@ -688,7 +699,7 @@ func Default() Config {
 			SimilarityThreshold: 0.90,
 			BM25MinScore:        0.35,
 		},
-		TUI: TUI{TerminalBell: true, HerdrNotification: true},
+		TUI: TUI{TerminalBell: true, HerdrNotification: true, MaxInstances: 1},
 		CLI: CLI{AIAgentFriendlyOutput: true},
 	}
 }

--- a/internal/config/tuiinstances_test.go
+++ b/internal/config/tuiinstances_test.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The instance limit is on by default: a config that predates the key (or has
+// no [tui] table at all) must still cap the TUI at one, which is what makes
+// this a fix for the CPU spike rather than an opt-in setting nobody finds.
+func TestTUIMaxInstancesDefaultsToOne(t *testing.T) {
+	if got := Default().TUI.MaxInstances; got != 1 {
+		t.Fatalf("Default().TUI.MaxInstances = %d, want 1", got)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	// A [tui] table that sets OTHER keys must not zero this one: absent means
+	// default, and the decoder merges into Default() field by field.
+	if err := os.WriteFile(path, []byte("[tui]\nterminal_bell = false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.TUI.MaxInstances != 1 {
+		t.Errorf("a [tui] table without max_instances gave %d, want the default 1", cfg.TUI.MaxInstances)
+	}
+	if cfg.TUI.TerminalBell {
+		t.Error("the sibling key should still have been applied")
+	}
+}
+
+// An explicit 0 means "no limit" and must survive Load — unlike the other
+// zero-means-default ints, fillZeroes must leave it alone.
+func TestTUIMaxInstancesZeroMeansNoLimit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[tui]\nmax_instances = 0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.TUI.MaxInstances != 0 {
+		t.Fatalf("max_instances = %d, want 0 preserved (no limit)", cfg.TUI.MaxInstances)
+	}
+}
+
+// A saved config round-trips the value, so `hap config set` persists it.
+func TestTUIMaxInstancesRoundTripsThroughSave(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	cfg := Default()
+	cfg.TUI.MaxInstances = 3
+	if err := Save(path, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	back, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if back.TUI.MaxInstances != 3 {
+		t.Fatalf("max_instances = %d after a Save/Load round trip, want 3", back.TUI.MaxInstances)
+	}
+}

--- a/internal/frontend/export_test.go
+++ b/internal/frontend/export_test.go
@@ -4,3 +4,7 @@ package frontend
 // package so expiry can be exercised at the real boundary instead of a
 // hard-coded duplicate that would silently drift from it.
 const CwdTTLForTest = cwdTTL
+
+// TUILimitSweepIntervalForTest exposes the instance-limit throttle for the same
+// reason: the test asserts at the real boundary, not a copy of it.
+const TUILimitSweepIntervalForTest = tuiLimitSweepInterval

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -62,6 +62,14 @@ type App struct {
 	// Tests inject it so no test ever opens a network connection.
 	FetchLatestVersion func(ctx context.Context) (string, error)
 
+	// TUISessions polices how many `hap tui` processes run at once (see
+	// EnforceTUISessionLimit). nil for every front-end that is not a TUI, and
+	// for a TUI that could not register itself — both simply do not enforce.
+	TUISessions TUISessionLimiter
+
+	// tuiLimit throttles the instance-limit sweep.
+	tuiLimit tuiLimitState
+
 	// cwdMu/cwdCache memoize pane working directories for FillAgentCwds.
 	// Without this, the TUI's 2s refresh would spawn one `herdr pane get` per
 	// agent per tick; the daemon caches its own lookups for the same reason. A
@@ -1562,6 +1570,7 @@ var ConfigFields = []ConfigFieldDef{
 	{Key: "tui.terminal_bell", TUIEditable: true},
 	{Key: "tui.herdr_notification", TUIEditable: true},
 	{Key: "tui.disable_check_for_update", TUIEditable: true},
+	{Key: "tui.max_instances", TUIEditable: true},
 	{Key: "cli.ai_agent_friendly_output", TUIEditable: true},
 }
 
@@ -1764,6 +1773,11 @@ func FieldValue(cfg config.Config, key string) string {
 		return strconv.FormatBool(cfg.TUI.HerdrNotification)
 	case "tui.disable_check_for_update":
 		return strconv.FormatBool(cfg.TUI.DisableCheckForUpdate)
+	case "tui.max_instances":
+		if cfg.TUI.MaxInstances <= 0 {
+			return "0 (no limit)"
+		}
+		return strconv.Itoa(cfg.TUI.MaxInstances)
 	case "cli.ai_agent_friendly_output":
 		return strconv.FormatBool(cfg.CLI.AIAgentFriendlyOutput)
 	}
@@ -2034,6 +2048,15 @@ func (a *App) SetField(ctx context.Context, key, value string) error {
 				return fmt.Errorf("tui.disable_check_for_update must be true or false, got %q", value)
 			}
 			cfg.TUI.DisableCheckForUpdate = v
+			return nil
+		case "tui.max_instances":
+			// 0 is "no limit" here, not "restore the default" — the default
+			// only applies to a config that never mentions the key.
+			v, err := strconv.Atoi(value)
+			if err != nil || v < 0 {
+				return fmt.Errorf("tui.max_instances must be a non-negative integer (0 = no limit), got %q", value)
+			}
+			cfg.TUI.MaxInstances = v
 			return nil
 		case "cli.ai_agent_friendly_output":
 			v, err := strconv.ParseBool(value)

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -2337,6 +2337,7 @@ func TestConfigFieldRegistryParity(t *testing.T) {
 		"tui.terminal_bell":                        "true",
 		"tui.herdr_notification":                   "false",
 		"tui.disable_check_for_update":             "true",
+		"tui.max_instances":                        "2",
 		"cli.ai_agent_friendly_output":             "false",
 	}
 

--- a/internal/frontend/tuisessions.go
+++ b/internal/frontend/tuisessions.go
@@ -1,0 +1,71 @@
+package frontend
+
+import (
+	"sync"
+	"time"
+)
+
+// TUISessionLimiter closes older `hap tui` processes so at most max of them
+// stay live, returning the pids it asked to exit. It is an optional capability
+// (internal/tuisession implements it): a nil limiter means this front-end is
+// not policing instances at all — a CLI run, a TUI that could not register, or
+// a platform without the file locks the registry needs.
+type TUISessionLimiter interface {
+	Enforce(max int) ([]int, error)
+}
+
+// tuiLimitSweepInterval throttles the sweep. The TUI calls it from its 2s
+// refresh, but the registry only changes when a TUI starts or exits, so a
+// slower cadence is plenty — and the case it exists for (a peer that had not
+// registered yet when we started, or an operator lowering the limit on a
+// running herd) is not urgent.
+const tuiLimitSweepInterval = 10 * time.Second
+
+// tuiLimitState is the throttle. It lives on App because both the startup
+// sweep and the periodic one go through EnforceTUISessionLimit.
+type tuiLimitState struct {
+	mu   sync.Mutex
+	last time.Time
+}
+
+// TUILimitSweep reports one instance-limit sweep: the limit that was in force
+// and the TUIs it closed. Max travels with the result so a caller can name the
+// setting in its message without re-reading config.
+type TUILimitSweep struct {
+	Max    int
+	Closed []int
+}
+
+// EnforceTUISessionLimit closes older TUI processes beyond `[tui]
+// max_instances`, and reports what it closed.
+//
+// It is throttled, so calling it every refresh is cheap; the first call after
+// start always runs. A config read error, a registry read error, or no limiter
+// at all leaves every TUI running — the limit is a performance guard, never
+// something worth failing a front-end over.
+func (a *App) EnforceTUISessionLimit() (TUILimitSweep, error) {
+	if a.TUISessions == nil {
+		return TUILimitSweep{}, nil
+	}
+	now := time.Now()
+	if a.Clock != nil {
+		now = a.Clock()
+	}
+	// Stamped before the work, not after: two refreshes overlapping must not
+	// both sweep, and the cost of that choice is only that a failed config
+	// read waits out one interval before retrying.
+	a.tuiLimit.mu.Lock()
+	if !a.tuiLimit.last.IsZero() && now.Sub(a.tuiLimit.last) < tuiLimitSweepInterval {
+		a.tuiLimit.mu.Unlock()
+		return TUILimitSweep{}, nil
+	}
+	a.tuiLimit.last = now
+	a.tuiLimit.mu.Unlock()
+
+	cfg, err := a.Config()
+	if err != nil {
+		return TUILimitSweep{}, err
+	}
+	closed, err := a.TUISessions.Enforce(cfg.TUI.MaxInstances)
+	return TUILimitSweep{Max: cfg.TUI.MaxInstances, Closed: closed}, err
+}

--- a/internal/frontend/tuisessions_test.go
+++ b/internal/frontend/tuisessions_test.go
@@ -1,0 +1,152 @@
+package frontend_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+)
+
+// fakeLimiter records the limits it was asked to enforce.
+type fakeLimiter struct {
+	calls  []int
+	closed []int
+	err    error
+}
+
+func (f *fakeLimiter) Enforce(max int) ([]int, error) {
+	f.calls = append(f.calls, max)
+	return f.closed, f.err
+}
+
+// The sweep passes the configured limit through and reports what closed.
+func TestEnforceTUISessionLimitUsesTheConfiguredMax(t *testing.T) {
+	app, _ := testApp(t)
+	lim := &fakeLimiter{closed: []int{4242}}
+	app.TUISessions = lim
+	if err := app.SetField(t.Context(), "tui.max_instances", "3"); err != nil {
+		t.Fatalf("set tui.max_instances: %v", err)
+	}
+	sweep, err := app.EnforceTUISessionLimit()
+	if err != nil {
+		t.Fatalf("EnforceTUISessionLimit: %v", err)
+	}
+	if len(lim.calls) != 1 || lim.calls[0] != 3 {
+		t.Fatalf("Enforce calls = %v, want [3]", lim.calls)
+	}
+	if sweep.Max != 3 || len(sweep.Closed) != 1 || sweep.Closed[0] != 4242 {
+		t.Fatalf("sweep = %+v, want max 3 and pid 4242 closed", sweep)
+	}
+}
+
+// A config that never mentions the key gets the default limit of 1 — the whole
+// point of the feature is that it is on without being asked for.
+func TestEnforceTUISessionLimitDefaultsToOne(t *testing.T) {
+	app, _ := testApp(t)
+	lim := &fakeLimiter{}
+	app.TUISessions = lim
+	if _, err := app.EnforceTUISessionLimit(); err != nil {
+		t.Fatalf("EnforceTUISessionLimit: %v", err)
+	}
+	if len(lim.calls) != 1 || lim.calls[0] != 1 {
+		t.Fatalf("Enforce calls = %v, want [1] from the built-in default", lim.calls)
+	}
+}
+
+// The sweep is throttled: the TUI calls it every 2s refresh, and re-scanning
+// the registry that often would defeat the point of the feature.
+func TestEnforceTUISessionLimitIsThrottled(t *testing.T) {
+	app, _ := testApp(t)
+	lim := &fakeLimiter{}
+	app.TUISessions = lim
+	now := time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC)
+	app.Clock = func() time.Time { return now }
+
+	if _, err := app.EnforceTUISessionLimit(); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(3 * time.Second)
+	if _, err := app.EnforceTUISessionLimit(); err != nil {
+		t.Fatal(err)
+	}
+	if len(lim.calls) != 1 {
+		t.Fatalf("Enforce ran %d times within the throttle window, want 1", len(lim.calls))
+	}
+	now = now.Add(frontend.TUILimitSweepIntervalForTest)
+	if _, err := app.EnforceTUISessionLimit(); err != nil {
+		t.Fatal(err)
+	}
+	if len(lim.calls) != 2 {
+		t.Fatalf("Enforce ran %d times, want 2 once the throttle expired", len(lim.calls))
+	}
+}
+
+// The setting's edges: an explicit 0 is a real value ("no limit"), and a
+// negative or non-numeric one is refused rather than silently reinterpreted.
+func TestSetFieldMaxInstances(t *testing.T) {
+	app, _ := testApp(t)
+	if err := app.SetField(t.Context(), "tui.max_instances", "0"); err != nil {
+		t.Fatalf("0 must be accepted as the no-limit setting: %v", err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TUI.MaxInstances != 0 {
+		t.Errorf("max_instances = %d, want 0 stored", cfg.TUI.MaxInstances)
+	}
+	if got := frontend.FieldValue(cfg, "tui.max_instances"); got != "0 (no limit)" {
+		t.Errorf("FieldValue = %q, want %q", got, "0 (no limit)")
+	}
+	for _, bad := range []string{"-1", "abc", "1.5", ""} {
+		if err := app.SetField(t.Context(), "tui.max_instances", bad); err == nil {
+			t.Errorf("SetField accepted %q", bad)
+		}
+	}
+	if err := app.SetField(t.Context(), "tui.max_instances", "3"); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ = app.Config()
+	if got := frontend.FieldValue(cfg, "tui.max_instances"); got != "3" {
+		t.Errorf("FieldValue = %q, want %q", got, "3")
+	}
+}
+
+// No limiter (any front-end that is not a TUI) is a silent no-op.
+func TestEnforceTUISessionLimitWithoutALimiter(t *testing.T) {
+	app, _ := testApp(t)
+	sweep, err := app.EnforceTUISessionLimit()
+	if err != nil {
+		t.Fatalf("want a no-op, got %v", err)
+	}
+	if sweep.Max != 0 || sweep.Closed != nil {
+		t.Fatalf("sweep = %+v, want zero", sweep)
+	}
+}
+
+// A registry error surfaces but closes nothing — the caller keeps running —
+// and it is still throttled, so a persistently failing registry is retried once
+// an interval rather than on every 2s refresh.
+func TestEnforceTUISessionLimitReportsRegistryErrors(t *testing.T) {
+	app, _ := testApp(t)
+	lim := &fakeLimiter{err: errors.New("registry unreadable")}
+	app.TUISessions = lim
+	now := time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC)
+	app.Clock = func() time.Time { return now }
+
+	sweep, err := app.EnforceTUISessionLimit()
+	if err == nil {
+		t.Fatal("want the registry error surfaced")
+	}
+	if len(sweep.Closed) != 0 {
+		t.Fatalf("nothing should be reported closed, got %+v", sweep)
+	}
+	now = now.Add(2 * time.Second)
+	if _, err := app.EnforceTUISessionLimit(); err != nil {
+		t.Fatalf("a throttled call must be a silent no-op, got %v", err)
+	}
+	if len(lim.calls) != 1 {
+		t.Fatalf("a failing sweep ran %d times inside the throttle window, want 1", len(lim.calls))
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -71,6 +71,11 @@ type refreshMsg struct {
 	// flight, so "l: retry LLM" is disabled while one is running (the daemon
 	// re-checks authoritatively). Populated only for retryable escalations.
 	pendingConsult map[string]bool
+	// tuiLimit reports the instance-limit sweep this refresh ran: the pids of
+	// older `hap tui` processes it asked to exit, so the operator learns why a
+	// pane they left open went away, and the limit that closed them. Normally
+	// nothing was closed.
+	tuiLimit frontend.TUILimitSweep
 	// update reports a newer release from the LAST CACHED check — a local file
 	// read, never a network call (updateCheckCmd does the fetch).
 	update frontend.UpdateStatus
@@ -843,6 +848,11 @@ type Model struct {
 	// which goroutine's result lands first.
 	pausePending bool
 
+	// pendingTUINote holds the "asked N older TUIs to close" explanation until
+	// the status line is free of an error note. Nothing regenerates it — the
+	// sweep reports a peer once — so it waits here rather than being dropped.
+	pendingTUINote string
+
 	// cursorUndo restores the cursor when an OPTIMISTIC nudge turns out to
 	// have been wrong. moveSelectedTask moves the cursor before its move
 	// lands, so the operator sees it follow the task; if the move is then
@@ -1242,6 +1252,15 @@ func refreshData(ctx context.Context, app *frontend.App) refreshMsg {
 	// Daemon health is read from local state files (never errors), so assess it
 	// first — it stays meaningful even when GetStatus fails (e.g. daemon down).
 	msg.daemonHealth = app.AssessDaemonHealth()
+	// Keep only the newest few TUIs alive: every extra one re-runs this whole
+	// refresh on its own 2s tick. Throttled inside the App, and deliberately
+	// not allowed to fail the refresh — an unenforceable limit is a slow TUI,
+	// not a broken one.
+	if sweep, err := app.EnforceTUISessionLimit(); err != nil {
+		slog.Warn("TUI instance limit not enforced", "error", err)
+	} else {
+		msg.tuiLimit = sweep
+	}
 	msg.status, msg.err = app.GetStatus(ctx)
 	if msg.err != nil {
 		return msg
@@ -1291,6 +1310,23 @@ func refreshData(ctx context.Context, app *frontend.App) refreshMsg {
 	msg.update = app.UpdateStatus(msg.cfg)
 	msg.updateDue = app.UpdateCheckDue(msg.cfg)
 	return msg
+}
+
+// closedTUINote explains a sweep that closed older TUIs, naming the setting to
+// raise (or zero) if the operator wanted those panes. It says "asked … to
+// close" rather than "closed": what the sweep did is deliver a SIGTERM, and the
+// peer then unwinds on its own schedule.
+func closedTUINote(sweep frontend.TUILimitSweep) string {
+	pids := make([]string, 0, len(sweep.Closed))
+	for _, pid := range sweep.Closed {
+		pids = append(pids, strconv.Itoa(pid))
+	}
+	noun := "older TUI"
+	if len(pids) > 1 {
+		noun = "older TUIs"
+	}
+	return fmt.Sprintf("asked %d %s to close (pid %s) — tui.max_instances=%d",
+		len(pids), noun, strings.Join(pids, ", "), sweep.Max)
 }
 
 // updateCheckAllowed gates the background release check on all three bounds:
@@ -1459,6 +1495,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.lastMaxEscalationID = maxEscalationID(msg.escalations)
 			m.lastPaused = msg.status.Paused
 			m.initialized = true
+		}
+		// Say so when this instance closed older ones: from the operator's side
+		// a pane they left open simply disappeared, and the reason (a limit they
+		// can raise) is only knowable from here.
+		// Never over an error the operator is reading: a failed action they
+		// just triggered is the one they need. It is held rather than dropped,
+		// because no later sweep will re-report it — a peer already asked to
+		// close is skipped for its whole grace, and gone after that — and a
+		// pane that vanished with no explanation is the thing this note exists
+		// to prevent.
+		if len(msg.tuiLimit.Closed) > 0 {
+			m.pendingTUINote = closedTUINote(msg.tuiLimit)
+		}
+		if m.pendingTUINote != "" && (m.status == nil || !m.status.err) {
+			m.status = &statusNote{text: m.pendingTUINote, at: time.Now()}
+			m.pendingTUINote = ""
 		}
 		// A failed refresh returns before the update fields are filled, so
 		// carry the last known ones forward — the hint must not blink out of

--- a/internal/tui/tuilimit_test.go
+++ b/internal/tui/tuilimit_test.go
@@ -1,0 +1,74 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+)
+
+// Closing an older TUI is invisible from the pane it happened in, so the
+// instance that did it must say so — including the setting to change if the
+// operator wanted that pane.
+func TestRefreshReportsClosedTUIs(t *testing.T) {
+	m := Model{width: 100, height: 30}
+	upd, _ := m.Update(refreshMsg{tuiLimit: frontend.TUILimitSweep{Max: 1, Closed: []int{4242, 4243}}})
+	got := upd.(Model)
+	if got.status == nil {
+		t.Fatal("closing older TUIs must leave a status note")
+	}
+	for _, want := range []string{"asked 2 older TUIs to close", "4242", "4243", "tui.max_instances=1"} {
+		if !strings.Contains(got.status.text, want) {
+			t.Errorf("status note %q is missing %q", got.status.text, want)
+		}
+	}
+	if got.status.err {
+		t.Error("the note is informational, not an error")
+	}
+}
+
+// The ordinary refresh — nothing closed — leaves the status line alone.
+func TestRefreshWithoutClosedTUIsSaysNothing(t *testing.T) {
+	m := Model{width: 100, height: 30}
+	upd, _ := m.Update(refreshMsg{tuiLimit: frontend.TUILimitSweep{Max: 1}})
+	if got := upd.(Model); got.status != nil {
+		t.Fatalf("unexpected status note %q", got.status.text)
+	}
+}
+
+// An error the operator just triggered outranks the sweep note — but the note
+// is HELD, not dropped: no later sweep re-reports a peer it already closed, so
+// dropping it would leave a vanished pane unexplained forever.
+func TestClosedTUINoteWaitsBehindAnErrorThenLands(t *testing.T) {
+	m := Model{width: 100, height: 30, status: &statusNote{text: "send failed", err: true}}
+	upd, _ := m.Update(refreshMsg{tuiLimit: frontend.TUILimitSweep{Max: 1, Closed: []int{4242}}})
+	got := upd.(Model)
+	if got.status == nil || got.status.text != "send failed" {
+		t.Fatalf("status = %+v, want the operator's error kept", got.status)
+	}
+	if got.pendingTUINote == "" {
+		t.Fatal("the sweep note was dropped instead of held")
+	}
+	// The error note is cleared (a later action succeeds); the held note lands
+	// on the next refresh, even though that sweep closed nothing.
+	got.status = nil
+	upd, _ = got.Update(refreshMsg{tuiLimit: frontend.TUILimitSweep{Max: 1}})
+	got = upd.(Model)
+	if got.status == nil || !strings.Contains(got.status.text, "4242") {
+		t.Fatalf("status = %+v, want the held note to land", got.status)
+	}
+	if got.pendingTUINote != "" {
+		t.Error("the held note should be consumed once shown")
+	}
+}
+
+// One closed TUI reads as singular.
+func TestClosedTUINoteSingular(t *testing.T) {
+	note := closedTUINote(frontend.TUILimitSweep{Max: 2, Closed: []int{7}})
+	if !strings.Contains(note, "asked 1 older TUI to close (pid 7)") {
+		t.Errorf("note = %q", note)
+	}
+	if strings.Contains(note, "TUIs") {
+		t.Errorf("note = %q, want the singular noun", note)
+	}
+}

--- a/internal/tuisession/registry_unix.go
+++ b/internal/tuisession/registry_unix.go
@@ -1,0 +1,114 @@
+//go:build !windows
+
+package tuisession
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// errUnsupported reports a platform without the file locks this package needs,
+// so Register stops retrying instead of sleeping through every attempt.
+var errUnsupported = errors.New("the TUI instance limit needs file locks")
+
+// claim opens path and takes its exclusive lock, which the session then holds
+// for its whole run. An already-locked file means a live peer with our pid —
+// impossible in practice — or, far more likely, a peer briefly probing the
+// file; either way the caller retries.
+func claim(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("lock %s: %w", path, err)
+	}
+	// Drop the previous holder's bytes the moment the lock is ours. Waiting
+	// for write() would leave a window in which this pid's record still shows
+	// a DEAD predecessor's start time — and a peer reading it there would take
+	// the newest TUI for the oldest one and close it.
+	if err := f.Truncate(0); err != nil {
+		release(f)
+		return nil, fmt.Errorf("clear %s: %w", path, err)
+	}
+	return f, nil
+}
+
+// processIdentity names the process space this pid belongs to, so a state dir
+// shared between a container and its host (a bind-mounted home) does not let
+// one side signal a pid that means something else on the other. Unknown ("")
+// disables the comparison rather than the limit.
+//
+// BOTH parts are needed, so it is hostname + pid namespace whenever both are
+// readable. The namespace alone does not identify a machine: the initial pid
+// namespace has a fixed inode, so every uncontainerized Linux host reports the
+// same string — and two hosts sharing a state dir over a network home would
+// then read as one, with flock visible across clients and a signal landing on
+// whatever local process happens to hold that pid. The hostname alone misses
+// the container-and-its-host case. Their failure modes are asymmetric: a
+// wrongly-foreign peer only turns the limit off, while a wrongly-local one
+// signals a stranger, so a hostname that changes under us (a laptop taking a
+// new DHCP name) is the cost worth paying.
+func processIdentity() string {
+	host, hostErr := os.Hostname()
+	ns, nsErr := os.Readlink("/proc/self/ns/pid")
+	if hostErr != nil {
+		host = ""
+	}
+	if nsErr != nil {
+		ns = ""
+	}
+	return sanitizeIdentity(strings.TrimSpace(host + " " + ns))
+}
+
+// sanitizeIdentity keeps an identity to the one line the record format allows;
+// a newline would forge an extra field, and there is no legitimate one.
+func sanitizeIdentity(id string) string {
+	id = strings.TrimSpace(id)
+	if strings.ContainsAny(id, "\r\n") {
+		return ""
+	}
+	return id
+}
+
+// release drops the lock and closes the file.
+func release(f *os.File) {
+	syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	f.Close()
+}
+
+// held reports whether some process still holds path's lock. It never creates
+// the file: a record that vanished between the directory listing and this call
+// is simply not live.
+func held(path string) (bool, error) {
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		// EWOULDBLOCK is the answer we came for; anything else is a real
+		// failure to probe.
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return true, nil
+		}
+		return false, err
+	}
+	syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return false, nil
+}
+
+// signalStop asks a TUI to exit the way closing its pane does: SIGTERM cancels
+// its run context, so it restores the terminal and closes its store instead of
+// dying where it stands (cmd/hap handles it in shutdownSignals). A pid that is
+// already gone is not an error.
+func signalStop(pid int) error {
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	return nil
+}

--- a/internal/tuisession/registry_unix_test.go
+++ b/internal/tuisession/registry_unix_test.go
@@ -1,0 +1,52 @@
+//go:build !windows
+
+package tuisession
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// signalStop maps "already gone" to success: a peer that exited between the
+// sweep that listed it and the signal is exactly the outcome we wanted, and
+// treating it as a failure would log a warning on the happy path.
+func TestSignalStopOnAVanishedProcess(t *testing.T) {
+	// A pid no process can hold: above the kernel's pid_max by construction.
+	if err := signalStop(1 << 30); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			t.Fatal("ESRCH reached the caller; it must be swallowed")
+		}
+		t.Fatalf("signalStop on a dead pid = %v, want nil", err)
+	}
+}
+
+// processIdentity never returns something that could forge an extra line in a
+// session record.
+func TestProcessIdentityIsSingleLine(t *testing.T) {
+	for _, r := range processIdentity() {
+		if r == '\n' || r == '\r' {
+			t.Fatalf("processIdentity() = %q contains a newline", processIdentity())
+		}
+	}
+}
+
+// The identity must carry the HOSTNAME, not the pid namespace alone: the
+// initial namespace has a fixed inode, so every uncontainerized Linux host
+// reports the same one — and two hosts sharing a state dir over a network home
+// would then read as one process space and signal each other's pids.
+func TestProcessIdentityDistinguishesHosts(t *testing.T) {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		t.Skip("this platform reports no hostname")
+	}
+	id := processIdentity()
+	if !strings.Contains(id, host) {
+		t.Errorf("processIdentity() = %q, want it to include the hostname %q", id, host)
+	}
+	if ns, err := os.Readlink("/proc/self/ns/pid"); err == nil && ns != "" && !strings.Contains(id, ns) {
+		t.Errorf("processIdentity() = %q, want it to include the pid namespace %q too", id, ns)
+	}
+}

--- a/internal/tuisession/registry_windows.go
+++ b/internal/tuisession/registry_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package tuisession
+
+import (
+	"errors"
+	"os"
+)
+
+// Windows support is a follow-up (NFR-008), matching daemonlock: these stubs
+// keep the build portable. Register fails fast on errUnsupported, so the TUI
+// runs with no instance limit rather than not running at all.
+
+var errUnsupported = errors.New("the TUI instance limit is not yet supported on Windows")
+
+func claim(_ string) (*os.File, error) { return nil, errUnsupported }
+
+func release(_ *os.File) {}
+
+func held(_ string) (bool, error) { return false, errUnsupported }
+
+func signalStop(_ int) error { return errUnsupported }
+
+// processIdentity is unknown here, which disables the cross-namespace
+// comparison — harmless, since no session can register in the first place.
+func processIdentity() string { return "" }

--- a/internal/tuisession/tuisession.go
+++ b/internal/tuisession/tuisession.go
@@ -1,0 +1,541 @@
+// Package tuisession tracks the live `hap tui` processes for one state
+// directory and closes the older ones when too many run at once.
+//
+// Every TUI polls the same SQLite state on a 2s tick and shells out to herdr
+// for pane metadata; each extra instance multiplies that work, and a handful of
+// forgotten panes is enough to keep a core busy. The operator only ever reads
+// one of them, so the newest wins: a starting TUI closes the oldest peers until
+// at most `[tui] max_instances` remain (default 1).
+//
+// Liveness is proved by an advisory file lock, not by a pid probe: a session
+// holds an exclusive flock on its registry file for its whole run, so a file
+// whose lock is free belongs to a process that is gone and is pruned. That is
+// what makes signalling safe — the pid we read always belongs to a live holder,
+// so a recycled pid can never be mistaken for a TUI (the same guarantee
+// daemonlock relies on). Live also requires the pid inside a record to match
+// the pid in its file name, so the lock and the pid cannot come apart.
+//
+// One bound is deliberately left open. A record is created, locked, and only
+// then written, so for the microseconds in between it is live but unparseable
+// and Live skips it. Three TUIs starting at the same instant can therefore
+// have a middle one briefly believe it is the newest and signal the oldest
+// alongside the true newest — a duplicate SIGTERM. Closing it would mean
+// treating any unreadable record as "possibly newer" and standing down, which
+// hands a single corrupt file the power to disable the limit for good. The
+// window is far smaller than that risk.
+package tuisession
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// dirName is the registry directory under the state dir.
+const dirName = "tui-sessions"
+
+const (
+	filePrefix = "session-"
+	fileSuffix = ".lock"
+)
+
+// claimAttempts bounds the retries Register makes. A claim fails transiently
+// while another process probes the same file (the probe takes the lock to test
+// it) or prunes it, both of which resolve in microseconds.
+const claimAttempts = 5
+
+// claimRetryDelay spaces those retries.
+var claimRetryDelay = 20 * time.Millisecond
+
+// signalGrace is how long a peer gets to unwind before it is signalled again.
+//
+// It is load-bearing, not politeness. `cmd/hap` releases its signal handler on
+// the FIRST signal so a wedged process stays killable, which means a second
+// SIGTERM inside the exit path kills the TUI where it stands — no terminal
+// restore, no store close — and that exit path is not instant: bubbletea's
+// teardown is followed by a bounded wait for in-flight commands. (The
+// submit-retry drain is NOT among the stakes: cmd/hap documents that those
+// workers run on the context the signal already cancelled, so any signalled
+// exit forfeits it.) An orderly exit must therefore never be interrupted by
+// the next sweep, and the sweeps are 10s apart. Past the grace the peer has
+// plainly ignored the request, and signalling again — now fatal — is the
+// right escalation.
+const signalGrace = 60 * time.Second
+
+// Info identifies one live TUI session.
+type Info struct {
+	Pid int
+	// Started is when the session registered. It orders sessions, so
+	// "oldest" means "registered first", not "lowest pid".
+	Started time.Time
+	// Identity names the process space the pid belongs to (see
+	// processIdentity). A state dir reached from two pid namespaces — a
+	// container and its host sharing a bind-mounted home — is the one case
+	// where a live record's pid names a different process to us, so a peer
+	// whose identity differs is left entirely alone. Empty means unknown,
+	// which compares equal to everything rather than stranding the limit.
+	Identity string
+	// Path is the registry file backing the session.
+	Path string
+}
+
+// signalKey identifies one session for the already-signalled bookkeeping.
+// Keying on the start time as well as the pid keeps a recycled pid from
+// inheriting its predecessor's grace period.
+type signalKey struct {
+	pid     int
+	started int64
+}
+
+func keyOf(i Info) signalKey { return signalKey{pid: i.Pid, started: i.Started.UnixNano()} }
+
+// Dir returns the registry directory for a state dir.
+func Dir(stateDir string) string { return filepath.Join(stateDir, dirName) }
+
+// Session is this process's entry in the registry. It stays valid until
+// Release; a nil *Session is inert, so callers that could not register (a
+// read-only state dir, say) need no special case — the TUI simply runs
+// without enforcing the limit.
+type Session struct {
+	dir  string
+	self Info
+	file *os.File
+	// stop signals a peer to shut down; nil means SIGTERM. Tests inject it.
+	stop func(pid int) error
+	// now is the clock the grace period is measured on; nil means time.Now.
+	now func() time.Time
+
+	// list reads the registry; nil means the real Live. Tests inject it to
+	// exercise a sweep that misses a peer it can still see the next time.
+	list func(dir string) ([]Info, error)
+
+	// mu guards signalled and released. Enforce runs on the front-end's
+	// refresh goroutine, and nothing promises there is only ever one of those.
+	mu sync.Mutex
+	// signalled records when each peer was last asked to exit.
+	signalled map[signalKey]time.Time
+	released  bool
+	// sweeping is held for the length of one Enforce. The front-end throttles
+	// by start time, which bounds how often a sweep BEGINS but not how long
+	// one takes — Live is per-file open/flock/read I/O and can block on a
+	// network home — so without this two overlapping sweeps in this one
+	// process could both find a peer unsignalled and both signal it, which is
+	// the fatal second SIGTERM signalGrace exists to prevent.
+	sweeping bool
+}
+
+// Register claims a session slot for this process.
+func Register(stateDir string) (*Session, error) {
+	dir := Dir(stateDir)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create the TUI session registry %s: %w", dir, err)
+	}
+	pid := os.Getpid()
+	path := filepath.Join(dir, filePrefix+strconv.Itoa(pid)+fileSuffix)
+	self := Info{Pid: pid, Identity: processIdentity(), Path: path}
+	var lastErr error
+	for attempt := range claimAttempts {
+		if attempt > 0 {
+			time.Sleep(claimRetryDelay)
+		}
+		f, err := claim(path)
+		if err != nil {
+			if errors.Is(err, errUnsupported) {
+				// No file locks here (Windows): retrying only delays the TUI.
+				return nil, fmt.Errorf("claim a TUI session slot in %s: %w", dir, err)
+			}
+			lastErr = err
+			continue
+		}
+		self.Started = time.Now()
+		if err := write(f, self); err != nil {
+			f.Close()
+			lastErr = err
+			continue
+		}
+		// A prune that ran between our open and our lock would have unlinked
+		// the file we now hold, leaving this session invisible to every peer
+		// (and so never counted, never closed). Confirm the path still names
+		// our inode before trusting the claim.
+		if !stillLinked(f, path) {
+			release(f)
+			lastErr = errors.New("session file was pruned during registration")
+			continue
+		}
+		return &Session{dir: dir, self: self, file: f, signalled: map[signalKey]time.Time{}}, nil
+	}
+	return nil, fmt.Errorf("claim a TUI session slot in %s: %w", dir, lastErr)
+}
+
+// Release drops the session, so peers stop counting it.
+func (s *Session) Release() {
+	if s == nil || s.file == nil {
+		return
+	}
+	// Flag FIRST, then let go of the record. The other order leaves a window —
+	// the unlock and unlink syscalls — in which a concurrent sweep sees a
+	// session that is not released yet but is already invisible in the
+	// registry, and signals a peer on our way out.
+	s.mu.Lock()
+	s.released = true
+	s.mu.Unlock()
+	release(s.file)
+	s.file = nil
+	// Best-effort: a leftover file is pruned by the next reader anyway (its
+	// lock is free), so a failed unlink is not worth surfacing.
+	_ = os.Remove(s.self.Path)
+}
+
+// beginSweep claims the single-sweep slot, reporting false when one is already
+// in flight.
+func (s *Session) beginSweep() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sweeping {
+		return false
+	}
+	s.sweeping = true
+	return true
+}
+
+func (s *Session) endSweep() {
+	s.mu.Lock()
+	s.sweeping = false
+	s.mu.Unlock()
+}
+
+// done reports that Release has run. The front-end's refresh runs on its own
+// goroutine and can still be in flight while the TUI unwinds (Release is
+// deferred last in cmd/hap, so it runs FIRST), and a released session that
+// still enforced would re-add itself in Surplus and close a peer on its way
+// out — leaving the operator with no TUI at all.
+func (s *Session) done() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.released
+}
+
+// Self reports this session's own identity.
+func (s *Session) Self() Info {
+	if s == nil {
+		return Info{}
+	}
+	return s.self
+}
+
+// Enforce asks the oldest peer sessions to exit until at most max remain live,
+// and returns the pids it signalled this sweep. max <= 0 disables the limit —
+// but the sweep still runs far enough to prune the records of TUIs that are
+// gone, so an unlimited registry does not accumulate forever.
+//
+// ONLY THE NEWEST live session signals, and it only ever signals peers older
+// than itself. Both halves matter. The second is what keeps two TUIs starting
+// at the same moment from closing each other — the ordering is total, so the
+// newest survives whichever runs first. The first is what keeps the grace
+// period meaningful: it is per-process state, so with three TUIs the middle one
+// and the newest would each independently SIGTERM the oldest, and the second of
+// those two signals arrives after `cmd/hap` has released its handler — killing
+// a TUI in the middle of its exit path, which is exactly what signalGrace
+// exists to prevent. Standing down costs nothing: the newest closes everyone
+// past the limit, and if it ever goes away the next-newest takes over.
+func (s *Session) Enforce(max int) ([]int, error) {
+	if s == nil {
+		return nil, nil
+	}
+	if !s.beginSweep() {
+		return nil, nil
+	}
+	defer s.endSweep()
+	listLive := s.list
+	if listLive == nil {
+		listLive = Live
+	}
+	live, err := listLive(s.dir)
+	if err != nil {
+		return nil, err
+	}
+	// Peers from another pid space share the directory but not the meaning of
+	// a pid, so they are neither counted nor signalled.
+	live = slices.DeleteFunc(live, func(i Info) bool {
+		if !foreign(i, s.self) {
+			return false
+		}
+		slog.Debug("ignoring a TUI session from another process space",
+			"pid", i.Pid, "peer_identity", i.Identity, "self_identity", s.self.Identity)
+		return true
+	})
+	if s.done() {
+		// This TUI is already unwinding; nothing it does now can help, and
+		// signalling on the way out could leave the operator with none at all.
+		return nil, nil
+	}
+	if max <= 0 {
+		s.forgetDeparted(live)
+		return nil, nil
+	}
+	if slices.ContainsFunc(live, func(i Info) bool { return older(s.self, i) }) {
+		s.forgetDeparted(live)
+		return nil, nil
+	}
+	stop := s.stop
+	if stop == nil {
+		stop = signalStop
+	}
+	s.forgetDeparted(live)
+	var closed []int
+	for _, doomed := range Surplus(live, s.self, max) {
+		if since, waiting := s.awaitingExit(doomed); waiting {
+			// Signalling again here would be fatal rather than graceful (see
+			// signalGrace), and this peer is still inside its exit path.
+			slog.Debug("older hap TUI is still exiting", "pid", doomed.Pid, "asked_ago", since)
+			continue
+		}
+		if s.done() {
+			// Released while this sweep was reading the registry.
+			return closed, nil
+		}
+		if err := stop(doomed.Pid); err != nil {
+			// A peer we cannot signal is left alone; the next sweep retries.
+			slog.Warn("could not close an older hap TUI", "pid", doomed.Pid, "error", err)
+			continue
+		}
+		s.markSignalled(doomed)
+		slog.Info("asked an older hap TUI to close, to stay within the instance limit",
+			"pid", doomed.Pid, "max_instances", max)
+		closed = append(closed, doomed.Pid)
+	}
+	return closed, nil
+}
+
+// clock is the time source the grace period is measured on.
+func (s *Session) clock() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+// awaitingExit reports whether this peer was already asked to exit recently,
+// and how long ago.
+func (s *Session) awaitingExit(peer Info) (time.Duration, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	at, ok := s.signalled[keyOf(peer)]
+	if !ok {
+		return 0, false
+	}
+	since := s.clock().Sub(at)
+	return since, since < signalGrace
+}
+
+func (s *Session) markSignalled(peer Info) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.signalled == nil {
+		s.signalled = map[signalKey]time.Time{}
+	}
+	s.signalled[keyOf(peer)] = s.clock()
+}
+
+// forgetDeparted drops bookkeeping for sessions that are gone AND out of their
+// grace, so the map cannot grow across a long-lived TUI's many peers.
+//
+// Absence alone is not enough to forget one. Live skips a record it cannot
+// probe or parse — fd exhaustion, a mid-write file — which is exactly the state
+// a struggling TUI is in, and forgetting it there would let the next sweep
+// re-signal it inside its exit path. The grace bounds the map either way.
+func (s *Session) forgetDeparted(live []Info) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.signalled) == 0 {
+		return
+	}
+	present := make(map[signalKey]bool, len(live))
+	for _, i := range live {
+		present[keyOf(i)] = true
+	}
+	now := s.clock()
+	for k, at := range s.signalled {
+		if !present[k] && now.Sub(at) >= signalGrace {
+			delete(s.signalled, k)
+		}
+	}
+}
+
+// foreign reports whether peer's pid belongs to a different process space than
+// self's. Only a KNOWN mismatch counts: an unknown identity on either side
+// degrades to trusting the pid, which is what every previous build did.
+func foreign(peer, self Info) bool {
+	return peer.Identity != "" && self.Identity != "" && peer.Identity != self.Identity
+}
+
+// Live lists the sessions currently holding their lock, oldest first, and
+// prunes the records of processes that are gone.
+func Live(dir string) ([]Info, error) {
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read the TUI session registry %s: %w", dir, err)
+	}
+	var out []Info
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasPrefix(name, filePrefix) || !strings.HasSuffix(name, fileSuffix) {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		locked, err := held(path)
+		if err != nil {
+			// Unreadable: treat it as none of our business rather than
+			// guessing a pid to signal.
+			continue
+		}
+		if !locked {
+			_ = os.Remove(path)
+			continue
+		}
+		info, err := read(path)
+		if err != nil || info.Pid <= 1 {
+			// Live but not yet parseable (registration writes its lines after
+			// taking the lock). Skipping it means this sweep neither counts nor
+			// closes it; the next one will.
+			continue
+		}
+		// The lock proves a live holder for this FILE; the pid comes from the
+		// file's contents. Requiring the two to agree is what ties the two
+		// facts together — otherwise a corrupt or hand-edited record could aim
+		// a signal at any pid in the operator's session.
+		if named, ok := pidFromName(name); !ok || named != info.Pid {
+			continue
+		}
+		info.Path = path
+		out = append(out, info)
+	}
+	slices.SortFunc(out, byAge)
+	return out, nil
+}
+
+// pidFromName reads the pid a registry file name claims.
+func pidFromName(name string) (int, bool) {
+	digits := strings.TrimSuffix(strings.TrimPrefix(name, filePrefix), fileSuffix)
+	pid, err := strconv.Atoi(digits)
+	return pid, err == nil
+}
+
+// byAge orders sessions oldest-first, with the pid as a tie-break so the order
+// is total (two sessions can share a timestamp on a coarse clock). It is the
+// same comparison older() makes, and the two must stay in step: Surplus takes a
+// prefix of this order and then re-checks each entry against self with older().
+func byAge(a, b Info) int {
+	if !a.Started.Equal(b.Started) {
+		return a.Started.Compare(b.Started)
+	}
+	return cmp.Compare(a.Pid, b.Pid)
+}
+
+// Surplus picks the sessions self should close so that at most max remain. It
+// returns them oldest first, and never includes self or a session newer than
+// self.
+func Surplus(live []Info, self Info, max int) []Info {
+	if max <= 0 {
+		return nil
+	}
+	ordered := slices.Clone(live)
+	if !slices.ContainsFunc(ordered, func(i Info) bool { return i.Pid == self.Pid }) {
+		// Our own record was missed (mid-write, or an unreadable file). Count
+		// ourselves anyway: the limit is about how many TUIs the operator has
+		// open, and we are one of them.
+		ordered = append(ordered, self)
+		slices.SortFunc(ordered, byAge)
+	}
+	surplus := len(ordered) - max
+	if surplus <= 0 {
+		return nil
+	}
+	var out []Info
+	for _, c := range ordered[:surplus] {
+		if c.Pid == self.Pid || c.Pid <= 1 {
+			continue
+		}
+		if !older(c, self) {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// older reports whether a registered before b, with the pid as a tie-break so
+// the ordering is total (two sessions can share a timestamp on a coarse clock).
+func older(a, b Info) bool {
+	if !a.Started.Equal(b.Started) {
+		return a.Started.Before(b.Started)
+	}
+	return a.Pid < b.Pid
+}
+
+// write records the holder: pid, the registration time as Unix nanoseconds,
+// and the process space that pid means something in.
+func write(f *os.File, self Info) error {
+	if err := f.Truncate(0); err != nil {
+		return fmt.Errorf("truncate session file: %w", err)
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		return fmt.Errorf("rewind session file: %w", err)
+	}
+	if _, err := fmt.Fprintf(f, "%d\n%d\n%s\n", self.Pid, self.Started.UnixNano(), self.Identity); err != nil {
+		return fmt.Errorf("write session file: %w", err)
+	}
+	return f.Sync()
+}
+
+// read parses a session file. A short or malformed file is an error, which
+// callers treat as "skip this record for now". A missing identity line is not
+// malformed — it reads as unknown, and foreign() then trusts the pid.
+func read(path string) (Info, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Info{}, err
+	}
+	lines := strings.SplitN(string(data), "\n", 4)
+	if len(lines) < 2 {
+		return Info{}, fmt.Errorf("session file %s is incomplete", path)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(lines[0]))
+	if err != nil {
+		return Info{}, fmt.Errorf("session file %s has no pid: %w", path, err)
+	}
+	nanos, err := strconv.ParseInt(strings.TrimSpace(lines[1]), 10, 64)
+	if err != nil {
+		return Info{}, fmt.Errorf("session file %s has no start time: %w", path, err)
+	}
+	info := Info{Pid: pid, Started: time.Unix(0, nanos), Path: path}
+	if len(lines) > 2 {
+		info.Identity = strings.TrimSpace(lines[2])
+	}
+	return info, nil
+}
+
+// stillLinked reports whether path still names the file we hold open.
+func stillLinked(f *os.File, path string) bool {
+	held, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	linked, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(held, linked)
+}

--- a/internal/tuisession/tuisession_test.go
+++ b/internal/tuisession/tuisession_test.go
@@ -1,0 +1,717 @@
+package tuisession
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// fakePid returns a pid that is certainly not this process's, so a fabricated
+// peer can never collide with the session Register claims for us.
+func fakePid(n int) int { return os.Getpid()*100 + n }
+
+// peer fabricates another TUI's registry entry and holds its lock for the rest
+// of the test, so Live sees it as live exactly the way a real peer is seen (the
+// lock is per open file, so our own process holding it still reads as taken).
+func peer(t *testing.T, dir string, pid int, started time.Time) Info {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir registry: %v", err)
+	}
+	path := filepath.Join(dir, filePrefix+strconv.Itoa(pid)+fileSuffix)
+	info := Info{Pid: pid, Started: started, Identity: processIdentity(), Path: path}
+	f, err := claim(path)
+	if err != nil {
+		t.Fatalf("claim peer %d: %v", pid, err)
+	}
+	if err := write(f, info); err != nil {
+		t.Fatalf("write peer %d: %v", pid, err)
+	}
+	t.Cleanup(func() { release(f) })
+	return info
+}
+
+// A registered session is visible to peers, and its record disappears again on
+// Release — otherwise a closed TUI would keep counting against the limit.
+func TestRegisterIsVisibleThenReleased(t *testing.T) {
+	state := t.TempDir()
+	s, err := Register(state)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	live, err := Live(Dir(state))
+	if err != nil {
+		t.Fatalf("Live: %v", err)
+	}
+	if len(live) != 1 || live[0].Pid != os.Getpid() {
+		t.Fatalf("want one live session for pid %d, got %+v", os.Getpid(), live)
+	}
+	if s.Self().Pid != os.Getpid() {
+		t.Errorf("Self() pid = %d, want %d", s.Self().Pid, os.Getpid())
+	}
+	s.Release()
+	if live, err = Live(Dir(state)); err != nil || len(live) != 0 {
+		t.Fatalf("after Release want no live sessions, got %+v (err %v)", live, err)
+	}
+}
+
+// Register survives a peer's prune sweep unlinking the file between our open
+// and our lock: the retry re-creates it, so the session is never invisible.
+func TestRegisterRetriesWhenItsFileIsPruned(t *testing.T) {
+	state := t.TempDir()
+	s, err := Register(state)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer s.Release()
+	// Simulate the lost race by removing the file behind our back, then
+	// confirm a fresh Register (same pid) still ends up visible.
+	if err := os.Remove(s.Self().Path); err != nil {
+		t.Fatalf("remove session file: %v", err)
+	}
+	if live, _ := Live(Dir(state)); len(live) != 0 {
+		t.Fatalf("an unlinked record should not be listed, got %+v", live)
+	}
+	s.Release()
+	s2, err := Register(state)
+	if err != nil {
+		t.Fatalf("re-Register: %v", err)
+	}
+	defer s2.Release()
+	if live, _ := Live(Dir(state)); len(live) != 1 {
+		t.Fatalf("want the re-registered session listed, got %+v", live)
+	}
+}
+
+// A record whose process is gone (its lock is free) is pruned, never counted
+// and never signalled — that is what keeps a recycled pid safe.
+func TestLivePrunesRecordsWithoutAHolder(t *testing.T) {
+	dir := Dir(t.TempDir())
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(dir, filePrefix+"424242"+fileSuffix)
+	if err := os.WriteFile(stale, []byte("424242\n"+strconv.FormatInt(time.Now().UnixNano(), 10)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	live, err := Live(dir)
+	if err != nil {
+		t.Fatalf("Live: %v", err)
+	}
+	if len(live) != 0 {
+		t.Fatalf("a dead record must not be live, got %+v", live)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("dead record should have been pruned, stat err = %v", err)
+	}
+}
+
+// A live record that is not yet parseable (registration writes after locking)
+// is skipped rather than guessed at.
+func TestLiveSkipsAnUnparseableRecord(t *testing.T) {
+	dir := Dir(t.TempDir())
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, filePrefix+"777"+fileSuffix)
+	f, err := claim(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release(f)
+	live, err := Live(dir)
+	if err != nil {
+		t.Fatalf("Live: %v", err)
+	}
+	if len(live) != 0 {
+		t.Fatalf("an empty (mid-write) record must be skipped, got %+v", live)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("a LOCKED record must never be pruned: %v", err)
+	}
+}
+
+// Live orders sessions oldest-first, which is the order Enforce closes them in.
+func TestLiveOrdersOldestFirst(t *testing.T) {
+	dir := Dir(t.TempDir())
+	base := time.Now()
+	first, second, third := fakePid(1), fakePid(2), fakePid(3)
+	peer(t, dir, third, base.Add(2*time.Second))
+	peer(t, dir, first, base)
+	peer(t, dir, second, base.Add(time.Second))
+	live, err := Live(dir)
+	if err != nil {
+		t.Fatalf("Live: %v", err)
+	}
+	got := make([]int, 0, len(live))
+	for _, i := range live {
+		got = append(got, i.Pid)
+	}
+	if want := []int{first, second, third}; !slices.Equal(got, want) {
+		t.Fatalf("Live order = %v, want %v", got, want)
+	}
+}
+
+// Enforce closes the oldest peers so that exactly max remain, and reports the
+// pids it signalled.
+func TestEnforceClosesTheOldestPeers(t *testing.T) {
+	state := t.TempDir()
+	dir := Dir(state)
+	base := time.Now()
+	oldest, middle := fakePid(1), fakePid(2)
+	peer(t, dir, oldest, base.Add(-3*time.Minute))
+	peer(t, dir, middle, base.Add(-2*time.Minute))
+	s, err := Register(state)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer s.Release()
+	var signalled []int
+	s.stop = func(pid int) error { signalled = append(signalled, pid); return nil }
+
+	closed, err := s.Enforce(1)
+	if err != nil {
+		t.Fatalf("Enforce: %v", err)
+	}
+	if want := []int{oldest, middle}; !slices.Equal(closed, want) || !slices.Equal(signalled, want) {
+		t.Fatalf("closed = %v, signalled = %v, want %v for both", closed, signalled, want)
+	}
+}
+
+// Only the NEWEST session signals. With three TUIs live, a middle one that also
+// enforced would send the oldest a second SIGTERM from a second process — and
+// the grace is per-process, so it could not know. `cmd/hap` releases its signal
+// handler after the first signal, so that second one kills the oldest where it
+// stands, with no terminal restore and no store close.
+func TestEnforceOnlyTheNewestSessionSignals(t *testing.T) {
+	state := t.TempDir()
+	dir := Dir(state)
+	base := time.Now()
+	oldest := fakePid(1)
+	// self is the MIDDLE session: one peer older, one newer.
+	peer(t, dir, oldest, base.Add(-3*time.Minute))
+	s, err := Register(state)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer s.Release()
+	newest := peer(t, dir, fakePid(3), s.Self().Started.Add(time.Second))
+	s.stop = func(pid int) error {
+		t.Fatalf("a middle session signalled pid %d; only the newest may", pid)
+		return nil
+	}
+	closed, err := s.Enforce(1)
+	if err != nil {
+		t.Fatalf("Enforce: %v", err)
+	}
+	if len(closed) != 0 {
+		t.Fatalf("closed = %v, want nothing while a newer TUI is live", closed)
+	}
+	_ = newest
+}
+
+// The newest one does the work — for every surplus session, in one sweep.
+func TestEnforceNewestClosesEveryOlderSession(t *testing.T) {
+	state := t.TempDir()
+	dir := Dir(state)
+	base := time.Now()
+	first, second := fakePid(1), fakePid(2)
+	peer(t, dir, first, base.Add(-3*time.Minute))
+	peer(t, dir, second, base.Add(-2*time.Minute))
+	s, err := Register(state) // registers now, so it is the newest
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer s.Release()
+	var signalled []int
+	s.stop = func(pid int) error { signalled = append(signalled, pid); return nil }
+	if _, err := s.Enforce(1); err != nil {
+		t.Fatalf("Enforce: %v", err)
+	}
+	if want := []int{first, second}; !slices.Equal(signalled, want) {
+		t.Fatalf("signalled = %v, want %v", signalled, want)
+	}
+}
+
+// A released session never signals: its own exit path can still run a refresh,
+// and closing a peer on the way out would leave the operator with no TUI.
+func TestReleasedSessionStopsEnforcing(t *testing.T) {
+	state := t.TempDir()
+	dir := Dir(state)
+	peer(t, dir, fakePid(1), time.Now().Add(-time.Minute))
+	s, err := Register(state)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	s.stop = func(pid int) error {
+		t.Fatalf("a released session signalled pid %d", pid)
+		return nil
+	}
+	s.Release()
+	closed, err := s.Enforce(1)
+	if err != nil {
+		t.Fatalf("Enforce after Release: %v", err)
+	}
+	if len(closed) != 0 {
+		t.Fatalf("closed = %v after Release, want nothing", closed)
+	}
+}
+
+// A record whose contents disagree with its file name is not a session we can
+// reason about — the lock proves a holder for the FILE, the pid comes from the
+// contents, and only their agreement ties the two together.
+func TestLiveSkipsARecordWhosePidDisagreesWithItsName(t *testing.T) {
+	dir := Dir(t.TempDir())
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, filePrefix+"4242"+fileSuffix)
+	f, err := claim(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release(f)
+	// Live and locked, but pointing at somebody else's pid.
+	if err := write(f, Info{Pid: 9999, Started: time.Now(), Identity: processIdentity()}); err != nil {
+		t.Fatal(err)
+	}
+	live, err := Live(dir)
+	if err != nil {
+		t.Fatalf("Live: %v", err)
+	}
+	if len(live) != 0 {
+		t.Fatalf("live = %+v, want the mismatched record skipped", live)
+	}
+}
+
+// Registering is best-effort: an unusable state dir must return an error (so
+// cmd/hap logs and runs without the limit), never panic or half-succeed.
+func TestRegisterFailsCleanlyOnAnUnusableStateDir(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s, err := Register(filepath.Join(blocker, "state"))
+	if err == nil {
+		s.Release()
+		t.Fatal("want an error when the registry cannot be created")
+	}
+	if s != nil {
+		t.Errorf("want a nil session alongside the error, got %+v", s)
+	}
+}
+
+// With room to spare — or with the limit turned off — Enforce closes nothing.
+func TestEnforceLeavesSessionsWithinTheLimit(t *testing.T) {
+	state := t.TempDir()
+	dir := Dir(state)
+	base := time.Now()
+	peer(t, dir, fakePid(1), base.Add(-time.Minute))
+	s, err := Register(state)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer s.Release()
+	for _, max := range []int{2, 5, 0, -1} {
+		var signalled []int
+		s.stop = func(pid int) error { signalled = append(signalled, pid); return nil }
+		closed, err := s.Enforce(max)
+		if err != nil {
+			t.Fatalf("Enforce(%d): %v", max, err)
+		}
+		if len(closed) != 0 || len(signalled) != 0 {
+			t.Errorf("Enforce(%d) closed %v (signalled %v), want nothing", max, closed, signalled)
+		}
+	}
+}
+
+// A peer we cannot signal is left alone and reported as not closed, so the
+// next sweep tries again instead of pretending the limit is satisfied.
+func TestEnforceSkipsAPeerItCannotSignal(t *testing.T) {
+	state := t.TempDir()
+	dir := Dir(state)
+	base := time.Now()
+	unsignallable, ordinary := fakePid(1), fakePid(2)
+	peer(t, dir, unsignallable, base.Add(-3*time.Minute))
+	peer(t, dir, ordinary, base.Add(-2*time.Minute))
+	s, err := Register(state)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer s.Release()
+	s.stop = func(pid int) error {
+		if pid == unsignallable {
+			return os.ErrPermission
+		}
+		return nil
+	}
+	closed, err := s.Enforce(1)
+	if err != nil {
+		t.Fatalf("Enforce: %v", err)
+	}
+	if want := []int{ordinary}; !slices.Equal(closed, want) {
+		t.Fatalf("closed = %v, want %v (%d could not be signalled)", closed, want, unsignallable)
+	}
+}
+
+// The sweep runs every 10s, but a TUI asked to close needs longer to unwind
+// (its drain is bounded at 15s) and `cmd/hap` releases its signal handler after
+// the FIRST signal — so a second SIGTERM inside that window would kill it where
+// it stands, with no terminal restore and no store close. A peer
+// already asked to exit must therefore be left alone until the grace expires.
+func TestEnforceDoesNotResignalAPeerThatIsStillExiting(t *testing.T) {
+	state := t.TempDir()
+	dir := Dir(state)
+	base := time.Now()
+	old := fakePid(1)
+	peer(t, dir, old, base.Add(-3*time.Minute))
+	s, err := Register(state)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer s.Release()
+	now := base
+	s.now = func() time.Time { return now }
+	var signalled []int
+	s.stop = func(pid int) error { signalled = append(signalled, pid); return nil }
+
+	if closed, err := s.Enforce(1); err != nil || len(closed) != 1 {
+		t.Fatalf("first sweep closed %v (err %v), want the one older peer", closed, err)
+	}
+	// The peer is still holding its lock — it is unwinding, not ignoring us.
+	now = now.Add(30 * time.Second)
+	closed, err := s.Enforce(1)
+	if err != nil {
+		t.Fatalf("second sweep: %v", err)
+	}
+	if len(closed) != 0 {
+		t.Errorf("second sweep re-signalled %v inside the grace period", closed)
+	}
+	if len(signalled) != 1 {
+		t.Fatalf("stop called %d times, want 1 inside the grace period", len(signalled))
+	}
+
+	// Past the grace it has plainly ignored SIGTERM; asking again is the
+	// right escalation.
+	now = now.Add(signalGrace)
+	if closed, err = s.Enforce(1); err != nil || len(closed) != 1 {
+		t.Fatalf("sweep after the grace closed %v (err %v), want the peer signalled again", closed, err)
+	}
+	if len(signalled) != 2 {
+		t.Errorf("stop called %d times, want 2 once the grace expired", len(signalled))
+	}
+}
+
+// A peer that exits is forgotten once its grace has run out, so the
+// bookkeeping cannot leak. It is NOT forgotten the moment it stops being
+// listed: a sweep that merely failed to read it would otherwise re-signal it
+// mid-exit, which is the very thing the grace prevents.
+func TestEnforceForgetsAPeerThatIsGone(t *testing.T) {
+	state := t.TempDir()
+	dir := Dir(state)
+	base := time.Now()
+	path := filepath.Join(dir, filePrefix+strconv.Itoa(fakePid(1))+fileSuffix)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	f, err := claim(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := write(f, Info{Pid: fakePid(1), Started: base.Add(-time.Minute), Identity: processIdentity()}); err != nil {
+		t.Fatal(err)
+	}
+	s, err := Register(state)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer s.Release()
+	now := base
+	s.now = func() time.Time { return now }
+	s.stop = func(int) error { return nil }
+	if closed, _ := s.Enforce(1); len(closed) != 1 {
+		t.Fatalf("first sweep closed %v, want the older peer", closed)
+	}
+	if got := s.trackedForTest(); got != 1 {
+		t.Fatalf("tracking %d signalled peers, want 1", got)
+	}
+	release(f) // the peer exited
+	now = now.Add(signalGrace / 2)
+	if closed, _ := s.Enforce(1); len(closed) != 0 {
+		t.Fatalf("sweep after the peer exited closed %v, want nothing", closed)
+	}
+	if got := s.trackedForTest(); got != 1 {
+		t.Errorf("tracking %d peers inside the grace, want the entry kept (it may only be unreadable)", got)
+	}
+	now = now.Add(signalGrace)
+	if _, err := s.Enforce(1); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.trackedForTest(); got != 0 {
+		t.Errorf("tracking %d signalled peers once the grace expired, want 0", got)
+	}
+}
+
+// A peer that a single sweep cannot see — an unreadable or mid-write record —
+// keeps its grace, so the sweep after it must not deliver a second, fatal
+// SIGTERM into the peer's exit path.
+func TestEnforceKeepsTheGraceAcrossASweepThatMissesThePeer(t *testing.T) {
+	state := t.TempDir()
+	dir := Dir(state)
+	base := time.Now()
+	old := peer(t, dir, fakePid(1), base.Add(-time.Minute))
+	s, err := Register(state)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer s.Release()
+	now := base
+	s.now = func() time.Time { return now }
+	var signalled []int
+	s.stop = func(pid int) error { signalled = append(signalled, pid); return nil }
+
+	if closed, _ := s.Enforce(1); len(closed) != 1 {
+		t.Fatalf("first sweep closed %v, want the older peer", closed)
+	}
+	// One sweep cannot read the peer's record (fd exhaustion, mid-write)...
+	s.list = func(dir string) ([]Info, error) {
+		live, err := Live(dir)
+		return slices.DeleteFunc(live, func(i Info) bool { return i.Pid == old.Pid }), err
+	}
+	now = now.Add(15 * time.Second)
+	if _, err := s.Enforce(1); err != nil {
+		t.Fatal(err)
+	}
+	// ...and the next one sees it again, still inside its grace.
+	s.list = nil
+	now = now.Add(15 * time.Second)
+	if closed, _ := s.Enforce(1); len(closed) != 0 {
+		t.Fatalf("re-signalled %v after a sweep that merely missed it", closed)
+	}
+	if len(signalled) != 1 {
+		t.Fatalf("stop called %d times, want 1 — the grace must survive an unreadable sweep", len(signalled))
+	}
+}
+
+// With the limit off the sweep still prunes: an unlimited registry must not
+// accumulate a record per uncleanly-exited TUI forever.
+func TestEnforceWithNoLimitStillPrunes(t *testing.T) {
+	state := t.TempDir()
+	dir := Dir(state)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(dir, filePrefix+strconv.Itoa(fakePid(9))+fileSuffix)
+	if err := os.WriteFile(stale, []byte("1\n2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s, err := Register(state)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer s.Release()
+	s.stop = func(int) error { t.Fatal("nothing may be signalled with the limit off"); return nil }
+	if _, err := s.Enforce(0); err != nil {
+		t.Fatalf("Enforce(0): %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("a dead record survived a no-limit sweep, stat err = %v", err)
+	}
+}
+
+// A peer from another pid space (a container sharing this state dir with its
+// host) is neither counted nor signalled: its pid names a different process
+// here, and signalling it would hit an unrelated one.
+func TestEnforceIgnoresAPeerFromAnotherProcessSpace(t *testing.T) {
+	state := t.TempDir()
+	dir := Dir(state)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, filePrefix+strconv.Itoa(fakePid(1))+fileSuffix)
+	f, err := claim(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release(f)
+	if err := write(f, Info{Pid: fakePid(1), Started: time.Now().Add(-time.Hour), Identity: "some-other-host pid:[1]"}); err != nil {
+		t.Fatal(err)
+	}
+	s, err := Register(state)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer s.Release()
+	// A local older peer alongside it: with max=1 the foreign one must not
+	// even be COUNTED, or this local peer would be the only surplus and the
+	// distinction would be invisible.
+	local := peer(t, dir, fakePid(2), time.Now().Add(-time.Minute))
+	var signalled []int
+	s.stop = func(pid int) error {
+		if pid == fakePid(1) {
+			t.Fatalf("signalled a foreign pid %d", pid)
+		}
+		signalled = append(signalled, pid)
+		return nil
+	}
+	closed, err := s.Enforce(2) // room for self + one peer
+	if err != nil {
+		t.Fatalf("Enforce: %v", err)
+	}
+	if len(closed) != 0 || len(signalled) != 0 {
+		t.Fatalf("closed = %v, want nothing: the foreign session must not count toward the limit", closed)
+	}
+	if closed, err = s.Enforce(1); err != nil {
+		t.Fatalf("Enforce: %v", err)
+	}
+	if want := []int{local.Pid}; !slices.Equal(closed, want) {
+		t.Fatalf("closed = %v, want %v (only the local peer)", closed, want)
+	}
+}
+
+// foreign() only fires on a KNOWN mismatch: an unknown identity on either side
+// must degrade to trusting the pid, not to disabling the limit.
+func TestForeignNeedsBothIdentities(t *testing.T) {
+	self := Info{Pid: 2, Identity: "host-a ns1"}
+	tests := []struct {
+		name string
+		peer Info
+		want bool
+	}{
+		{"same space", Info{Pid: 1, Identity: "host-a ns1"}, false},
+		{"different space", Info{Pid: 1, Identity: "host-b ns2"}, true},
+		{"peer unknown", Info{Pid: 1}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := foreign(tc.peer, self); got != tc.want {
+				t.Errorf("foreign = %v, want %v", got, tc.want)
+			}
+			if got := foreign(tc.peer, Info{Pid: 2}); got {
+				t.Error("an unknown identity on OUR side must never make a peer foreign")
+			}
+		})
+	}
+}
+
+// A registered session records an identity, so the guard above has something
+// to compare in production.
+func TestRegisterRecordsAProcessIdentity(t *testing.T) {
+	s, err := Register(t.TempDir())
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer s.Release()
+	if s.Self().Identity == "" {
+		t.Skip("this platform reports no hostname or pid namespace")
+	}
+	live, err := Live(s.dir)
+	if err != nil || len(live) != 1 {
+		t.Fatalf("Live = %v (err %v), want our own session", live, err)
+	}
+	if live[0].Identity != s.Self().Identity {
+		t.Errorf("identity round-trip: read %q, wrote %q", live[0].Identity, s.Self().Identity)
+	}
+}
+
+// Claiming clears the record immediately, so a reused pid can never be read
+// with its dead predecessor's start time — which would make the NEWEST TUI
+// look like the oldest and get itself closed.
+func TestClaimClearsAStaleRecordBeforeItCanBeRead(t *testing.T) {
+	dir := Dir(t.TempDir())
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, filePrefix+"4242"+fileSuffix)
+	// A dead session's record, left behind by an unclean exit.
+	if err := os.WriteFile(path, []byte("4242\n1\nold-identity\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := claim(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release(f)
+	if _, err := read(path); err == nil {
+		t.Error("a freshly claimed record still parsed — the predecessor's bytes are readable")
+	}
+}
+
+// trackedForTest reports how many peers the grace bookkeeping remembers.
+func (s *Session) trackedForTest() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.signalled)
+}
+
+// A nil session is inert, so a TUI that could not register never panics.
+func TestNilSessionIsInert(t *testing.T) {
+	var s *Session
+	s.Release()
+	if got := s.Self(); got != (Info{}) {
+		t.Errorf("Self() on nil = %+v, want zero", got)
+	}
+	closed, err := s.Enforce(1)
+	if err != nil || closed != nil {
+		t.Errorf("Enforce on nil = (%v, %v), want (nil, nil)", closed, err)
+	}
+}
+
+// Surplus is the whole policy: newest wins, never self, never a newer peer.
+func TestSurplus(t *testing.T) {
+	base := time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC)
+	at := func(sec int, pid int) Info {
+		return Info{Pid: pid, Started: base.Add(time.Duration(sec) * time.Second)}
+	}
+	a, b, c := at(0, 11), at(1, 12), at(2, 13)
+
+	tests := []struct {
+		name string
+		live []Info
+		self Info
+		max  int
+		want []int
+	}{
+		{"newest closes both older", []Info{a, b, c}, c, 1, []int{11, 12}},
+		{"middle closes only the older one", []Info{a, b, c}, b, 1, []int{11}},
+		{"oldest closes nobody — a newer peer will close it", []Info{a, b, c}, a, 1, nil},
+		{"a higher limit keeps more", []Info{a, b, c}, c, 2, []int{11}},
+		{"limit off", []Info{a, b, c}, c, 0, nil},
+		{"negative limit off", []Info{a, b, c}, c, -3, nil},
+		{"alone", []Info{a}, a, 1, nil},
+		{"self missing from the registry still counts itself",
+			[]Info{a, b}, Info{Pid: 99, Started: base.Add(3 * time.Second)}, 1, []int{11, 12}},
+		{"same timestamp: the lower pid is the older one",
+			[]Info{{Pid: 7, Started: base}, {Pid: 9, Started: base}}, Info{Pid: 9, Started: base}, 1, []int{7}},
+		{"pid 1 and below are never signalled",
+			[]Info{{Pid: 1, Started: base}, c}, c, 1, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := make([]int, 0, len(tc.want))
+			for _, i := range Surplus(tc.live, tc.self, tc.max) {
+				got = append(got, i.Pid)
+			}
+			if len(got) == 0 {
+				got = nil
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("Surplus = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The registry survives a state dir that has never held one.
+func TestLiveOnMissingRegistry(t *testing.T) {
+	live, err := Live(Dir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("Live on a missing registry must not error: %v", err)
+	}
+	if len(live) != 0 {
+		t.Fatalf("got %+v, want none", live)
+	}
+}

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -291,6 +291,12 @@ herdr_notification = true  # raise a herdr desktop notification on those same tw
 disable_check_for_update = false  # turn off the periodic GitHub release check — the
                            # plugin's only outbound call; the header flags a newer
                            # release, install it with `hap update`
+max_instances = 1          # how many `hap tui` processes may run at once. Each one
+                           # re-polls the whole state every 2s and shells out to
+                           # herdr per agent, so forgotten TUI panes cost real CPU
+                           # while only one is ever read. Starting a TUI closes the
+                           # OLDEST ones past this limit (SIGTERM — the same clean
+                           # exit as closing the pane). 0 = no limit
 
 # Optional per-role color overrides layered on the selected theme; unset
 # roles inherit the theme. Values are terminal colors ("205", "#ff5faf").


### PR DESCRIPTION
## Why

Every `hap tui` re-reads the whole state on a 2s tick and shells out to herdr for each agent's pane. Instances left open in other tabs keep doing that for a view nobody is reading — a handful is enough to keep a core busy.

## What

Starting a TUI now closes the older ones, keeping only the newest `[tui] max_instances`.

```sh
hap config set tui.max_instances 2   # keep two
hap config set tui.max_instances 0   # no limit (previous behavior)
```

Default is **1**, and it applies to configs that never mention the key (`Load` starts from `Default()`, and `fillZeroes` deliberately leaves this field alone so an explicit `0` still means "no limit"). A lowered limit takes effect within 10s without restarting anything. The instance that swept reports it: `asked 2 older TUIs to close (pid 4242, 4243) — tui.max_instances=1`.

## How it stays safe

- **Liveness is proved by an advisory file lock**, not a pid probe. A session holds an exclusive flock on its record for its whole run, so a record whose lock is free belongs to a dead process and is pruned rather than signalled — a recycled pid can never be mistaken for a TUI (the guarantee `daemonlock` already relies on). `Live` also requires a record's pid to match its `session-<pid>.lock` file name, so the lock and the pid cannot come apart.
- **Only the newest session signals, and only peers older than itself.** The second half keeps two TUIs starting at the same moment from closing each other; the first makes signalling single-writer, so with three TUIs a middle session and the newest can't both SIGTERM the oldest.
- **A peer already asked to close is left alone for 60s.** `cmd/hap` releases its signal handler on the first signal so a wedged process stays killable — which means a second SIGTERM inside the exit path kills the TUI where it stands, with no terminal restore and no store close. Past the grace it has plainly ignored the request and asking again is the right escalation.
- **Closing is the ordinary "pane closed" exit** (SIGTERM → cancelled context → bubbletea teardown), so the victim restores the terminal and closes its store.
- **A peer from another pid space is neither counted nor signalled** — a state dir reached from two pid namespaces (a container and its host sharing a bind-mounted home) is the one case where flock says "live" while the pid names someone else. Identity is hostname + pid namespace; unknown on either side degrades to trusting the pid.
- **Fails open throughout.** An unreadable registry, a failed registration, or an unsignallable peer leaves every TUI running. The limit is a performance guard, never a reason for a TUI to fail.

One bound is deliberately left open and documented in the package comment: a record is created, locked, and only then written, so for the microseconds in between three simultaneously-starting TUIs could send one duplicate SIGTERM. Closing it would mean treating any unreadable record as "possibly newer" and standing down, which would let a single corrupt file disable the limit for good.

## Testing

- **40 test functions** across `internal/tuisession`, `internal/frontend`, `internal/tui`, `internal/config` — including the invariants: only the newest signals, the grace survives a sweep that couldn't read a peer, a released session stops enforcing, a pid/name mismatch is skipped, and `0` vs an absent key.
- **Race-clean** (`go test -race ./internal/tuisession/ ./internal/frontend/`).
- **Live-verified against real TUIs** (two and three at once): exactly one survives, every victim exits with code 0 — a clean unwind, signalled once each — stale records are pruned, and `max_instances = 0` disables it.
- `golangci-lint run --build-tags "vectors,cpu"`: 0 issues.

Note: `TestClientRealModel` / `TestEmbedTextRealModel` can fail locally on a loaded machine — they assert a fixed 2s stall guard around real llama.cpp inference. `internal/embedder` imports only `config` and `selfpath`, so nothing here reaches them; they pass on an idle box.

## Notes

- No manifest bump — patch work, so `herdr-plugin.toml` stays at `0.5.13` and auto-release handles it.
- Changelog is under `## 0.5.15`, leaving `0.5.14` for the PR already in review.
- Closing a plugin pane's process does not restart it (herdr respawns a *shell* when a launch command exits), so two TUI panes cannot oscillate by re-closing each other.
