### PR TITLE
#1 chore: bump plugin version to 0.5.30 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.5.30
+
+- Fixed the session id being read from the truncated copy of an LLM CLI's output rather than the whole of it. For a CLI that reports its own id (`codex`), enough output before the announcement would push it past the 16 KiB the audit row keeps, and hap would silently record the id it had minted instead — naming a conversation that never existed, with no error to explain it.
+
 ## 0.5.29
 
 - Fixed the LLM session id being recorded only on escalations. A decision the LLM answered and hap delivered — the most common outcome — left its audit row blank, so exactly the rows most worth tracing could not be tied back to the transcript behind them. Every audit row carrying LLM detail now carries the id: delivered actions and no-ops, multi-tab and remote-environment answers, task-list reviews, and the row written when an agent was disabled mid-flight.

--- a/changelog.d/fix-codex-session-id-untruncated.md
+++ b/changelog.d/fix-codex-session-id-untruncated.md
@@ -1,1 +1,0 @@
-- Fixed the session id being read from the truncated copy of an LLM CLI's output rather than the whole of it. For a CLI that reports its own id (`codex`), enough output before the announcement would push it past the 16 KiB the audit row keeps, and hap would silently record the id it had minted instead — naming a conversation that never existed, with no error to explain it.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.5.29"
+version = "0.5.30"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.5.30 is being released from this commit by the Auto Release workflow.