### PR TITLE
#1 chore: bump plugin version to 0.5.21 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.5.21
+
+- Fixed a test that could fail spuriously on a busy machine, making CI runs fail for reasons unrelated to the change under review.
+
 ## 0.5.20
 
 - Fixed `embedding.bm25_highbar_score` being invisible to `hap config` and the TUI config screen. It shipped settable in `config.toml` but `hap config set` rejected it as an unknown field, so the only way to change it was editing the file by hand. It is now listed and editable in both.

--- a/changelog.d/fix-flaky-bm25-bar-test.md
+++ b/changelog.d/fix-flaky-bm25-bar-test.md
@@ -1,1 +1,0 @@
-- Fixed a test that could fail spuriously on a busy machine, making CI runs fail for reasons unrelated to the change under review.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.5.20"
+version = "0.5.21"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.5.21 is being released from this commit by the Auto Release workflow.