### PR TITLE
#1 feat: write changelog entries as fragments instead of editing CHANGELOG.md

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -105,6 +105,15 @@ jobs:
             local CUR; CUR=$(version)
             git checkout -B "${BRANCH}" origin/main
             sed -i "s/^version = \"${CUR}\"/version = \"${NEXT}\"/" herdr-plugin.toml
+            # Fold this release's changelog fragments into CHANGELOG.md in the
+            # SAME commit as the manifest bump. This is the only moment the
+            # version is a fact rather than a guess, which is exactly why
+            # contributors no longer write one: they drop a file in
+            # changelog.d/ and two PRs can never collide on it.
+            # `git commit -a` below picks up the modified CHANGELOG.md; the
+            # script git-rm's the fragments itself, so the deletions are
+            # already staged.
+            bash scripts/assemble-changelog.sh "${NEXT}"
             git commit -am "${TITLE}"
             git push --force origin "HEAD:${BRANCH}"
             local PR
@@ -166,6 +175,31 @@ jobs:
 
           grep -q "^version = \"${RELEASE}\"" herdr-plugin.toml || {
             echo "::error::manifest does not carry ${RELEASE} at tag time"; exit 1; }
+          # Changelog fragments should be folded into CHANGELOG.md by now: the
+          # patch path does it inside bump(), the manual minor/major path does
+          # it in the feature PR.
+          #
+          # This WARNS and continues; it must never fail the run. A release
+          # that stops here after bump() merged would leave main carrying a
+          # version with no tag and no release — precisely the state the
+          # manifest invariant forbids, breaking `herdr plugin install` for
+          # everyone, and it does not self-heal: every queued run would hit the
+          # same guard, and manual recovery is blocked because the script
+          # refuses a version whose section already exists. Path B is no safer:
+          # its manifest already names the untagged RELEASE before this runs,
+          # so refusing to tag strands it identically.
+          #
+          # Leftovers are also NORMAL on the patch path: a feature PR merging
+          # during bump()'s PR round-trip lands its fragment after assembly.
+          # Those simply roll into the next patch. Gate on the real failure —
+          # this release having no section at all — so the warning means
+          # something when it appears.
+          LEFTOVER=$(find changelog.d -maxdepth 1 -name '*.md' ! -name 'README.md' -type f 2>/dev/null | LC_ALL=C sort || true)
+          if [ -n "${LEFTOVER}" ] && ! grep -qE "^## ${RELEASE//./\\.}\$" CHANGELOG.md; then
+            echo "::warning::releasing ${RELEASE} with no CHANGELOG.md section; these fragments were never assembled:"
+            echo "${LEFTOVER}"
+            echo "::warning::run 'bash scripts/assemble-changelog.sh <next-version>' in a follow-up PR — they will roll into the next release"
+          fi
           # Never tag a commit whose message carries a GitHub skip-ci
           # keyword: the tag push onto it would be suppressed and the
           # release would silently not build (no failed run to re-run).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,77 @@ jobs:
           go test ./internal/domain/ -run 'TestSeedNeverAutoCatchesCorpus$' -v -count=1 | tee /tmp/corpus-gate.out
           grep -q -- '--- PASS: TestSeedNeverAutoCatchesCorpus' /tmp/corpus-gate.out \
             || { echo '::error::corpus gate did not execute TestSeedNeverAutoCatchesCorpus (test renamed?)'; exit 1; }
