### PR TITLE
#341 fix: hap update checks the live release first and reports the version that actually installed

### DIFF
--- a/changelog.d/fix-hap-update-stale-latest.md
+++ b/changelog.d/fix-hap-update-stale-latest.md
@@ -1,0 +1,2 @@
+- Fixed `hap update` naming a stale version: the "installing …" line now does a live release check first and uses the cached record only when the fetch fails, so a cache written before a release published can no longer misname the target.
+- Changed `hap update`'s closing line to report the version read back from the installed binary itself — including the case where install.sh fell back to an earlier release's assets — with a note to retry when the newest release's assets were not published yet; when nothing can be read back it says "install finished" instead of guessing.

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -88,7 +88,7 @@ func main() {
 		return
 	}
 	if verb == "version" || verb == "--version" || verb == "-V" {
-		fmt.Println("hap (herd-auto-prompter)", buildinfo.Version)
+		fmt.Println(buildinfo.VersionLine())
 		return
 	}
 

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -12,6 +12,14 @@ var Version = "dev"
 // Label renders Version for display (the TUI header).
 func Label() string { return LabelOf(Version) }
 
+// VersionLine is the one-line `hap --version` output. It is a contract, not a
+// convenience: `hap update` executes the NEWLY INSTALLED binary's --version
+// and parses the version out of this exact shape (cli.versionFromOutput, with
+// a round-trip test), so a release that changed the line would silently cost
+// every operator updating to it the "installed vX" report. Keep the version
+// the last whitespace-separated field.
+func VersionLine() string { return "hap (herd-auto-prompter) " + Version }
+
 // LabelOf gives a version string its customary "v" prefix ("0.5.2" → "v0.5.2").
 // A value that is already prefixed, or that is not a release version at all
 // (the "dev" default), is shown verbatim so a local build never reads "vdev".

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -83,9 +84,12 @@ func update(ctx context.Context, app *frontend.App, out io.Writer, args []string
 	}
 	// Name the target up front: the install output is herdr's, not ours, so
 	// without this the operator cannot tell what version they are getting.
+	// "newest known" is a hedge, not sloppiness — the install reads main's
+	// manifest while this line reads GitHub's releases, and for the ~15 minutes
+	// between a bump merge and its release publishing the two disagree.
 	latest := latestKnownVersion(ctx, app)
 	if latest != "" {
-		fmt.Fprintf(out, "installing %s (current: %s)\n", latest, buildinfo.Label())
+		fmt.Fprintf(out, "installing the latest release (newest known: %s, current: %s)\n", latest, buildinfo.Label())
 	} else {
 		fmt.Fprintf(out, "installing the latest release (current: %s)\n", buildinfo.Label())
 	}
