### PR TITLE
#1 fix: dedup an idle escalation before the task generator runs, and widen the window to 10m

### DIFF
--- a/changelog.d/fix-dedup-before-llm-and-window.md
+++ b/changelog.d/fix-dedup-before-llm-and-window.md
@@ -1,2 +1,3 @@
 - Fixed an idle agent's duplicate escalation costing a full task-generation LLM run before being discarded — the duplicate-ask check now runs before the generator is invoked, not after its result comes back. Measured on one agent in one morning, six of fourteen generation subprocesses were executed purely to be thrown away.
 - Changed the escalation duplicate-ask window from 5 to 10 minutes, so a re-fire of a situation the operator just resolved no longer slips through as a second escalation when they come back to the pane a few minutes later.
+- Fixed the startup warning for the retired `limits.escalation_dedup_window_seconds` key still telling operators the window is fixed at 5 minutes.

--- a/changelog.d/fix-dedup-before-llm-and-window.md
+++ b/changelog.d/fix-dedup-before-llm-and-window.md
@@ -1,0 +1,2 @@
+- Fixed an idle agent's duplicate escalation costing a full task-generation LLM run before being discarded — the duplicate-ask check now runs before the generator is invoked, not after its result comes back. Measured on one agent in one morning, six of fourteen generation subprocesses were executed purely to be thrown away.
+- Changed the escalation duplicate-ask window from 5 to 10 minutes, so a re-fire of a situation the operator just resolved no longer slips through as a second escalation when they come back to the pane a few minutes later.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1732,8 +1732,19 @@ func Load(path string) (Config, error) {
 	// `escalation_dedup_jitter_percent`: the escalation duplicate-ask tuning is now
 	// a fixed internal constant. Probe the raw file to warn rather than silently
 	// drop them; Save omits them (no struct fields).
+	//
+	// The values below are spelled out by HAND and cannot be derived: they live in
+	// daemon.escalationDedupWindow / escalationDedupJitterPercent, and daemon
+	// imports config, so config cannot import them back. This package's own tests
+	// assert only on the KEY name, so nothing here catches the values drifting —
+	// which is how the window text went on claiming 5 minutes after it became 10,
+	// telling every operator with a legacy config something false. The guard is
+	// daemon.TestDedupConstantsMatchTheRetiredKeyWarnings, which sits on the side
+	// that can see both: it drives Load and fails if either sentence stops
+	// matching its constant. Keep the phrasing it greps for ("fixed N minutes" /
+	// "fixed N%") intact when rewording.
 	if legacy.Limits.EscalationDedupWindowSeconds != nil {
-		warnOnce("config key `limits.escalation_dedup_window_seconds` is no longer supported and is ignored; the escalation dedup window is a fixed 5 minutes",
+		warnOnce("config key `limits.escalation_dedup_window_seconds` is no longer supported and is ignored; the escalation dedup window is a fixed 10 minutes",
 			"path", path, "configured_value", *legacy.Limits.EscalationDedupWindowSeconds)
 	}
 	if legacy.Limits.EscalationDedupJitterPercent != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1993,6 +1993,22 @@ func (d *Daemon) decideAndAct(ctx context.Context, situation domain.Situation,
 		// escalate()'s guard is what makes this safe (and why the obvious weaker
 		// justification is wrong). escalate() still re-checks, which covers the
 		// async outcome landing after the queue moved on.
+		//
+		// The read and the ignore are separate operations, so an operator
+		// dismissing the matching pending row in between makes this suppress a
+		// generation escalate() would by then have allowed. That window is
+		// inherent to the check rather than introduced here — escalate() reads
+		// the same set and writes the same row non-atomically — and this call
+		// site NARROWS it, from "an LLM subprocess plus a write" to just the
+		// write. Its cost is also bounded to one skipped cycle: nothing is
+		// staged before this point (StageLLMRequest lives inside generateTask),
+		// so no request row, reservation or file write is stranded, and the next
+		// attention event or idle re-drive raises the situation again. Making it
+		// atomic would need a store method fusing the query with the audit write,
+		// applied to escalate() too or the two verdicts diverge — a large change
+		// against a race whose worst outcome self-heals, and whose trigger
+		// (the operator retiring exactly this ask) is the case where skipping is
+		// arguably right anyway.
 		if d.duplicateAskBeforeLLM(ctx, situation) {
 			// Mirror escalate()'s own first act: this episode is resolving without
 			// an autonomous send, so an auto-send pairing held for this agent is

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1606,7 +1606,14 @@ const (
 	// re-fire would raise a second, duplicate escalation. Measured from when the
 	// escalation was raised; still-pending escalations dedup regardless of age —
 	// only resolved ones are time-gated.
-	escalationDedupWindow = 5 * time.Minute
+	//
+	// 10 minutes rather than the original 5: measured live (2026-08-17) against a
+	// real herd, the re-fire of a just-resolved situation regularly lands well
+	// past the 5-minute mark, because the delay is set by when the OPERATOR next
+	// looks at the pane, not by anything the daemon controls. A window shorter
+	// than that gap lets the re-fire raise a second, duplicate escalation for a
+	// question the operator has already answered.
+	escalationDedupWindow = 10 * time.Minute
 	// escalationDedupJitterPercent is how much two large pane captures may differ
 	// (0-100) and still count as the same screen for the duplicate-ask check —
 	// absorbing residual TUI jitter the normalizer misses. It applies ONLY to
@@ -1660,6 +1667,61 @@ func (d *Daemon) duplicatePendingEscalation(ctx context.Context, s domain.Situat
 	return domain.DuplicatesPendingEscalation(s.Type,
 		truncateTailRunes(s.Content, snapshotMaxRunes), snapshotMaxRunes,
 		escalationDedupJitterPercent, pending)
+}
+
+// duplicateAskBeforeLLM reports whether a would-be escalation for this situation
+// is already awaiting the operator — the SAME verdict escalate() reaches, asked
+// early enough to skip an LLM subprocess whose only possible product is that
+// duplicate escalation.
+//
+// It exists because the duplicate check inside escalate() runs too late for the
+// task-generation path: generateTask shells out to the operator's LLM CLI (tens
+// of seconds to minutes, with tool calls, in the agent's cwd) and its outcome
+// funnels back through escalate(), which then discards it. Measured live
+// (2026-08-17) on a single agent in one morning: 14 task-generation subprocesses
+// produced 8 escalations — six full runs executed purely to be thrown away.
+// HasPendingLLMConsult does not cover this: it blocks only CONCURRENT
+// generations, never sequential ones.
+//
+// It mirrors escalate()'s guard exactly, INCLUDING the auto-dismiss precedence:
+// a proven-gone or disabled agent must still reach escalate(), so its lifecycle
+// decision is recorded as a dismissal in history rather than hidden behind an
+// opaque "duplicate".
+//
+// WHY THIS IS SAFE — and the reason is VERDICT EQUIVALENCE, not "the gated path
+// only escalates". That weaker-sounding rule is the tempting one and it is
+// FALSE: escalate() does not end at the audit row, it ends at
+// maybeFSPAcceptNow, which under [full_self_prompting] enabled +
+// accept_generated_task claims the row and DELIVERS the generated task to the
+// pane. So with that mode on, a generated-task escalation is precisely a
+// potential send. What makes the early gate sound is that escalate() applies
+// this same verdict BEFORE the audit write and before the FSP hook — so a
+// situation this helper suppresses could never have reached the delivery
+// either. The set of suppressed situations is identical; only the LLM
+// subprocess in between is skipped.
+//
+// Do NOT restate this as "safe to gate any path that can only escalate" — with
+// full self-prompting on, EVERY escalation is a potential pane delivery, so that
+// rule gives the wrong answer for any other call site.
+//
+// consultLLM is deliberately NOT gated, and there the difference is real rather
+// than cosmetic: handleLLMOutcome can promote a consult to a SEND on a path that
+// does NOT run escalate()'s dedup first, so a situation whose escalation would
+// be a duplicate may still be legitimately auto-answered. Gating it would
+// convert that answer into silence and leave the agent blocked — the same
+// reasoning escalate() gives for not gating before decideAndAct. It also costs
+// nothing to leave it out: every wasted call measured above was a task
+// generation, not a consult.
+// The two checks are ordered cheapest-first, which escalate() cannot do because
+// it needs the auto-dismiss reason either way: duplicatePendingEscalation is a
+// local SQLite read, while escalationAutoDismissReason costs a herdr ListAgents
+// round-trip on the main loop. Since both must hold, testing the cheap one first
+// leaves the common (non-duplicate) case paying only the query.
+func (d *Daemon) duplicateAskBeforeLLM(ctx context.Context, s domain.Situation) bool {
+	if !d.duplicatePendingEscalation(ctx, s) {
+		return false
+	}
+	return d.escalationAutoDismissReason(ctx, s.AgentID) == ""
 }
 
 // ignoreDuplicate audits a no-op for an event whose situation already has a
@@ -1922,6 +1984,22 @@ func (d *Daemon) decideAndAct(ctx context.Context, situation domain.Situation,
 				d.escalate(ctx, situation, sig, decision, tr, now)
 				return
 			}
+		}
+		// Dedup BEFORE the LLM runs, not after. handleTaskGenOutcome funnels every
+		// outcome back through escalate(), which applies this same verdict before
+		// its audit write — so when the answer is "duplicate", the whole generation
+		// is dead work, and it is the expensive kind: a full LLM CLI subprocess in
+		// the agent's cwd. See duplicateAskBeforeLLM for why equivalence with
+		// escalate()'s guard is what makes this safe (and why the obvious weaker
+		// justification is wrong). escalate() still re-checks, which covers the
+		// async outcome landing after the queue moved on.
+		if d.duplicateAskBeforeLLM(ctx, situation) {
+			// Mirror escalate()'s own first act: this episode is resolving without
+			// an autonomous send, so an auto-send pairing held for this agent is
+			// spent and must not be withheld from the rest of the herd.
+			d.dropAutoTaskClaim(situation.AgentID)
+			d.ignoreDuplicate(ctx, situation, tr, now)
+			return
 		}
 		d.generateTask(ctx, cfg, situation, sig, tr, now, declared != nil)
 	default:

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1776,8 +1776,10 @@ func TestPipelineDedupAfterResolveWithinWindow(t *testing.T) {
 	}
 
 	// Herdr re-delivers the same screen (done->idle when the operator read the
-	// pane). The default window is 5 minutes, so this immediate re-fire is well
-	// inside it: no new escalation, and one ignored audit row.
+	// pane). This immediate re-fire is well inside the window whatever it is
+	// tuned to, so it stays a duplicate: no new escalation, and one ignored audit
+	// row. The window's actual span is pinned separately, by
+	// TestResolvedEscalationSevenMinutesOldStillDedups.
 	h.herdr.setPane(approvalPane)
 	h.push("agent-resolve-dup", "idle")
 	waitFor(t, 3*time.Second, func() bool { return len(ignoredRows(t, h)) == 1 })

--- a/internal/daemon/dedupbeforellm_test.go
+++ b/internal/daemon/dedupbeforellm_test.go
@@ -1,0 +1,279 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+)
+
+// dedupCutoffStore records the resolvedSince cutoff every duplicate-ask check
+// hands PendingEscalationExcerpts, so a test can assert the dedup WINDOW
+// behaviorally — what the query actually spans — rather than by reading the
+// constant back, which would pass no matter what the daemon does with it.
+type dedupCutoffStore struct {
+	ports.StorePort
+	mu      sync.Mutex
+	cutoffs []time.Time
+	asOf    []time.Time
+}
+
+func (s *dedupCutoffStore) PendingEscalationExcerpts(ctx context.Context,
+	agentID, agentType string, resolvedSince time.Time) ([]domain.PendingEscalation, error) {
+	s.mu.Lock()
+	s.cutoffs = append(s.cutoffs, resolvedSince)
+	s.asOf = append(s.asOf, time.Now())
+	s.mu.Unlock()
+	return s.StorePort.PendingEscalationExcerpts(ctx, agentID, agentType, resolvedSince)
+}
+
+func (s *dedupCutoffStore) windows() []time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]time.Duration, len(s.cutoffs))
+	for i := range s.cutoffs {
+		out[i] = s.asOf[i].Sub(s.cutoffs[i])
+	}
+	return out
+}
+
+// TestDuplicateIdleEventSkipsTheTaskGenerator is the invariant behind moving the
+// duplicate-ask check ahead of the LLM: a second idle event whose escalation
+// would be a duplicate must not spend a task-generation subprocess to discover
+// that.
+//
+// The check used to live only inside escalate(), which for this path runs AFTER
+// generateTask has already shelled out to the operator's LLM CLI — so every
+// suppressed duplicate still cost a full generation whose output was then
+// discarded (measured live 2026-08-17: 14 generations, 8 surviving escalations).
+// HasPendingLLMConsult does not cover it: that guard blocks only CONCURRENT
+// generations, never sequential ones.
+//
+// Asserting the generator call COUNT is the whole point — the escalation count
+// alone stayed correct throughout the bug, which is exactly why it shipped
+// green.
+func TestDuplicateIdleEventSkipsTheTaskGenerator(t *testing.T) {
+	idlePane := "Task is complete.\n"
+	h, tg := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+		return "Investigate the flaky auth test and add a retry guard", nil
+	})
+	h.herdr.setPane(idlePane)
+	ctx := context.Background()
+
+	// First idle event: no task source, so it generates a suggestion and
+	// escalates it.
+	h.push("agent-dedup-gen", "idle")
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	if calls := tg.genCalls(); len(calls) != 1 {
+		t.Fatalf("first idle event should generate once, got %d", len(calls))
+	}
+
+	// Second identical event while that escalation is still pending. It is a
+	// duplicate ask, so it must be ignored — and ignored BEFORE the generator
+	// runs.
+	h.push("agent-dedup-gen", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(ignoredRows(t, h)) == 1 })
+
+	if calls := tg.genCalls(); len(calls) != 1 {
+		t.Errorf("duplicate event invoked the task generator again: %d calls, want 1 "+
+			"(the duplicate check must run BEFORE the LLM, not after it)", len(calls))
+	}
+	if esc, _ := h.raw.PendingEscalations(ctx); len(esc) != 1 {
+		t.Errorf("duplicate event created a second escalation: got %d, want 1", len(esc))
+	}
+	if ign := ignoredRows(t, h); ign[0].Rationale != "duplicated event" {
+		t.Errorf("ignored rationale = %q, want %q", ign[0].Rationale, "duplicated event")
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Errorf("a suppressed duplicate must send nothing, sent %v", h.herdr.sentInputs())
+	}
+}
+
+// TestNewIdleSituationStillReachesTheTaskGenerator is the other half: the
+// pre-LLM gate must suppress only a genuine duplicate. A different screen on the
+// same agent is a different ask and must still generate, or the fix would trade
+// wasted LLM calls for silently dropped work.
+func TestNewIdleSituationStillReachesTheTaskGenerator(t *testing.T) {
+	h, tg := newHarnessTaskGen(t, "", func(ctx context.Context, req domain.TaskGenRequest) (string, error) {
+		return "Investigate the flaky auth test and add a retry guard", nil
+	})
+	ctx := context.Background()
+
+	h.herdr.setPane("Task is complete.\n")
+	h.push("agent-dedup-new", "idle")
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+
+	// A genuinely different idle screen on the SAME agent, while the first
+	// escalation is still pending.
+	h.herdr.setPane("All migrations applied. Nothing left in the queue.\n")
+	h.push("agent-dedup-new", "idle")
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(ctx)
+		return len(esc) == 2
+	})
+
+	if calls := tg.genCalls(); len(calls) != 2 {
+		t.Errorf("a new situation must still reach the generator: %d calls, want 2", len(calls))
+	}
+}
+
+// TestConsultIsNotGatedByTheDuplicateCheck pins the deliberate scope limit of
+// the pre-LLM gate, and it is a SAFETY bound rather than an efficiency one.
+//
+// The gate is sound for task generation only because handleTaskGenOutcome can
+// end in nothing but an escalation — it never touches the pane. A consult can be
+// promoted to a SEND, so a situation whose escalation would be a duplicate may
+// still be auto-answered. Gating consults would convert that answer into
+// silence, leaving the agent blocked on a question hap could have resolved —
+// the same reasoning escalate() gives for not gating before decideAndAct.
+func TestConsultIsNotGatedByTheDuplicateCheck(t *testing.T) {
+	var mu sync.Mutex
+	var consults int
+	// The fake MUST be installed before Run — assigning h.llm.consult afterwards
+	// races the startup sweep, which would consult with no fake and fold this
+	// test's own event in as a duplicate of that escalation.
+	h := newHarnessConsult(t, "", func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+		mu.Lock()
+		consults++
+		mu.Unlock()
+		// Low self-reported confidence: the consult resolves to an escalation
+		// rather than a send, so the pending queue stays comparable across both
+		// events and the assertion isolates the consult COUNT.
+		return &domain.LLMDecision{Action: "Yes", ConfidentScore: 10, Rationale: "unsure"}, nil
+	})
+	h.herdr.setPane(approvalPane)
+	ctx := context.Background()
+
+	h.push("agent-dedup-consult", "blocked")
+	waitFor(t, 5*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+	mu.Lock()
+	first := consults
+	mu.Unlock()
+	if first != 1 {
+		t.Fatalf("first blocked event should consult once, got %d", first)
+	}
+
+	// The identical event is a duplicate ASK, so no second escalation is
+	// raised — but the consult itself must still have run.
+	h.push("agent-dedup-consult", "blocked")
+	waitFor(t, 5*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return consults == 2
+	})
+
+	mu.Lock()
+	got := consults
+	mu.Unlock()
+	if got != 2 {
+		t.Errorf("consult calls = %d, want 2: the pre-LLM duplicate gate must NOT "+
+			"cover consults, which can be promoted to a send", got)
+	}
+	if esc, _ := h.raw.PendingEscalations(ctx); len(esc) != 1 {
+		t.Errorf("the duplicate consult must not raise a second escalation: got %d, want 1", len(esc))
+	}
+}
+
+// TestResolvedEscalationSevenMinutesOldStillDedups is the DISCRIMINATING pin on
+// the window bump: a re-fire of a situation the operator resolved seven minutes
+// ago must still be suppressed. It fails at the old 5-minute window and passes
+// at 10, which is what makes it a behavior pin rather than a change-detector.
+//
+// No fake clock is needed. The window is applied to the CORRECTION's created_at
+// (store.PendingEscalationExcerpts group 2), and MarkCorrectionSent does not
+// touch that column — so back-dating the correction on insert ages the resolved
+// row deterministically.
+func TestResolvedEscalationSevenMinutesOldStillDedups(t *testing.T) {
+	h := newHarness(t, "")
+	ctx := context.Background()
+	h.herdr.setPane(approvalPane)
+
+	h.push("agent-window-7m", "blocked")
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(ctx)
+		return len(esc) == 1
+	})
+
+	// The operator answered it seven minutes ago and the answer was DELIVERED
+	// (sent=1) — only a delivered correction makes a resolved row a dedup
+	// candidate, which is what keeps shadow-mode learning re-escalating.
+	esc, _ := h.raw.PendingEscalations(ctx)
+	corrID, err := h.raw.InsertCorrection(ctx, domain.CorrectionRecord{
+		AuditID: esc[0].ID, CorrectedAction: "respond: Yes", Author: "test",
+		CreatedAt: time.Now().Add(-7 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.raw.MarkCorrectionSent(ctx, corrID); err != nil {
+		t.Fatal(err)
+	}
+	if claimed, err := h.raw.ResolveEscalation(ctx, esc[0].ID); err != nil || !claimed {
+		t.Fatalf("resolve escalation: claimed=%v err=%v", claimed, err)
+	}
+
+	// Herdr re-delivers the same screen. Seven minutes is outside the old
+	// 5-minute window and inside the current one, so it must be ignored.
+	h.push("agent-window-7m", "idle")
+	waitFor(t, 3*time.Second, func() bool { return len(ignoredRows(t, h)) == 1 })
+
+	if p, _ := h.raw.PendingEscalations(ctx); len(p) != 0 {
+		t.Errorf("a re-fire 7m after the answer raised a duplicate ask: got %d, want 0 "+
+			"(the dedup window must outlast how long an operator takes to look back at a pane)", len(p))
+	}
+	if len(h.herdr.sentInputs()) != 0 {
+		t.Errorf("a suppressed duplicate must send nothing, sent %v", h.herdr.sentInputs())
+	}
+}
+
+// TestEscalationDedupWindowSpansTenMinutes asserts the window BEHAVIORALLY — the
+// cutoff the daemon actually hands the store — rather than by comparing the
+// constant to itself. It guards the plumbing (that the query still spans the
+// constant at all); TestResolvedEscalationSevenMinutesOldStillDedups above is
+// what pins the VALUE, so retuning the constant for a good reason breaks a test
+// that is actually about the behavior being retuned.
+//
+// The window bounds how long a just-RESOLVED escalation keeps suppressing a
+// re-fire of the same situation. It is set by when the operator next looks at
+// the pane, which the daemon does not control, so 5 minutes regularly expired
+// before the re-fire arrived and let a duplicate through.
+func TestEscalationDedupWindowSpansTenMinutes(t *testing.T) {
+	var rec *dedupCutoffStore
+	fl := &fakeLLM{}
+	h := newHarnessCore(t, "", nil, fl, fl, func(inner ports.StorePort) ports.StorePort {
+		rec = &dedupCutoffStore{StorePort: inner}
+		return rec
+	})
+	h.herdr.setPane(approvalPane)
+
+	h.push("agent-dedup-window", "blocked")
+	waitFor(t, 3*time.Second, func() bool {
+		esc, _ := h.raw.PendingEscalations(context.Background())
+		return len(esc) == 1
+	})
+
+	windows := rec.windows()
+	if len(windows) == 0 {
+		t.Fatal("no duplicate-ask query was made")
+	}
+	// Allow slack for the time between the daemon's clock read and the
+	// recorder's; only the order of magnitude is being pinned.
+	const slack = 30 * time.Second
+	for i, w := range windows {
+		if w < 10*time.Minute-slack || w > 10*time.Minute+slack {
+			t.Errorf("dedup query %d spanned %v, want ~10m", i, w)
+		}
+	}
+}

--- a/internal/daemon/retention_test.go
+++ b/internal/daemon/retention_test.go
@@ -1,8 +1,16 @@
 package daemon
 
 import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store"
 )
 
@@ -28,5 +36,46 @@ func TestEscalationDedupWindowFitsAuditExcerptMargin(t *testing.T) {
 func TestRetentionIntervalIsDailyNotPerSweep(t *testing.T) {
 	if retentionInterval < 24*60*60*1e9 {
 		t.Errorf("retentionInterval = %v, want at least 24h", retentionInterval)
+	}
+}
+
+// TestDedupConstantsMatchTheRetiredKeyWarnings pins a second relationship the
+// type system cannot express, in the opposite direction from the one above.
+//
+// config.Load warns operators that the retired `limits.escalation_dedup_*` keys
+// are now fixed internal constants, and it spells the VALUES out in prose
+// because config cannot import daemon (daemon imports config). Nothing fails
+// when they drift — config's own tests assert only on the KEY name — so the
+// 5-minute text survived this window becoming 10 and told every operator with a
+// legacy config something false. This test lives in daemon, which CAN see both
+// sides, and fails the moment either constant stops matching its sentence.
+func TestDedupConstantsMatchTheRetiredKeyWarnings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(
+		"[limits]\nescalation_dedup_window_seconds = 300\nescalation_dedup_jitter_percent = 7\n"),
+		0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	defer slog.SetDefault(prev)
+
+	if _, err := config.Load(path); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	got := logs.String()
+	for _, want := range []string{
+		fmt.Sprintf("fixed %d minutes", int(escalationDedupWindow/time.Minute)),
+		fmt.Sprintf("fixed %d%%", escalationDedupJitterPercent),
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the retired-key warning no longer states %q — a constant was retuned "+
+				"without updating its operator-facing sentence in internal/config/config.go.\nwarnings: %s",
+				want, got)
+		}
 	}
 }

