### PR TITLE
#1 fix: keep sudo when only part of the native install prefix is writable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,33 @@ env:
   GO_BUILD_TAGS: vectors cpu
 
 jobs:
+  # gofmt is pure text: it neither builds nor typechecks, so it needs no
+  # submodules, no CGO toolchain and no native libraries. Split out of the lint
+  # job so a formatting mistake is reported in seconds instead of waiting on
+  # (and being maskable by) a ~2min FAISS/llama build.
+  format:
+    name: Format (gofmt)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: gofmt
+        run: |
+          out=$(gofmt -l . | grep -v '^submodule/' || true)
+          if [ -n "$out" ]; then
+            echo "gofmt violations:" && echo "$out" && exit 1
+          fi
+
+  # go vet and golangci-lint DO need the native build: both typecheck the cgo
+  # packages, and the FAISS headers they need (${PREFIX}/include/faiss) are put
+  # there by setup-native.sh. Dropping the build tags to avoid it would stop
+  # linting engine_cpu.go, knn_vectors.go and the rest of the tag-gated files —
+  # the CGO code most worth linting.
   lint:
-    name: Lint (gofmt, go vet, golangci-lint)
+    name: Lint (go vet, golangci-lint)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,12 +68,6 @@ jobs:
           key: native-lint-${{ runner.os }}-${{ env.ImageOS }}-${{ hashFiles('scripts/setup-native.sh') }}-${{ steps.subsha.outputs.sha }}
       - name: Build native dependencies
         run: bash scripts/setup-native.sh
-      - name: gofmt
-        run: |
-          out=$(gofmt -l . | grep -v '^submodule/' || true)
-          if [ -n "$out" ]; then
-            echo "gofmt violations:" && echo "$out" && exit 1
-          fi
       - name: go vet
         run: go vet -tags "${GO_BUILD_TAGS}" ./...
       - name: golangci-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ section in `CLAUDE.md`. Entries go under the version that will carry them: mergi
 to main auto-releases the next patch, so a PR adds its lines under that number
 (or under the minor/major version it bumps the manifest to).
 
+## 0.5.16
+
+- Fixed `scripts/setup-native.sh` dropping `sudo` when only part of the install prefix was writable, which failed the build with `Permission denied` on `apt-get` and on `/usr/local/include/faiss`. It now keeps `sudo` unless BOTH `lib` and `include` are writable, and always uses it for the package manager, which needs real root regardless
+- Changed CI to check formatting in its own job, so a `gofmt` slip is reported in seconds rather than behind a two-minute native build
+
 ## 0.5.14
 
 - Changed the daemon to raise its herdr notifications over the socket API instead of the `herdr notification show` CLI, so it now learns whether a toast was actually displayed. The CLI exits 0 even when herdr paints nothing, which meant an escalation could be dropped — notifications turned off, rate limited, no foreground client — with the daemon assuming the operator had been told

--- a/scripts/setup-native.sh
+++ b/scripts/setup-native.sh
@@ -26,8 +26,26 @@ CACHE="${HAP_NATIVE_CACHE:-${REPO_ROOT}/.cache/native}"
 PREFIX="${HAP_NATIVE_PREFIX:-/usr/local}"
 JOBS="${HAP_NATIVE_JOBS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)}"
 
+# Two different privilege questions, and conflating them broke CI.
+#
+# SUDO covers writing into ${PREFIX}. Dropping it needs BOTH install targets
+# writable, not just lib: this script writes ${PREFIX}/lib AND
+# ${PREFIX}/include/faiss, and GitHub's ubuntu runner image is exactly the
+# shape that tells them apart — /usr/local/lib is writable by the runner user
+# while /usr/local/include is not. Probing lib alone blanked SUDO and the run
+# then died at `mkdir ${PREFIX}/include/faiss: Permission denied`.
 SUDO="sudo"
-if [ -w "${PREFIX}/lib" ] || [ "$(id -u)" = "0" ]; then SUDO=""; fi
+if [ "$(id -u)" = "0" ]; then
+  SUDO=""
+elif [ -w "${PREFIX}/lib" ] && [ -w "${PREFIX}/include" ]; then
+  SUDO=""
+fi
+
+# APT_SUDO covers the package manager, which always needs real root no matter
+# who owns ${PREFIX}. Reusing SUDO here meant a writable prefix silently ran
+# `apt-get update` unprivileged, failing on /var/lib/apt/lists/lock.
+APT_SUDO=""
+if [ "$(id -u)" != "0" ]; then APT_SUDO="sudo"; fi
 
 OS="$(uname -s)"
 case "$OS" in
