### PR TITLE
#0 chore: run CI on pull requests only, and skip it for the release bump PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 name: CI
 
+# PRs only, deliberately. Every commit that lands on main arrived through a PR
+# that ran this workflow on the same tree, so a push trigger only re-runs it —
+# and main is still never released unverified, because release.yml runs its own
+# full `gate` job on the tag before a single asset is built.
 on:
-  push:
-    branches: [main]
-    tags-ignore: ['**']
   pull_request:
 
 permissions:
@@ -17,8 +18,19 @@ jobs:
   # submodules, no CGO toolchain and no native libraries. Split out of the lint
   # job so a formatting mistake is reported in seconds instead of waiting on
   # (and being maskable by) a ~2min FAISS/llama build.
+  #
+  # Every job carries the same `release/bump-v` guard. That branch is minted by
+  # auto-release.yml and carries nothing but the manifest version bump and the
+  # changelog fragments folded into CHANGELOG.md — there is no code to check, and
+  # the FAISS/llama build plus the two-OS matrix and the race detector cost ~15
+  # minutes of every release for no signal. GitHub cannot filter a pull_request
+  # trigger by HEAD branch (on.pull_request.branches filters the BASE), so the
+  # guard has to be repeated per job. Skipping rather than passing is safe here:
+  # auto-release merges that PR with `gh pr merge --squash --admin`, which
+  # bypasses required status checks, so a skipped job cannot wedge the release.
   format:
     name: Format (gofmt)
+    if: ${{ !startsWith(github.head_ref, 'release/bump-v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +52,7 @@ jobs:
   # the CGO code most worth linting.
   lint:
     name: Lint (go vet, golangci-lint)
+    if: ${{ !startsWith(github.head_ref, 'release/bump-v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -78,6 +91,7 @@ jobs:
 
   test:
     name: Tests (${{ matrix.os }})
+    if: ${{ !startsWith(github.head_ref, 'release/bump-v') }}
     strategy:
       matrix:
         # One linux and one macos runner; CGO makes cross-compile checks
@@ -150,6 +164,7 @@ jobs:
 
   corpus-gate:
     name: Allowlist corpus regression gate (NFR-005a)
+    if: ${{ !startsWith(github.head_ref, 'release/bump-v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -171,8 +186,11 @@ jobs:
     name: Changelog fragment present
     # Only PRs: a push to main is a merge whose fragment already landed, and
     # the release path deletes fragments, so requiring one there would fail
-    # every bump commit.
-    if: github.event_name == 'pull_request'
+    # every bump commit. The workflow no longer runs on push at all, but the
+    # condition stays as the statement of intent — and it is ANDed with the
+    # bump-branch guard rather than written as a second `if:`, since a job
+    # takes exactly one.
+    if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release/bump-v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What

- `ci.yml` now triggers on `pull_request` only. Every commit that reaches `main` arrives through a PR that already ran this exact workflow on the same tree, so the push run was a duplicate. Main is still never released unverified — `release.yml` runs its own full `gate` job on the tag before any asset is built.
- Every job now carries `if: ${{ !startsWith(github.head_ref, 'release/bump-v') }}`, so the auto-release bump PR skips CI entirely. That branch contains nothing but the manifest version bump and the changelog fragments folded into `CHANGELOG.md`; building FAISS/llama, running the two-OS matrix and the race detector on it cost ~15 minutes of every release for no signal.

## Why the guard is repeated per job

GitHub cannot filter a `pull_request` trigger by *head* branch — `on.pull_request.branches` filters the base — so there is no workflow-level place to put it. `changelog-fragment` already had an `if:`, and a job takes exactly one, so its condition is ANDed rather than duplicated.

## Why skipping is safe

`auto-release.yml` merges the bump PR with `gh pr merge --squash --admin`, which bypasses required status checks, so a skipped job cannot wedge the release. The fragment gate also still exempts a hand-made bump by grepping `[skip release]`.

No changelog fragment: `.github/**`-only changes do not release, and the fragment gate exempts that path.

https://claude.ai/code/session_01QuzmZBxJZx86FAgdTWjvug