### PR TITLE
#1 chore: bump plugin version to 0.6.10 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.6.10
+
+- Added `hap --skill` (also `hap skill` / `hap skill show`): prints the bundled hap agent skill document — SKILL.md now ships inside the binary, so no repo checkout is needed to read it.
+- Added skill installation for coding agents: `hap skill install <claude|codex|agents>...` and a Config-tab quick shortcut in the TUI (multi-select Claude / Codex / Others) write the bundled SKILL.md to `~/.claude/skills/hap/`, `~/.codex/skills/hap/`, or `~/.agents/skills/hap/`.
+- Changed `hap pause` / `hap resume` (and the TUI `p`/`r` keys) to be idempotent: pausing while already paused or resuming while already running now reports "already paused/resumed" and records no kill-history event, so repeated presses no longer flood the history with no-op rows.
+
 ## 0.6.9
 
 - Changed the default `learning.graduation_n` from 2 to 1 and `learning.confirmation_weight` from 3.0 to 2.0 — a rule now graduates to autonomous after a single consistent operator confirmation.

--- a/changelog.d/feat-skill-flag.md
+++ b/changelog.d/feat-skill-flag.md
@@ -1,3 +1,0 @@
-- Added `hap --skill` (also `hap skill` / `hap skill show`): prints the bundled hap agent skill document — SKILL.md now ships inside the binary, so no repo checkout is needed to read it.
-- Added skill installation for coding agents: `hap skill install <claude|codex|agents>...` and a Config-tab quick shortcut in the TUI (multi-select Claude / Codex / Others) write the bundled SKILL.md to `~/.claude/skills/hap/`, `~/.codex/skills/hap/`, or `~/.agents/skills/hap/`.
-- Changed `hap pause` / `hap resume` (and the TUI `p`/`r` keys) to be idempotent: pausing while already paused or resuming while already running now reports "already paused/resumed" and records no kill-history event, so repeated presses no longer flood the history with no-op rows.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.6.9"
+version = "0.6.10"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.6.10 is being released from this commit by the Auto Release workflow.