@@ -42,14 +60,14 @@ FAISS_CMAKE_ENV=()
 if [ "$OS" = "Linux" ]; then
   if ! ldconfig -p 2>/dev/null | grep -q libopenblas && command -v apt-get >/dev/null 2>&1; then
     echo "==> installing libopenblas-dev (FAISS BLAS backend)"
-    $SUDO apt-get update -qq && $SUDO apt-get install -y -qq libopenblas-dev
+    $APT_SUDO apt-get update -qq && $APT_SUDO apt-get install -y -qq libopenblas-dev
   fi
   # Both builds below shell out to cmake; without this the script dies ~100
   # lines later with a bare "cmake: command not found" and no hint that a
   # prerequisite is missing.
   if ! command -v cmake >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
     echo "==> installing cmake (llama.cpp + FAISS build driver)"
-    $SUDO apt-get update -qq && $SUDO apt-get install -y -qq cmake
+    $APT_SUDO apt-get update -qq && $APT_SUDO apt-get install -y -qq cmake
   fi
 elif [ "$OS" = "Darwin" ]; then
   command -v brew >/dev/null 2>&1 || { echo "Homebrew is required on macOS (for LLVM/OpenMP)" >&2; exit 1; }


### PR DESCRIPTION
## The failure

The Lint job on #283 died in **Build native dependencies**, before it ever reached golangci-lint:

```
==> installing libopenblas-dev (FAISS BLAS backend)
E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
...
==> install FAISS shared libraries to /usr/local/lib
mkdir: cannot create directory '/usr/local/include/faiss': Permission denied
```

## Why it is a real bug and not a flake

`scripts/setup-native.sh` decided it could skip `sudo` by probing **one** directory:

```sh
SUDO="sudo"
if [ -w "${PREFIX}/lib" ] || [ "$(id -u)" = "0" ]; then SUDO=""; fi
```

But the script also writes `${PREFIX}/include/faiss` (line 148) and shells out to `apt-get`, which needs real root no matter who owns the prefix.

A retry passed, which looks like a flake — it isn't. The two attempts landed on **different runner images**:

| Attempt | Image | `/usr/local/lib` | Result |
|---|---|---|---|
| 1 | `ubuntu24/`**`20260726`**`.254` | writable → `SUDO=""` | apt + mkdir denied |
| 2 (retry) | `ubuntu24/`**`20260720`**`.247` | not writable → `SUDO="sudo"` | passed |

GitHub is mid-rollout of `20260726`, which made `/usr/local/lib` writable by the runner user while leaving `/usr/local/include` root-only. The retry passed only because it drew the older image. Once the rollout completes this fails **every** time.

## Fix

- `SUDO` is dropped only when **both** `lib` and `include` are writable (or we are root) — so a partially-writable prefix keeps `sudo` instead of failing halfway through the install.
- `APT_SUDO` is now separate and always `sudo` unless already root, because the package manager's privileges have nothing to do with who owns `${PREFIX}`.

Verified as a genuine non-root user across all three shapes (`setpriv`, since `-w` is always true for root):

| prefix state | before | after |
|---|---|---|
| lib writable, include not (the runner) | `SUDO=""` → **fails** | `SUDO="sudo"` |
| both writable (devcontainer / custom `HAP_NATIVE_PREFIX`) | `SUDO=""` | `SUDO=""` (optimization kept) |
| root | `SUDO=""` | `SUDO=""` |

## Also: gofmt no longer waits on a native build

Answering "does lint really need the native build?" — **partly**. `go vet` and `golangci-lint` do: both typecheck the cgo packages, and the FAISS headers they need are installed by this very script. Dropping the build tags to avoid it would stop linting `engine_cpu.go`, `knn_vectors.go` and the other tag-gated files — the CGO code most worth linting.

`gofmt` needs none of it. It is pure text: no submodules, no CGO, no native libraries. It is now its own job that reports a formatting slip in seconds instead of behind a ~2min FAISS/llama build (and instead of being masked when that build fails, which is exactly what happened here).

## Note

The changelog heading guesses **0.5.16** (0.5.15 is taken by another PR), assuming #283 (which opens 0.5.14) merges first. If this lands first, the heading needs renumbering.