--- a/internal/store/retention_test.go
+++ b/internal/store/retention_test.go
@@ -265,7 +265,10 @@ func TestPruneAuditExcerptsPreservesPendingEscalationDedupSet(t *testing.T) {
 		t.Fatalf("mark sent: %v", err)
 	}
 
-	resolvedSince := now.Add(-5 * time.Minute) // the daemon's escalationDedupWindow
+	// An arbitrary window this test picks for itself. store cannot import daemon,
+	// so this deliberately does NOT track escalationDedupWindow — don't "fix" it
+	// to match that constant, and don't read it as documenting its value.
+	resolvedSince := now.Add(-5 * time.Minute)
 	before, err := s.PendingEscalationExcerpts(ctx, "pane-1", "claude", resolvedSince)
 	if err != nil {
 		t.Fatalf("dedup set before: %v", err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -388,7 +388,10 @@ func TestPendingEscalationExcerpts(t *testing.T) {
 		return id
 	}
 
-	// The daemon derives this as now-window; here a 5-minute window.
+	// The daemon derives this as now-window. The 5 minutes here is a span this
+	// test picks for itself and deliberately does NOT track
+	// daemon.escalationDedupWindow — store cannot import daemon — so don't "fix"
+	// it to match that constant, and don't read it as documenting its value.
 	resolvedSince := now.Add(-5 * time.Minute)
 
 	// resolveSent marks an escalation resolved with a DELIVERED answer (the


### PR DESCRIPTION
## What

Two fixes to escalation duplicate-ask handling, both found by verifying the dedup logic against a live herdr + real Claude agents.

**1. Dedup now runs before the task-generation LLM, not after it.**

The duplicate-ask check lived only inside `escalate()`. On the task-generation path that is too late: `generateTask` shells out to the operator's LLM CLI first, and its outcome funnels back through `escalate()`, which then discards it. Every suppressed duplicate still cost a full subprocess — tens of seconds to minutes, with tool calls, in the agent's cwd.

Measured on one agent in one morning: **14 task-generation subprocesses produced 8 escalations**, so six complete runs executed purely to be thrown away.

```
788 03:24:59 → 1082 03:25:25 ignored
790 03:31:20 → 1084 03:31:44 ignored
792 03:42:04 → 1086 03:42:26 ignored
798 05:00:05 → 1095 05:00:28 ignored
800 07:18:11 → 1097 07:18:42 ignored
803 07:21:59 → 1100 07:22:57 ignored
```

`HasPendingLLMConsult` does not cover this — it blocks only *concurrent* generations, never sequential ones.

**2. `escalationDedupWindow` 5m → 10m.**

The window is set by when the operator next looks at the pane, which the daemon does not control, so 5 minutes regularly expired before the re-fire arrived. Still well inside `store.AuditExcerptDedupMargin` (1h), so the retention pin holds.

## Why it is safe

The justification here matters more than usual, and the first version of it was **wrong** (caught in review).

The tempting argument is "safe to gate, because this path can only produce an escalation and never touches the pane." That is false: `escalate()` does not end at the audit row, it ends at `maybeFSPAcceptNow`, which under `[full_self_prompting] enabled` + `accept_generated_task` claims the row and **delivers the generated task to the pane**. With that mode on, a generated-task escalation is precisely a potential send.

What actually makes the early gate sound is **verdict equivalence**: `escalate()` applies this same verdict *before* its audit write and *before* the FSP hook, so a situation the early gate suppresses could never have reached the delivery either. The suppressed set is identical; only the LLM subprocess in between is skipped. The code comments now say this, and explicitly warn against restating it as the weaker rule — with FSP on, *every* escalation is a potential pane delivery, so that rule gives the wrong answer at any other call site.

`consultLLM` is deliberately **not** gated. `handleLLMOutcome` can promote a consult to a SEND on a path that does not run the dedup first, so gating it would convert a real answer into silence and leave the agent blocked. It also costs nothing to leave out — every wasted call measured above was a generation, not a consult.

## Tests

Five new tests, two of them mutation-proven:

- `TestDuplicateIdleEventSkipsTheTaskGenerator` — asserts the generator **call count**, which is the whole point: the escalation count stayed correct throughout the bug, which is why it shipped green. Reverting the gate makes it fail *while the "ignored duplicate" log still appears*.
- `TestResolvedEscalationSevenMinutesOldStillDedups` — the discriminating pin on the window bump: fails at 5m, passes at 10m. No fake clock needed — the window applies to the correction's `created_at`, and `MarkCorrectionSent` does not touch that column, so back-dating on insert ages the row deterministically.
- `TestNewIdleSituationStillReachesTheTaskGenerator` — the gate suppresses only genuine duplicates, so the fix cannot trade wasted LLM calls for dropped work.
- `TestConsultIsNotGatedByTheDuplicateCheck` — pins the scope limit above as a safety bound.
- `TestEscalationDedupWindowSpansTenMinutes` — guards that the query still spans the constant at all.

Full suite green (`go test -tags "vectors cpu" ./... -count=1`), `golangci-lint` clean, `gofmt` clean.

## Verified live

Swapped the daemon into a running herdr and forced three captures of one standing screen on a real Claude agent:

```
#1107  escalated          ← 1 task-generation LLM call
#1108  duplicated event   ← no LLM call, 3s later
#1109  duplicated event   ← no LLM call
gentask_calls = 1
```

Pre-fix that would have been three calls. The ~3s latency is itself the evidence the subprocess was skipped — the old path took 25–60s waiting on it.

## Deliberately not in this PR

- **The root cause of the duplicate escalations themselves.** For `idle`/`no_task_source`, dedup is keyed on normalized pane content, but that class's question ("this agent is parked with no task source") does not depend on the pane at all. An actively-driven agent's screen changes between every idle event, so the class can never dedup. This PR fixes the *cost* of that, not the cause. The fix needs a reason-keyed identity with a store-level field, and it must key on the escalate reason rather than situation type — `noop_vs_pending_tasks` is also `idle`-typed and must keep escalating.
- **An under-escalation bug found while testing.** Twice, an agent settling to idle produced no attention event at all — herdr never observed a "working" state for a fast reply, so no transition fired. Opposite direction, adjacent to #356.
