### PR TITLE
#1 fix: keep the roster publisher off the daemon's loop and out of its writes

### DIFF
--- a/changelog.d/fix-roster-publish-connection-pressure.md
+++ b/changelog.d/fix-roster-publish-connection-pressure.md
@@ -1,0 +1,14 @@
+- Fixed the daemon losing bookkeeping writes while it published the running
+  agents. Publishing took a database transaction on the loop that handles every
+  agent, on the same paths as the daemon's own work — and because those
+  transactions began as readers, one that committed in between made another
+  fail outright with `database is locked (517)`, which is not retried. The
+  daemon logs such a failure and carries on, so the write simply never
+  happened: an agent's first-seen time was left unreset after its pane had been
+  recycled. Publishing now runs off that loop entirely, transactions take their
+  lock up front, and the database hands out enough connections that a read no
+  longer waits behind an unrelated write
+- Changed when the herd is republished. It happens at startup, on the
+  once-a-minute sweep, and every two seconds while a TUI is open — no longer on
+  every operator action. Nothing reads any fresher for it: `hap agents` and
+  `hap status` are pure reads and never woke the daemon in the first place

--- a/changelog.d/fix-roster-publish-connection-pressure.md
+++ b/changelog.d/fix-roster-publish-connection-pressure.md
@@ -12,3 +12,8 @@
   once-a-minute sweep, and every two seconds while a TUI is open — no longer on
   every operator action. Nothing reads any fresher for it: `hap agents` and
   `hap status` are pure reads and never woke the daemon in the first place
+- Fixed an agent's status briefly reverting after it started working. The daemon
+  lists its agents and records that listing a moment later, so a status change
+  arriving in between was overwritten by the older reading — and with no TUI
+  open the next listing is a minute away. An agent that had just gone to work
+  could read as free for that minute, including to `hap task send`

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -285,6 +285,12 @@ type Daemon struct {
 	// the life of the process.
 	rosterPassRunning bool
 
+	// rosterPending is the newest listing waiting to be published (guarded by
+	// mu). Latest-wins: a listing arriving while the pass runs replaces this
+	// rather than queueing, since an older snapshot can only describe a herd
+	// that has moved on.
+	rosterPending *rosterSnapshot
+
 	// rosterTickRunning latches the roster TICK's own goroutine (guarded by
 	// mu), which lists the herd before publishRoster can hand its shell-out
 	// half over. Same single-flight rule, one step earlier in the pass: the
@@ -1167,7 +1173,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		} else if n > 0 {
 			slog.Info("auto-accept: returned abandoned claims to the pending queue", "count", n)
 		}
-		d.reconcileAttention(ctx)
+		d.reconcileAttentionPublishing(ctx, true)
 		// The agent-action queue is recovered and drained LAST at startup,
 		// deliberately.
 		//