+
+  changelog-fragment:
+    name: Changelog fragment present
+    # Only PRs: a push to main is a merge whose fragment already landed, and
+    # the release path deletes fragments, so requiring one there would fail
+    # every bump commit.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The merge-base comparison below needs both branches' history.
+          fetch-depth: 0
+      - name: A code change needs an entry in changelog.d/
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          CHANGED=$(git diff --name-only "${BASE}...${HEAD}")
+          # The release automation's own bump PR assembles fragments away.
+          if git log -1 --format=%s "${HEAD}" | grep -q '\[skip release\]'; then
+            echo "release bump PR; fragment not required"; exit 0
+          fi
+
+          # A PR may legitimately write a CHANGELOG.md section itself, but ONLY
+          # on the manual minor/major path — where it hand-writes the version
+          # into herdr-plugin.toml and runs assemble-changelog.sh, because no
+          # bump commit is ever created to assemble into. That path adds AND
+          # deletes its fragment within the branch, so the file is net-zero in
+          # the diff and the fragment check below would fail the one PR shape
+          # that did everything right.
+          #
+          # The manifest is what tells that apart from the OLD hand-edited
+          # style this change replaces: a legitimate assembly's section always
+          # matches the version the PR is shipping. Anything else is someone
+          # editing CHANGELOG.md by hand, which must be rejected — on merge it
+          # would make the release script abort ("section already exists") with
+          # no tag produced.
+          MANIFEST=$(sed -n 's/^version = "\(.*\)"/\1/p' herdr-plugin.toml)
+          SECTIONS=$(git diff "${BASE}...${HEAD}" -- CHANGELOG.md \
+            | grep -E '^\+## [0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^+## //' || true)
+          if [ -n "${SECTIONS}" ]; then
+            for v in ${SECTIONS}; do
+              if [ "${v}" != "${MANIFEST}" ]; then
+                echo "::error::CHANGELOG.md gained a '## ${v}' section, but herdr-plugin.toml says ${MANIFEST}."
+                echo "::error::Do not write changelog sections by hand — add changelog.d/<your-branch>.md instead (see changelog.d/README.md)."
+                echo "::error::Only a minor/major PR may assemble its own section, and then the manifest must carry exactly that version."
+                exit 1
+              fi
+            done
+            echo "PR assembles its own '## ${MANIFEST}' section (manual minor/major path); fragment not required"
+            exit 0
+          fi
+
+          # Doc/workflow-only changes do not release (see auto-release.yml),
+          # so they need no entry. Anything else does.
+          NEEDS=$(echo "${CHANGED}" | grep -vE '^(docs/|\.github/|changelog\.d/|.*\.md$)' || true)
+          if [ -z "${NEEDS}" ]; then
+            echo "no releasing changes; fragment not required"; exit 0
+          fi
+          # ADDED files only: a PR that DELETES someone else's fragment, or
+          # edits one, must not satisfy its own requirement. -x anchors the
+          # README exclusion so a file merely containing that name cannot pass.
+          ADDED=$(git diff --name-only --diff-filter=A "${BASE}...${HEAD}" \
+            | grep -E '^changelog\.d/.+\.md$' | grep -vx 'changelog\.d/README\.md' || true)
+          if [ -n "${ADDED}" ]; then
+            echo "changelog fragment(s) present:"; echo "${ADDED}"; exit 0
+          fi
+          echo "::error::This PR changes code that will be released, but adds no changelog fragment."
+          echo "::error::Add changelog.d/<your-branch>.md with your entry — see changelog.d/README.md."
+          echo "Changed files needing an entry:"
+          echo "${NEEDS}"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
 Every change gets a line here, including patch releases — see the Changelog
-section in `CLAUDE.md`. Entries go under the version that will carry them: merging
-to main auto-releases the next patch, so a PR adds its lines under that number
-(or under the minor/major version it bumps the manifest to).
+section in `CLAUDE.md`.
+
+**This file is assembled, not edited.** Contributors add a fragment in
+`changelog.d/` (one file per PR, so two PRs can never conflict); the release
+automation folds those into a new section here under the version it actually
+assigns. Do not add a heading or an entry by hand.
 
 ## 0.5.15
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,26 +108,35 @@ ticket/issue id**. Examples:
 
 ## Changelog (MANDATORY)
 
-**Every change gets an entry in `CHANGELOG.md` at the repo root — including
-patch releases.** No exceptions for "small", "internal", or "just a fix": if it
-merges, it is in the changelog. A PR without one is incomplete.
+**Every change gets an entry — including patch releases.** No exceptions for
+"small", "internal", or "just a fix": if it merges, it is in the changelog. A PR
+without one is incomplete. Entries are written as **fragments in
+`changelog.d/`**, never into `CHANGELOG.md` directly.
 
