### PR TITLE
#0 fix: resolve the audit agent name per node, and name it in `hap audit`

### DIFF
--- a/changelog.d/fix-audit-agent-name.md
+++ b/changelog.d/fix-audit-agent-name.md
@@ -1,0 +1,7 @@
+- Fixed the TUI Audit tab and `hap audit` labelling another machine's rows with a local
+  agent's name: a herdr pane id repeats on every node sharing the store, so audit rows
+  now resolve the same `name@node` identity the Escalations tab already used — and an
+  audit row from another node no longer borrows a local agent's type
+- Added an `agent=` column to `hap audit`, which never had one; it is appended beside
+  `node=` so nothing parsing the existing tab-separated fields moves
+- Added the node to an audit/escalation detail view when the row came from another machine

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1172,7 +1172,7 @@ func escalations(ctx context.Context, app *frontend.App, out io.Writer, args []s
 	}
 	rules, gradN := ruleIndex(ctx, app)
 	for _, e := range esc {
-		agent := st.EscalationAgent(e)
+		agent := st.RecordAgent(e)
 		rule := "none yet"
 		if row, ok := rules[e.Signature]; ok {
 			rule = frontend.RuleSummary(row, gradN)
@@ -1337,10 +1337,13 @@ func audit(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 		if row, ok := rules[r.Signature]; ok {
 			rule = string(row.Mode)
 		}
-		fmt.Fprintf(out, "#%d\t%s\t%s\t%s\t%s\tconf=%s\tllm=%s\trule=%s\t%s\tnode=%s\n",
+		// agent= is APPENDED rather than folded into the positional columns:
+		// these rows are tab-separated and parsed by scripts, so a new keyed
+		// token beside node= cannot shift a field anything already reads.
+		fmt.Fprintf(out, "#%d\t%s\t%s\t%s\t%s\tconf=%s\tllm=%s\trule=%s\t%s\tagent=%s\tnode=%s\n",
 			r.ID, r.CreatedAt.Format("01-02 15:04:05"), frontend.AuditStatusLabel(r), r.SituationType,
 			r.Action, frontend.ConfidenceLabel(r.Confidence), llmConfCLI(r.LLMConfidence), rule, r.Rationale,
-			st.NodeLabel(r.NodeID))
+			st.RecordAgent(r), st.NodeLabel(r.NodeID))
 	}
 	return nil
 }

--- a/internal/cli/fleet_test.go
+++ b/internal/cli/fleet_test.go
@@ -331,3 +331,68 @@ func TestRemoteAnswersNameTheNodeAndStatusSplitsTheCount(t *testing.T) {
 		t.Errorf("a remote answer must name the node acting on it:\n%s", out)
 	}
 }
