### PR TITLE
#1 feat: bundle the hap skill doc — print via --skill, install via TUI/CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,11 @@ Prefer these for how-to detail — this file keeps only what must stay in view.
 - **`hap-development-local`** — the local dev loop: link the working tree, rebuild,
   hot-swap the daemon (`hap daemon --ensure`), and live-test against a real agent.
 
+The hap skill also ships inside the binary: `hap --skill` prints it, and
+`hap skill install <claude|codex|agents>...` (or the TUI Config-tab shortcut)
+installs it into `~/.claude/skills/hap/`, `~/.codex/skills/hap/`, or
+`~/.agents/skills/hap/`.
+
 ## Build, test, lint
 
 The semantic matcher links native code (llama.cpp via CGO, FAISS behind bleve's

--- a/changelog.d/feat-skill-flag.md
+++ b/changelog.d/feat-skill-flag.md
@@ -1,2 +1,3 @@
-- Added `hap --skill` (also `hap skill`): prints the bundled hap agent skill document — SKILL.md now ships inside the binary, so no repo checkout is needed to read it.
+- Added `hap --skill` (also `hap skill` / `hap skill show`): prints the bundled hap agent skill document — SKILL.md now ships inside the binary, so no repo checkout is needed to read it.
 - Added skill installation for coding agents: `hap skill install <claude|codex|agents>...` and a Config-tab quick shortcut in the TUI (multi-select Claude / Codex / Others) write the bundled SKILL.md to `~/.claude/skills/hap/`, `~/.codex/skills/hap/`, or `~/.agents/skills/hap/`.
+- Changed `hap pause` / `hap resume` (and the TUI `p`/`r` keys) to be idempotent: pausing while already paused or resuming while already running now reports "already paused/resumed" and records no kill-history event, so repeated presses no longer flood the history with no-op rows.

--- a/changelog.d/feat-skill-flag.md
+++ b/changelog.d/feat-skill-flag.md
@@ -1,0 +1,2 @@
+- Added `hap --skill` (also `hap skill`): prints the bundled hap agent skill document — SKILL.md now ships inside the binary, so no repo checkout is needed to read it.
+- Added skill installation for coding agents: `hap skill install <claude|codex|agents>...` and a Config-tab quick shortcut in the TUI (multi-select Claude / Codex / Others) write the bundled SKILL.md to `~/.claude/skills/hap/`, `~/.codex/skills/hap/`, or `~/.agents/skills/hap/`.

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -113,17 +113,17 @@ func main() {
 	}
 }
 