-- **Never use an `Unreleased` heading.** Merging to main auto-releases, so the
-  version a PR ships in is knowable at write time — write that number as the
-  heading, in the same commit as the change:
-  1. Read `CHANGELOG.md` on the latest **remote** `main`
-     (`git fetch origin main && git show origin/main:CHANGELOG.md | head -20`) —
-     not your branch, which may be behind. The topmost `## X.Y.Z` is the latest
-     entry.
-  2. If that version is already released (`git tag -l vX.Y.Z` finds it, i.e. it
-     matches `version` in `herdr-plugin.toml`), your section is the **next patch**:
-     `## X.Y.(Z+1)`. If it is NOT yet released, another unmerged PR already opened
-     that section — add your lines to it instead of starting a new one.
-  3. Exception: when the user explicitly asks for a minor/major bump, the version
-     is not a guess — you overwrite `version` in `herdr-plugin.toml` inside the PR
-     (see *Version bump & release*), so use exactly that number as the heading.
-- The guess can be wrong if a race merges another PR first; that is fine and
-  self-correcting — fix the heading in a follow-up rather than reverting.
+- **Never edit `CHANGELOG.md` by hand, and never write a version number.** Add a
+  fragment instead — a new file nobody else's PR can touch:
+
+  ```sh
+  cat > changelog.d/$(git branch --show-current | tr / -).md <<'EOF'
+  - Fixed the thing that used to happen
+  EOF
+  ```
+
+  Just the bullets, no heading. `changelog.d/README.md` has the full format.
+- **Why:** every PR used to insert its section at the top of one shared file, so
+  two open PRs always conflicted on the same lines even when the changes were
+  unrelated — and each had to GUESS its version, which is only knowable when the
+  release is cut. Fragments make the conflict structurally impossible and delete
+  the guess.
+- On merge, the auto-release workflow runs `scripts/assemble-changelog.sh
+  <version>`, folding every fragment into `CHANGELOG.md` under the real version
+  and deleting them — inside the same commit that bumps `herdr-plugin.toml`.
+  A CI job fails any PR that changes releasing code without a fragment.
+- **Minor/major is the manual exception**: you hand-write the version into
+  `herdr-plugin.toml` inside your PR (see *Version bump & release*), and no bump
+  commit is ever created to assemble into — so run
+  `bash scripts/assemble-changelog.sh X.Y.0` in that same PR and commit the
+  result. The release refuses to tag while unassembled fragments remain.
 - Style: a flat list of verb-first one-liners — `Added …`, `Fixed …`,
   `Changed …`, `Removed …`. No sub-sections.
 - Write what it MEANS for the reader, not what the diff did. GitHub already

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,56 @@
+# changelog.d — one fragment per PR
+
+Every change gets a changelog entry (see `CLAUDE.md`). Instead of editing
+`CHANGELOG.md` directly, **add a new file here**:
+
+```
+changelog.d/<your-branch-name>.md
+```
+
+Name it after your branch (or anything unique to your PR). The name never
+appears in the output — it exists only so two PRs can never touch the same
+file.
+
+## What goes in it
+
+Just the bullets, no version heading — the version is added when the release
+is cut:
+
+```markdown
+- Fixed the daemon assuming an escalation reached you when herdr had silently
+  dropped the toast
+- Added `notified=` to the `escalated` log line, so the log can say whether
+  anyone was actually interrupted
+```
+
+Style is unchanged from `CHANGELOG.md`: a flat list of verb-first one-liners
+(`Added …`, `Fixed …`, `Changed …`, `Removed …`), no sub-sections. Write what
+it MEANS for the reader, not what the diff did — GitHub already generates a
+list of PR titles per release; this file is for what a title cannot carry.
+Mark a breaking change **Breaking.** at the start of its line.
+
+## Why not just edit CHANGELOG.md
+
+Because every PR inserted its section at the same place — the top of one
+shared file — so two open PRs always conflicted on the same lines even when
+the changes were unrelated. Worse, each PR had to *guess* its version number,
+which is only knowable when the release is actually cut.
+
+One file per PR makes the conflict structurally impossible, and nobody writes
+a version number at all.
+
+## What happens to it
+
+On merge to main, the auto-release workflow computes the next version, runs
+`scripts/assemble-changelog.sh <version>`, which folds every fragment here
+into `CHANGELOG.md` under a `## <version>` heading and deletes them — all
+inside the same commit that bumps `herdr-plugin.toml`.
+
+Fragments are concatenated in filename order. If two entries need a specific
+order relative to each other, put them in one fragment.
+
+**Minor/major releases are the manual exception**: you already hand-write the
+version into `herdr-plugin.toml` inside your PR, so run
+`bash scripts/assemble-changelog.sh X.Y.0` in that same PR and commit the
+result. The workflow tags your merge commit directly and never opens a bump
+commit to assemble into.

--- a/changelog.d/changelog-fragments.md
+++ b/changelog.d/changelog-fragments.md
@@ -1,0 +1,4 @@
+- Changed how changelog entries are written: add a fragment in `changelog.d/` instead of editing `CHANGELOG.md`. One file per PR means two open PRs can no longer conflict on the same lines, which they did on every parallel change
+- Removed the need to guess a version number. Contributors write no version at all — the release automation folds the fragments into `CHANGELOG.md` under the version it actually assigns, which is the only moment that number is a fact
+- Added a CI check that fails a PR changing releasing code without a fragment, so the mandatory-changelog rule is enforced rather than remembered
+- Added a release guard that refuses to tag while unassembled fragments remain, which catches the manual minor/major path forgetting to run `scripts/assemble-changelog.sh`

