### PR TITLE
#1 fix: stop a BM25 bar test sampling a scoring race

### DIFF
--- a/changelog.d/fix-flaky-bm25-bar-test.md
+++ b/changelog.d/fix-flaky-bm25-bar-test.md
@@ -1,0 +1,1 @@
+- Fixed a test that could fail spuriously on a busy machine, making CI runs fail for reasons unrelated to the change under review.

--- a/internal/daemon/cosinemiss_test.go
+++ b/internal/daemon/cosinemiss_test.go
@@ -571,6 +571,7 @@ func TestResolveSignatureSalientFloorSelectsWhichBM25BarApplies(t *testing.T) {
 
 			seedIdleRules(t, d, 24) // measure in the production regime
 			learned := d.resolveSignature(ctx, cfg, storedSig, storedSit)
+			compactMatchIndex(t, d)
 			got := d.resolveSignature(ctx, cfg, swappedSig, swappedSit)
 
 			merged := got.Signature == learned.Signature
@@ -661,5 +662,45 @@ func TestBM25BarSelection(t *testing.T) {
 					tc.cosineMissed, got, tc.want)
 			}
 		})
+	}
+}
+
+// compactMatchIndex rebuilds the match index from the store in ONE batch,
+// making BM25 scores reproducible for a test that asserts which side of a
+// threshold a pair lands on.
+//
+// Why it is needed: MatchText normalizes a hit by a SECOND search
+// (match.textCandidates -> textSelfScore) that is not snapshot-consistent with
+// the first. Seeding through resolveSignature grows the index by repeated
+// matcher.Add, which leaves many small scorch segments, and a background merge
+// landing between those two searches inflates the ratio. Measured over 40
+// identical trials on an Add-built index the same pair scored 0.658 in 80% of
+// them and 0.766 / 0.813 / 0.861 / 0.944 / 1.000 in the rest, while a
+// Rebuild-built index returned 0.657887 every time. Under CPU load the
+// inflation crosses bm25_highbar_score and flips a merge verdict, which is what
+// made TestResolveSignatureSalientFloorSelectsWhichBM25BarApplies fail roughly
+// one full-suite run in five.
+//
+// This makes the TEST deterministic; it does not make the underlying scoring
+// stable. A production index is Add-built, so the same inflation is reachable
+// there — which is exactly why a structured salient refused by cosine is closed
+// by a RULE (daemon.bm25RetryAllowed) rather than held to a threshold, and why
+// bm25_highbar_score is a bound on pane-tail drift rather than a guarantee. Do
+// not read a passing test here as evidence that the normalization is sound.
+func compactMatchIndex(t *testing.T, d *Daemon) {
+	t.Helper()
+	rows, err := d.opt.Store.ListSignatureEmbeddings(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dims := 0
+	for _, r := range rows {
+		if r.Dims > 0 {
+			dims = r.Dims
+			break
+		}
+	}
+	if err := d.matcher.Rebuild(rows, dims); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## The problem

`TestResolveSignatureSalientFloorSelectsWhichBM25BarApplies` has been failing roughly one full-suite run in five since #293 merged. It is my test, from that PR, and it has been failing on `main` — not pre-existing background noise.

It asserts that a long pane-tail one-word variant does **not** merge, on the strength of `0.6567` sitting below the `0.70` `bm25_highbar_score`. That margin is **0.043**, well inside the excursions this scorer produces.

## Why it was hard to see

It passes cleanly in isolation. I ran it **40 times alone: zero failures** — which is exactly why it kept getting waved through as "known daemon flakiness" on re-run.

It needs CPU contention, which a full suite supplies. Reproduced deliberately with 8 busy-loops on 4 cores:

```
before fix:  5 failures in 50 runs under load
```

Every failure identical:

```
merged = true, want false (method "bm25", score 0.8082; min 0.35, high 0.70)
```

## Cause

`MatchText` normalizes a hit by dividing it by a **second** search (`textCandidates` → `textSelfScore`, `match.go:416`) that is not snapshot-consistent with the first. Seeding through `resolveSignature` grows the index by repeated `matcher.Add`, leaving many small scorch segments, and a background merge landing between those two searches inflates the ratio.

Measured over 40 identical trials on the same corpus:

| index built by | score distribution |
|---|---|
| `Rebuild` (one batch) | `0.657887` — every single trial |
| `Add` (incremental) | `0.658` in 80%; then `0.766` / `0.813` / `0.861` / `0.944` / **`1.000`** |

## The fix

`compactMatchIndex` rebuilds from the store in one batch before the decisive resolve, so the test measures the threshold semantics it is about rather than segment timing — the same reason the `internal/match` characterization tests build in one batch.

```
after fix:  0 failures in 50 runs under the same load
            0 failures in 75 runs under load (independent verification)
```

## What this does NOT fix — please do not let a green test hide it

This makes the **test** deterministic, not the **scoring**. A production index is `Add`-built (every minted signature calls `matcher.Add`), so the same inflation is reachable in production. Consequences, both recorded in the helper's doc comment so a passing test is not misread as evidence the normalization is sound:

- `bm25_highbar_score` **bounds** pane-tail drift rather than guaranteeing it.
- This is precisely why a structured salient refused by cosine is closed by a **rule** (`daemon.bm25RetryAllowed`) rather than held to a threshold — a threshold cannot be trusted against a score that intermittently reaches a perfect 1.0.

The underlying snapshot-consistency defect in `internal/match` is unfixed and still needs its own issue. This is the second concrete cost it has incurred.

## Scope

Test file plus a changelog fragment. No production code changes.