-// runSkill serves `hap skill` / `hap --skill`: with no arguments it dumps the
-// bundled SKILL.md; `install <target>...` writes it into the named agents'
-// skill directories. Any other subcommand is refused — a typo of "install"
-// must not answer with the 77KB document.
+// runSkill serves `hap skill` / `hap --skill`: with no arguments (or the
+// explicit `show`) it dumps the bundled SKILL.md; `install <target>...`
+// writes it into the named agents' skill directories. Any other subcommand
+// is refused — a typo must not answer with the 77KB document.
 func runSkill(w io.Writer, args []string) error {
-	if len(args) == 0 {
+	if len(args) == 0 || args[0] == "show" {
 		_, err := io.WriteString(w, skilldoc.HapSkill)
 		return err
 	}
 	if args[0] != "install" {
-		return fmt.Errorf("unknown skill subcommand %q (did you mean install?)", args[0])
+		return fmt.Errorf("unknown skill subcommand %q (did you mean show or install?)", args[0])
 	}
 	// A mid-list write failure still reports the targets that DID install,
 	// so the operator knows ~/.claude was refreshed even when ~/.codex broke.

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -125,14 +125,13 @@ func runSkill(w io.Writer, args []string) error {
 	if args[0] != "install" {
 		return fmt.Errorf("unknown skill subcommand %q (did you mean install?)", args[0])
 	}
+	// A mid-list write failure still reports the targets that DID install,
+	// so the operator knows ~/.claude was refreshed even when ~/.codex broke.
 	written, err := skilldoc.Install(args[1:])
-	if err != nil {
-		return err
-	}
 	for _, path := range written {
 		fmt.Fprintln(w, "installed", path)
 	}
-	return nil
+	return err
 }
 
 // shutdownSignals are the signals that cancel the run context instead of

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -17,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	skilldoc "github.com/0xGosu/herdr-auto-pilot"
 	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
 	"github.com/0xGosu/herdr-auto-pilot/internal/cli"
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
@@ -91,6 +93,15 @@ func main() {
 		fmt.Println(buildinfo.VersionLine())
 		return
 	}
+	// Like version, dispatched before run() so printing or installing the
+	// bundled skill never resolves config paths or opens the store.
+	if verb == "skill" || verb == "--skill" {
+		if err := runSkill(os.Stdout, args); err != nil {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	if err := run(verb, args); err != nil {
 		// `hap status` on an unhealthy daemon already printed the human detail;
@@ -100,6 +111,28 @@ func main() {
 		}
 		os.Exit(1)
 	}
+}
+
+// runSkill serves `hap skill` / `hap --skill`: with no arguments it dumps the
+// bundled SKILL.md; `install <target>...` writes it into the named agents'
+// skill directories. Any other subcommand is refused — a typo of "install"
+// must not answer with the 77KB document.
+func runSkill(w io.Writer, args []string) error {
+	if len(args) == 0 {
+		_, err := io.WriteString(w, skilldoc.HapSkill)
+		return err
+	}
+	if args[0] != "install" {
+		return fmt.Errorf("unknown skill subcommand %q (did you mean install?)", args[0])
+	}
+	written, err := skilldoc.Install(args[1:])
+	if err != nil {
+		return err
+	}
+	for _, path := range written {
+		fmt.Fprintln(w, "installed", path)
+	}
+	return nil
 }
 
 // shutdownSignals are the signals that cancel the run context instead of

--- a/cmd/hap/main_test.go
+++ b/cmd/hap/main_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	skilldoc "github.com/0xGosu/herdr-auto-pilot"
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 )
 
@@ -108,5 +110,45 @@ func TestDaemonFlagParsingRejectsUnknownAndOrderIndependent(t *testing.T) {
 	// running, and --replace-only is in effect).
 	if err := runDaemon(context.Background(), paths, []string{"--replace-only", "--ensure"}); err != nil {
 		t.Fatalf("reversed flag order = %v, want it accepted", err)
+	}
+}
+
+// TestRunSkill covers the `hap skill` dispatch main routes before run(): the
+// bare form dumps the embedded document, install writes it under $HOME, and a
+// typo of "install" is refused rather than answered with the 77KB dump.
+func TestRunSkill(t *testing.T) {
+	var out strings.Builder
+	if err := runSkill(&out, nil); err != nil {
+		t.Fatalf("runSkill: %v", err)
+	}
+	if out.String() != skilldoc.HapSkill {
+		t.Fatal("bare `hap skill` should print exactly the embedded document")
+	}
+
+	if err := runSkill(io.Discard, []string{"instal"}); err == nil ||
+		!strings.Contains(err.Error(), "unknown skill subcommand") {
+		t.Fatalf("a typo of install must be refused, got %v", err)
+	}
+	if err := runSkill(io.Discard, []string{"install"}); err == nil ||
+		!strings.Contains(err.Error(), "no install target named") {
+		t.Fatalf("install without a target must name the valid ones, got %v", err)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	out.Reset()
+	if err := runSkill(&out, []string{"install", "claude"}); err != nil {
+		t.Fatalf("install claude: %v", err)
+	}
+	dest := filepath.Join(home, ".claude", "skills", "hap", "SKILL.md")
+	if !strings.Contains(out.String(), dest) {
+		t.Fatalf("install should print the written path %s, got %q", dest, out.String())
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != skilldoc.HapSkill {
+		t.Fatal("installed file differs from the embedded document")
 	}
 }

--- a/cmd/hap/main_test.go
+++ b/cmd/hap/main_test.go
@@ -124,6 +124,10 @@ func TestRunSkill(t *testing.T) {
 	if out.String() != skilldoc.HapSkill {
 		t.Fatal("bare `hap skill` should print exactly the embedded document")
 	}
+	out.Reset()
+	if err := runSkill(&out, []string{"show"}); err != nil || out.String() != skilldoc.HapSkill {
+		t.Fatalf("`hap skill show` should print exactly the embedded document (err=%v)", err)
+	}
 
 	if err := runSkill(io.Discard, []string{"instal"}); err == nil ||
 		!strings.Contains(err.Error(), "unknown skill subcommand") {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -107,7 +107,18 @@ func help(out io.Writer, args []string) error {
 			return nil
 		}
 	}
-	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+	if len(args) == 0 {
+		Overview(out)
+		return nil
+	}
+	if strings.HasPrefix(args[0], "-") {
+		// A dashed arg is normally a flag aimed at help itself — but a
+		// registered dashed ALIAS (--skill) names a command being asked
+		// about, so `hap --skill --help` answers with that guide.
+		if cmd, ok := Lookup(args[0]); ok {
+			PrintHelp(out, cmd)
+			return nil
+		}
 		Overview(out)
 		return nil
 	}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -167,6 +167,22 @@ func buildCommands() {
 			},
 		},
 		{
+			Name:    "skill",
+			Aliases: []string{"--skill"},
+			Group:   groupCore,
+			Summary: "print the bundled hap agent skill document, or install it for coding agents",
+			Usage:   []string{"hap skill", "hap --skill", "hap skill install <claude|codex|agents>..."},
+			Details: "The SKILL.md that teaches a coding agent to drive hap ships inside the binary,\n" +
+				"so no repo checkout is needed. Without arguments the document is printed to\n" +
+				"stdout. `install` writes it into the named agents' skill directories:\n" +
+				"  claude → ~/.claude/skills/hap/SKILL.md\n" +
+				"  codex  → ~/.codex/skills/hap/SKILL.md\n" +
+				"  agents → ~/.agents/skills/hap/SKILL.md   (other tools sharing ~/.agents)\n" +
+				"The TUI's Config tab offers the same install as a quick shortcut.",
+			Examples: []string{"hap skill | less", "hap skill install claude codex"},
+			Bare:     true,
+		},
+		{
 			Name:    "help",
 			Group:   groupCore,
 			Summary: "print this overview, or a full guide for one command",

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -171,10 +171,11 @@ func buildCommands() {
 			Aliases: []string{"--skill"},
 			Group:   groupCore,
 			Summary: "print the bundled hap agent skill document, or install it for coding agents",
-			Usage:   []string{"hap skill", "hap --skill", "hap skill install <claude|codex|agents>..."},
+			Usage:   []string{"hap skill", "hap skill show", "hap --skill", "hap skill install <claude|codex|agents>..."},
 			Details: "The SKILL.md that teaches a coding agent to drive hap ships inside the binary,\n" +
-				"so no repo checkout is needed. Without arguments the document is printed to\n" +
-				"stdout. `install` writes it into the named agents' skill directories:\n" +
+				"so no repo checkout is needed. Without arguments (or with the explicit `show`)\n" +
+				"the document is printed to stdout. `install` writes it into the named agents'\n" +
+				"skill directories:\n" +
 				"  claude → ~/.claude/skills/hap/SKILL.md\n" +
 				"  codex  → ~/.codex/skills/hap/SKILL.md\n" +
 				"  agents → ~/.agents/skills/hap/SKILL.md   (other tools sharing ~/.agents)\n" +
@@ -516,8 +517,13 @@ func buildCommands() {
 				{Cmd: "hap kill-history", Why: "see who paused and when"},
 			},
 			Handler: func(ctx context.Context, app *frontend.App, out io.Writer, _ []string) error {
-				if err := app.Pause(ctx); err != nil {
+				changed, err := app.Pause(ctx)
+				if err != nil {
 					return err
+				}
+				if !changed {
+					fmt.Fprintln(out, "automation already paused (kill switch active)")
+					return nil
 				}
 				fmt.Fprintln(out, "automation paused (kill switch active)")
 				return nil
@@ -535,8 +541,13 @@ func buildCommands() {
 				{Cmd: "hap escalations", Why: "handle what queued up while paused"},
 			},
 			Handler: func(ctx context.Context, app *frontend.App, out io.Writer, _ []string) error {
-				if err := app.Resume(ctx); err != nil {
+				changed, err := app.Resume(ctx)
+				if err != nil {
 					return err
+				}
+				if !changed {
+					fmt.Fprintln(out, "automation already resumed")
+					return nil
 				}
 				fmt.Fprintln(out, "automation resumed")
 				return nil

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -156,6 +156,11 @@ func TestWantsCommandHelp(t *testing.T) {
 		{verb: "task", args: []string{"agent", "list", "--help"}, want: true},
 		{verb: "version", want: false},
 		{verb: "--version", args: []string{"--help"}, want: false},
+		{verb: "skill", args: []string{"--help"}, want: true},
+		// Unlike --version, --skill is a registered alias, so `hap --skill
+		// --help` answers with the guide instead of the 77KB document.
+		{verb: "--skill", args: []string{"--help"}, want: true},
+		{verb: "skill", want: false},
 		{verb: "not-a-command", args: []string{"--help"}, want: false},
 		{verb: "resolve", args: []string{"1", "--action", "--help"}, want: false},
 	}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -598,28 +598,46 @@ func (a *App) KillHistory(ctx context.Context, limit int) ([]domain.KillEvent, e
 	return a.Store.KillEvents(ctx, limit)
 }
 
-// Pause activates the global pause/kill switch (FR-017).
-func (a *App) Pause(ctx context.Context) error {
+// Pause activates the global pause/kill switch (FR-017). Pausing while
+// already paused is reported as changed=false and records NO kill event, so
+// a repeated "p"/`hap pause` cannot flood the history with no-op rows.
+func (a *App) Pause(ctx context.Context) (changed bool, err error) {
+	latest, err := a.Store.LatestKillEvent(ctx)
+	if err != nil {
+		return false, err
+	}
+	if domain.KillStateActive(latest) {
+		return false, nil
+	}
 	if _, err := a.Store.InsertKillEvent(ctx, domain.KillEvent{
 		State: "active", Scope: "global", Author: a.Author, CreatedAt: time.Now(),
 	}); err != nil {
-		return err
+		return false, err
 	}
 	// The nudge is best-effort: the daemon reads the latest kill row every
 	// pipeline tick, so the pause takes effect regardless.
 	a.nudge(ctx, control.KindReload)
-	return nil
+	return true, nil
 }
 
-// Resume deactivates the pause/kill switch.
-func (a *App) Resume(ctx context.Context) error {
+// Resume deactivates the pause/kill switch. Resuming while automation is
+// already running (including never having been paused) is a no-op reported
+// as changed=false, mirroring Pause.
+func (a *App) Resume(ctx context.Context) (changed bool, err error) {
+	latest, err := a.Store.LatestKillEvent(ctx)
+	if err != nil {
+		return false, err
+	}
+	if !domain.KillStateActive(latest) {
+		return false, nil
+	}
 	if _, err := a.Store.InsertKillEvent(ctx, domain.KillEvent{
 		State: "resumed", Scope: "global", Author: a.Author, CreatedAt: time.Now(),
 	}); err != nil {
-		return err
+		return false, err
 	}
 	a.nudge(ctx, control.KindReload)
-	return nil
+	return true, nil
 }
 
 // FocusAgent brings the herdr UI to the agent's exact pane (tab focus + pane

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -248,16 +248,18 @@ func TestPauseResumeAppendsKillEvents(t *testing.T) {
 	app, st := testApp(t)
 	ctx := context.Background()
 
-	if err := app.Pause(ctx); err != nil {
-		t.Fatal(err)
+	changed, err := app.Pause(ctx)
+	if err != nil || !changed {
+		t.Fatalf("pause: changed=%v err=%v", changed, err)
 	}
 	stat, err := app.GetStatus(ctx)
 	if err != nil || !stat.Paused {
 		t.Fatalf("pause not reflected: %+v %v", stat, err)
 	}
 
-	if err := app.Resume(ctx); err != nil {
-		t.Fatal(err)
+	changed, err = app.Resume(ctx)
+	if err != nil || !changed {
+		t.Fatalf("resume: changed=%v err=%v", changed, err)
 	}
 	stat, _ = app.GetStatus(ctx)
 	if stat.Paused {
@@ -268,6 +270,44 @@ func TestPauseResumeAppendsKillEvents(t *testing.T) {
 	events, _ := st.KillEvents(ctx, 10)
 	if len(events) != 2 {
 		t.Errorf("kill history rows = %d, want 2", len(events))
+	}
+}
+
+// A pause while already paused (or a resume while already running) is a
+// no-op: reported as changed=false and recording NO kill event, so pressing
+// "p"/"r" repeatedly cannot flood the history.
+func TestPauseResumeNoOpsRecordNoKillEvent(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+
+	// Resume before any pause: nothing to lift.
+	if changed, err := app.Resume(ctx); err != nil || changed {
+		t.Fatalf("resume on a never-paused daemon: changed=%v err=%v, want a no-op", changed, err)
+	}
+	if events, _ := st.KillEvents(ctx, 10); len(events) != 0 {
+		t.Fatalf("no-op resume recorded %d kill events, want 0", len(events))
+	}
+
+	if changed, err := app.Pause(ctx); err != nil || !changed {
+		t.Fatalf("first pause: changed=%v err=%v", changed, err)
+	}
+	if changed, err := app.Pause(ctx); err != nil || changed {
+		t.Fatalf("second pause: changed=%v err=%v, want a no-op", changed, err)
+	}
+	if stat, err := app.GetStatus(ctx); err != nil || !stat.Paused {
+		t.Fatalf("no-op pause must leave the daemon paused: %+v %v", stat, err)
+	}
+
+	if changed, err := app.Resume(ctx); err != nil || !changed {
+		t.Fatalf("first resume: changed=%v err=%v", changed, err)
+	}
+	if changed, err := app.Resume(ctx); err != nil || changed {
+		t.Fatalf("second resume: changed=%v err=%v, want a no-op", changed, err)
+	}
+
+	events, _ := st.KillEvents(ctx, 10)
+	if len(events) != 2 {
+		t.Errorf("kill history rows = %d, want only the two real transitions", len(events))
 	}
 }
 

--- a/internal/tui/bell_test.go
+++ b/internal/tui/bell_test.go
@@ -164,6 +164,66 @@ func TestBellPausePendingClearedOnFailedPauseAction(t *testing.T) {
 	}
 }
 
+// A "p" press while already paused is a no-op: like a failed pause, Paused
+// never transitions, so the no-op result itself must consume the flag.
+func TestBellPausePendingClearedOnNoOpPauseAction(t *testing.T) {
+	m, buf := bellModel()
+	cfg := config.Config{TUI: config.TUI{TerminalBell: true}}
+
+	// Already paused when "p" is pressed (an earlier refresh said so).
+	upd, _ := m.Update(refreshMsg{cfg: cfg, status: frontend.Status{Paused: true}})
+	m = upd.(Model)
+	m.pausePending = true
+
+	upd, _ = m.Update(actionResultMsg{message: "automation already paused", pauseAction: true, pauseNoChange: true})
+	m = upd.(Model)
+	if m.pausePending {
+		t.Fatal("a no-op pause action must clear pausePending, not leave it dangling")
+	}
+
+	// A later external resume→pause cycle must now correctly ring.
+	upd, _ = m.Update(refreshMsg{cfg: cfg, status: frontend.Status{Paused: false}})
+	m = upd.(Model)
+	upd, _ = m.Update(refreshMsg{cfg: cfg, status: frontend.Status{Paused: true}})
+	m = upd.(Model)
+	if got := buf.Bytes(); len(got) != 1 || got[0] != 0x07 {
+		t.Fatalf("external pause after a cleared pausePending should ring, got %v", got)
+	}
+}
+
+// A rapid DOUBLE-press of "p" from an unpaused state: the second press's
+// no-op result lands before the refresh that reports the first press's
+// false→true transition. The no-op must NOT clear pausePending there —
+// the pause is self-caused, and clearing would ring the bell for it.
+func TestBellNoOpPauseBeforeObservedTransitionKeepsSuppression(t *testing.T) {
+	m, buf := bellModel()
+	cfg := config.Config{TUI: config.TUI{TerminalBell: true}}
+
+	upd, _ := m.Update(refreshMsg{cfg: cfg, status: frontend.Status{Paused: false}})
+	m = upd.(Model)
+	m.pausePending = true // both presses set it synchronously
+
+	// First press's result, then the second press's no-op result — both
+	// arrive before the next refresh.
+	upd, _ = m.Update(actionResultMsg{message: "automation paused", pauseAction: true})
+	m = upd.(Model)
+	upd, _ = m.Update(actionResultMsg{message: "automation already paused", pauseAction: true, pauseNoChange: true})
+	m = upd.(Model)
+	if !m.pausePending {
+		t.Fatal("a no-op result before the transition is observed must keep pausePending")
+	}
+
+	// The refresh finally reports the operator's own pause: no bell.
+	upd, _ = m.Update(refreshMsg{cfg: cfg, status: frontend.Status{Paused: true}})
+	m = upd.(Model)
+	if got := buf.Bytes(); len(got) != 0 {
+		t.Fatalf("self-caused pause should not ring after a no-op second press, got %v", got)
+	}
+	if m.pausePending {
+		t.Fatal("the observed transition should consume pausePending")
+	}
+}
+
 func TestBellNilOutputNeverPanics(t *testing.T) {
 	m := Model{width: 100, height: 30} // bellOut left nil
 	cfg := config.Config{TUI: config.TUI{TerminalBell: true}}

--- a/internal/tui/skillinstall_test.go
+++ b/internal/tui/skillinstall_test.go
@@ -1,0 +1,124 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+)
+
+func skillInstallModel(t *testing.T, install func([]string) ([]string, error)) Model {
+	t.Helper()
+	m := configModel(t, config.Default())
+	m.cursors[m.tab] = itemIndex(t, m, func(item ruleItem) bool {
+		return item.kind == "shortcut" && item.key == "install-skill"
+	})
+	m.installSkill = install
+	return m
+}
+
+func TestConfigSkillShortcutRendersUnderQuickShortcuts(t *testing.T) {
+	m := skillInstallModel(t, nil)
+	view := m.View()
+	header := strings.LastIndex(view, "Quick Shortcuts")
+	row := strings.LastIndex(view, "Install hap agent skill")
+	if header < 0 || row < header {
+		t.Fatalf("Quick Shortcuts section or skill-install row missing:\n%s", view)
+	}
+}
+
+func TestConfigSkillShortcutInstallsCheckedTargets(t *testing.T) {
+	var got []string
+	m := skillInstallModel(t, func(names []string) ([]string, error) {
+		got = append([]string(nil), names...)
+		return []string{"/home/op/.claude/skills/hap/SKILL.md", "/home/op/.codex/skills/hap/SKILL.md"}, nil
+	})
+
+	m = press(t, m, "enter")
+	if m.prompt == nil || !m.prompt.multi {
+		t.Fatalf("enter on the shortcut should open the multi-select, got %+v", m.prompt)
+	}
+	if len(m.prompt.options) != 3 {
+		t.Fatalf("expected the three install targets, got %v", m.prompt.options)
+	}
+	if view := m.View(); !strings.Contains(view, "space: toggle") {
+		t.Fatalf("help line should advertise the toggle key:\n%s", view)
+	}
+
+	m = press(t, m, " ", "down", " ") // check Claude, then Codex
+	if view := m.View(); !strings.Contains(view, "[x]") || !strings.Contains(view, "[ ]") {
+		t.Fatalf("checkbox state should be visible:\n%s", view)
+	}
+
+	updated, cmd := m.Update(pressKeyMsg("enter"))
+	m = updated.(Model)
+	if cmd == nil {
+		t.Fatal("submitting the multi-select should return the install command")
+	}
+	if got != nil {
+		t.Fatal("install command must remain asynchronous until Bubble Tea runs it")
+	}
+	if m.prompt != nil {
+		t.Fatal("prompt should close on submit")
+	}
+	msg, ok := cmd().(actionResultMsg)
+	if !ok || msg.err != nil || !strings.Contains(msg.message, ".claude/skills/hap/SKILL.md") {
+		t.Fatalf("unexpected install result: %+v", msg)
+	}
+	if strings.Join(got, ",") != "claude,codex" {
+		t.Fatalf("installer received %v, want the two checked targets", got)
+	}
+}
+
+// Nothing checked submits the highlighted row — the same fallback the
+// Escalations and Tasks multi-selects use.
+func TestConfigSkillShortcutFallsBackToHighlightedRow(t *testing.T) {
+	var got []string
+	m := skillInstallModel(t, func(names []string) ([]string, error) {
+		got = append([]string(nil), names...)
+		return []string{"/home/op/.codex/skills/hap/SKILL.md"}, nil
+	})
+
+	m = press(t, m, "enter", "down") // highlight Codex, no toggle
+	_, cmd := m.Update(pressKeyMsg("enter"))
+	if cmd == nil {
+		t.Fatal("submitting should return the install command")
+	}
+	if msg, ok := cmd().(actionResultMsg); !ok || msg.err != nil {
+		t.Fatalf("unexpected install result: %+v", msg)
+	}
+	if strings.Join(got, ",") != "codex" {
+		t.Fatalf("installer received %v, want just the highlighted target", got)
+	}
+}
+
+func TestConfigSkillShortcutEscCancels(t *testing.T) {
+	ran := false
+	m := skillInstallModel(t, func([]string) ([]string, error) {
+		ran = true
+		return nil, nil
+	})
+
+	m = press(t, m, "enter", " ", "esc")
+	if m.prompt != nil || m.message != "cancelled" || ran {
+		t.Fatalf("esc should cancel without installing: prompt=%v message=%q ran=%v",
+			m.prompt != nil, m.message, ran)
+	}
+}
+
+func TestConfigSkillShortcutReportsInstallError(t *testing.T) {
+	m := skillInstallModel(t, func([]string) ([]string, error) {
+		return nil, errors.New("permission denied")
+	})
+
+	m = press(t, m, "enter", " ")
+	_, cmd := m.Update(pressKeyMsg("enter"))
+	if cmd == nil {
+		t.Fatal("submitting should return the install command")
+	}
+	msg, ok := cmd().(actionResultMsg)
+	if !ok || msg.err == nil {
+		t.Fatalf("an installer failure should surface as an error result, got %+v", msg)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -116,6 +116,10 @@ type actionResultMsg struct {
 	// if the pause request itself failed (the state never transitioned, so
 	// nothing will consume the flag otherwise).
 	pauseAction bool
+	// pauseNoChange marks a pause that was a no-op (already paused): like a
+	// failure, the state never transitions, so the flag must be cleared here
+	// rather than left to wrongly suppress a later external pause's bell.
+	pauseNoChange bool
 	// token identifies WHICH action produced this result, for state a
 	// keypress stashed awaiting its own completion. Zero for the untagged
 	// majority; see doTagged.
@@ -1782,11 +1786,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case actionResultMsg:
 		m.applyTaskLists(msg.taskLists)
-		if msg.pauseAction && msg.err != nil {
-			// The pause request itself failed, so Paused never transitions
-			// and the refreshMsg diff above will never consume the flag —
+		if msg.pauseAction && (msg.err != nil || (msg.pauseNoChange && m.lastPaused)) {
+			// The pause request failed, or was a no-op on a pause this TUI
+			// had already OBSERVED (lastPaused): Paused never transitions,
+			// so the refreshMsg diff above will never consume the flag —
 			// clear it here so it doesn't wrongly suppress some later,
-			// unrelated external pause.
+			// unrelated external pause. A no-op while lastPaused is still
+			// false is different: it is the second of a rapid double-press
+			// whose FIRST press's transition is still en route to the next
+			// refresh, and clearing would make that self-caused pause read
+			// as external and ring the bell.
 			m.pausePending = false
 		}
 		if msg.err != nil {
@@ -2251,7 +2260,16 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.pauseCmd()
 	case "r":
 		m.beginAction()
-		return m, m.do("automation resumed", func(ctx context.Context) error { return m.app.Resume(ctx) })
+		return m, m.doResult(func(ctx context.Context) (string, error) {
+			changed, err := m.app.Resume(ctx)
+			if err != nil {
+				return "", err
+			}
+			if !changed {
+				return "automation already resumed", nil
+			}
+			return "automation resumed", nil
+		})
 	case "R":
 		switch d := m.data.status.Drift; {
 		case !d.Detected:
@@ -2425,6 +2443,26 @@ func (m Model) do(okMsg string, fn func(context.Context) error) tea.Cmd {
 	return m.doTagged(0, okMsg, fn)
 }
 
+// doResult is do for a mutation whose success message depends on its outcome
+// (e.g. resume reporting "already resumed" on a no-op), with the same
+// inflight accounting.
+func (m Model) doResult(fn func(context.Context) (string, error)) tea.Cmd {
+	ctx, wg := m.ctx, m.inflight
+	if wg != nil {
+		wg.Add(1)
+	}
+	return func() tea.Msg {
+		if wg != nil {
+			defer wg.Done()
+		}
+		okMsg, err := fn(ctx)
+		if err != nil {
+			return actionResultMsg{err: err}
+		}
+		return actionResultMsg{message: okMsg}
+	}
+}
+
 // doTagged runs a mutation and reports its outcome, stamping the result with
 // tok so Update can tell THIS action's completion from any other's. Mutations
 // are concurrent and unordered — the UI keeps accepting keys while one is in
@@ -2576,12 +2614,24 @@ func ringBellTo(w io.Writer) {
 
 // pauseCmd activates the pause/kill switch, tagging its result as
 // pauseAction so Update can clear Model.pausePending if the request itself
-// failed — the generic do() helper has no channel for that extra signal.
+// failed or was a no-op — the generic do()/doResult() helpers have no channel
+// for those extra signals. It carries the same inflight accounting as do(),
+// so a "p" pressed just before quit still lands before Run's drain returns.
 func (m Model) pauseCmd() tea.Cmd {
-	app, ctx := m.app, m.ctx
+	app, ctx, wg := m.app, m.ctx, m.inflight
+	if wg != nil {
+		wg.Add(1)
+	}
 	return func() tea.Msg {
-		if err := app.Pause(ctx); err != nil {
+		if wg != nil {
+			defer wg.Done()
+		}
+		changed, err := app.Pause(ctx)
+		if err != nil {
 			return actionResultMsg{err: err, pauseAction: true}
+		}
+		if !changed {
+			return actionResultMsg{message: "automation already paused", pauseAction: true, pauseNoChange: true}
 		}
 		return actionResultMsg{message: "automation paused", pauseAction: true}
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -4803,7 +4803,7 @@ func (m Model) openSkillInstallPrompt() (tea.Model, tea.Cmd) {
 	opts := make([]string, len(targets))
 	nameByOpt := make(map[string]string, len(targets))
 	for i, t := range targets {
-		opts[i] = fmt.Sprintf("%s (%s)", t.Label, t.HomeDir())
+		opts[i] = fmt.Sprintf("%s (%s)", t.Label, t.DestDir())
 		nameByOpt[opts[i]] = t.Name
 	}
 	m.message = ""
@@ -4822,6 +4822,11 @@ func (m Model) openSkillInstallPrompt() (tea.Model, tea.Cmd) {
 			return func() tea.Msg {
 				written, err := install(names)
 				if err != nil {
+					// A mid-list failure already refreshed the earlier
+					// targets — say so instead of discarding them.
+					if len(written) > 0 {
+						err = fmt.Errorf("%w (already installed: %s)", err, strings.Join(written, ", "))
+					}
 					return actionResultMsg{err: err}
 				}
 				return actionResultMsg{message: "installed skill: " + strings.Join(written, ", ")}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -26,6 +26,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mattn/go-runewidth"
 
+	skilldoc "github.com/0xGosu/herdr-auto-pilot"
 	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
 	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -191,6 +192,14 @@ type prompt struct {
 	// operator picks from the known set instead of typing a name blind.
 	options []string
 	optIdx  int
+	// multi turns the picker into a multi-select: space toggles the
+	// highlighted option's checkbox, enter submits every checked option —
+	// falling back to the highlighted one when none is checked, the same
+	// fallback convention as the list-tab multi-selects — and the choices go
+	// to onSubmitMulti instead of onSubmit.
+	multi         bool
+	checked       []bool
+	onSubmitMulti func([]string) tea.Cmd
 	// cursor is the caret's position as a RUNE index into input (0 = before
 	// the first rune, len = past the last), so every edit lands where the
 	// operator put it instead of always at the end. Rune-indexed, not
@@ -670,6 +679,23 @@ func (m Model) submitPrompt() (tea.Model, tea.Cmd) {
 	p := m.prompt
 	m.prompt = nil
 	if len(p.options) > 0 {
+		if p.multi {
+			// Multi-select picker: submit the checked options, or the
+			// highlighted one when nothing is checked.
+			if p.onSubmitMulti == nil {
+				return m, nil
+			}
+			var chosen []string
+			for i, opt := range p.options {
+				if i < len(p.checked) && p.checked[i] {
+					chosen = append(chosen, opt)
+				}
+			}
+			if len(chosen) == 0 {
+				chosen = []string{p.options[p.optIdx]}
+			}
+			return m, p.onSubmitMulti(chosen)
+		}
 		// Picker mode: submit the highlighted option verbatim.
 		return m, p.onSubmit(p.options[p.optIdx])
 	}
@@ -799,6 +825,10 @@ type Model struct {
 	// installShortcut is injectable so the key flow can be tested without
 	// writing /usr/local/bin. A nil value uses installHAPShortcut.
 	installShortcut func() error
+
+	// installSkill is injectable so the skill-install flow can be tested
+	// without writing the real $HOME. A nil value uses skilldoc.Install.
+	installSkill func(names []string) ([]string, error)
 
 	// cursors is the selected row of each tab, remembered across tab switches
 	// so returning to a tab restores the row you left it on (CR-038). Only the
@@ -1607,6 +1637,11 @@ func buildRuleItems(cfg config.Config) []ruleItem {
 		key:   "install-hap",
 		label: shortcutLabel(hapShortcutState()),
 	})
+	items = append(items, ruleItem{
+		kind:  "shortcut",
+		key:   "install-skill",
+		label: "Install hap agent skill for coding agents (Claude / Codex / others)",
+	})
 	return items
 }
 
@@ -2091,6 +2126,14 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "down", "j":
 			if m.prompt.optIdx < len(m.prompt.options)-1 {
 				m.prompt.optIdx++
+			}
+			return m, nil
+		case " ":
+			if m.prompt.multi {
+				if len(m.prompt.checked) != len(m.prompt.options) {
+					m.prompt.checked = make([]bool, len(m.prompt.options))
+				}
+				m.prompt.checked[m.prompt.optIdx] = !m.prompt.checked[m.prompt.optIdx]
 			}
 			return m, nil
 		default:
@@ -4717,29 +4760,74 @@ func (m Model) activateSelectedConfig() (tea.Model, tea.Cmd) {
 	if item.kind != "shortcut" {
 		return m.editSelectedRule()
 	}
-	if item.key != "install-hap" {
+	// The two shortcuts confirm differently on purpose: the symlink touches
+	// /usr/local/bin and keeps its Y/n modal; the skill install's multi-select
+	// IS the confirmation (it only creates or refreshes hap's own file under
+	// the operator's home).
+	switch item.key {
+	case "install-hap":
+		install := m.installShortcut
+		if install == nil {
+			install = installHAPShortcut
+		}
+		// Read the state once, here, so the prompt and the result message agree
+		// with each other and with the row the operator selected.
+		state := hapShortcutState()
+		m.message = ""
+		m.confirm = &confirmation{
+			label: shortcutConfirm(state),
+			onConfirm: func() tea.Cmd {
+				return func() tea.Msg {
+					if err := install(); err != nil {
+						return actionResultMsg{err: err}
+					}
+					return actionResultMsg{message: shortcutResult(state)}
+				}
+			},
+		}
 		return m, nil
+	case "install-skill":
+		return m.openSkillInstallPrompt()
 	}
+	return m, nil
+}
 
-	install := m.installShortcut
+// openSkillInstallPrompt opens the multi-select of agent skill directories
+// the bundled SKILL.md can be installed into.
+func (m Model) openSkillInstallPrompt() (tea.Model, tea.Cmd) {
+	install := m.installSkill
 	if install == nil {
-		install = installHAPShortcut
+		install = skilldoc.Install
 	}
-	// Read the state once, here, so the prompt and the result message agree
-	// with each other and with the row the operator selected.
-	state := hapShortcutState()
+	targets := skilldoc.Targets()
+	opts := make([]string, len(targets))
+	nameByOpt := make(map[string]string, len(targets))
+	for i, t := range targets {
+		opts[i] = fmt.Sprintf("%s (%s)", t.Label, t.HomeDir())
+		nameByOpt[opts[i]] = t.Name
+	}
 	m.message = ""
-	m.confirm = &confirmation{
-		label: shortcutConfirm(state),
-		onConfirm: func() tea.Cmd {
+	m.openPrompt(&prompt{
+		label:   "Install hap agent skill into:",
+		options: opts,
+		multi:   true,
+		checked: make([]bool, len(opts)),
+		onSubmitMulti: func(chosen []string) tea.Cmd {
+			names := make([]string, 0, len(chosen))
+			for _, opt := range chosen {
+				if name, ok := nameByOpt[opt]; ok {
+					names = append(names, name)
+				}
+			}
 			return func() tea.Msg {
-				if err := install(); err != nil {
+				written, err := install(names)
+				if err != nil {
 					return actionResultMsg{err: err}
 				}
-				return actionResultMsg{message: shortcutResult(state)}
+				return actionResultMsg{message: "installed skill: " + strings.Join(written, ", ")}
 			}
 		},
-	}
+	})
 	return m, nil
 }
 
@@ -5672,7 +5760,15 @@ func (m Model) View() string {
 			if i == m.prompt.optIdx {
 				marker = "❯ "
 			}
-			fmt.Fprintf(&b, "%s%s\n", marker, oneLine(opt, max(1, m.contentWidth()-promptIndentWidth)))
+			box := ""
+			if m.prompt.multi {
+				box = "[ ] "
+				if i < len(m.prompt.checked) && m.prompt.checked[i] {
+					box = "[x] "
+				}
+			}
+			fmt.Fprintf(&b, "%s%s%s\n", marker, box,
+				oneLine(opt, max(1, m.contentWidth()-promptIndentWidth-len(box))))
 		}
 	} else if m.prompt != nil {
 		// The input expands the box: one rendered row per line break AND per
@@ -5763,6 +5859,9 @@ func (m Model) helpLine() string {
 	// would push that text onto its own row for no reason.
 	if m.prompt != nil {
 		if len(m.prompt.options) > 0 {
+			if m.prompt.multi {
+				return "↑/↓: choose  space: toggle  enter: submit  esc: cancel"
+			}
 			return "↑/↓: choose  enter: select  esc: cancel"
 		}
 		newline := ""

--- a/skilldoc.go
+++ b/skilldoc.go
@@ -1,0 +1,132 @@
+// Package skilldoc bundles the agent skill documents shipped with the hap
+// binary, so an installed release can print or install them without a repo
+// checkout.
+package skilldoc
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// HapSkill is the hap agent skill document (.claude/skills/hap/SKILL.md),
+// embedded at build time. The path names the file explicitly: a leading-dot
+// directory is only excluded from go:embed WILDCARD walks, not from a named
+// file.
+//
+//go:embed .claude/skills/hap/SKILL.md
+var HapSkill string
+
+// SkillFileName is the file name the skill is installed under, inside a
+// per-skill "hap" directory (the layout coding agents discover skills by).
+const SkillFileName = "SKILL.md"
+
+// Target names one agent's skill directory the bundled skill can be
+// installed into.
+type Target struct {
+	Name  string // selector used by `hap skill install` and the TUI
+	Label string // display label ("Others" covers the shared ~/.agents dir)
+	Dir   string // home-relative skills directory
+}
+
+// Targets lists the supported install destinations, in display order.
+func Targets() []Target {
+	return []Target{
+		{Name: "claude", Label: "Claude", Dir: ".claude/skills"},
+		{Name: "codex", Label: "Codex", Dir: ".codex/skills"},
+		{Name: "agents", Label: "Others", Dir: ".agents/skills"},
+	}
+}
+
+// TargetNames lists the valid selector names, in display order.
+func TargetNames() []string {
+	targets := Targets()
+	names := make([]string, len(targets))
+	for i, t := range targets {
+		names[i] = t.Name
+	}
+	return names
+}
+
+// HomeDir is the destination directory as shown to the operator, e.g.
+// "~/.claude/skills".
+func (t Target) HomeDir() string {
+	return "~/" + t.Dir
+}
+
+// Install writes the bundled skill into the named targets' skill directories
+// under the current user's home, returning the paths written.
+func Install(names []string) ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home dir: %w", err)
+	}
+	return InstallTo(home, names)
+}
+
+// InstallTo is Install against an explicit home directory. Each selected
+// target gets <home>/<target dir>/hap/SKILL.md, created or overwritten
+// atomically. An unknown name fails before anything else is written.
+func InstallTo(home string, names []string) ([]string, error) {
+	valid := strings.Join(TargetNames(), ", ")
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no install target named; valid targets: %s", valid)
+	}
+	targets := Targets()
+	byName := make(map[string]Target, len(targets))
+	for _, t := range targets {
+		byName[t.Name] = t
+	}
+	picked := make([]Target, 0, len(names))
+	for _, name := range names {
+		t, ok := byName[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown install target %q; valid targets: %s", name, valid)
+		}
+		picked = append(picked, t)
+	}
+	written := make([]string, 0, len(picked))
+	for _, t := range picked {
+		dir := filepath.Join(home, filepath.FromSlash(t.Dir), "hap")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return written, fmt.Errorf("create %s: %w", dir, err)
+		}
+		dest := filepath.Join(dir, SkillFileName)
+		if err := writeFileAtomic(dest, []byte(HapSkill)); err != nil {
+			return written, err
+		}
+		written = append(written, dest)
+	}
+	return written, nil
+}
+
+// writeFileAtomic replaces path via a same-directory temp file and rename, so
+// a reader never sees a half-written skill. Deliberately local: the repo-wide
+// guard test bans new taskfile.WriteFileAtomic callers (task-list mutators
+// must go through the store), and this is not a task list.
+func writeFileAtomic(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".skill-*")
+	if err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	tmpName := tmp.Name()
+	_, err = tmp.Write(data)
+	if err == nil {
+		err = tmp.Chmod(0o644)
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err == nil {
+		err = os.Rename(tmpName, path)
+	}
+	if err != nil {
+		if rmErr := os.Remove(tmpName); rmErr != nil && !os.IsNotExist(rmErr) {
+			err = fmt.Errorf("%w (cleanup: %v)", err, rmErr)
+		}
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/skilldoc.go
+++ b/skilldoc.go
@@ -50,26 +50,41 @@ func TargetNames() []string {
 	return names
 }
 
-// HomeDir is the destination directory as shown to the operator, e.g.
-// "~/.claude/skills".
-func (t Target) HomeDir() string {
-	return "~/" + t.Dir
+// DestDir is the directory the skill is installed into, as shown to the
+// operator, e.g. "~/.claude/skills/hap".
+func (t Target) DestDir() string {
+	return "~/" + t.Dir + "/hap"
 }
 
 // Install writes the bundled skill into the named targets' skill directories
-// under the current user's home, returning the paths written.
+// under the current user's home, returning the paths written. A write failure
+// mid-list still returns the paths already written alongside the error.
 func Install(names []string) ([]string, error) {
+	picked, err := pickTargets(names)
+	if err != nil {
+		return nil, err
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("resolve home dir: %w", err)
 	}
-	return InstallTo(home, names)
+	return installTargets(home, picked)
 }
 
 // InstallTo is Install against an explicit home directory. Each selected
 // target gets <home>/<target dir>/hap/SKILL.md, created or overwritten
 // atomically. An unknown name fails before anything else is written.
 func InstallTo(home string, names []string) ([]string, error) {
+	picked, err := pickTargets(names)
+	if err != nil {
+		return nil, err
+	}
+	return installTargets(home, picked)
+}
+
+// pickTargets validates the selection before anything touches the filesystem,
+// so an argument mistake is reported as one even when $HOME is unresolvable.
+func pickTargets(names []string) ([]Target, error) {
 	valid := strings.Join(TargetNames(), ", ")
 	if len(names) == 0 {
 		return nil, fmt.Errorf("no install target named; valid targets: %s", valid)
@@ -87,6 +102,10 @@ func InstallTo(home string, names []string) ([]string, error) {
 		}
 		picked = append(picked, t)
 	}
+	return picked, nil
+}
+
+func installTargets(home string, picked []Target) ([]string, error) {
 	written := make([]string, 0, len(picked))
 	for _, t := range picked {
 		dir := filepath.Join(home, filepath.FromSlash(t.Dir), "hap")

--- a/skilldoc_test.go
+++ b/skilldoc_test.go
@@ -1,0 +1,93 @@
+package skilldoc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The embed path names the file explicitly, so a move or rename of
+// .claude/skills/hap/SKILL.md fails the build — this guards the content
+// being the hap skill at all.
+func TestHapSkillIsEmbedded(t *testing.T) {
+	if len(HapSkill) == 0 {
+		t.Fatal("embedded skill document is empty")
+	}
+	if !strings.Contains(HapSkill, "name: hap") {
+		t.Fatalf("embedded document does not carry the hap skill frontmatter:\n%.200s", HapSkill)
+	}
+}
+
+func TestInstallToWritesEverySelectedTarget(t *testing.T) {
+	home := t.TempDir()
+	written, err := InstallTo(home, []string{"claude", "codex", "agents"})
+	if err != nil {
+		t.Fatalf("InstallTo: %v", err)
+	}
+	want := []string{
+		filepath.Join(home, ".claude", "skills", "hap", "SKILL.md"),
+		filepath.Join(home, ".codex", "skills", "hap", "SKILL.md"),
+		filepath.Join(home, ".agents", "skills", "hap", "SKILL.md"),
+	}
+	if len(written) != len(want) {
+		t.Fatalf("written = %v, want %v", written, want)
+	}
+	for i, path := range want {
+		if written[i] != path {
+			t.Errorf("written[%d] = %q, want %q", i, written[i], path)
+		}
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if string(got) != HapSkill {
+			t.Errorf("%s content differs from the embedded document", path)
+		}
+	}
+}
+
+func TestInstallToOverwritesAnExistingInstall(t *testing.T) {
+	home := t.TempDir()
+	dest := filepath.Join(home, ".claude", "skills", "hap", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte("an older release's skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := InstallTo(home, []string{"claude"}); err != nil {
+		t.Fatalf("InstallTo over an existing file: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != HapSkill {
+		t.Error("existing install was not replaced with the embedded document")
+	}
+}
+
+// An unknown name fails before ANY target is written, so a typo in a list
+// never half-installs.
+func TestInstallToRefusesAnUnknownTargetBeforeWriting(t *testing.T) {
+	home := t.TempDir()
+	_, err := InstallTo(home, []string{"claude", "cursor"})
+	if err == nil || !strings.Contains(err.Error(), `unknown install target "cursor"`) {
+		t.Fatalf("expected an unknown-target error naming the valid set, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "claude, codex, agents") {
+		t.Errorf("error should list the valid targets, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".claude")); !os.IsNotExist(statErr) {
+		t.Errorf("the valid target was written despite the refusal (stat err = %v)", statErr)
+	}
+}
+
+func TestInstallToRequiresATarget(t *testing.T) {
+	_, err := InstallTo(t.TempDir(), nil)
+	if err == nil || !strings.Contains(err.Error(), "no install target named") {
+		t.Fatalf("expected a no-target error, got %v", err)
+	}
+}

--- a/skilldoc_test.go
+++ b/skilldoc_test.go
@@ -91,3 +91,33 @@ func TestInstallToRequiresATarget(t *testing.T) {
 		t.Fatalf("expected a no-target error, got %v", err)
 	}
 }
+
+// A write failure mid-list must still report what DID install, so the caller
+// can tell the operator ~/.claude was refreshed even though ~/.codex broke.
+func TestInstallToReportsPartialWritesOnFailure(t *testing.T) {
+	home := t.TempDir()
+	// A plain file where the .codex directory should go makes that target's
+	// MkdirAll fail after the claude write succeeded.
+	if err := os.WriteFile(filepath.Join(home, ".codex"), []byte("in the way"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	written, err := InstallTo(home, []string{"claude", "codex"})
+	if err == nil {
+		t.Fatal("expected the codex write to fail")
+	}
+	want := filepath.Join(home, ".claude", "skills", "hap", "SKILL.md")
+	if len(written) != 1 || written[0] != want {
+		t.Fatalf("written = %v, want the already-installed %q", written, want)
+	}
+}
+
+// Argument mistakes are reported as such even when $HOME is unresolvable —
+// validation must run before home resolution.
+func TestInstallValidatesTargetsBeforeResolvingHome(t *testing.T) {
+	t.Setenv("HOME", "")
+	_, err := Install([]string{"cursor"})
+	if err == nil || !strings.Contains(err.Error(), `unknown install target "cursor"`) {
+		t.Fatalf("expected the unknown-target error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- **`hap --skill` / `hap skill` / `hap skill show`** prints the hap agent skill document (`.claude/skills/hap/SKILL.md`) to stdout. The file ships **inside the binary** via the repo's first `go:embed` (new root package `skilldoc` — the only package that can reach `.claude/` without duplication, since embed paths cannot contain `..`).
- **`hap skill install <claude|codex|agents>...`** writes the bundled SKILL.md to `~/.claude/skills/hap/`, `~/.codex/skills/hap/`, or `~/.agents/skills/hap/` (atomic temp+rename; validates targets before touching the filesystem; a mid-list failure still reports what did install).
- **TUI Config-tab quick shortcut** "Install hap agent skill" opens a new **multi-select picker mode** (space toggles `[x]`, enter submits the checked set, highlighted-row fallback when none checked — same convention as the list-tab multi-selects). Reports through the usual async `actionResultMsg` → status note; the existing install-hap symlink confirm flow is untouched.
- **Idempotent pause/resume**: `hap pause`/`hap resume` and the TUI `p`/`r` keys now detect a no-op (pausing while paused, resuming while running) — they report "already paused/resumed" and record **no kill-history event**, so repeated presses no longer flood the history. The TUI's self-caused-pause bell suppression survives a rapid double-press (`pausePending` is only cleared on a no-op the TUI had already observed as paused), and `pauseCmd` gained the inflight-WaitGroup accounting so a `p` just before quit still lands.
- `hap skill --help`, `hap --skill --help`, and `hap help skill` all render the registry guide (`help()` now resolves a dashed registered alias instead of falling back to the overview).
- Deliberately not using `taskfile.WriteFileAtomic` (repo guard test bans new callers); the installer carries its own local temp+rename.

## Testing
- New tests: `skilldoc_test.go` (embed presence, all-target install, overwrite, fail-before-write, partial-write reporting, validate-before-home), `cmd/hap` `TestRunSkill` (print/`show`/typo/no-target/real install under fake `$HOME`), `internal/tui/skillinstall_test.go` (row placement, toggle render, async submit, fallback, esc, error surfacing), `TestWantsCommandHelp` alias cases, `TestPauseResumeNoOpsRecordNoKillEvent`, `TestBellPausePendingClearedOnNoOpPauseAction`, `TestBellNoOpPauseBeforeObservedTransitionKeepsSuppression`.
- Full suite `go test -tags "vectors cpu" ./... -count=1`: all touched packages green across five runs; only failures are the two documented pre-existing flakes (`internal/daemon` shutdown-drain timing, `internal/embedder` stall-guard under load) in untouched packages.
- `gofmt`, `go vet`, `golangci-lint run --build-tags "vectors,cpu"`: clean.
- Manual smoke: `hap --skill | wc -c` = 77320 (byte-identical to the repo file); `hap skill show` identical; install under a fake `$HOME` creates all three layouts; typo/no-target refused with exit 1.