--- a/scripts/assemble-changelog.sh
+++ b/scripts/assemble-changelog.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Fold the changelog fragments in changelog.d/ into CHANGELOG.md under a
+# version heading, then delete them.
+#
+# Why fragments exist: every PR used to insert its section at the TOP of one
+# shared CHANGELOG.md, so two PRs always collided on the same lines even when
+# the changes were unrelated — and each had to GUESS its version number,
+# because the real one is only known when the release is cut. One file per PR
+# makes the conflict structurally impossible, and this script supplies the
+# version at the only moment it is a fact rather than a guess.
+#
+# Usage: scripts/assemble-changelog.sh <version>          # e.g. 0.5.16
+#
+# Idempotent-ish: run it once per release. With no fragments it leaves
+# CHANGELOG.md untouched and exits 0, so a release with nothing to say (a
+# docs-only merge) never fails the pipeline.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VERSION="${1:-}"
+if [ -z "${VERSION}" ]; then
+  echo "usage: $0 <version>   (e.g. $0 0.5.16)" >&2
+  exit 2
+fi
+if ! printf '%s' "${VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "::error::version must be X.Y.Z, got '${VERSION}'" >&2
+  exit 2
+fi
+
+FRAGMENT_DIR="changelog.d"
+CHANGELOG="CHANGELOG.md"
+
+# README.md documents the directory itself and is never a fragment.
+#
+# A read loop, not `mapfile`: that is a bash 4.0 builtin and macOS still ships
+# bash 3.2, where `#!/usr/bin/env bash` resolves to it — and CONTRIBUTORS run
+# this by hand on the minor/major path (see CLAUDE.md), not just CI. The
+# explicit `FRAGMENTS=()` also keeps `${#FRAGMENTS[@]}` legal under `set -u` on
+# 3.2. LC_ALL=C pins the sort so fragment order cannot differ between a
+# contributor's locale and the runner's.
+FRAGMENTS=()
+while IFS= read -r f; do
+  FRAGMENTS+=("${f}")
+done < <(
+  find "${FRAGMENT_DIR}" -maxdepth 1 -name '*.md' ! -name 'README.md' -type f 2>/dev/null | LC_ALL=C sort
+)
+
+if [ "${#FRAGMENTS[@]}" -eq 0 ]; then
+  echo "no changelog fragments in ${FRAGMENT_DIR}/; leaving ${CHANGELOG} unchanged"
+  exit 0
+fi
+
+if grep -qE "^## ${VERSION//./\\.}\$" "${CHANGELOG}"; then
+  echo "::error::${CHANGELOG} already has a '## ${VERSION}' section" >&2
+  exit 1
+fi
+
+echo "==> assembling ${#FRAGMENTS[@]} fragment(s) into ${CHANGELOG} as ${VERSION}"
+
+SECTION="$(mktemp)"
+trap 'rm -f "${SECTION}" "${SECTION}.new"' EXIT
+{
+  printf '## %s\n\n' "${VERSION}"
+  for f in "${FRAGMENTS[@]}"; do
+    echo "    + ${f}" >&2
+    # Strip leading/trailing blank lines so fragment files can be written
+    # with or without a trailing newline without changing the output.
+    sed -e '/./,$!d' "${f}" | sed -e ':a' -e '/^\n*$/{$d;N;ba' -e '}'
+  done
+  printf '\n'
+} >"${SECTION}"
+
+# Insert immediately before the FIRST existing version heading, which keeps
+# the file's explanatory preamble on top and the releases reverse-chronological.
+# A CHANGELOG with no '## ' heading yet gets the section appended.
+awk -v section_file="${SECTION}" '
+  BEGIN { inserted = 0 }
+  /^## / && !inserted {
+    while ((getline line < section_file) > 0) print line
+    close(section_file)
+    inserted = 1
+  }
+  { print }
+  END {
+    if (!inserted) {
+      while ((getline line < section_file) > 0) print line
+      close(section_file)
+    }
+  }
+' "${CHANGELOG}" >"${SECTION}.new"
+
+mv "${SECTION}.new" "${CHANGELOG}"
+
+# Post-condition before anything is deleted. awk's `getline < file` returns -1
+# (not 0) when the file cannot be read, so a failed read skips the insert loop,
+# still sets inserted=1, and exits 0 — the CHANGELOG would come through
+# unchanged and we would then git rm every fragment, losing the entries from
+# both places. Prove the section landed instead of trusting the exit status.
+grep -qE "^## ${VERSION//./\\.}\$" "${CHANGELOG}" || {
+  echo "::error::assembly produced no '## ${VERSION}' section; refusing to delete fragments" >&2
+  exit 1
+}
+
+# git rm when the fragments are tracked (the release path), plain rm otherwise
+# (a local dry run on files not yet committed).
+#
+# -f is required, not cosmetic: plain `git rm` REFUSES a file whose staged
+# content differs from HEAD, which is every freshly-added fragment. Without it
+# the script dies here having ALREADY rewritten CHANGELOG.md — a half-applied
+# state with the entry duplicated in both places. We are deleting the file on
+# purpose, so any staged state is irrelevant.
+for f in "${FRAGMENTS[@]}"; do
+  if git ls-files --error-unmatch "${f}" >/dev/null 2>&1; then
+    git rm -q -f "${f}"
+  else
+    rm -f "${f}"
+  fi
+done
+
+echo "==> ${CHANGELOG} now carries ${VERSION}; fragments removed"