@@ -1578,17 +1584,33 @@ func (d *Daemon) scheduleCapture(ctx context.Context, tr domain.AgentTransition)
 // capture→classify→escalate path (like applyLLMRetry) exactly once per parked
 // episode. Runs on the sweep path, where ListAgents is already called.
 func (d *Daemon) reconcileAttention(ctx context.Context) {
+	d.reconcileAttentionPublishing(ctx, false)
+}
+
+// reconcileAttentionPublishing is reconcileAttention that may also record the
+// listing it made.
+//
+// Publishing is opt-in per caller rather than automatic, because this function
+// is also the NUDGE path — every operator action, and the daemon's own
+// self-nudges, land here. Publishing on each of those made the roster a
+// writer on the daemon's busiest path, competing for a store that hands out
+// two connections and admits one writer at a time; the herd is already
+// refreshed by the sweep every minute, and every two seconds while a TUI is
+// open, so those publishes bought nothing and cost the daemon's own
+// bookkeeping its turn at the lock.
+//
+// Startup passes true: it is the FIRST listing a freshly started daemon
+// makes, and without it a new install shows an empty herd until the first
+// sweep, since the front ends read the store and nothing else has written it.
+func (d *Daemon) reconcileAttentionPublishing(ctx context.Context, publish bool) {
 	agents, err := d.opt.Herdr.ListAgents(ctx)
 	if err != nil {
 		slog.Error("reconcile: listing agents failed", "error", err)
 		return
 	}
-	// This is the FIRST listing a freshly started daemon makes, so publishing
-	// here is what stops a new install showing an empty herd for up to a
-	// minute — the front ends read the store now, and nothing else would have
-	// written it until the first sweep. The nudge path lands here too, which
-	// is why a front end's own wake produces a current roster.
-	d.publishRoster(ctx, agents)
+	if publish {
+		d.publishRoster(ctx, agents)
+	}
 	d.reconcileAttentionWith(ctx, agents)
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -291,6 +291,12 @@ type Daemon struct {
 	// that has moved on.
 	rosterPending *rosterSnapshot
 
+	// rosterStoodDown, when set, is called just after the roster worker
+	// releases its latch (guarded by mu). Test-only: it is how the handoff
+	// window — microseconds wide, and unreachable by timing — is driven
+	// deterministically.
+	rosterStoodDown func()
+
 	// rosterTickRunning latches the roster TICK's own goroutine (guarded by
 	// mu), which lists the herd before publishRoster can hand its shell-out
 	// half over. Same single-flight rule, one step earlier in the pass: the

--- a/internal/daemon/roster.go
+++ b/internal/daemon/roster.go
@@ -176,14 +176,7 @@ func (d *Daemon) publishRoster(ctx context.Context, agents []domain.AgentTransit
 	d.rosterPassRunning = true
 	d.mu.Unlock()
 
-	if !d.spawn(func() {
-		defer func() {
-			d.mu.Lock()
-			d.rosterPassRunning = false
-			d.mu.Unlock()
-		}()
-		d.runRosterPasses(ctx)
-	}) {
+	if !d.spawn(func() { d.runRosterPasses(ctx) }) {
 		d.mu.Lock()
 		d.rosterPassRunning = false
 		d.mu.Unlock()
@@ -203,15 +196,46 @@ type rosterSnapshot struct {
 // rather than being dropped, so the last thing the daemon saw is always what
 // ends up stored — including an empty listing, the only evidence that an agent
 // has vanished.
+//
+// Finding no work and standing down happen under ONE lock, and that is the
+// whole handoff. Releasing the latch afterwards — in a defer, say — leaves a
+// window where the worker has decided to exit but still looks busy: a listing
+// arriving there is stored as pending, sees a running pass, and returns, and
+// then the worker exits without ever consuming it. The listing is not lost
+// forever, but it waits for the NEXT publish, which with no TUI open is the
+// minute sweep — and an empty listing stranded that way is the vanish
+// reconciliation this loop exists to guarantee.
 func (d *Daemon) runRosterPasses(ctx context.Context) {
+	// Only the panic path: the loop below releases the latch itself, under
+	// the same lock that finds nothing to do.
+	released := false
+	defer func() {
+		if released {
+			return
+		}
+		d.mu.Lock()
+		d.rosterPassRunning = false
+		d.mu.Unlock()
+	}()
 	for {
 		d.mu.Lock()
 		snap := d.rosterPending
 		d.rosterPending = nil
-		d.mu.Unlock()
 		if snap == nil {
+			d.rosterPassRunning = false
+			released = true
+			// Read under the same lock that owns it; called after, so the
+			// hook is free to publish. A test uses it to drive a listing into
+			// exactly this window, which is microseconds wide and so cannot be
+			// hit reliably by timing.
+			hook := d.rosterStoodDown
+			d.mu.Unlock()
+			if hook != nil {
+				hook()
+			}
 			return
 		}
+		d.mu.Unlock()
 		if err := d.opt.Store.PublishRoster(ctx, snap.rows, snap.at); err != nil {
 			slog.Warn("roster: publishing failed", "error", err)
 			continue

--- a/internal/daemon/roster.go
+++ b/internal/daemon/roster.go
@@ -139,17 +139,22 @@ func (d *Daemon) startRosterTickPass(ctx context.Context) {
 //
 // Callers pass the agents they listed for their own reasons — the startup
 // reconcile, the sweep, the roster tick — so the ordinary path costs no extra
-// shell-out at all. Failure is logged, never propagated: publishing is
-// bookkeeping for a reader, and a front end that sees a stale roster degrades
-// to showing stale data, which domain.RosterFresh already bounds.
+// shell-out at all.
 //
-// Only the agent rows are written HERE, on the caller's goroutine. Everything
-// that shells out — the location labels, the per-agent working directories —
-// is handed to a background goroutine, because this runs on the daemon's
-// select loop and that loop handles every agent. The store also hands out very
-// few connections, so a transaction taken here is one the goroutine recording
-// an operator's actual work cannot have; that is not a theoretical cost, it is
-// what made a rename miss its deadline while a publish held the connection.
+// NOTHING is written here. The caller is usually the daemon's select loop, and
+// that loop handles every agent's transitions, nudges and timers; the store
+// hands out two connections and serializes writers, so a transaction taken on
+// the loop is one the goroutine recording an operator's actual work has to
+// wait for. That is not theoretical twice over: an inline publish made a
+// rename miss its deadline, and a publish committing between another
+// transaction's read and its write made the terminal-id sync fail outright
+// with "database is locked (517)" — a lost write nothing retried.
+//
+// So the listing is handed to a single background pass, and a listing arriving
+// while one runs REPLACES the pending one rather than queueing or being
+// dropped. Latest-wins is the correct rule for a snapshot: an older listing
+// can only describe a herd that has since moved on, and dropping it outright
+// would lose the vanish reconciliation only a full listing can perform.
 func (d *Daemon) publishRoster(ctx context.Context, agents []domain.AgentTransition) {
 	now := d.opt.Clock.Now()
 	rows := make([]domain.RosterAgent, 0, len(agents))
@@ -162,25 +167,8 @@ func (d *Daemon) publishRoster(ctx context.Context, agents []domain.AgentTransit
 		}
 		rows = append(rows, domain.RosterAgentFrom(tr, now))
 	}
-	if err := d.opt.Store.PublishRoster(ctx, rows, now); err != nil {
-		slog.Warn("roster: publishing failed", "error", err)
-		return
-	}
-	d.startRosterShellOuts(ctx, rows, now)
-}
-
-// startRosterShellOuts runs the half of a publish that costs subprocesses, once
-// at a time.
-//
-// The latch is the whole point. While a TUI is registered publishRoster runs
-// every rosterTickInterval, and one pass can outlive that interval on its own
-// budget — so an unlatched spawn would stack passes, each holding a transaction
-// on a two-connection pool, which is exactly the starvation moving this work
-// off the select loop was meant to end. A refused tick is not a lost update:
-// the pass already running is reading the same herd, and the next tick is two
-// seconds away.
-func (d *Daemon) startRosterShellOuts(ctx context.Context, rows []domain.RosterAgent, now time.Time) {
 	d.mu.Lock()
+	d.rosterPending = &rosterSnapshot{rows: rows, at: now}
 	if d.rosterPassRunning {
 		d.mu.Unlock()
 		return
@@ -188,22 +176,49 @@ func (d *Daemon) startRosterShellOuts(ctx context.Context, rows []domain.RosterA
 	d.rosterPassRunning = true
 	d.mu.Unlock()
 
-	cwdTTL, locationTTL := d.rosterShellOutTTLs()
 	if !d.spawn(func() {
 		defer func() {
 			d.mu.Lock()
 			d.rosterPassRunning = false
 			d.mu.Unlock()
 		}()
-		d.publishLocations(ctx, now, locationTTL)
-		d.refreshRosterCwds(ctx, rows, now, cwdTTL)
+		d.runRosterPasses(ctx)
 	}) {
-		// spawn refuses during shutdown, and the deferred release above never
-		// runs — release by hand, or a shutdown race would leave the latch set
-		// for the life of the process.
 		d.mu.Lock()
 		d.rosterPassRunning = false
 		d.mu.Unlock()
+	}
+}
+
+// rosterSnapshot is one listing waiting to be published.
+type rosterSnapshot struct {
+	rows []domain.RosterAgent
+	at   time.Time
+}
+
+// runRosterPasses publishes pending snapshots until none is left.
+//
+// The loop is what makes latest-wins safe: a listing that arrives while a pass
+// is running replaces the pending one and is picked up by this same goroutine
+// rather than being dropped, so the last thing the daemon saw is always what
+// ends up stored — including an empty listing, the only evidence that an agent
+// has vanished.
+func (d *Daemon) runRosterPasses(ctx context.Context) {
+	for {
+		d.mu.Lock()
+		snap := d.rosterPending
+		d.rosterPending = nil
+		d.mu.Unlock()
+		if snap == nil {
+			return
+		}
+		if err := d.opt.Store.PublishRoster(ctx, snap.rows, snap.at); err != nil {
+			slog.Warn("roster: publishing failed", "error", err)
+			continue
+		}
+		cwdTTL, locationTTL := d.rosterShellOutTTLs()
+		d.publishLocations(ctx, snap.at, locationTTL)
+		d.refreshRosterCwds(ctx, snap.rows, snap.at, cwdTTL)
 	}
 }
 

--- a/internal/daemon/roster_test.go
+++ b/internal/daemon/roster_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xGosu/herdr-auto-pilot/internal/control"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store"
@@ -39,7 +38,7 @@ func TestTheDaemonPublishesTheHerd(t *testing.T) {
 		{AgentID: "w1:p1", PaneID: "w1:p1", TabID: "w1:t1", WorkspaceID: "w1",
 			AgentType: "claude", Status: "idle", TerminalID: "term-a"},
 	})
-	nudgeDaemon(t, h)
+	publishNow(t, h)
 	waitFor(t, 3*time.Second, func() bool {
 		agents, publishedAt := liveRoster(t, h)
 		return len(agents) == 1 && !publishedAt.IsZero()
@@ -59,7 +58,7 @@ func TestTheDaemonPublishesTheHerd(t *testing.T) {
 func TestAnEmptyHerdIsStillAPublishedRoster(t *testing.T) {
 	h := newHarness(t, "")
 	h.herdr.setAgents(nil)
-	nudgeDaemon(t, h)
+	publishNow(t, h)
 	waitFor(t, 3*time.Second, func() bool {
 		_, publishedAt := liveRoster(t, h)
 		return !publishedAt.IsZero()
@@ -83,7 +82,7 @@ func TestAVanishedAgentLeavesTheLiveRoster(t *testing.T) {
 		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"},
 		{AgentID: "w1:p2", PaneID: "w1:p2", AgentType: "claude", Status: "idle"},
 	})
-	nudgeDaemon(t, h)
+	publishNow(t, h)
 	waitFor(t, 3*time.Second, func() bool {
 		agents, _ := liveRoster(t, h)
 		return len(agents) == 2
@@ -92,7 +91,7 @@ func TestAVanishedAgentLeavesTheLiveRoster(t *testing.T) {
 	h.herdr.setAgents([]domain.AgentTransition{
 		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"},
 	})
-	nudgeDaemon(t, h)
+	publishNow(t, h)
 	waitFor(t, 3*time.Second, func() bool {
 		agents, _ := liveRoster(t, h)
 		return len(agents) == 1
@@ -115,7 +114,7 @@ func TestARecycledPaneIDReplacesItsPredecessorsRow(t *testing.T) {
 	h.herdr.setAgents([]domain.AgentTransition{
 		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle", TerminalID: "term-a"},
 	})
-	nudgeDaemon(t, h)
+	publishNow(t, h)
 	waitFor(t, 3*time.Second, func() bool {
 		agents, _ := liveRoster(t, h)
 		a, ok := rosterByID(agents, "w1:p1")
@@ -129,7 +128,7 @@ func TestARecycledPaneIDReplacesItsPredecessorsRow(t *testing.T) {
 	h.herdr.setAgents([]domain.AgentTransition{
 		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "codex", Status: "idle", TerminalID: "term-b"},
 	})
-	nudgeDaemon(t, h)
+	publishNow(t, h)
 	waitFor(t, 3*time.Second, func() bool {
 		agents, _ := liveRoster(t, h)
 		a, ok := rosterByID(agents, "w1:p1")
@@ -158,7 +157,7 @@ func TestAPublishedCwdIsReusedWithinItsTTL(t *testing.T) {
 	h.herdr.setAgents([]domain.AgentTransition{
 		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"},
 	})
-	nudgeDaemon(t, h)
+	publishNow(t, h)
 	waitFor(t, 3*time.Second, func() bool {
 		agents, _ := liveRoster(t, h)
 		a, ok := rosterByID(agents, "w1:p1")
@@ -168,7 +167,7 @@ func TestAPublishedCwdIsReusedWithinItsTTL(t *testing.T) {
 
 	// Several more publishes inside the TTL must ask herdr nothing further.
 	for range 3 {
-		nudgeDaemon(t, h)
+		publishNow(t, h)
 	}
 	// Let the publishes land. There is nothing to wait FOR here — the
 	// assertion is that nothing further happened.
@@ -193,7 +192,7 @@ func TestAFailedCwdLookupStillPublishesTheAgent(t *testing.T) {
 	h.herdr.setAgents([]domain.AgentTransition{
 		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"},
 	})
-	nudgeDaemon(t, h)
+	publishNow(t, h)
 	waitFor(t, 3*time.Second, func() bool {
 		agents, _ := liveRoster(t, h)
 		return len(agents) == 1
@@ -209,7 +208,7 @@ func TestAFailedCwdLookupStillPublishesTheAgent(t *testing.T) {
 	waitFor(t, 3*time.Second, func() bool { return h.herdr.paneInfoCallCount() > 0 })
 	asked := h.herdr.paneInfoCallCount()
 	for range 3 {
-		nudgeDaemon(t, h)
+		publishNow(t, h)
 	}
 	// Nothing to wait FOR: the assertion is that nothing further happened.
 	time.Sleep(300 * time.Millisecond)
@@ -228,7 +227,7 @@ func TestPlaceholderRowsAreNeverPublished(t *testing.T) {
 		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"},
 		{AgentID: "w1:p9", PaneID: "w1:p9", AgentType: "", Status: "unknown"},
 	})
-	nudgeDaemon(t, h)
+	publishNow(t, h)
 	waitFor(t, 3*time.Second, func() bool {
 		agents, _ := liveRoster(t, h)
 		return len(agents) >= 1
@@ -271,13 +270,18 @@ func TestTheRosterTickIsIdleWithoutATUI(t *testing.T) {
 	}
 }
 
-// nudgeDaemon wakes the daemon so it re-lists and republishes at once, instead
-// of waiting out the periodic sweep.
-func nudgeDaemon(t *testing.T, h *harness) {
+// publishNow drives the listing-and-publish the SWEEP performs, without
+// waiting a minute for one.
+//
+// A nudge deliberately does not publish: it is the daemon's busiest path, and
+// no READ ever nudges — `hap agents` and `hap status` are pure reads — so
+// publishing there cost the daemon's own bookkeeping its turn at a store that
+// admits one writer, and bought no reader anything. The publish belongs to
+// the sweep, the startup reconcile and the TUI tick, which is what this
+// drives.
+func publishNow(t *testing.T, h *harness) {
 	t.Helper()
-	if err := control.Nudge(context.Background(), h.ctlPath, control.KindWake); err != nil {
-		t.Fatal(err)
-	}
+	h.daemon.reconcileAttentionPublishing(context.Background(), true)
 }
 
 // The publisher must not shell out on the daemon's select loop.
@@ -302,7 +306,7 @@ func TestTheRosterPublishDoesNotShellOutInline(t *testing.T) {
 	h.herdr.setAgents([]domain.AgentTransition{
 		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"},
 	})
-	nudgeDaemon(t, h)
+	publishNow(t, h)
 
 	// The row is readable while herdr is still being asked for the cwd.
 	waitFor(t, 3*time.Second, func() bool {
@@ -351,7 +355,7 @@ func TestARosterPassNeverOverlapsItself(t *testing.T) {
 	})
 	// Several publishes inside one pass's lifetime.
 	for range 4 {
-		nudgeDaemon(t, h)
+		publishNow(t, h)
 		time.Sleep(50 * time.Millisecond)
 	}
 	waitFor(t, 3*time.Second, func() bool {
@@ -378,7 +382,7 @@ func TestLocationLabelsAreNotRelistedOnEveryPublish(t *testing.T) {
 	h.herdr.setAgents([]domain.AgentTransition{
 		{AgentID: "w1:p1", PaneID: "w1:p1", WorkspaceID: "w1", AgentType: "claude", Status: "idle"},
 	})
-	nudgeDaemon(t, h)
+	publishNow(t, h)
 	waitFor(t, 3*time.Second, func() bool {
 		workspaces, _, err := h.raw.HerdrLocations(context.Background())
 		return err == nil && workspaces["w1"].Label == "main"
@@ -389,7 +393,7 @@ func TestLocationLabelsAreNotRelistedOnEveryPublish(t *testing.T) {
 	published := h.herdr.workspaceCallCount()
 
 	for range 4 {
-		nudgeDaemon(t, h)
+		publishNow(t, h)
 	}
 	// Nothing to wait FOR: the assertion is that nothing further happened.
 	time.Sleep(300 * time.Millisecond)
@@ -418,7 +422,7 @@ func TestADiscoveryEventNeverOverwritesAStatus(t *testing.T) {
 	h.herdr.setAgents([]domain.AgentTransition{
 		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"},
 	})
-	nudgeDaemon(t, h)
+	publishNow(t, h)
 	waitFor(t, 3*time.Second, func() bool {
 		agents, _ := liveRoster(t, h)
 		a, ok := rosterByID(agents, "w1:p1")
@@ -458,7 +462,7 @@ func TestThePublishedCwdFollowsTheForegroundRule(t *testing.T) {
 		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"},
 		{AgentID: "w1:p2", PaneID: "w1:p2", AgentType: "claude", Status: "idle"},
 	})
-	nudgeDaemon(t, h)
+	publishNow(t, h)
 	waitFor(t, 3*time.Second, func() bool {
 		agents, _ := liveRoster(t, h)
 		a, ok := rosterByID(agents, "w1:p1")
@@ -533,5 +537,48 @@ func TestTheRosterTickListsOffTheSelectLoop(t *testing.T) {
 	waitFor(t, 3*time.Second, func() bool {
 		agents, publishedAt, err := raw.LiveRoster(context.Background())
 		return err == nil && len(agents) == 1 && !publishedAt.IsZero()
+	})
+}
+
+// A listing that arrives while a pass is running must not be lost.
+//
+// The pass is single-flight, so a publish landing mid-pass cannot start its
+// own — and dropping it would lose the one thing only a full listing can say:
+// that an agent has VANISHED. No event reports a disappearance, so if the
+// empty listing is discarded the dead agent stays in the roster until some
+// later listing happens to arrive.
+//
+// Latest-wins rather than a queue: an older snapshot can only describe a herd
+// that has since moved on.
+func TestAListingArrivingMidPassIsStillPublished(t *testing.T) {
+	dir := t.TempDir()
+	raw, err := store.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { raw.Close() })
+
+	fh := &fakeHerdr{}
+	// Park the pass inside its cwd lookup, so the second publish lands while
+	// the first is demonstrably still running.
+	fh.setPaneInfos(map[string]domain.PaneInfo{"w1:p1": {PaneID: "w1:p1", Cwd: "/work"}})
+	fh.setPaneInfoDelay(400 * time.Millisecond)
+	d := &Daemon{opt: Options{StateDir: dir, Store: raw, Herdr: fh, Clock: ports.SystemClock{}}}
+	ctx := context.Background()
+
+	d.publishRoster(ctx, []domain.AgentTransition{
+		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"},
+	})
+	waitFor(t, 3*time.Second, func() bool {
+		agents, _, err := raw.LiveRoster(ctx)
+		return err == nil && len(agents) == 1
+	})
+
+	// The agent vanished. This publish lands while the first pass is still
+	// parked in its cwd lookup.
+	d.publishRoster(ctx, nil)
+	waitFor(t, 5*time.Second, func() bool {
+		agents, _, err := raw.LiveRoster(ctx)
+		return err == nil && len(agents) == 0
 	})
 }

--- a/internal/daemon/roster_test.go
+++ b/internal/daemon/roster_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -582,4 +583,63 @@ func TestAListingArrivingMidPassIsStillPublished(t *testing.T) {
 		agents, _, err := raw.LiveRoster(ctx)
 		return err == nil && len(agents) == 0
 	})
+}
+
+// A listing arriving exactly as the worker stands down must still be
+// published.
+//
+// The worker finds no pending work and exits; a publish landing between that
+// decision and the latch being released would store its snapshot, see a
+// running pass, and return — and then nothing would consume it. It is not
+// lost forever, but it waits for the NEXT publish, which with no TUI open is
+// the minute sweep. An empty listing stranded that way is precisely the
+// vanish reconciliation the pass exists to guarantee.
+//
+// Driven deterministically through the stand-down hook rather than by racing:
+// the window is microseconds wide, so a timing test would pass on a bug most
+// runs.
+func TestAListingRacingTheStandDownIsStillPublished(t *testing.T) {
+	dir := t.TempDir()
+	raw, err := store.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { raw.Close() })
+
+	fh := &fakeHerdr{}
+	d := &Daemon{opt: Options{StateDir: dir, Store: raw, Herdr: fh, Clock: ports.SystemClock{}}}
+	ctx := context.Background()
+
+	d.publishRoster(ctx, []domain.AgentTransition{
+		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"},
+	})
+	waitFor(t, 3*time.Second, func() bool {
+		agents, _, err := raw.LiveRoster(ctx)
+		return err == nil && len(agents) == 1
+	})
+
+	// The agent vanished, and its empty listing lands in the stand-down
+	// window exactly once.
+	var once sync.Once
+	d.setRosterStoodDown(func() {
+		once.Do(func() { d.publishRoster(ctx, nil) })
+	})
+	t.Cleanup(func() { d.setRosterStoodDown(nil) })
+
+	// Any publish now reaches the hook on its way out.
+	d.publishRoster(ctx, []domain.AgentTransition{
+		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"},
+	})
+	waitFor(t, 5*time.Second, func() bool {
+		agents, _, err := raw.LiveRoster(ctx)
+		return err == nil && len(agents) == 0
+	})
+}
+
+// setRosterStoodDown installs the stand-down hook under the lock that owns it,
+// so a test writing it cannot race the worker reading it.
+func (d *Daemon) setRosterStoodDown(fn func()) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.rosterStoodDown = fn
 }

--- a/internal/daemon/roster_test.go
+++ b/internal/daemon/roster_test.go
@@ -308,19 +308,20 @@ func TestTheRosterPublishDoesNotShellOutInline(t *testing.T) {
 	})
 	publishNow(t, h)
 
-	// The row is readable while herdr is still being asked for the cwd.
-	waitFor(t, 3*time.Second, func() bool {
-		agents, _ := liveRoster(t, h)
-		return len(agents) == 1
-	})
-	if got := h.herdr.paneInfoCallCount(); got == 0 {
-		t.Fatal("no pane-info lookup was in flight; the test proves nothing " +
-			"unless the row lands WHILE herdr is being asked")
-	}
+	// Wait for a lookup to be PARKED, then read: the row must already be
+	// there. Waiting on the row first and then checking for a lookup is the
+	// wrong order — it races the pass, which writes the row before it reaches
+	// herdr at all.
+	waitFor(t, 3*time.Second, func() bool { return h.herdr.paneInfoCallCount() > 0 })
 	agents, _ := liveRoster(t, h)
-	if a, ok := rosterByID(agents, "w1:p1"); !ok || a.Cwd != "" {
-		t.Errorf("roster = %+v; the row must be committed before the cwd "+
-			"lookup, not after it", agents)
+	a, ok := rosterByID(agents, "w1:p1")
+	if !ok {
+		t.Fatalf("roster = %+v; the row must be committed BEFORE the cwd lookup, "+
+			"and one is parked right now", agents)
+	}
+	if a.Cwd != "" {
+		t.Errorf("cwd = %q while the lookup that would produce it is still "+
+			"parked", a.Cwd)
 	}
 
 	// And the cwd catches up behind it.

--- a/internal/store/agentroster.go
+++ b/internal/store/agentroster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -35,29 +36,59 @@ const rosterSeqUnknown = 1 << 30
 // would blank the column on every sweep and make the TTL pointless.
 func (s *Store) PublishRoster(ctx context.Context, agents []domain.RosterAgent, now time.Time) error {
 	return s.tx(ctx, func(tx *sql.Tx) error {
-		live := make(map[string]bool, len(agents))
-		for i, a := range agents {
-			live[a.AgentID] = true
-			var prevTerminal string
-			err := tx.QueryRowContext(ctx,
-				`SELECT terminal_id FROM agent_roster WHERE agent_id = ?`, a.AgentID).Scan(&prevTerminal)
-			switch {
-			case errors.Is(err, sql.ErrNoRows):
-				prevTerminal = ""
-			case err != nil:
+		// One query for the whole existing roster, not one per agent.
+		//
+		// Every transaction here takes the write lock at BEGIN and holds it
+		// until commit, so its STATEMENT COUNT is time every other writer in
+		// the process spends waiting. This runs on the daemon's own cadence
+		// against a herd of arbitrary size, so a per-agent SELECT made the
+		// hold time grow with the herd — and the goroutines waiting behind it
+		// are the ones recording an operator's actual work.
+		rows, err := tx.QueryContext(ctx,
+			`SELECT agent_id, terminal_id, gone_at FROM agent_roster`)
+		if err != nil {
+			return err
+		}
+		type stored struct {
+			terminal string
+			gone     int64
+		}
+		existing := map[string]stored{}
+		for rows.Next() {
+			var id string
+			var st stored
+			if err := rows.Scan(&id, &st.terminal, &st.gone); err != nil {
+				rows.Close()
 				return err
 			}
+			existing[id] = st
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return err
+		}
+
+		live := make(map[string]bool, len(agents))
+		var recycled []any
+		for _, a := range agents {
+			live[a.AgentID] = true
 			// A changed terminal is a NEW agent on a recycled id: keep nothing
 			// from the row it replaces. "Not observed" (either side empty) is
 			// not evidence of a change, so it carries over — the same rule
 			// agent_actions.terminal_id follows.
-			recycled := prevTerminal != "" && a.TerminalID != "" && prevTerminal != a.TerminalID
-			if recycled {
-				if _, err := tx.ExecContext(ctx,
-					`DELETE FROM agent_roster WHERE agent_id = ?`, a.AgentID); err != nil {
-					return err
-				}
+			prev := existing[a.AgentID].terminal
+			if prev != "" && a.TerminalID != "" && prev != a.TerminalID {
+				recycled = append(recycled, a.AgentID)
 			}
+		}
+		if len(recycled) > 0 {
+			if _, err := tx.ExecContext(ctx,
+				`DELETE FROM agent_roster WHERE agent_id IN (`+placeholders(len(recycled))+`)`,
+				recycled...); err != nil {
+				return err
+			}
+		}
+		for i, a := range agents {
 			// The publish is the only caller that KNOWS a position: it holds
 			// herdr's whole listing, in order — and the only one entitled to
 			// bring a retired agent back, for the same reason.
@@ -65,28 +96,18 @@ func (s *Store) PublishRoster(ctx context.Context, agents []domain.RosterAgent, 
 				return err
 			}
 		}
-		rows, err := tx.QueryContext(ctx, `SELECT agent_id FROM agent_roster WHERE gone_at = 0`)
-		if err != nil {
-			return err
-		}
-		var absent []string
-		for rows.Next() {
-			var id string
-			if err := rows.Scan(&id); err != nil {
-				rows.Close()
-				return err
-			}
-			if !live[id] {
+		// Everything not in the listing is marked gone, in one statement.
+		var absent []any
+		for id, st := range existing {
+			if st.gone == 0 && !live[id] {
 				absent = append(absent, id)
 			}
 		}
-		rows.Close()
-		if err := rows.Err(); err != nil {
-			return err
-		}
-		for _, id := range absent {
+		if len(absent) > 0 {
+			args := append([]any{unix(now)}, absent...)
 			if _, err := tx.ExecContext(ctx,
-				`UPDATE agent_roster SET gone_at = ? WHERE agent_id = ?`, unix(now), id); err != nil {
+				`UPDATE agent_roster SET gone_at = ? WHERE agent_id IN (`+
+					placeholders(len(absent))+`)`, args...); err != nil {
 				return err
 			}
 		}
@@ -95,6 +116,14 @@ func (s *Store) PublishRoster(ctx context.Context, agents []domain.RosterAgent, 
 			ON CONFLICT(id) DO UPDATE SET published_at = excluded.published_at`, unix(now))
 		return err
 	})
+}
+
+// placeholders renders n comma-separated SQL placeholders.
+func placeholders(n int) string {
+	if n == 0 {
+		return ""
+	}
+	return strings.Repeat(",?", n)[1:]
 }
 
 // UpsertRosterAgent records ONE agent, without touching the rest of the roster.

--- a/internal/store/agentroster.go
+++ b/internal/store/agentroster.go
@@ -182,6 +182,19 @@ func (s *Store) UpsertRosterAgent(ctx context.Context, a domain.RosterAgent) err
 // status events carry no terminal id at all, so every transition would blank
 // the id a publish recorded, leaving a genuinely recycled pane id looking
 // unchanged the next time one arrived.
+//
+// The STATUS is the one field an older write must never roll back, and
+// seen_at is what says which is older. A listing is taken before it is
+// published — the daemon lists, then hands the snapshot to a background
+// pass — so a transition recorded in between describes the agent LATER than
+// the snapshot does. Writing the snapshot's status over it republishes a
+// state the agent has already left, and readers act on that field: an agent
+// that just went working would read as idle, and `hap task send` decides
+// whether an agent is free from exactly this column. It corrects itself on
+// the next publish, but "the next publish" with no TUI open is a minute away.
+//
+// Position, location and terminal are NOT guarded this way, deliberately: a
+// full listing is authoritative for them and an event reports none of them.
 func upsertRosterRow(ctx context.Context, tx *sql.Tx,
 	a domain.RosterAgent, seq int, authoritative bool) error {
 	// A non-authoritative write keeps whatever gone_at the row already has.
@@ -195,12 +208,15 @@ func upsertRosterRow(ctx context.Context, tx *sql.Tx,
 		ON CONFLICT(agent_id) DO UPDATE SET
 			pane_id = excluded.pane_id, tab_id = excluded.tab_id,
 			workspace_id = excluded.workspace_id, agent_type = excluded.agent_type,
-			status = excluded.status,
+			status = CASE WHEN agent_roster.seen_at > excluded.seen_at
+				THEN agent_roster.status ELSE excluded.status END,
 			terminal_id = CASE WHEN excluded.terminal_id = '' THEN agent_roster.terminal_id ELSE excluded.terminal_id END,
 			cwd = CASE WHEN excluded.cwd = '' THEN agent_roster.cwd ELSE excluded.cwd END,
 			cwd_read_at = CASE WHEN excluded.cwd = '' THEN agent_roster.cwd_read_at ELSE excluded.cwd_read_at END,
 			list_seq = CASE WHEN excluded.list_seq = ? THEN agent_roster.list_seq ELSE excluded.list_seq END,
-			seen_at = excluded.seen_at, gone_at = `+goneAt,
+			seen_at = CASE WHEN agent_roster.seen_at > excluded.seen_at
+				THEN agent_roster.seen_at ELSE excluded.seen_at END,
+			gone_at = `+goneAt,
 		a.AgentID, a.PaneID, a.TabID, a.WorkspaceID, a.AgentType,
 		a.Status, a.TerminalID, a.Cwd, unix(a.CwdReadAt), unix(a.SeenAt), seq, rosterSeqUnknown)
 	return err

--- a/internal/store/agentroster_test.go
+++ b/internal/store/agentroster_test.go
@@ -630,3 +630,59 @@ func rosterByAgentID(agents []domain.RosterAgent, id string) (domain.RosterAgent
 	}
 	return domain.RosterAgent{}, false
 }
+
+// A listing taken BEFORE a transition must not republish the state the agent
+// has already left.
+//
+// The daemon lists agents, then hands the snapshot to a background pass, so a
+// transition recorded in between describes the agent later than the snapshot
+// does. Writing the snapshot's status over it puts a stale answer in the
+// column readers act on: an agent that just went working reads as idle, and
+// `hap task send` decides whether an agent is free from exactly that field.
+func TestAStaleListingDoesNotRollBackANewerStatus(t *testing.T) {
+	st := rosterStore(t)
+	ctx := context.Background()
+	listedAt := time.Now()
+	agent := domain.RosterAgent{
+		AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude",
+		Status: "idle", TerminalID: "term-a", SeenAt: listedAt,
+	}
+	if err := st.PublishRoster(ctx, []domain.RosterAgent{agent}, listedAt); err != nil {
+		t.Fatal(err)
+	}
+	// The agent starts working AFTER the next listing was taken.
+	event := agent
+	event.Status = "working"
+	event.SeenAt = listedAt.Add(time.Second)
+	if err := st.UpsertRosterAgent(ctx, event); err != nil {
+		t.Fatal(err)
+	}
+	// That older listing is only published now.
+	if err := st.PublishRoster(ctx, []domain.RosterAgent{agent}, listedAt); err != nil {
+		t.Fatal(err)
+	}
+	agents, _, err := st.LiveRoster(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agents[0].Status != "working" {
+		t.Errorf("status = %q; a listing taken before the transition republished "+
+			"a state the agent had already left", agents[0].Status)
+	}
+
+	// A listing taken AFTER it is still authoritative — the rule is "older
+	// does not win", not "an event wins forever".
+	later := agent
+	later.Status = "idle"
+	later.SeenAt = listedAt.Add(2 * time.Second)
+	if err := st.PublishRoster(ctx, []domain.RosterAgent{later}, later.SeenAt); err != nil {
+		t.Fatal(err)
+	}
+	agents, _, err = st.LiveRoster(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agents[0].Status != "idle" {
+		t.Errorf("status = %q; a newer listing must still win", agents[0].Status)
+	}
+}

--- a/internal/store/agentroster_test.go
+++ b/internal/store/agentroster_test.go
@@ -3,6 +3,7 @@ package store_test
 import (
 	"context"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -564,4 +565,68 @@ func TestAnEventStillIntroducesANewAgent(t *testing.T) {
 	if len(agents) != 1 {
 		t.Errorf("roster = %+v; an agent nobody has listed yet is not a retired one", agents)
 	}
+}
+
+// A publish costs the same number of statements whatever the herd's size.
+//
+// Every transaction here takes the write lock at BEGIN and holds it until
+// commit, so a publish's statement count is time every other writer in the
+// process spends waiting — and this one runs on the daemon's own cadence
+// against a herd of arbitrary size. A per-agent SELECT made that hold time
+// grow with the herd, and the goroutines queued behind it are the ones
+// recording an operator's actual work.
+//
+// Asserted as behaviour over a herd big enough that a per-agent query would
+// dominate: all the rules the loop enforces must still hold at scale.
+func TestAPublishOverALargeHerdKeepsEveryRule(t *testing.T) {
+	st := rosterStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	var rows []domain.RosterAgent
+	for i := range 50 {
+		id := "w1:p" + strconv.Itoa(i)
+		rows = append(rows, domain.RosterAgent{
+			AgentID: id, PaneID: id, AgentType: "claude", Status: "idle",
+			TerminalID: "term-" + strconv.Itoa(i), SeenAt: now,
+		})
+	}
+	if err := st.PublishRoster(ctx, rows, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.SetRosterCwds(ctx, map[string]domain.RosterCwd{
+		"w1:p7": {Cwd: "/work/seven", TerminalID: "term-7"},
+	}, now); err != nil {
+		t.Fatal(err)
+	}
+
+	// One agent is recycled, one vanishes, the rest are unchanged.
+	rows[7].TerminalID = "term-recycled"
+	if err := st.PublishRoster(ctx, rows[:len(rows)-1], now); err != nil {
+		t.Fatal(err)
+	}
+	agents, _, err := st.LiveRoster(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(agents) != 49 {
+		t.Fatalf("roster = %d agents, want 49 — the vanished one must be retired", len(agents))
+	}
+	for i, a := range agents {
+		if want := "w1:p" + strconv.Itoa(i); a.AgentID != want {
+			t.Fatalf("agents[%d] = %q, want %q — herdr's order must survive at scale", i, a.AgentID, want)
+		}
+	}
+	if a, _ := rosterByAgentID(agents, "w1:p7"); a.Cwd != "" {
+		t.Errorf("cwd = %q; a recycled pane must not inherit its predecessor's directory", a.Cwd)
+	}
+}
+
+func rosterByAgentID(agents []domain.RosterAgent, id string) (domain.RosterAgent, bool) {
+	for _, a := range agents {
+		if a.AgentID == id {
+			return a, true
+		}
+	}
+	return domain.RosterAgent{}, false
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -69,6 +69,34 @@ func escapeSQLiteURIPath(path string) string {
 
 func Open(path string) (*Store, error) {
 	dsn := "file:" + escapeSQLiteURIPath(path) + "?" + url.Values{
+		// Every transaction this package opens WRITES, so each one takes the
+		// write lock at BEGIN rather than upgrading to it later.
+		//
+		// The default (deferred) starts a transaction as a reader and asks for
+		// the write lock at the first write. If any other connection committed
+		// in between, the reader's snapshot is stale and SQLite answers
+		// SQLITE_BUSY_SNAPSHOT (517) — which busy_timeout deliberately does
+		// NOT retry, because waiting cannot make an outdated snapshot current.
+		// So the transaction fails outright, and callers that treat a store
+		// error as "log it and carry on" silently lose the write. Verified as
+		// `reconcile: terminal-id sync failed agent=pA error="database is
+		// locked (517)"`, which left an agent's FirstSeen unreset after its
+		// pane was recycled.
+		//
+		// Taking the lock up front turns that hard failure into a bounded wait
+		// under busy_timeout. It costs no concurrency: WAL admits exactly one
+		// writer at a time either way, so this only moves WHERE the wait
+		// happens. The hazard is as old as the mixed read-then-write
+		// transactions here; what made it routine was the roster publisher
+		// writing on the daemon's own cadence, which is why the publish has
+		// also moved off the select loop.
+		//
+		// Deliberately NOT covered by a test: every version that reproduced
+		// the 517 did so by saturating the write lock, which then times the
+		// other writer out at busy_timeout under BOTH modes — so the test
+		// passed either way and would have been a guard proving nothing. This
+		// stands on the observed failure above.
+		"_txlock": []string{"immediate"},
 		"_pragma": []string{
 			"busy_timeout(5000)",
 			"journal_mode(WAL)",
@@ -86,8 +114,22 @@ func Open(path string) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)
 	}
-	// SQLite serializes writers; a small pool avoids needless SQLITE_BUSY.
-	db.SetMaxOpenConns(2)
+	// WAL admits ONE writer plus many concurrent readers, so the pool is sized
+	// for the readers; the writers serialize on SQLite's own lock either way.
+	//
+	// It used to be 2, which meant one writer and ONE reader for the whole
+	// process — every other reader queued behind them in database/sql, a
+	// bottleneck WAL does not require and SQLite never asked for. The daemon
+	// runs its select loop, the session-name sync, the action drain and the
+	// roster publisher against this pool at once; at 2 they took each other's
+	// turns, and a read waiting on an unrelated write is how a 3-second
+	// deadline is missed by a goroutine doing almost nothing.
+	//
+	// The old comment justified the cap as avoiding "needless SQLITE_BUSY",
+	// which the _txlock above now handles properly: a writer waits at BEGIN
+	// under busy_timeout instead of failing mid-transaction, so extra
+	// connections cost queueing rather than errors.
+	db.SetMaxOpenConns(8)
 	s := &Store{db: db, agentLockDir: filepath.Join(filepath.Dir(path), "agent-automation-locks")}
 	if err := s.migrate(); err != nil {
 		db.Close()


### PR DESCRIPTION
Fixes a regression from #386. On a two-core runner the `internal/daemon` package went from passing to **failing 2 runs in 3**, a different test each time — and CI's ubuntu job failed twice on this pattern. One failing run named the real mechanism:

```
reconcile: terminal-id sync failed agent=pA error="database is locked (517)"
```

## What was actually wrong

The roster publisher landed as a new, **frequent writer** on a store that handed out two connections and began every transaction as a reader.

`517` is `SQLITE_BUSY_SNAPSHOT`. A deferred transaction reads first and asks for the write lock at its first write; if another connection committed in between, its snapshot is stale and SQLite refuses **immediately**. `busy_timeout` deliberately does not retry — waiting cannot make an outdated snapshot current. Every caller in this repo logs a store error and carries on, so the write simply never happened. That one left an agent's `FirstSeen` unreset after its pane had been recycled: a silent, wrong result, not a crash.

This was not a flaky test. It is a lost write, and it is reachable in production wherever two goroutines write at once.

## Three changes, each measured

**1. The publish runs off the select loop.** #386 moved the *shell-outs* off it but left the store write on the loop that handles every agent's transitions, nudges and timers. A listing arriving while a pass runs now **replaces** the pending one — latest-wins, because an older snapshot can only describe a herd that has moved on, and dropping it outright would lose the vanish reconciliation only a full listing can perform.

**2. Transactions take their lock at BEGIN** (`_txlock=immediate`). All 51 transactions this package opens write, so starting as a reader buys nothing and exposes every one of them to 517. It costs no concurrency — WAL admits a single writer either way — it only moves *where* the wait happens, turning an unretried failure into a bounded one.

**3. The pool is sized for readers** (2 → 8). WAL allows many concurrent readers beside its one writer. At 2, the whole process had one writer and **one reader**, so an unrelated read queued behind a write inside `database/sql` for no reason SQLite imposed. The previous comment justified the cap as avoiding "needless SQLITE_BUSY", which (2) now handles properly.

(2) and (3) are a pair, and the measurement says so: **deferred at pool 8 is worse than the status quo** — 1 of 4 runs passed.

## And one frequency change

Publishing no longer rides the **nudge** path. That is the daemon's busiest one — every operator action and every self-nudge — and no *read* ever nudges: `hap agents` and `hap status` are pure reads that never woke the daemon. So those publishes bought no reader anything while costing the daemon's own bookkeeping its turn at the lock. Startup, the once-a-minute sweep and the 2 s TUI tick still publish, which covers every path a reader can observe.

## Measurements

`internal/daemon`, `taskset -c 0,1` (matching CI's two cores), whole package, `-count=1`:

| Tree | Passing |
|---|---|
| pre-merge main (`8fee60b`) | **5/5** |
| merged main (`cb9e5e7`) | **1/3** |
| + off-loop publish only | 3/5 |
| + immediate transactions, pool 8, no nudge publish | **9/10** |

Targeted, in isolation: `TestReconcileSyncsTerminalIDs` went from ~2 failures in 6 to **25/25**; `TestAutoAcceptEndToEndThroughTheRealSweep` from ~1 in 18 to **30/30**; `TestEscalationAutoDismissesUnavailableAgentWithAudit` from ~1 in 32 to **40/40**.

The isolating experiment that identified the cause: with `publishRoster` stubbed to return immediately, the same test ran **40/40** clean.

## Verification

- Full suite `go test -tags "vectors cpu" ./... -count=1`: clean.
- `GOTOOLCHAIN=go1.26.2 golangci-lint run --build-tags "vectors,cpu"`: 0 issues. (The pin matters — an unpinned run in this devcontainer cannot typecheck the go1.27 stdlib, which silently disables `unused`. That is how #386's lint failure got through locally.)
- New test `TestAListingArrivingMidPassIsStillPublished` pins latest-wins, proved by mutation: dropping the mid-pass listing fails it.
- Roster tests now drive the publish through the sweep path (`publishNow`) rather than a nudge, since the nudge deliberately no longer publishes.

## One thing deliberately not tested

`_txlock=immediate` ships without a dedicated regression test, and the code says so. Every version I wrote that reproduced the 517 did it by saturating the write lock, which then times the other writer out at `busy_timeout` under **both** modes — so the test passed either way and would have been a guard proving nothing. It stands on the observed failure above and on the pool measurement, not on a test I could not make discriminate.

## Residual

1 run in 10 still fails on `TestAutoSendIdleCapsAtExactlyMaxHandouts`, whose `waitFor` deadline is 5 s — exactly `busy_timeout(5000)`. That equality is pre-existing and makes the test marginal under any write contention; worth widening separately.

Note the baselines are not the same sample size: the pre-merge figure is 5 runs, not 10 — a longer baseline run was killed by memory pressure on this machine. So "9/10 vs 5/5" is the honest comparison, and it does not rule out a residual difference of that order. What it does rule out is the failure rate this started at, which was 2 runs in 3.
