### PR TITLE
#1 fix: read a reported session id from the full CLI output, not the audit copy

### DIFF
--- a/changelog.d/fix-codex-session-id-untruncated.md
+++ b/changelog.d/fix-codex-session-id-untruncated.md
@@ -1,0 +1,1 @@
+- Fixed the session id being read from the truncated copy of an LLM CLI's output rather than the whole of it. For a CLI that reports its own id (`codex`), enough output before the announcement would push it past the 16 KiB the audit row keeps, and hap would silently record the id it had minted instead — naming a conversation that never existed, with no error to explain it.

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -307,7 +307,8 @@ func (a *Adapter) runConsult(ctx context.Context, spec commandSpec, self string,
 	runErr := cmd.Run()
 	elapsed := time.Since(started)
 
-	captured := truncate(out.String(), 16*1024)
+	raw := out.String()
+	captured := truncate(raw, 16*1024)
 
 	// Regardless of exit status, the authoritative signal is the staged
 	// submission in the DB.
@@ -317,8 +318,15 @@ func (a *Adapter) runConsult(ctx context.Context, spec commandSpec, self string,
 	}
 	// A CLI that mints its own session id reports it in the output we already
 	// captured; that one is authoritative over anything hap passed in.
+	//
+	// Read from the RAW output, not the 16 KiB `captured` copy the audit row
+	// keeps. The banner is early today (codex prints it at startup, and the
+	// truncation keeps the head), but stdout and stderr share this one buffer —
+	// so a CLI that wrote enough before announcing itself would push the banner
+	// past the cap and silently lose the id. Scanning the full string costs
+	// nothing here and removes the whole class.
 	sessionID := req.SessionID
-	if reported := ExtractSessionID(argv[0], captured); reported != "" {
+	if reported := ExtractSessionID(argv[0], raw); reported != "" {
 		sessionID = reported
 	}
 	return &consultAttempt{

--- a/internal/llm/sessionid_exec_test.go
+++ b/internal/llm/sessionid_exec_test.go
@@ -187,3 +187,41 @@ func containsPair(args []string, flag, value string) bool {
 	}
 	return false
 }
+
+// TestConsultReadsCodexSessionBehindBulkyOutput guards the capture against the
+// audit-log truncation.
+//
+// runConsult merges stdout and stderr into ONE buffer and keeps only the first
+// 16 KiB on the audit row. Extraction must read the RAW output instead: a CLI
+// that writes a lot before announcing itself would otherwise push its banner
+// past the cap, and the id would be lost silently — no error, just an empty
+// column that nothing would explain later.
+func TestConsultReadsCodexSessionBehindBulkyOutput(t *testing.T) {
+	st, db := testStore(t)
+	const codexID = "019fc84d-a8b8-77f2-8e20-8ea2c12822f4"
+	// 20 KiB of chatter on stdout, THEN the banner on stderr — well past the
+	// 16 KiB the audit copy keeps.
+	script := writeNamedScript(t, "codex",
+		"awk 'BEGIN{for(i=0;i<400;i++) printf \"%051d\\n\", i}'\n"+
+			"echo \"session id: "+codexID+"\" >&2\n")
+	a := &Adapter{
+		CommandTemplate: []string{script, "exec", "hello"},
+		Timeout:         10 * time.Second,
+		DBPath:          db, Store: st, SelfPath: "/bin/true",
+	}
+	req := domain.LLMRequest{
+		RequestID: "req-bulky", SessionID: "11111111-2222-4333-8444-555555555555",
+		CreatedAt: time.Now(),
+	}
+	if _, err := st.StageLLMRequest(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+
+	_, sessionID, _ := a.ConsultWithSession(context.Background(), req)
+
+	if sessionID != codexID {
+		t.Errorf("session id = %q, want %q — the banner fell outside the "+
+			"16 KiB audit copy and extraction did not read the raw output",
+			sessionID, codexID)
+	}
+}


### PR DESCRIPTION
## 📌 Background

Follow-up to #310 / #313, from live-testing the session-id capture against the **real `codex` CLI** (codex-cli 0.146.0).

Scope is narrow and deliberate: capturing the session id correctly for each LLM invocation and persisting it. Nothing here is about where transcripts live.

## 🔧 Reason for Changes

`runConsult` merges stdout and stderr into a single buffer and keeps the first 16 KiB for the audit row:

```go
raw := out.String()
captured := truncate(raw, 16*1024)   // head, not tail
```

Extraction read `captured`. For a CLI that **reports its own id** rather than accepting one — `codex` — enough output before the announcement pushes the banner past the cap, and hap falls back to the id it minted itself.

That fallback is silently **wrong** for codex: codex ignores anything hap passes and mints its own, so the recorded id names a conversation that never existed. No error, no warning — just a column that cannot be reconciled with anything.

It is not reachable with codex today (it prints its banner at startup, and the truncation keeps the head), but stdout and stderr share one buffer, so the ordering that protects it is incidental rather than guaranteed.

## ✅ Changes Implemented

One line: extract from the raw output rather than the truncated audit copy. The audit row still stores the 16 KiB `captured` copy exactly as before — only the scan changed.

## 🔍 Testing Results

- [x] Unit tests passed — `internal/llm` green.
- [ ] Integration tests passed — not run.
- [x] Manually tested in local/dev environment — real `codex` 0.146.0 driven through the adapter.

**Live verification** (before this fix, on the existing code) that codex capture works at all:

```
task="- do the thing"  sessionID="019fc84f-11a8-70f2-9cff-38be5c0e8fec"  err=<nil>
```

hap passed no `--session-id` (correct — codex has no such flag), and the id it read back beat the one hap had minted.

**New test:** `TestConsultReadsCodexSessionBehindBulkyOutput` puts 20 KiB on stdout before the banner. **Mutation-tested** — restoring the truncated read makes it fail exactly as the bug would:

```
session id = "11111111-2222-4333-8444-555555555555",
        want "019fc84d-a8b8-77f2-8e20-8ea2c12822f4"
```

which is the failure mode itself: hap's own id, silently recorded, for a session codex never had.

`gofmt` / `go vet` clean; **golangci-lint 0 issues**.

## 🚀 Deployment / Migration Details

None. No schema change, no config change, no behaviour change for `claude` (which is passed an id and never reports one).

---

### 📝 Additional Notes

Unrelated, and not touched here — worth its own issue if it bites anyone: codex refuses to start with `Not inside a trusted directory and --skip-git-repo-check was not specified`. hap runs the LLM CLI from `Adapter.WorkDir()`, which resolves to the state directory — never a git repo — so a codex-configured operator likely needs `--skip-git-repo-check` in their `llm.command`.