### PR DESCRIPTION
## The problem

Every PR inserted its entry at the **top of one shared `CHANGELOG.md`**, so two open PRs always conflicted on the same lines even when the changes were completely unrelated. Right now every open PR in this repo is reporting a conflict on that file.

It was worse than a merge conflict: each PR also had to **guess its version number**, which is only knowable when the release is actually cut. In one session we hit this three times — wrote `0.5.14`, another PR took it; moved to `0.5.15`, taken; landed on `0.5.16`. A conflict at every step, and a merge that silently blocked CI (GitHub can't build a merge ref for a conflicting PR, so it creates **no run at all** — which reads as "CI is broken").

## The fix

A PR adds a fragment — a file nobody else's PR can touch:

```
changelog.d/my-branch.md
```

Containing only bullets, **no version heading**:

```markdown
- Fixed the thing that used to happen
```

Two PRs can never touch the same file, so the conflict becomes *structurally impossible* rather than merely rarer. And nobody writes a version number: it's assigned once, by the automation, at the only moment it's a fact.

| File | Role |
|---|---|
| `scripts/assemble-changelog.sh` | folds fragments into a `## <version>` section, then deletes them |
| `auto-release.yml` | calls it inside `bump()`, in the same commit as the manifest bump |
| `ci.yml` | new `changelog-fragment` job |
| `CLAUDE.md`, `changelog.d/README.md` | the ~15 lines of version-guessing ritual are gone |

## Why the release path is safe

The two release paths differ, and only one has a commit to assemble into:

- **Patch (default)** — `bump()` creates `release/bump-vNEXT`. Assembly happens there, so `git commit -am` captures both the rewritten `CHANGELOG.md` and the script's staged deletions.
- **Manual minor/major** — hand-writes the version into `herdr-plugin.toml` and tags HEAD directly; **no bump commit exists**. That path runs the script in its own PR, as documented.

**The pre-tag check warns and never fails.** This is deliberate and load-bearing. Failing there after `bump()` had already merged would leave main carrying a version with **no tag and no release** — exactly the state the manifest invariant forbids, which 404s `herdr plugin install` for everyone. It also would not self-heal: every queued run hits the same guard, and manual recovery is blocked because the script refuses a version whose section already exists.

Leftover fragments are *normal* on the patch path too — a feature PR merging during `bump()`'s PR round-trip lands its fragment after assembly. Those roll into the next patch, which is correct.

## Verified, not just written

Running the actual release path caught a bug in my own script: plain `git rm` **refuses** a file whose staged content differs from HEAD — every freshly-added fragment — and it died having already rewritten `CHANGELOG.md`, leaving the entry in both places. Fixed with `git rm -f`.

Tested end-to-end in a throwaway repo:

| Case | Result |
|---|---|
| two fragments, committed | assembled in `LC_ALL=C` filename order, `README.md` preserved, deletions staged |
| no fragments | untouched, exit 0 (a docs-only release can't fail the pipeline) |
| version already present | exit 1, **fragments preserved** |
| malformed / missing version | exit 2 |
| awk insert silently no-ops | exit 1, **fragments preserved** (see below) |

That last one is a real trap: awk's `getline < file` returns `-1`, not `0`, when a file can't be read — so the loop never runs, awk exits 0, and the CHANGELOG passes through untouched. The script would then have deleted every fragment, losing the entries from *both* places. It now proves the section landed before deleting anything, verified by simulating the failure.

Also: no `mapfile` — a bash 4.0 builtin, and macOS ships 3.2, where contributors run this by hand on the minor/major path.

## Dogfooded

This PR ships `changelog.d/changelog-fragments.md` and touches `CHANGELOG.md` only to rewrite its preamble. If the new CI job is correct it passes; if I got the regex wrong it fails on itself.

## Note

I skipped a `.gitattributes` union-merge stopgap: with fragments, `CHANGELOG.md` is written only by automation, so it would be dead config.