+
+// TestAuditNamesTheAgentAndNeverBorrowsALocalName: `hap audit` gained an
+// agent= token (it had none), and it resolves the pair (node, agent) rather
+// than the agent id alone. A herdr pane id repeats on every machine sharing
+// the store and the audit log spans the fleet, so an id-keyed lookup labels
+// the laptop's row with THIS node's agent — silently, with nothing marking it
+// as another machine's. Both nodes use pane "1" here, which is what makes the
+// case discriminate.
+func TestAuditNamesTheAgentAndNeverBorrowsALocalName(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	now := time.Now()
+	if err := st.UpsertNode(ctx, domain.NodeInfo{Label: "here", LastSeen: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AssignAgentName(ctx, "1", "patient-lemur"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.AppendAudit(ctx, domain.AuditRecord{AgentID: "1", AgentType: "claude", Trigger: "t",
+		SituationType: domain.SituationIdle, Action: "auto:continue", Status: "auto", CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	other, err := store.OpenAs(filepath.Join(filepath.Dir(app.ConfigPath), "t.db"), "bbbbbbbbbbbbbbbb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer other.Close()
+	if err := other.UpsertNode(ctx, domain.NodeInfo{Label: "laptop", LastSeen: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := other.AssignAgentName(ctx, "1", "brave-otter"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := other.AppendAudit(ctx, domain.AuditRecord{AgentID: "1", AgentType: "claude", Trigger: "t",
+		SituationType: domain.SituationIdle, Action: "auto:continue", Status: "auto",
+		CreatedAt: now.Add(time.Second)}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "audit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var local, remote string
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.Contains(line, "node=here"):
+			local = line
+		case strings.Contains(line, "node=laptop"):
+			remote = line
+		}
+	}
+	if local == "" || remote == "" {
+		t.Fatalf("want one row per node:\n%s", out)
+	}
+	if !strings.Contains(local, "agent=patient-lemur\t") {
+		t.Errorf("local row should name its own agent: %q", local)
+	}
+	if !strings.Contains(remote, "agent=brave-otter@laptop\t") {
+		t.Errorf("remote row should read name@node, got %q", remote)
+	}
+	if strings.Contains(remote, "patient-lemur") {
+		t.Errorf("the laptop's row borrowed this node's agent name: %q", remote)
+	}
+}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -546,8 +546,10 @@ func buildCommands() {
 				{Name: "--limit", Arg: "N", Default: "30", Desc: "number of records, newest first"},
 			},
 			Details: "Columns: #id, time, status, situation type, action, confidence, LLM score,\n" +
-				"rule mode, rationale. This is the record to read when something was answered\n" +
-				"automatically and you want to know why.",
+				"rule mode, rationale, agent, node. This is the record to read when something\n" +
+				"was answered automatically and you want to know why. On a fleet, agent= reads\n" +
+				"name@node for another machine's row — a herdr pane id repeats across machines,\n" +
+				"so the name alone is not an identity.",
 			Examples: []string{"hap audit", "hap audit --limit 100"},
 			Next: []Hint{
 				{Cmd: "hap signatures show <prefix>", Why: "inspect the rule behind a row"},

--- a/internal/frontend/fleet.go
+++ b/internal/frontend/fleet.go
@@ -49,8 +49,8 @@ func (r RemoteAgent) ShortName() string {
 // Display is the row's name as the unified surfaces print it: name@node.
 //
 // Kept for the surfaces where nothing else carries the node — the Escalations
-// tab's AGENT column (Status.EscalationAgent) is one flat field, so the suffix
-// is the only thing distinguishing two machines' pane "1".
+// and Audit tabs' AGENT column (Status.RecordAgent) is one flat field, so the
+// suffix is the only thing distinguishing two machines' pane "1".
 func (r RemoteAgent) Display() string {
 	return r.ShortName() + "@" + r.NodeLabel
 }
@@ -73,20 +73,28 @@ func (st Status) NodeLabel(nodeID string) string {
 	return domain.NodeLabelOrID(domain.NodeInfo{ID: nodeID})
 }
 
-// EscalationAgent is the AGENT column for an escalation row: the local name
-// for this node's rows, name@node for another machine's.
-func (st Status) EscalationAgent(e domain.AuditRecord) string {
-	if e.NodeID == "" || e.NodeID == st.NodeID {
-		if n := st.AgentName(e.AgentID); n != "" {
+// RecordAgent is the AGENT column for ANY audit record — an escalation or a
+// plain audit row: the local name for this node's rows, name@node for another
+// machine's.
+//
+// It is never Status.AgentName: that map is keyed by agent id alone, and an
+// agent id IS a herdr pane id, which repeats on every machine sharing the
+// store. A remote row read through it either falls back to a bare pane id or,
+// when the id collides with a local pane, renders a LOCAL agent's name with
+// nothing marking it as another machine's. Identity is the PAIR
+// (NodeID, AgentID); neither half is an address on its own.
+func (st Status) RecordAgent(r domain.AuditRecord) string {
+	if r.NodeID == "" || r.NodeID == st.NodeID {
+		if n := st.AgentName(r.AgentID); n != "" {
 			return n
 		}
-		return e.AgentID
+		return r.AgentID
 	}
-	name := st.FleetNames[domain.NodeAgent{NodeID: e.NodeID, AgentID: e.AgentID}]
+	name := st.FleetNames[domain.NodeAgent{NodeID: r.NodeID, AgentID: r.AgentID}]
 	if name == "" {
-		name = e.AgentID
+		name = r.AgentID
 	}
-	return name + "@" + st.NodeLabel(e.NodeID)
+	return name + "@" + st.NodeLabel(r.NodeID)
 }
 
 // RemoteNodes reports how many OTHER nodes share the store and how many of

--- a/internal/frontend/fleet_test.go
+++ b/internal/frontend/fleet_test.go
@@ -184,8 +184,8 @@ func TestResolveFilesARemoteEscalationUnderItsOwner(t *testing.T) {
 	// The fleet view labels the row with the laptop's agent.
 	status, _ := app.GetStatus(ctx)
 	esc, _ := app.Escalations(ctx)
-	if len(esc) != 1 || !strings.HasSuffix(status.EscalationAgent(esc[0]), "@laptop") {
-		t.Errorf("escalation label = %q, want …@laptop", status.EscalationAgent(esc[0]))
+	if len(esc) != 1 || !strings.HasSuffix(status.RecordAgent(esc[0]), "@laptop") {
+		t.Errorf("escalation label = %q, want …@laptop", status.RecordAgent(esc[0]))
 	}
 }
 

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -206,6 +206,50 @@ func TestAuditRowsRenderAgentName(t *testing.T) {
 	}
 }
 
+// TestAuditRowFromAnotherNodeIsNotLabelledWithALocalName: a herdr pane id
+// repeats on every machine sharing the store, and Store.AuditLog spans the
+// fleet — so the id "w1:p1" on the row below belongs to the LAPTOP's agent
+// while this node has an agent at the same id. Resolving through
+// Status.AgentName (keyed on the id alone) renders the local stranger's name
+// with nothing marking it as another machine's; the Escalations tab has used
+// the node-aware lookup since the fleet migration and the Audit tab did not.
+//
+// The single-node fixture above passes either way, which is why this case
+// exists: it is the only one that fails on the bug.
+func TestAuditRowFromAnotherNodeIsNotLabelledWithALocalName(t *testing.T) {
+	m := Model{width: 140, height: 30}
+	msg := refreshMsg{cfg: config.Default()}
+	msg.status.NodeID = "node-here"
+	msg.status.AgentNames = map[string]string{"w1:p1": "patient-lemur"}
+	msg.status.MonitoredAgents = []domain.AgentTransition{{AgentID: "w1:p1", AgentType: "claude"}}
+	msg.status.Nodes = []domain.NodeInfo{{ID: "node-here"}, {ID: "node-there", Label: "laptop"}}
+	msg.status.FleetNames = map[domain.NodeAgent]string{
+		{NodeID: "node-there", AgentID: "w1:p1"}: "brave-otter",
+	}
+	msg.audit = []domain.AuditRecord{{
+		ID: 1, NodeID: "node-there", AgentID: "w1:p1", SituationType: domain.SituationIdle,
+		Status: "auto", Action: "auto:continue", CreatedAt: time.Now(),
+	}}
+	upd, _ := m.Update(msg)
+	m = upd.(Model)
+	m.tab = tabAudit
+
+	view := m.View()
+	if strings.Contains(view, "patient-lemur") {
+		t.Errorf("the laptop's row is labelled with THIS node's agent name:\n%s", view)
+	}
+	// The column caps at agentNameColWidth, so assert the prefix rather than
+	// the whole "brave-otter@laptop".
+	if !strings.Contains(view, "brave-otter@") {
+		t.Errorf("want the laptop's agent name with an @node suffix:\n%s", view)
+	}
+	// agentTypeFor must not borrow the local agent's type either: MonitoredAgents
+	// is this node's herd, so the honest answer for a remote row is "unknown".
+	if strings.Contains(view, "claude") {
+		t.Errorf("the remote row borrowed a local agent's type:\n%s", view)
+	}
+}
+
 func TestEscalationAuditAndRulesListsRenderSingleHeader(t *testing.T) {
 	m := testModel(t)
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1483,7 +1483,7 @@ func (m Model) filterAudit(t tab, rows []domain.AuditRecord) []domain.AuditRecor
 		if m.matchesQuery(t,
 			fmt.Sprintf("#%d", r.ID), string(r.SituationType), r.Status,
 			frontend.AuditStatusLabel(r),
-			m.data.status.AgentName(r.AgentID), r.AgentID, m.agentTypeFor(r),
+			m.data.status.RecordAgent(r), r.AgentID, m.agentTypeFor(r),
 			r.Action, r.Rationale, r.Suggestion) {
 			out = append(out, r)
 		}
@@ -2955,10 +2955,7 @@ func escalationAlertText(msg refreshMsg) (title, body string) {
 			newest = r
 		}
 	}
-	agent := msg.status.AgentName(newest.AgentID)
-	if agent == "" {
-		agent = newest.AgentID
-	}
+	agent := msg.status.RecordAgent(newest)
 	if agent == "" {
 		// No escalation row to describe (an id-only diff, or a pruned list):
 		// still alert, just without the specifics.
@@ -5217,11 +5214,18 @@ type auditDetailOptions struct {
 
 func (m Model) auditDetailLines(r domain.AuditRecord, snapshot string, w int, opts auditDetailOptions) []string {
 	var lines []string
-	agent := r.AgentID
-	if n := m.data.status.AgentName(r.AgentID); n != "" {
-		agent = fmt.Sprintf("%s (%s)", n, r.AgentID)
+	// RecordAgent already carries the @node suffix for another machine's row;
+	// the pane id alone is not an identity, so it is only ever a parenthetical.
+	agent := m.data.status.RecordAgent(r)
+	if agent != r.AgentID {
+		agent = fmt.Sprintf("%s (%s)", agent, r.AgentID)
 	}
 	lines = m.detailField(lines, w, "When", r.CreatedAt.Format(time.RFC3339))
+	// Only for another machine's row, the way agentDetailLines does it: on a
+	// single-node install every row is this node's and the line says nothing.
+	if r.NodeID != "" && r.NodeID != m.data.status.NodeID {
+		lines = m.detailField(lines, w, "Node", m.data.status.NodeLabel(r.NodeID))
+	}
 	lines = m.detailField(lines, w, "Status", r.Status)
 	// Only worth a line when true: it explains the amber row, and its absence
 	// on an ordinary row is not information the operator needs repeated.
@@ -7145,6 +7149,12 @@ func (m Model) agentTypeFor(r domain.AuditRecord) string {
 	if r.AgentType != "" {
 		return r.AgentType
 	}
+	// MonitoredAgents holds THIS node's agents, keyed by a herdr pane id that
+	// repeats across machines, so a remote row matching one of them would
+	// borrow a local stranger's type. "Unknown" is the honest answer.
+	if r.NodeID != "" && r.NodeID != m.data.status.NodeID {
+		return ""
+	}
 	for _, a := range m.data.status.MonitoredAgents {
 		if a.AgentID == r.AgentID {
 			return a.AgentType
@@ -7188,7 +7198,7 @@ func (m Model) renderEscalations(b *strings.Builder) {
 		e := esc[i]
 		// name@node for another machine's row: pane ids repeat across
 		// machines, so a local name lookup would mislabel it.
-		agent := m.data.status.EscalationAgent(e)
+		agent := m.data.status.RecordAgent(e)
 		mark := " "
 		if m.marked[e.ID] {
 			mark = "✓"
@@ -7266,10 +7276,10 @@ func (m Model) renderAudit(b *strings.Builder) {
 	start, end := m.window(len(rows))
 	for i := start; i < end; i++ {
 		r := rows[i]
-		agent := m.data.status.AgentName(r.AgentID)
-		if agent == "" {
-			agent = r.AgentID
-		}
+		// RecordAgent, not AgentName: an audit row can come from another node
+		// (Store.AuditLog spans the fleet) and a pane id repeats across
+		// machines, so a name keyed on the id alone mislabels it.
+		agent := m.data.status.RecordAgent(r)
 		line := fmt.Sprintf(auditRowFmt,
 			shortAuditID(r.ID), humanizeWhen(r.CreatedAt, m.renderNow()),
 			r.SituationType, oneLine(orDash(m.agentTypeFor(r)), 8), oneLine(orDash(agent), agentNameColWidth),


### PR DESCRIPTION
## The bug

The Audit tab resolved an agent through `Status.AgentName(r.AgentID)` — a map keyed by the agent id **alone**. An agent id IS a herdr pane id, which repeats on every machine sharing the store, and `Store.AuditLog` spans the fleet. So another node's audit row either:

- fell back to a bare pane id (`1`, `w1:p2`), or
- when that pane id collided with a local one, rendered **this node's agent name**, with nothing marking it as another machine's.

The Escalations tab has used the node-aware `Status.EscalationAgent` since the 0.8.0 fleet migration (`1eae7d6`), which wired it into `renderEscalations` and `hap escalations` and left `renderAudit` untouched. This is that oversight, not a deliberate asymmetry.

## The fix

`Status.EscalationAgent` → `Status.RecordAgent`. It always took a `domain.AuditRecord`; only its name was escalation-specific. Every audit-record lookup now goes through it:

| Site | Was |
|---|---|
| `renderAudit` | `AgentName(r.AgentID)` + bare-id fallback |
| `auditDetailLines` | `AgentName(r.AgentID)` |
| `filterAudit` (the `/` search) | `AgentName(r.AgentID)` — `/name` matched a row the column did not show |
| `escalationAlertText` (toast) | `AgentName(...)` |
| `renderEscalations`, `hap escalations` | rename only |

`agentTypeFor` gets the same guard: `MonitoredAgents` is this node's herd, so a remote row now reads `-` rather than borrowing a local agent's type. The audit/escalation detail overlay gains a `Node` line for a remote row, matching what `agentDetailLines` already did.

## `hap audit`

It printed **no agent field at all** — never implemented; the help's column list agreed. It now carries `agent=`, **appended** beside `node=`, so nothing parsing the existing tab-separated fields moves. `agent=` reads `name@node` for another machine's row, exactly as `hap escalations` does.

## Tests

The existing `TestAuditRowsRenderAgentName` uses a single-node status and passes with or without the fix, so both new cases are **two-node with a colliding pane id**: `TestAuditRowFromAnotherNodeIsNotLabelledWithALocalName` (TUI — also asserts the type is not borrowed) and `TestAuditNamesTheAgentAndNeverBorrowsALocalName` (CLI, driving a real second-node store).

Full suite green: `go test -tags "vectors cpu" ./... -count=1`.

https://claude.ai/code/session_01QuzmZBxJZx86FAgdTWjvug