### PR TITLE
#1 chore: bump plugin version to 0.6.7 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.6.7
+
+- Fixed `hap update` naming a stale version: the "installing …" line now does a live release check first and uses the cached record only when the fetch fails, so a cache written before a release published can no longer misname the target.
+- Changed `hap update`'s closing line to report the version read back from the installed binary itself — including the case where install.sh fell back to an earlier release's assets — with a note to retry when the newest release's assets were not published yet; when nothing can be read back it says "install finished" instead of guessing.
+
 ## 0.6.6
 
 - Fixed accepting an LLM-generated task escalation against a `github_gist` task source, which always failed with `422 Validation Failed` and created no task list. hap created the agent's list blank and filled it a moment later; GitHub cannot store a blank gist file at all, and its refusal named neither the list nor the cause. The list is now created with its header, the way every other create-on-demand path already did.

--- a/changelog.d/fix-hap-update-stale-latest.md
+++ b/changelog.d/fix-hap-update-stale-latest.md
@@ -1,2 +1,0 @@
-- Fixed `hap update` naming a stale version: the "installing …" line now does a live release check first and uses the cached record only when the fetch fails, so a cache written before a release published can no longer misname the target.
-- Changed `hap update`'s closing line to report the version read back from the installed binary itself — including the case where install.sh fell back to an earlier release's assets — with a note to retry when the newest release's assets were not published yet; when nothing can be read back it says "install finished" instead of guessing.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.6.6"
+version = "0.6.7"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.6.7 is being released from this commit by the Auto Release workflow.