@@ -94,13 +98,61 @@ func update(ctx context.Context, app *frontend.App, out io.Writer, args []string
 	if err := updateRunner(ctx, out); err != nil {
 		return err
 	}
-	if latest != "" {
-		fmt.Fprintf(out, "\ninstalled %s\n", latest)
+	// Report what actually landed, not what was expected: install.sh falls
+	// back to the newest release WITH assets when the manifest's version has
+	// not published yet, so the installed binary is the only honest source.
+	installed := installedVersion(ctx)
+	if installed != "" {
+		fmt.Fprintf(out, "\ninstalled %s\n", installed)
+		if updatecheck.IsNewer(installed, latest) {
+			fmt.Fprintf(out, "note: %s exists but its assets were not available yet — run `hap update` again in a few minutes to get it\n", latest)
+		}
 	} else {
 		fmt.Fprintln(out, "\ninstall finished")
 	}
 	printEnsureStep(out)
 	return nil
+}
+
+// installedVersion reads the version back from the binary the install left
+// behind. A var so tests substitute a fake instead of executing anything.
+var installedVersion = readInstalledVersion
+
+// readInstalledVersion runs the newly installed binary's `--version` and
+// parses the release out of it. Every failure returns "" — the caller then
+// says "install finished" rather than naming a version it cannot prove.
+func readInstalledVersion(ctx context.Context) string {
+	// The same structural guarantee as runHerdrInstall: no unit test — in any
+	// package — ever executes whatever binary the host's herdr registry names.
+	if testing.Testing() {
+		return ""
+	}
+	bin := installedBinary()
+	if bin == "" {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	raw, err := exec.CommandContext(ctx, bin, "--version").Output()
+	if err != nil {
+		return ""
+	}
+	return versionFromOutput(string(raw))
+}
+
+// versionFromOutput extracts the release from `hap --version` output
+// ("hap (herd-auto-prompter) v0.6.5"). Only a release version is reported:
+// a dev build's stamp would make "installed dev-…" read as a malfunction.
+func versionFromOutput(s string) string {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return ""
+	}
+	v := fields[len(fields)-1]
+	if !updatecheck.IsRelease(v) {
+		return ""
+	}
+	return buildinfo.LabelOf(v)
 }
 
 // printEnsureStep names the binary that must run `daemon --ensure`.
@@ -132,29 +184,26 @@ func sameAsPathHap(bin string) bool {
 
 // hasFlag reports whether args carry the given flag.
 func hasFlag(args []string, flag string) bool {
-	for _, a := range args {
-		if a == flag {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(args, flag)
 }
 
-// latestKnownVersion resolves the release being installed: the cached check
-// first, then one live check. It is advisory — an unknown version only costs a
-// vaguer message, never the upgrade.
+// latestKnownVersion resolves the newest release GitHub knows of: one live
+// check first, falling back to the cached record only when the fetch fails.
+// The operator asked to update NOW and the install is about to spend minutes
+// downloading, so the 5s fetch is free — while a cached answer can be hours
+// stale and name the release BEFORE the one being installed. It is advisory —
+// an unknown version only costs a vaguer message, never the upgrade.
 func latestKnownVersion(ctx context.Context, app *frontend.App) string {
 	if app == nil {
 		return ""
+	}
+	if status, err := app.CheckForUpdate(ctx); err == nil && updatecheck.IsRelease(status.Latest) {
+		return status.Latest
 	}
 	if app.StateDir != "" {
 		if st, ok := updatecheck.Read(app.StateDir); ok && updatecheck.IsRelease(st.LatestVersion) {
 			return st.LatestVersion
 		}
 	}
-	status, err := app.CheckForUpdate(ctx)
-	if err != nil {
-		return ""
-	}
-	return status.Latest
+	return ""
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -141,15 +141,17 @@ func readInstalledVersion(ctx context.Context) string {
 }
 
 // versionFromOutput extracts the release from `hap --version` output
-// ("hap (herd-auto-prompter) v0.6.5"). Only a release version is reported:
-// a dev build's stamp would make "installed dev-…" read as a malfunction.
+// (buildinfo.VersionLine — the round-trip test pins the two together). Only a
+// dotted release version is reported: a dev build's stamp would make
+// "installed dev-…" read as a malfunction, and IsRelease alone also accepts a
+// bare integer, which any exit-0 diagnostic could legitimately end with.
 func versionFromOutput(s string) string {
 	fields := strings.Fields(s)
 	if len(fields) == 0 {
 		return ""
 	}
 	v := fields[len(fields)-1]
-	if !updatecheck.IsRelease(v) {
+	if !strings.Contains(v, ".") || !updatecheck.IsRelease(v) {
 		return ""
 	}
 	return buildinfo.LabelOf(v)
@@ -192,7 +194,9 @@ func hasFlag(args []string, flag string) bool {
 // The operator asked to update NOW and the install is about to spend minutes
 // downloading, so the 5s fetch is free — while a cached answer can be hours
 // stale and name the release BEFORE the one being installed. It is advisory —
-// an unknown version only costs a vaguer message, never the upgrade.
+// an unknown version only costs a vaguer message, never the upgrade. (Without
+// a state dir CheckForUpdate is a no-op rather than a fetch — there is nowhere
+// to cache into — so a stateless app degrades to the vague message.)
 func latestKnownVersion(ctx context.Context, app *frontend.App) string {
 	if app == nil {
 		return ""

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -376,6 +376,7 @@ func TestVersionFromOutput(t *testing.T) {
 		{"unstamped dev refused", "hap (herd-auto-prompter) dev\n", ""},
 		{"empty output", "", ""},
 		{"garbage refused", "usage: hap <command>", ""},
+		{"trailing bare number refused", "warmed 3", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -383,6 +384,65 @@ func TestVersionFromOutput(t *testing.T) {
 				t.Errorf("versionFromOutput(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestVersionFromOutputRoundTripsVersionLine pins the parse to the line the
+// binary actually prints: `hap update` executes a FUTURE build's --version, so
+// a drifted format would silently cost every operator the "installed vX"
+// report — this is the test that makes such a change fail loudly instead.
+func TestVersionFromOutputRoundTripsVersionLine(t *testing.T) {
+	stampRelease(t, "v0.6.5")
+	if got := versionFromOutput(buildinfo.VersionLine()); got != "v0.6.5" {
+		t.Errorf("versionFromOutput(VersionLine()) = %q, want %q", got, "v0.6.5")
+	}
+}
+
+// TestUpdateNoNoteWhenLatestUnknown guards the note's gate: with no latest
+// version known at all (fetch fails, no cache), a successful read-back must
+// print "installed vX" and no note — the tempting `installed != latest`
+// comparison would emit a malformed note naming an empty version here.
+func TestUpdateNoNoteWhenLatestUnknown(t *testing.T) {
+	stampRelease(t, "v0.6.3")
+	stubRunner(t, nil)
+	stubInstalledVersion(t, "v0.6.4")
+
+	var out bytes.Buffer
+	if err := update(context.Background(), updateTestApp(t, ""), &out, nil); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "installed v0.6.4") {
+		t.Errorf("closing line does not report the read-back version:\n%s", got)
+	}
+	if strings.Contains(got, "note:") {
+		t.Errorf("unknown latest still produced an asset-fallback note:\n%s", got)
+	}
+}
+
+// TestUpdateWithoutStateDirStaysVague pins the stateless edge: CheckForUpdate
+// is a no-op without a state dir to cache into, so even a working fetcher is
+// never consulted and the message degrades to the vague form — same behavior
+// as before the live-first change, now deliberate rather than accidental.
+func TestUpdateWithoutStateDirStaysVague(t *testing.T) {
+	stampRelease(t, "v0.6.4")
+	stubRunner(t, nil)
+	app := &frontend.App{
+		FetchLatestVersion: func(context.Context) (string, error) {
+			return "v0.6.5", nil
+		},
+	}
+
+	var out bytes.Buffer
+	if err := update(context.Background(), app, &out, nil); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "installing the latest release (current: v0.6.4)") {
+		t.Errorf("stateless app did not degrade to the vague message:\n%s", got)
+	}
+	if strings.Contains(got, "newest known:") {
+		t.Errorf("stateless app named a version nothing could have cached:\n%s", got)
 	}
 }
 

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -50,6 +50,26 @@ func updateTestApp(t *testing.T, cached string) *frontend.App {
 	}
 }
 
+// updateTestAppLive is updateTestApp with a WORKING release fetch, for the
+// cases that prove the live check outranks whatever the cache says.
+func updateTestAppLive(t *testing.T, cached, live string) *frontend.App {
+	t.Helper()
+	app := updateTestApp(t, cached)
+	app.FetchLatestVersion = func(context.Context) (string, error) {
+		return live, nil
+	}
+	return app
+}
+
+// stubInstalledVersion swaps the post-install version read-back for a fake, so
+// no test executes whatever binary the host's herdr registry names.
+func stubInstalledVersion(t *testing.T, v string) {
+	t.Helper()
+	orig := installedVersion
+	t.Cleanup(func() { installedVersion = orig })
+	installedVersion = func(context.Context) string { return v }
+}
+
 // stampRelease makes this binary look like a published release, which is what
 // `hap update` requires before it will install anything.
 func stampRelease(t *testing.T, v string) {
@@ -239,6 +259,138 @@ func TestUpdateEnsureStepFallsBackToPlainCommand(t *testing.T) {
 				t.Errorf("expected the plain follow-up command:\n%s", out.String())
 			}
 		})
+	}
+}
+
+// TestUpdateLiveCheckOutranksStaleCache is the fix for the v0.6.4/v0.6.5
+// mismatch: the cached record can predate a release that published minutes
+// ago, so a successful live fetch must name the version — the cache is only
+// the fallback for a fetch that fails.
+func TestUpdateLiveCheckOutranksStaleCache(t *testing.T) {
+	stampRelease(t, "v0.6.4")
+	stubRunner(t, nil)
+	app := updateTestAppLive(t, "v0.6.4", "v0.6.5")
+
+	var out bytes.Buffer
+	if err := update(context.Background(), app, &out, nil); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !strings.Contains(out.String(), "newest known: v0.6.5") {
+		t.Errorf("live check did not outrank the stale cache:\n%s", out.String())
+	}
+	// The successful check also refreshes the record, so the next reader
+	// (the TUI header) stops naming the stale version too.
+	if st, ok := updatecheck.Read(app.StateDir); !ok || st.LatestVersion != "v0.6.5" {
+		t.Errorf("cache not refreshed by the live check: %+v (ok=%v)", st, ok)
+	}
+}
+
+// TestUpdateFallsBackToCacheWhenFetchFails keeps the message useful offline:
+// a dead network costs freshness, never the version hint entirely.
+func TestUpdateFallsBackToCacheWhenFetchFails(t *testing.T) {
+	stampRelease(t, "v0.5.1")
+	stubRunner(t, nil)
+	var out bytes.Buffer
+	// updateTestApp's fetch always errors, so the cache is all there is.
+	if err := update(context.Background(), updateTestApp(t, "v0.5.2"), &out, nil); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !strings.Contains(out.String(), "newest known: v0.5.2") {
+		t.Errorf("failed fetch did not fall back to the cached version:\n%s", out.String())
+	}
+}
+
+// TestUpdateReportsTheVersionThatActuallyInstalled pins the closing line to
+// the installed binary's own report, not to the expectation printed up front.
+func TestUpdateReportsTheVersionThatActuallyInstalled(t *testing.T) {
+	stampRelease(t, "v0.6.4")
+	stubRunner(t, nil)
+	stubInstalledVersion(t, "v0.6.5")
+
+	var out bytes.Buffer
+	if err := update(context.Background(), updateTestAppLive(t, "", "v0.6.5"), &out, nil); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "installed v0.6.5") {
+		t.Errorf("closing line does not report the read-back version:\n%s", got)
+	}
+	if strings.Contains(got, "note:") {
+		t.Errorf("expected no asset-fallback note when installed == latest:\n%s", got)
+	}
+}
+
+// TestUpdateAssetFallbackNamesWhatLanded covers the publish gap: the checkout's
+// manifest names a release whose assets have not published, install.sh falls
+// back to the previous release's binaries, and the closing line must report
+// THAT version — plus a note that the newer one is worth a retry.
+func TestUpdateAssetFallbackNamesWhatLanded(t *testing.T) {
+	stampRelease(t, "v0.6.3")
+	stubRunner(t, nil)
+	stubInstalledVersion(t, "v0.6.4")
+
+	var out bytes.Buffer
+	if err := update(context.Background(), updateTestAppLive(t, "", "v0.6.5"), &out, nil); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "installed v0.6.4") {
+		t.Errorf("closing line does not report what actually landed:\n%s", got)
+	}
+	if !strings.Contains(got, "note: v0.6.5") {
+		t.Errorf("missing the retry note naming the release that was expected:\n%s", got)
+	}
+}
+
+// TestUpdateUnreadableInstalledVersionStaysVague keeps the old honest default:
+// a version that cannot be read back is never guessed at.
+func TestUpdateUnreadableInstalledVersionStaysVague(t *testing.T) {
+	stampRelease(t, "v0.6.4")
+	stubRunner(t, nil)
+	stubInstalledVersion(t, "")
+
+	var out bytes.Buffer
+	if err := update(context.Background(), updateTestAppLive(t, "", "v0.6.5"), &out, nil); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "install finished") {
+		t.Errorf("unreadable version did not fall back to the vague line:\n%s", got)
+	}
+	if strings.Contains(got, "installed v") {
+		t.Errorf("closing line names a version nothing proved:\n%s", got)
+	}
+}
+
+// TestVersionFromOutput pins the parse against the one-line `hap --version`
+// format, and refuses anything that is not a release version.
+func TestVersionFromOutput(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"release build", "hap (herd-auto-prompter) v0.6.5\n", "v0.6.5"},
+		{"bare semver gets the v prefix", "hap (herd-auto-prompter) 0.6.5\n", "v0.6.5"},
+		{"dev build refused", "hap (herd-auto-prompter) dev-20260812042612\n", ""},
+		{"unstamped dev refused", "hap (herd-auto-prompter) dev\n", ""},
+		{"empty output", "", ""},
+		{"garbage refused", "usage: hap <command>", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := versionFromOutput(tc.in); got != tc.want {
+				t.Errorf("versionFromOutput(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReadInstalledVersionRefusesUnderTest is the structural guarantee that no
+// unit test ever executes whatever binary the host's herdr registry names.
+func TestReadInstalledVersionRefusesUnderTest(t *testing.T) {
+	if got := readInstalledVersion(context.Background()); got != "" {
+		t.Errorf("readInstalledVersion under `go test` = %q, want refusal", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #341.

## What

`hap update` printed `installing v0.6.4` while the install underneath fetched v0.6.5 — and its closing line would have claimed `installed v0.6.4`. Two causes, both fixed:

1. **`latestKnownVersion` trusted the cached `update.check.json` unconditionally** (no staleness check; the live fetch ran only when no cache existed). It now runs the live check first — the operator asked to update NOW and is about to spend minutes downloading, so the 5s fetch is free — and falls back to the cache only when the fetch fails. A successful check also refreshes the cache, so the TUI header stops naming the stale version too.
2. **The closing line reported the expectation, not what landed.** It now executes the newly installed binary's `--version` and reports that (guarded by `testing.Testing()` so no unit test ever executes a host binary — same structural pattern as `runHerdrInstall`). When install.sh's asset fallback landed an older release (the ~15-minute bump-then-tag publish gap), the output says so and suggests re-running `hap update`; when nothing can be read back it says "install finished" instead of guessing.

The opening line is hedged as `installing the latest release (newest known: vX, current: vY)` because even a fresh check reads GitHub `releases/latest` while the install reads main's manifest — those disagree by design during the publish gap.

## Details

- `buildinfo.VersionLine()` is now the single definition of the `--version` output, and a round-trip test pins `versionFromOutput` against it, so a future release changing the line fails loudly instead of silently killing the read-back for every operator updating to it.
- `versionFromOutput` requires a dotted version: `IsRelease` alone accepts a bare integer, which any exit-0 diagnostic could end with.
- The retry note is gated on `updatecheck.IsNewer`, and a test pins that an unknown latest produces no note (the tempting `installed != latest` comparison would print a malformed note).
- The stateless edge (`StateDir == ""`) is pinned: `CheckForUpdate` is a no-op without a state dir, so the message degrades to the vague form — same behavior as before, now deliberate.

## Testing

- `go test -tags "vectors cpu" ./... -count=1`: 38/39 packages pass; the one failure is `internal/daemon TestConsultCarriesTheAgentsCwd`, a known pre-existing timing flake (passed 5/5 in isolation; run under load average 14 on 4 cores).
- `internal/cli`, `internal/buildinfo`, `cmd/hap` re-run clean after the review fixes.
- `golangci-lint run --build-tags "vectors,cpu"`: 0 issues; gofmt clean.
- Changelog fragment: `changelog.d/fix-hap-update-stale-latest.md`.

@CharlieHelps please review.