### PR TITLE
#0 feat!: default new installs to the sqlite task-list backend

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -534,7 +534,7 @@ tab-separated stdout is unaffected.
 | `tui.disable_check_for_update` | false | turn off the GitHub release check (TUI only, at most every 6h) |
 | `tui.max_instances` | 1 | how many `hap tui` processes may run; starting one closes the oldest past this cap. `0` = no limit |
 | `cli.ai_agent_friendly_output` | true | append the "Next steps" footer to command output |
-| `task_source_provider.provider` | `local_fs` | default storage for every task list: `local_fs`, `github_gist`, or `sqlite` (inside hap's database; syncs under the turso engine) |
+| `task_source_provider.provider` | `sqlite` | default storage for every task list: `sqlite` (inside hap's database; syncs under the turso engine), `local_fs` (a markdown file on disk — the only provider where `path` is a filesystem path), or `github_gist`. The default applies to a config file that does not exist yet; an install that already has one is pinned to `local_fs`. |
 | `task_source_provider.env_file` | (none) | file holding `GITHUB_TOKEN` for `github_gist`; read at use time |
 | `task_source_provider.timeout_seconds` | 20 | per remote store call |
 | `task_source_provider.refresh_seconds` | 30 | how long a remote list is cached |

--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -665,15 +665,24 @@ Deprecated but still loading, migrated on the next config save:
 
 ## task sources
 
-A task source points an agent at a checklist file so idle agents get the next
-unchecked item. `hap config task-source` manages **which file**; `hap task`
+A task source points an agent at a checklist so idle agents get the next
+unchecked item. `hap config task-source` manages **which list**; `hap task`
 manages the **items inside it**.
+
+Under the default `sqlite` provider the checklist argument is OPTIONAL: leave it
+out and each matched agent gets its own list inside hap's database. Give it only
+to share ONE list across the agents a source matches — and then it is a list
+NAME, never a filesystem path. For a markdown file on disk, pass
+`--provider local_fs` (an install that predates the default is pinned there, and
+its sources keep taking a path).
 
 ```bash
 hap config task-source list                                   # every source, with its index
-hap config task-source add --agent backend-dev ./docs/tasks.md
-hap config task-source add --workspace "codex-*" ./docs/tasks.md   # "*" wildcards
-hap config task-source add ./docs/tasks.md                    # any agent, any workspace
+hap config task-source add --agent backend-dev                # its own list, derived per agent
+hap config task-source add --workspace "codex-*"              # "*" wildcards
+hap config task-source add --agent backend-dev shared.md      # share ONE list by name
+hap config task-source add --agent legacy-fox --provider local_fs ./docs/tasks.md
+hap config task-source add                                    # any agent, any workspace
 hap config task-source remove <index|agent>
 ```
 
@@ -712,9 +721,9 @@ resolves against **your** shell's cwd (the daemon runs from the state dir).
 
 ### where task lists are stored
 
-By default a checklist is a file on this machine. `[task_source_provider]` sets
-the **default** storage; each source may override it, so some agents can be
-local and others in a gist at once:
+By default a checklist is a row in hap's own database on this machine.
+`[task_source_provider]` sets the **default** storage; each source may override
+it, so some agents can be files on disk and others in a gist at once:
 
 ```bash
 hap config set task_source_provider.provider github_gist
@@ -755,7 +764,7 @@ handing the next pending `[ ]` item to any matching agent idle for over a
 minute:
 
 ```bash
-hap config task-source add --agent backend-dev --auto-send-when-idle ./docs/tasks.md
+hap config task-source add --agent backend-dev --auto-send-when-idle
 hap config task-source set <index|agent> auto-send-when-idle true
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.0
+
+- **Breaking.** Changed the default task-list backend for NEW installs to `sqlite`: a
+  checklist is a row in hap's own database instead of a markdown file, so `hap task`
+  needs no file lock, each matched agent gets its own list without you naming a path,
+  and under the turso engine the lists are visible fleet-wide
+- An install that already has a `config.toml` keeps `local_fs` — hap pins it on load,
+  before anything else reads the file — so no checklist you already have changes where
+  it lives, and no source changes locator
+- Changed `hap config task-source add` on a fresh install: the `<checklist.md>` argument
+  is now optional (one list per agent is derived), and a filesystem path is refused with
+  a message naming the two ways out — `--provider local_fs`, or omit the path
+- Fixed `hap config task-source add --help` omitting the `sqlite` provider from its
+  `--provider` values and from what `<checklist.md>` means
+
 ## 0.8.8
 
 - Fixed the TUI Audit tab and `hap audit` labelling another machine's rows with a local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ assigns. Do not add a heading or an entry by hand.
 - Changed `hap config task-source add` on a fresh install: the `<checklist.md>` argument
   is now optional (one list per agent is derived), and a filesystem path is refused with
   a message naming the two ways out — `--provider local_fs`, or omit the path
+- Added `--agent`, `--workspace` and `--provider` to the TUI's add-task-source prompt,
+  so the pathless per-agent form is expressible there at all: the prompt took the
+  checklist as its FIRST positional field, leaving an operator on a fresh install with
+  nothing to type in its place
+- Changed the "add a task source" guidance printed by `hap task`, `hap confirm`, the
+  help pages and the bundled skill to the pathless form, and it now shows
+  `--provider local_fs` beside the filesystem examples — the commands it suggested
+  failed outright on a fresh install
 - Fixed `hap config task-source add --help` omitting the `sqlite` provider from its
   `--provider` values and from what `<checklist.md>` means
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -891,6 +891,27 @@ whose manifest carries exactly that version).
   daemon's cwd and CREATE local checklist files while the operator believed their lists were
   remote. A missing `gist_id` is deliberately not a write-time rule either: it would make the keys
   order-dependent to set (`TestValidateTaskSourceAcceptsAMissingGistID` pins the omission).
+  **The TOP-LEVEL key is the opposite: it IS materialized, and that is what made flipping its
+  default safe.** `Default()` names `sqlite` and `Load` pins `local_fs` the moment the config FILE
+  exists — before the decode, so an explicit key still wins and every return carries the pin,
+  including the two error paths and the `AutoAccept.validate()` branch that keeps the decoded
+  config rather than rebuilding it. A post-decode pin misses that third one, and the miss is
+  silent: a typo in the file would move an install's storage backend. `ResolveProvider`'s own
+  literal fallback stays `local_fs` — it is reached only by a `Config{}` assembled in memory,
+  where the posture needing no store handle and no node id is the right answer. And
+  `AnyNonDefaultProvider` cannot be written as "anything but local_fs" any more: there are now TWO
+  postures an operator reaches without touching the setting, so it asks whether the config is
+  MIXED and otherwise stays quiet on either local backend — a naive version turns on the provider
+  column for every new install. Keep `TestAFreshConfigDefaultsToSQLite` /
+  `TestAnExistingConfigWithoutTheKeyStaysLocalFS` (the discriminating one: a config built in
+  memory cannot tell "no file yet" from "a file omitting the key", so it must write a real file) /
+  `TestAZeroConfigStillResolvesLocally`. Note the test suites: `internal/cli` and
+  `internal/frontend` fixtures whose list is a FILE now declare it (`localFSApp`/`localFSCfg`)
+  rather than riding on the default — a suite where every test runs on a local file, where a
+  locator IS a path, is the single reason the locator-is-not-a-path bugs kept shipping green, so
+  `testApp` deliberately stays on the DEFAULT and the sqlite path has its own coverage
+  (`tasksource_sqlite_default_test.go`, the sqlite subtest of
+  `TestBootstrapWritesWhereItRegisters`).
 - **A task-list locator is never handled as a FILE outside the local backend** — `taskfile.Mutate`,
   `MutateWithin` and `WriteFileAtomic` take a path; a locator is not one. Under a remote provider it
   is a `gist://<id>/<file>` URI that `os.Stat` can only fail on, and the failure reads like a missing

--- a/README.md
+++ b/README.md
@@ -447,16 +447,22 @@ Every option is settable from the CLI at creation time or in place afterwards:
 
 ```sh
 hap config task-source list                                    # every source, with its index
-hap config task-source add --agent backend-dev ./docs/tasks.md
+hap config task-source add --agent backend-dev                 # its own list, derived per agent
+hap config task-source add --agent legacy-fox --provider local_fs ./docs/tasks.md
 hap config task-source add --workspace 'codex-*' --template 'Do: {next_task_content}' \
-    --auto-send-when-idle --enable-llm-review-before-auto-send --max-tasks 40 ./docs/tasks.md
+    --auto-send-when-idle --enable-llm-review-before-auto-send --max-tasks 40
 hap config task-source set backend-dev path /new/tasks.md      # path|agent|workspace|template
 hap config task-source set backend-dev auto-send-when-idle true
 hap config task-source set backend-dev max-tasks 40
 hap config task-source remove <index|agent>
 ```
 
-Flags must come **before** the path — Go stops parsing flags at the first
+The checklist argument is optional under the default `sqlite` provider (leave it
+out for one derived list per matched agent, give a NAME to share one list) and
+required under `local_fs`, where it is a filesystem path. See
+[Where task lists are stored](#where-task-lists-are-stored).
+
+Flags must come **before** the checklist — Go stops parsing flags at the first
 positional argument (hap detects one written after and refuses rather than
 ignoring it).
 

--- a/README.md
+++ b/README.md
@@ -501,14 +501,14 @@ rewriting a list you wrote is your call.
 
 ### Where task lists are stored
 
-By default a checklist is a file on the machine hap runs on, and nothing about
-it leaves that machine. `[task_source_provider]` sets the **default** storage;
-every `[[task_sources]]` entry may override it, so one agent can keep a local
-checklist while another's lives in a gist:
+By default a checklist lives **inside hap's own database** on the machine hap
+runs on, and nothing about it leaves that machine. `[task_source_provider]` sets
+the **default** storage; every `[[task_sources]]` entry may override it, so one
+agent can keep a checklist as a file on disk while another's lives in a gist:
 
 ```toml
 [task_source_provider]
-provider = "github_gist"                     # "local_fs" (default) | "github_gist"
+provider = "github_gist"                     # "sqlite" (default) | "local_fs" | "github_gist"
 env_file = "~/.config/hap/task_source.env"   # holds GITHUB_TOKEN; read at use time
 timeout_seconds = 20
 refresh_seconds = 30
@@ -542,7 +542,7 @@ matched agent shares one list; leave it out and each gets its own
 `env_file` names (`GITHUB_TOKEN=…`, `gist` scope, mode `0600`), is read when hap
 reaches the store, and never enters `config.toml`.
 
-A third provider, **`sqlite`**, keeps a source's checklist **inside hap's own
+The default provider, **`sqlite`**, keeps a source's checklist **inside hap's own
 database** instead of a file. Nothing leaves the machine under the default
 engine; under the [central database](#central-database-turso) those lists sync
 with everything else, so the Tasks tab and `hap task --node <machine> <agent> …`
@@ -552,9 +552,19 @@ per agent), there is nothing to create and no credential to hold, and the
 daemon that owns a machine is the only one handing its items out — a list is
 never shared between two machines' agents.
 
-Three things stay as they were: a `[[task_sources]]` entry is still what opts an
-agent in, every safety control still applies at delivery, and `local_fs` is
-still the default.
+**Want your lists as markdown files instead?** Pass `--provider local_fs` when
+you add the source, or set `hap config set task_source_provider.provider
+local_fs` once and every inheriting source follows. Only under `local_fs` is
+`path` a filesystem path; under the other two it is a name inside the store, so
+pointing the default at `/home/me/tasks.md` is refused rather than silently
+creating a list somewhere else.
+
+**An install you already have does not move.** The default applies to a
+`config.toml` that does not exist yet; hap pins `local_fs` for any config file
+already on disk, so every checklist you have keeps its path.
+
+Two things stay as they were: a `[[task_sources]]` entry is still what opts an
+agent in, and every safety control still applies at delivery.
 
 **Privacy.** Enabling `github_gist` sends those sources' task lists to GitHub.
 That is the only thing it sends — no pane content, no learned rules, no audit

--- a/docs/architect/herd-auto-prompter-architecture.md
+++ b/docs/architect/herd-auto-prompter-architecture.md
@@ -958,8 +958,9 @@ Exactly two tools:
   `github_gist` task-list backend (`internal/taskstore/gist/gist.go`), which reads
   and writes the checklists of the task sources configured for it — task text
   only — in a gist the operator owns, with a token the operator supplies in
-  `[task_source_provider] env_file`. The default provider is `local_fs`, so an
-  install that never sets one makes neither call beyond the release check. The
+  `[task_source_provider] env_file`. The default provider makes no outbound call —
+  `sqlite` for a new install, `local_fs` for one that predates it — so an install
+  that never sets one makes neither call beyond the release check. The
   no-egress test bans the GitHub SDK by its own import path as well as
   `net/http`, because it checks DIRECT imports and an adapter naming only the SDK
   would otherwise egress while passing. The TUI drives it in the background at most
@@ -1085,7 +1086,7 @@ the sections they gate.
 | **NFR-005** | Auditability completeness | Represent 100% of automated decisions and escalations in the audit log (1:1 action-to-record ratio); no autonomous action without a corresponding record. |
 | **NFR-005a** | Allowlist corpus regression | Maintain and CI-regression-test the irreversible-op corpus so seed patterns match 100% of it; a corpus miss fails the build. |
 | **NFR-006** | LLM fallback timeout | Bound LLM consultation by a configurable timeout; on timeout / missing / unparseable output, fail safe and escalate. |
-| **NFR-007** | Privacy / no telemetry | Keep all data local; make no outbound calls beyond the Herdr socket, the configured local LLM CLI, the opt-out GitHub release check (`internal/updatecheck`, version numbers only), and — only when the operator explicitly selects them — two opt-in remotes the operator owns: a remote task-list storage provider's API, carrying the task text of the sources configured for it and nothing else; and, under `[database] engine = "turso"`, the operator's own Turso Cloud database, which then holds the WHOLE store (agents, escalations with pane excerpts, audit, learned rules) so several of the operator's machines share one view. The default posture is fully local: the default provider is `local_fs` and the default engine is `sqlite`. Emit no telemetry. |
+| **NFR-007** | Privacy / no telemetry | Keep all data local; make no outbound calls beyond the Herdr socket, the configured local LLM CLI, the opt-out GitHub release check (`internal/updatecheck`, version numbers only), and — only when the operator explicitly selects them — two opt-in remotes the operator owns: a remote task-list storage provider's API, carrying the task text of the sources configured for it and nothing else; and, under `[database] engine = "turso"`, the operator's own Turso Cloud database, which then holds the WHOLE store (agents, escalations with pane excerpts, audit, learned rules) so several of the operator's machines share one view. The default posture is fully local: the default provider (`sqlite`, hap's own database) and the default engine (`sqlite`, a local file) both stay on the machine, and so does the `local_fs` provider an older install is pinned to. Emit no telemetry. |
 | **NFR-008** | Portability | Run on Linux and macOS, avoiding design that precludes a future Windows build. |
 | **NFR-009** | Control-mutation propagation | Reflect a control mutation (esp. pause/kill) issued from TUI/CLI in daemon behavior within a small bounded delay (target ≤ 1 s). |
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.8.8"
+version = "0.9.0"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1999,7 +1999,7 @@ func taskSource(ctx context.Context, app *frontend.App, out io.Writer, args []st
 			// ran and found empty.
 			PrintNextSteps(out, []Hint{
 				{Cmd: "hap agents", Why: "the agent names `--agent` takes"},
-				{Cmd: "hap config task-source add --agent <name> ./docs/tasks.md", Why: "point an agent at a checklist"},
+				{Cmd: "hap config task-source add --agent <name>", Why: "give an agent its own checklist (add `--provider local_fs ./docs/tasks.md` for a file on disk)"},
 			})
 			return nil
 		}
@@ -2241,7 +2241,7 @@ func resolveTaskSourceRef(cfg config.Config, ref string) (int, error) {
 		// one, which is the state this resolver then refuses to address.
 		return 0, fmt.Errorf("no task source is scoped to agent %q — it may be scoped by the "+
 			"agent's id or type instead, so check `hap config task-source list` and address it "+
-			"by index; or add one: hap config task-source add --agent %s <checklist.md>",
+			"by index; or add one: hap config task-source add --agent %s",
 			token, token)
 	default:
 		idxs := make([]string, len(matches))

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -41,6 +41,39 @@ func testApp(t *testing.T) (*frontend.App, *store.Store) {
 	}, st
 }
 
+// localFSApp is testApp for a test whose lists are FILES on disk: it seeds a
+// config declaring the local_fs provider, the posture an install that predates
+// the sqlite default runs under.
+//
+// It is a separate helper rather than a change to testApp on purpose. Making
+// testApp local would mean no CLI or frontend test exercises the DEFAULT task
+// store at all, which is the failure this repo keeps rediscovering — every
+// test running on a local file, where a locator IS a path, is the single
+// reason the locator-is-not-a-path bugs kept shipping green.
+func localFSApp(t *testing.T) (*frontend.App, *store.Store) {
+	t.Helper()
+	app, st := testApp(t)
+	seedLocalFSConfig(t, app.ConfigPath)
+	return app, st
+}
+
+// localFSCfg is config.Default() for a fixture whose sources are FILES on
+// disk. Default() means the sqlite provider now, under which a filesystem path
+// is not a legal list name — so a test that saves a path-bearing source has to
+// declare the file backend.
+func localFSCfg() config.Config {
+	cfg := config.Default()
+	cfg.TaskSourceProvider.Provider = config.ProviderLocalFS
+	return cfg
+}
+
+func seedLocalFSConfig(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("[task_source_provider]\nprovider = \"local_fs\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // listedRows returns the rows a listing printed, dropping the trailing
 // "Next steps" footer the CLI adds for its (often AI) callers.
 func listedRows(out string) []string {
@@ -1696,7 +1729,7 @@ func TestTaskStartMarksInProgress(t *testing.T) {
 }
 
 func TestTaskByAgentResolvesSource(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	path := writeTaskFile(t, "- [ ] alpha\n- [ ] beta\n")
 	if err := app.AddTaskSource(context.Background(), "backend", "", path, ""); err != nil {
 		t.Fatal(err)
@@ -1726,7 +1759,7 @@ func TestTaskByAgentResolvesSource(t *testing.T) {
 // prompt only points the agent here, so a listing that omits them leaves the
 // agent with no way to learn `start`/`done`.
 func TestTaskListPrintsManagementHints(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	path := writeTaskFile(t, "- [ ] alpha\n")
 	if err := app.AddTaskSource(context.Background(), "backend", "", path, ""); err != nil {
 		t.Fatal(err)
@@ -1810,7 +1843,7 @@ func TestTaskListHintsQuotePathWithSpace(t *testing.T) {
 }
 
 func TestTaskResolutionErrors(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	pathA := writeTaskFile(t, "- [ ] a\n")
 	pathB := writeTaskFile(t, "- [ ] b\n")
 
@@ -1854,7 +1887,7 @@ func TestTaskResolutionErrors(t *testing.T) {
 // matching several). Bare digits can never be an agent name (herdr names
 // start with a lowercase letter), and '#N' works quoted.
 func TestTaskSourceIndexSelector(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	path := writeTaskFile(t, "- [ ] first job\n- [x] old job\n")
 	// A workspace-scoped source: exactly the shape a name cannot address.
 	if err := app.AddTaskSource(context.Background(), "", "codex-*", path, ""); err != nil {
@@ -1932,7 +1965,7 @@ func TestTaskSourceListShowsAutoSendFlag(t *testing.T) {
 	// visible in `task-source list`; the key itself is config.toml-only, so
 	// this listing is the operator's only confirmation that it took effect.
 	app, _ := testApp(t)
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{
 		{Agent: "quiet-fox", Path: "/tmp/quiet.md"},
 		{Agent: "busy-otter", Path: "/tmp/busy.md", EnableAutoSendTaskWhenIdle: true},
@@ -1977,7 +2010,7 @@ func TestTaskSourceAddAutoSendWhenIdle(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			app, _ := testApp(t)
+			app, _ := localFSApp(t)
 			path := writeTaskFile(t, "- [ ] a\n")
 			out, err := run(t, app, "task-source", append(tc.args, path)...)
 			if err != nil {
@@ -2013,7 +2046,7 @@ func TestTaskSourceAddAutoSendWhenIdle(t *testing.T) {
 // ordering CANNOT enable auto-send — the important half is that it fails
 // loudly instead of adding a source with the flag quietly off.
 func TestTaskSourceAddFlagPlacement(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	path := writeTaskFile(t, "- [ ] a\n")
 
 	_, err := run(t, app, "task-source", "add", path, "--auto-send-when-idle")
@@ -2040,7 +2073,7 @@ func TestTaskSourceAddFlagPlacement(t *testing.T) {
 // TestTaskSourceAddAutoSendIsPerSource guards the blast radius: turning the
 // flag on for one source must not switch on sources added before it.
 func TestTaskSourceAddAutoSendIsPerSource(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	quiet := writeTaskFile(t, "- [ ] a\n")
 	busy := writeTaskFile(t, "- [ ] b\n")
 	if _, err := run(t, app, "task-source", "add", "--agent", "quiet-fox", quiet); err != nil {
@@ -2320,8 +2353,8 @@ func TestTaskRefScreenMatchesDomain(t *testing.T) {
 // config.toml, and a bad key/value/index must be refused rather than silently
 // doing nothing.
 func TestTaskSourceSet(t *testing.T) {
-	app, _ := testApp(t)
-	cfg := config.Default()
+	app, _ := localFSApp(t)
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{
 		{Agent: "quiet-fox", Path: "/tmp/quiet.md"},
 		{Agent: "busy-otter", Path: "/tmp/busy.md"},
@@ -2390,8 +2423,8 @@ func TestTaskSourceSet(t *testing.T) {
 // toggle, including the dual key spelling (dashed CLI form and the raw TOML
 // key) and the pasted "#index" form.
 func TestTaskSourceSetReviewBeforeAutoSend(t *testing.T) {
-	app, _ := testApp(t)
-	cfg := config.Default()
+	app, _ := localFSApp(t)
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{
 		{Agent: "quiet-fox", Path: "/tmp/quiet.md"},
 		{Agent: "busy-otter", Path: "/tmp/busy.md"},
@@ -2438,7 +2471,7 @@ func TestTaskSourceSetReviewBeforeAutoSend(t *testing.T) {
 func TestTaskSourceListShowsLLMReview(t *testing.T) {
 	app, _ := testApp(t)
 	on := true
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{
 		{Agent: "quiet-fox", Path: "/tmp/quiet.md"},
 		{Agent: "busy-otter", Path: "/tmp/busy.md", EnableLLMReviewBeforeAutoSend: &on},
@@ -2477,7 +2510,7 @@ func TestTaskSourceAddLLMReview(t *testing.T) {
 		{name: "flag after path is refused", args: []string{"PATH", "--enable-llm-review-before-auto-send"}, wantErr: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			app, _ := testApp(t)
+			app, _ := localFSApp(t)
 			path := filepath.Join(t.TempDir(), "tasks.md")
 			if err := os.WriteFile(path, []byte("- [ ] a\n"), 0o600); err != nil {
 				t.Fatal(err)
@@ -2528,7 +2561,7 @@ func TestTaskSourceAddLLMReview(t *testing.T) {
 // escalates now, so both surfaces must accept the pair.
 func TestTaskSourceReviewAndAutoSendComposeCLI(t *testing.T) {
 	// add, with both flags at once.
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	path := filepath.Join(t.TempDir(), "tasks.md")
 	if err := os.WriteFile(path, []byte("- [ ] a\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -2550,7 +2583,7 @@ func TestTaskSourceReviewAndAutoSendComposeCLI(t *testing.T) {
 
 	// set, from each standing state.
 	on := true
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{
 		{Agent: "reviewer", Path: "/tmp/reviewed.md", EnableLLMReviewBeforeAutoSend: &on},
 		{Agent: "handout", Path: "/tmp/handout.md", EnableAutoSendTaskWhenIdle: true},
@@ -2580,7 +2613,7 @@ func TestTaskSourceReviewAndAutoSendComposeCLI(t *testing.T) {
 // teach a spelling hap is retiring.
 func TestTaskSourceRetiredReviewKeysRefused(t *testing.T) {
 	app, _ := testApp(t)
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{{Agent: "a", Path: "/tmp/a.md"}}
 	if err := config.Save(app.ConfigPath, cfg); err != nil {
 		t.Fatal(err)
@@ -2603,7 +2636,7 @@ func TestTaskSourceRetiredReviewKeysRefused(t *testing.T) {
 // other agent's source pointing at the shared file.
 func TestTaskSourceRemoveDuplicatePath(t *testing.T) {
 	app, _ := testApp(t)
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{
 		{Agent: "alpha", Path: "/tmp/shared.md"},
 		{Agent: "beta", Path: "/tmp/shared.md"},
@@ -2644,7 +2677,7 @@ func TestTaskSourceRemoveDuplicatePath(t *testing.T) {
 // persists to config.toml, and is validated — the CLI half of the parity the
 // TUI add prompt mirrors.
 func TestTaskSourceAddMaxTasks(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	dir := t.TempDir()
 	capped := filepath.Join(dir, "capped.md")
 	plain := filepath.Join(dir, "plain.md")

--- a/internal/cli/configlists_test.go
+++ b/internal/cli/configlists_test.go
@@ -80,7 +80,7 @@ func TestEveryTaskSourceFieldIsEditable(t *testing.T) {
 	// keys against the struct: an entry naming a key `set` has no case arm for
 	// — a typo, or an arm deleted later — would otherwise pass green while the
 	// field it claims to cover stayed creation-only.
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	if err := app.AddTaskSource(ctx, "a", "", filepath.Join(t.TempDir(), "t.md"), ""); err != nil {
 		t.Fatal(err)
@@ -115,7 +115,7 @@ func TestEveryTaskSourceFieldIsEditable(t *testing.T) {
 // absolutized in the OPERATOR's process — the daemon runs from the state dir,
 // so a path stored verbatim would resolve somewhere else entirely).
 func TestTaskSourceSelectorsAreEditableInPlace(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	dir := t.TempDir()
 	first := filepath.Join(dir, "first.md")
@@ -192,7 +192,7 @@ func TestTaskSourceSelectorsAreEditableInPlace(t *testing.T) {
 // after it and a remembered number silently means a different entry; a name
 // does not move.
 func TestTaskSourceAddressableByAgentName(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	dir := t.TempDir()
 	for _, agent := range []string{"brave-otter", "swift-heron"} {
@@ -232,7 +232,7 @@ func TestTaskSourceAddressableByAgentName(t *testing.T) {
 // two sources feeding one agent is legal, and a name that could mean either
 // must be refused rather than resolved to whichever comes first.
 func TestTaskSourceAgentRefRefusesAmbiguity(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	dir := t.TempDir()
 	for _, f := range []string{"a.md", "b.md"} {
@@ -262,7 +262,7 @@ func TestTaskSourceAgentRefRefusesAmbiguity(t *testing.T) {
 // agents a list feeds is exactly the kind of thing an operator should be told
 // about rather than discover from a later listing.
 func TestTaskSourceSetEmptySelectorWidensAndSaysSo(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	if err := app.AddTaskSource(ctx, "brave-otter", "ws", filepath.Join(t.TempDir(), "t.md"), ""); err != nil {
 		t.Fatal(err)
@@ -285,7 +285,7 @@ func TestTaskSourceSetEmptySelectorWidensAndSaysSo(t *testing.T) {
 // so a relative path must be resolved against the OPERATOR's cwd here or it
 // silently names a different file.
 func TestTaskSourceSetPathIsAbsolutized(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	if err := app.AddTaskSource(ctx, "a", "", filepath.Join(t.TempDir(), "x.md"), ""); err != nil {
 		t.Fatal(err)

--- a/internal/cli/confirm_test.go
+++ b/internal/cli/confirm_test.go
@@ -21,6 +21,19 @@ import (
 // confirmTestApp wires a store-backed App to a recording herdr fake whose only
 // agent reports the given status, and seeds one LLM-generated-task escalation
 // for it. Returns the app, the fake, the agent's short name, and the audit id.
+// seedLocalFSConfigIn writes a config declaring the local_fs provider into dir
+// and returns its path, for a fixture whose task list is a FILE on disk. The
+// package default is the sqlite provider, under which a filesystem path is not
+// a legal list name at all.
+func seedLocalFSConfigIn(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte("[task_source_provider]\nprovider = \"local_fs\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 func confirmTestApp(t *testing.T, status, task string) (*frontend.App, *sendRecorderHerdr, string, int64) {
 	t.Helper()
 	dir := t.TempDir()
@@ -42,7 +55,7 @@ func confirmTestApp(t *testing.T, status, task string) (*frontend.App, *sendReco
 		t.Fatal(err)
 	}
 	app := &frontend.App{Store: st, Herdr: h, StateDir: dir,
-		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator",
+		ConfigPath: seedLocalFSConfigIn(t, dir), Author: "operator",
 		DaemonInfo: func() (bool, int, string) { return true, os.Getpid(), buildinfo.Version },
 	}
 	startStandInConfirmDrain(t, st, app, h)
@@ -208,7 +221,7 @@ func noTaskSourceApp(t *testing.T) (*frontend.App, *store.Store, int64) {
 	}
 	t.Cleanup(func() { st.Close() })
 	app := &frontend.App{Store: st, StateDir: dir,
-		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+		ConfigPath: seedLocalFSConfigIn(t, dir), Author: "operator"}
 	id, err := st.AppendAudit(context.Background(), domain.AuditRecord{
 		AgentID: "w1:p1", Signature: "sig", Trigger: "t",
 		SituationType: domain.SituationIdle, Action: "escalated", Status: "escalated",

--- a/internal/cli/destructive_test.go
+++ b/internal/cli/destructive_test.go
@@ -91,7 +91,7 @@ func TestClearDataRefusesWithoutYes(t *testing.T) {
 // hap learned; re-deriving them is manual work, so clear-data must not touch
 // them.
 func TestClearDataYesWipesLearnedStateOnly(t *testing.T) {
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	seedSignatures(t, st)
 	ctx := context.Background()
 
@@ -166,7 +166,7 @@ func TestClearDataYesWipesLearnedStateOnly(t *testing.T) {
 // addressed positionally, so an off-by-one here silently retires a different
 // agent's checklist.
 func TestTaskSourceRemoveTargetsTheListedEntry(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	paths := make([]string, 3)
 	for i, agent := range []string{"alpha", "beta", "gamma"} {
@@ -207,7 +207,7 @@ func TestTaskSourceRemoveTargetsTheListedEntry(t *testing.T) {
 // may be reading from a stale terminal, and a non-numeric token is read as an
 // AGENT NAME, which must name exactly one source.
 func TestTaskSourceRemoveRejectsBadIndex(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	path := writeTaskFile(t, "- [ ] only\n")
 	if err := app.AddTaskSource(ctx, "solo", "", path, ""); err != nil {
@@ -258,7 +258,7 @@ func TestTaskSourceRemoveRejectsBadIndex(t *testing.T) {
 // was valid a moment ago can now be out of range. It must fail, not wrap onto
 // the survivor.
 func TestTaskSourceRemoveIndicesShift(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	keep := writeTaskFile(t, "- [ ] keep\n")
 	drop := writeTaskFile(t, "- [ ] drop\n")

--- a/internal/cli/fleet_test.go
+++ b/internal/cli/fleet_test.go
@@ -220,7 +220,13 @@ func TestSQLiteProviderNeverPrintsGistFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"provider default: sqlite", `db_list=<agent-name>.md (per matched agent)`, `db_list="shared.md"`} {
+	// No "provider default:" header — sqlite is the default now, and a uniform
+	// config on it prints no storage detail at all (the same silence a local_fs
+	// install has always had). What names the backend is the row's own token.
+	if strings.Contains(out, "provider default:") {
+		t.Errorf("a uniform sqlite config must not grow a provider header:\n%s", out)
+	}
+	for _, want := range []string{`db_list=<agent-name>.md (per matched agent)`, `db_list="shared.md"`} {
 		if !strings.Contains(out, want) {
 			t.Errorf("task-source list missing %q:\n%s", want, out)
 		}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -945,7 +945,7 @@ func buildCommands() {
 				{Name: "--auto-send-when-idle", Desc: "also hand out tasks on the periodic idle poll, not only on a herdr attention event"},
 				{Name: "--enable-llm-review-before-auto-send", Desc: "let the configured [llm].command revise the task list and pick the task, immediately before the daemon auto-sends one"},
 				{Name: "--max-tasks", Arg: "N", Default: "config default", Desc: "cap on how many items this list may hold before task generation stops refilling it"},
-				{Name: "--provider", Arg: "P", Default: "the [task_source_provider] default", Desc: "where THIS source's list is stored: local_fs | github_gist; omit to inherit the default and keep inheriting it"},
+				{Name: "--provider", Arg: "P", Default: "the [task_source_provider] default (sqlite for a new install)", Desc: "where THIS source's list is stored: sqlite | local_fs | github_gist; omit to inherit the default and keep inheriting it"},
 				{Name: "--gist-id", Arg: "ID", Default: "the [task_source_provider.github_gist] default", Desc: "store this source's list in a specific gist instead of the default one (github_gist only)"},
 			},
 			Details: "Flags must come BEFORE the <checklist.md> path — Go's flag parsing stops at the\n" +
@@ -957,6 +957,10 @@ func buildCommands() {
 				"source that names no provider keeps INHERITING the default, so changing the\n" +
 				"default moves it — hap never writes the inherited value into the source.\n" +
 				"The <checklist.md> argument means different things per provider:\n" +
+				"  sqlite       a list NAME inside hap's database (the default). Give one and\n" +
+				"               every agent this source matches shares that list; leave it out\n" +
+				"               and each gets its own \"<agent-name>.md\". A filesystem path is\n" +
+				"               REFUSED here — pass --provider local_fs for a file on disk.\n" +
 				"  local_fs     a filesystem path. REQUIRED.\n" +
 				"  github_gist  a file name INSIDE the gist. Give one and every agent this\n" +
 				"               source matches shares that list; leave it out and each matched\n" +

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -785,7 +785,7 @@ func buildCommands() {
 				"hap config set-threshold approval 0.80",
 				"echo -n \"$ANTHROPIC_API_KEY\" | hap config env set command ANTHROPIC_API_KEY",
 				"hap config rules list",
-				"hap config task-source add --agent vivid-falcon ./docs/tasks.md",
+				"hap config task-source add --agent vivid-falcon",
 			},
 			Next: []Hint{
 				{Cmd: "hap config fields", Why: "list every field and its current value"},
@@ -1000,7 +1000,8 @@ func buildCommands() {
 				"is rewritten on the next save, but the CLI refuses it.\n" +
 				"Use `hap task` to manage the ITEMS inside the file.",
 			Examples: []string{
-				"hap config task-source add --agent vivid-falcon --max-tasks 20 ./docs/tasks.md",
+				"hap config task-source add --agent vivid-falcon --max-tasks 20",
+				"hap config task-source add --agent vivid-falcon --provider local_fs ./docs/tasks.md",
 				"hap config task-source list",
 				"hap config task-source set 0 auto-send-when-idle true",
 				"hap config task-source set 0 enable-llm-review-before-auto-send true",
@@ -1169,7 +1170,7 @@ var workflows = []struct {
 		Title: "Set up a task list for an agent",
 		Steps: []string{
 			"hap rename <pane-id> <name>           # give the agent a stable short name",
-			"hap config task-source add --agent <name> ./docs/tasks.md",
+			"hap config task-source add --agent <name>   # add --provider local_fs ./docs/tasks.md for a file",
 			"hap config task-source list           # confirm it, note the index",
 			"hap task <name> list                  # the agent sees these items",
 		},

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -310,7 +310,7 @@ func TestTaskSourceUsageKeysAreAccepted(t *testing.T) {
 
 	// The runtime usage string is unreachable from the registry, so provoke it:
 	// a wrong key prints it alongside the error.
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	seedTaskSource(t, app)
 	_, err := run(t, app, "task-source", "set", "0", "definitely-not-a-key", "1")
 	if err == nil {
@@ -331,7 +331,7 @@ func TestTaskSourceUsageKeysAreAccepted(t *testing.T) {
 	}
 	for _, key := range append(keys, runtimeKeys...) {
 		t.Run(key, func(t *testing.T) {
-			app, _ := testApp(t)
+			app, _ := localFSApp(t)
 			seedTaskSource(t, app)
 			value, ok := values[key]
 			if !ok {
@@ -360,7 +360,7 @@ var seededTaskSource = config.TaskSource{
 
 func seedTaskSource(t *testing.T, app *frontend.App) {
 	t.Helper()
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{seededTaskSource}
 	if err := config.Save(app.ConfigPath, cfg); err != nil {
 		t.Fatal(err)

--- a/internal/cli/task_escaped_id_test.go
+++ b/internal/cli/task_escaped_id_test.go
@@ -49,7 +49,7 @@ func escapedApp(t *testing.T) (*frontend.App, *sendRecorderHerdr, string) {
 		t.Fatal(err)
 	}
 	app := &frontend.App{Store: st, Herdr: h, StateDir: dir,
-		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator",
+		ConfigPath: seedLocalFSConfigIn(t, dir), Author: "operator",
 		DaemonInfo: func() (bool, int, string) { return true, os.Getpid(), buildinfo.Version }}
 	startStandInSendTaskDrain(t, st, app, h)
 	path := filepath.Join(dir, "tasks.md")

--- a/internal/cli/task_send_test.go
+++ b/internal/cli/task_send_test.go
@@ -53,7 +53,7 @@ func sendTestApp(t *testing.T, status string) (*frontend.App, *sendRecorderHerdr
 		t.Fatal(err)
 	}
 	app := &frontend.App{Store: st, Herdr: h, StateDir: dir,
-		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator",
+		ConfigPath: seedLocalFSConfigIn(t, dir), Author: "operator",
 		DaemonInfo: func() (bool, int, string) { return true, os.Getpid(), buildinfo.Version }}
 	startStandInSendTaskDrain(t, st, app, h)
 	seedRoster(t, st, h.agents...)

--- a/internal/cli/tasksource_sqlite_default_test.go
+++ b/internal/cli/tasksource_sqlite_default_test.go
@@ -1,0 +1,98 @@
+package cli_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// The tests in this file exercise the DEFAULT task store, which a fresh
+// install runs on without configuring anything. Every other CLI test that
+// touches a checklist declares local_fs, because its list is a file on disk —
+// and a suite where that is the only shape is exactly how the
+// locator-is-not-a-path bugs kept shipping green. These are the counterweight:
+// they never write a file, and a locator here is a `db://` URI that os.Stat can
+// only fail on.
+
+// TestFreshInstallAddsAPathlessSourceAndRoundTripsItsTasks is the end-to-end
+// evidence for the default: a source created with no path at all, a list
+// created on demand, and every `hap task` verb reading and writing it through
+// the store.
+func TestFreshInstallAddsAPathlessSourceAndRoundTripsItsTasks(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	// A derived source names one list per SEEN agent, so the agent has to
+	// exist before its list can be created on demand.
+	if err := st.AssignAgentName(ctx, "w1:p1", "brave-otter"); err != nil {
+		t.Fatal(err)
+	}
+	seedRoster(t, st, domain.AgentTransition{
+		AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle",
+	})
+
+	// No positional checklist argument: under the default the file name is
+	// derived per matched agent.
+	if _, err := run(t, app, "config", "task-source", "add", "--agent", "brave-otter"); err != nil {
+		t.Fatalf("a pathless source must be creatable on a fresh install: %v", err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 1 {
+		t.Fatalf("got %d sources, want 1", len(cfg.TaskSources))
+	}
+	if got := cfg.TaskSources[0].Path; got != "" {
+		t.Errorf("path = %q, want it left empty so the name derives per agent", got)
+	}
+	// The inheritance is a live link and must never be materialized onto the
+	// entry — that is what lets the operator move every source at once.
+	if got := cfg.TaskSources[0].Provider; got != "" {
+		t.Errorf("provider = %q, want the inheritance left empty", got)
+	}
+	if got := cfg.ResolveProvider(cfg.TaskSources[0]).Name; got != config.ProviderSQLite {
+		t.Errorf("resolved provider = %q, want %q", got, config.ProviderSQLite)
+	}
+
+	for _, item := range []string{"alpha", "beta"} {
+		if _, err := run(t, app, "task", "brave-otter", "add", item); err != nil {
+			t.Fatalf("add %q: %v", item, err)
+		}
+	}
+	out, err := run(t, app, "task", "brave-otter", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "alpha") || !strings.Contains(out, "beta") {
+		t.Errorf("the database-backed list must show its items:\n%s", out)
+	}
+	if _, err := run(t, app, "task", "brave-otter", "done", "2"); err != nil {
+		t.Fatal(err)
+	}
+	out, err = run(t, app, "task", "brave-otter", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "[x]") && !strings.Contains(out, "done") {
+		t.Errorf("completing an item must survive the round trip:\n%s", out)
+	}
+}
+
+// TestFreshInstallRefusalNamesTheWayOut: pointing the default at a markdown
+// file is the first thing a new operator tries, and the refusal has to say
+// what to type instead — not only what is wrong.
+func TestFreshInstallRefusalNamesTheWayOut(t *testing.T) {
+	app, _ := testApp(t)
+	_, err := run(t, app, "config", "task-source", "add", "--agent", "brave-otter", "/tmp/tasks.md")
+	if err == nil {
+		t.Fatal("a filesystem path under the sqlite provider must be refused")
+	}
+	for _, want := range []string{"--provider " + config.ProviderLocalFS, "omit the path"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal must mention %q, got: %v", want, err)
+		}
+	}
+}

--- a/internal/cli/tasksourcefooter_test.go
+++ b/internal/cli/tasksourcefooter_test.go
@@ -19,7 +19,7 @@ func TestTaskSourceEveryBranchPrintsItsOwnFooter(t *testing.T) {
 	countFooters := func(s string) int { return strings.Count(s, "\nNext steps:\n") }
 
 	t.Run("empty listing points at add, not at itself", func(t *testing.T) {
-		app, _ := testApp(t)
+		app, _ := localFSApp(t)
 		out, err := run(t, app, "config", "task-source", "list")
 		if err != nil {
 			t.Fatal(err)
@@ -37,7 +37,7 @@ func TestTaskSourceEveryBranchPrintsItsOwnFooter(t *testing.T) {
 		}
 	})
 
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	dir := t.TempDir()
 	if err := app.AddTaskSource(ctx, "brave-otter", "", filepath.Join(dir, "a.md"), ""); err != nil {
@@ -78,7 +78,7 @@ func TestTaskSourceEveryBranchPrintsItsOwnFooter(t *testing.T) {
 // naming that agent would emit a command `resolveTaskSourceRef` refuses — on
 // the very screen that exists to resolve the ambiguity.
 func TestTaskSourceListFooterNeverSuggestsARefusedCommand(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	dir := t.TempDir()
 	for _, f := range []string{"a.md", "b.md"} {
@@ -104,7 +104,7 @@ func TestTaskSourceListFooterNeverSuggestsARefusedCommand(t *testing.T) {
 // 3 — so it is refused where it would be written, not worked around at the
 // point of use.
 func TestNumericAgentSelectorIsRefused(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	dir := t.TempDir()
 

--- a/internal/cli/tasksourcelist_provider_test.go
+++ b/internal/cli/tasksourcelist_provider_test.go
@@ -11,8 +11,12 @@ import (
 // compatibility promise: an install that never touched the storage setting must
 // see exactly the output it always saw. Every existing script, and the
 // copy-pasteable "#0" convention, depends on it.
+//
+// "Never touched it" is now TWO postures — an older install pinned to local_fs
+// (this case) and a fresh one on the sqlite default (the case below) — and
+// neither may grow a provider column.
 func TestTaskSourceListIsByteIdenticalWithoutAnyProviderConfigured(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	if _, err := run(t, app, "task-source", "add", "--agent", "brave-otter", "/tmp/tasks.md"); err != nil {
 		t.Fatal(err)
 	}
@@ -151,4 +155,31 @@ func taskSourceRows(out string) []string {
 		}
 	}
 	return rows
+}
+
+// TestTaskSourceListIsQuietOnTheSQLiteDefault is the other half of the
+// compatibility promise: a FRESH install runs on the sqlite provider without
+// ever configuring it, so it must not grow a provider column either. Without
+// this case the predicate could be written as "anything but local_fs" and
+// every new install would print storage detail nobody asked for.
+func TestTaskSourceListIsQuietOnTheSQLiteDefault(t *testing.T) {
+	app, _ := testApp(t)
+	if _, err := run(t, app, "task-source", "add", "--agent", "brave-otter"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := run(t, app, "task-source", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := taskSourceRows(out)
+	want := []string{
+		"#0\tagent=\"brave-otter\" workspace=\"\" db_list=<agent-name>.md (per matched agent) " +
+			"enable_llm_review_before_auto_send=false max_tasks=20",
+	}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Errorf("list output for a fresh install:\n got %q\nwant %q", got, want)
+	}
+	if strings.Contains(out, "provider") {
+		t.Error("a fresh install must not grow a provider column")
+	}
 }

--- a/internal/cli/tasksourceprovider_test.go
+++ b/internal/cli/tasksourceprovider_test.go
@@ -8,11 +8,16 @@ import (
 )
 
 // TestTaskSourceAddPositionalIsRequiredOnlyUnderLocalFS pins the conditional
-// argument: a remote source may derive its file name per agent, so demanding a
-// path there would make the whole per-agent form unreachable from the CLI.
+// argument: a source that is not a file on disk may derive its list name per
+// agent, so demanding a path there would make the whole per-agent form
+// unreachable from the CLI.
+//
+// local_fs is now the exception rather than the default, so the first case has
+// to declare it. The default's own behaviour — a pathless add succeeding on a
+// fresh install — is TestFreshInstallAddsAPathlessSourceAndRoundTripsItsTasks.
 func TestTaskSourceAddPositionalIsRequiredOnlyUnderLocalFS(t *testing.T) {
 	t.Run("local_fs still requires it", func(t *testing.T) {
-		app, _ := testApp(t)
+		app, _ := localFSApp(t)
 		_, err := run(t, app, "task-source", "add", "--agent", "brave-otter")
 		if err == nil {
 			t.Fatal("a source with no path under local_fs must be refused")
@@ -24,7 +29,7 @@ func TestTaskSourceAddPositionalIsRequiredOnlyUnderLocalFS(t *testing.T) {
 	})
 
 	t.Run("an explicit remote provider accepts none", func(t *testing.T) {
-		app, _ := testApp(t)
+		app, _ := localFSApp(t)
 		if _, err := run(t, app, "config", "set",
 			"task_source_provider.github_gist.gist_id", "3f2a1b9c"); err != nil {
 			t.Fatal(err)
@@ -50,7 +55,7 @@ func TestTaskSourceAddPositionalIsRequiredOnlyUnderLocalFS(t *testing.T) {
 	})
 
 	t.Run("an inherited remote provider accepts none and records no override", func(t *testing.T) {
-		app, _ := testApp(t)
+		app, _ := localFSApp(t)
 		for _, kv := range [][2]string{
 			{"task_source_provider.provider", "github_gist"},
 			{"task_source_provider.github_gist.gist_id", "3f2a1b9c"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -901,6 +901,11 @@ func (c Config) ResolveProvider(src TaskSource) ResolvedProvider {
 		out.Name, out.NameInherited = c.TaskSourceProvider.Provider, true
 	}
 	if out.Name == "" {
+		// Reached only by a Config that was never built through Load or
+		// Default (a zero value assembled in memory). The conservative
+		// file-backed posture is the right answer there: it needs no store
+		// handle and no node id, so it can never fail where a caller had no
+		// reason to expect a backend at all.
 		out.Name = ProviderLocalFS
 	}
 	if out.GistID == "" {
@@ -909,22 +914,26 @@ func (c Config) ResolveProvider(src TaskSource) ResolvedProvider {
 	return out
 }
 
-// AnyNonDefaultProvider reports whether anything in this config selects a
-// storage backend other than the built-in local_fs default.
+// AnyNonDefaultProvider reports whether this config's storage is worth
+// printing: any source resolving to a different backend than the default, or a
+// uniform config on a backend that is not one of the two local ones.
 //
 // It is the single predicate gating every "print the provider" branch in the
 // CLI and TUI, which is what keeps an install that has never touched the
-// setting byte-identical in its output.
+// setting byte-identical in its output. That is why it cannot be written as
+// "anything other than local_fs": there are now TWO postures an operator can
+// arrive at without ever touching the setting — a fresh install on sqlite and
+// an older one pinned to local_fs — and neither should grow a provider column.
+// Mixedness still does: a config where one source's backend differs from the
+// rest is exactly when an operator needs to see which is which.
 func (c Config) AnyNonDefaultProvider() bool {
-	if c.TaskSourceProvider.Provider != "" && c.TaskSourceProvider.Provider != ProviderLocalFS {
-		return true
-	}
+	top := c.ResolveProvider(TaskSource{}).Name
 	for _, src := range c.TaskSources {
-		if src.Provider != "" && src.Provider != ProviderLocalFS {
+		if c.ResolveProvider(src).Name != top {
 			return true
 		}
 	}
-	return false
+	return top != ProviderLocalFS && top != ProviderSQLite
 }
 
 // TaskSource points an agent or workspace at a declared next-task list (FR-011).
@@ -1159,8 +1168,15 @@ func ValidateTaskSource(cfg Config, src TaskSource) error {
 	// path-shaped value corrupts silently rather than failing.
 	if name := strings.TrimSpace(src.Path); name != "" {
 		if err := ValidateStoreFileName(name); err != nil {
+			// Naming the way OUT matters most under the sqlite provider,
+			// because that is the DEFAULT for a new install: the first thing a
+			// fresh operator does is point a source at a markdown file, and
+			// "this is not a store file name" says what is wrong without
+			// saying what to type instead.
 			return fmt.Errorf("under provider=%s, path names a file INSIDE the store, not a "+
-				"filesystem path: %w", p.Name, err)
+				"filesystem path: %w; for a checklist file on disk pass "+
+				"`--provider %s`, or omit the path to get one list per agent "+
+				"inside the store", p.Name, err, ProviderLocalFS)
 		}
 	}
 	return nil
@@ -1588,11 +1604,21 @@ func Default() Config {
 		Logging: Logging{Level: "info", MaxSizeMB: 16},
 		TUI:     TUI{TerminalBell: true, HerdrNotification: true, MaxInstances: 1},
 		CLI:     CLI{AIAgentFriendlyOutput: true},
-		// Task lists stay on this machine unless the operator says otherwise.
+		// Task lists live in hap's own database unless the operator says
+		// otherwise: no file lock behind every read-modify-write, one list per
+		// agent derived rather than hand-pathed, and — under the turso engine —
+		// visible across the fleet. It stays on this machine either way; the
+		// sqlite provider makes no outbound call (only github_gist does, see
+		// ResolvedProvider.Egress).
+		//
+		// This default reaches an install ONLY through a config file that does
+		// not exist yet. Load pins local_fs for any file already on disk, so
+		// nobody's markdown checklists change locator underneath them.
+		//
 		// Named explicitly rather than left to the zero value so FieldValue
 		// renders something for the registry parity test, and so an operator
 		// reading a saved config sees the posture they are running under.
-		TaskSourceProvider: TaskSourceProvider{Provider: ProviderLocalFS},
+		TaskSourceProvider: TaskSourceProvider{Provider: ProviderSQLite},
 		// The local file unless the operator says otherwise, named for the
 		// same two reasons as the provider above.
 		Database: Database{Engine: EngineSQLite},
@@ -1831,13 +1857,27 @@ func Load(path string) (Config, error) {
 	cfg := Default()
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
+		// A fresh install: today's defaults apply, including the sqlite
+		// task-list backend.
 		return cfg, nil
 	}
+	// The file EXISTS from here on, so this is an install that predates the
+	// task-store default flip. An omitted [task_source_provider] provider key
+	// means its lists are markdown FILES on disk: pin local_fs rather than
+	// re-pointing them at db:// locators nothing ever wrote. Set BEFORE the
+	// decode so an explicitly written key still wins, and so EVERY return
+	// below carries the pin — including the two error paths, which keep this
+	// config rather than rebuilding it (a typo in the file must not move an
+	// install's storage backend). With it set here, fillZeroes' own fill only
+	// ever applies to a Default()-sourced config.
+	cfg.TaskSourceProvider.Provider = ProviderLocalFS
 	if err != nil {
 		return cfg, fmt.Errorf("read config: %w", err)
 	}
 	if err := toml.Unmarshal(data, &cfg); err != nil {
-		return Default(), fmt.Errorf("parse config %s: %w", path, err)
+		legacy := Default()
+		legacy.TaskSourceProvider.Provider = ProviderLocalFS
+		return legacy, fmt.Errorf("parse config %s: %w", path, err)
 	}
 	// Every deprecated/removed key is probed from THIS ONE decode. The probes
 	// exist because a key absent from the Config struct is indistinguishable

--- a/internal/config/taskstoreprovider_test.go
+++ b/internal/config/taskstoreprovider_test.go
@@ -81,30 +81,93 @@ path = "brave-otter.md"
 	}
 }
 
-func TestTaskSourceProviderDefaultsToLocalFS(t *testing.T) {
+// TestAFreshConfigDefaultsToSQLite: an install with no config file on disk
+// gets the database-backed task store — no file lock behind every checklist
+// write, one list derived per agent, and fleet-visible under turso.
+func TestAFreshConfigDefaultsToSQLite(t *testing.T) {
 	cases := []struct {
 		name string
 		cfg  Config
 	}{
 		{"Default()", Default()},
 		{"missing file", loadConfig(t, filepath.Join(t.TempDir(), "absent.toml"))},
-		{"empty section", loadConfig(t, writeConfig(t, "[task_source_provider]\n"))},
-		{"zero value", Config{}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.cfg.ResolveProvider(TaskSource{})
-			if got.Name != ProviderLocalFS {
-				t.Errorf("provider = %q, want %q — task lists must stay local until the "+
-					"operator says otherwise", got.Name, ProviderLocalFS)
+			if got.Name != ProviderSQLite {
+				t.Errorf("provider = %q, want %q", got.Name, ProviderSQLite)
 			}
-			if got.Remote() {
-				t.Error("the default provider must not be remote")
+			if got.Egress() {
+				t.Error("the default provider must make no outbound call")
 			}
 			if tc.cfg.AnyNonDefaultProvider() {
-				t.Error("AnyNonDefaultProvider must be false, or every CLI/TUI surface changes its output")
+				t.Error("a fresh install must not grow a provider column in any CLI/TUI surface")
 			}
 		})
+	}
+}
+
+// TestAnExistingConfigWithoutTheKeyStaysLocalFS is the guard on the default
+// flip, and it is the ONLY shape that discriminates: a config built in memory
+// cannot tell "no file yet" from "a file that omits the key", so the case has
+// to write a real file. An install that predates the flip keeps markdown
+// checklists on disk, and re-pointing it at db:// locators nothing ever wrote
+// would make every one of its lists vanish.
+//
+// The pin is set before the decode, so the error paths — which keep the
+// caller's config rather than rebuilding it — carry it too: a typo in the file
+// must not move an install's storage backend either.
+func TestAnExistingConfigWithoutTheKeyStaysLocalFS(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{name: "no section at all", body: "[logging]\nlevel = \"info\"\n"},
+		{name: "empty section", body: "[task_source_provider]\n"},
+		{name: "sources but no provider key",
+			body: "[[task_sources]]\nagent = \"brave-otter\"\npath = \"/tmp/tasks.md\"\n"},
+		{name: "malformed file", body: "[logging\n", wantErr: true},
+		// The one error path that KEEPS the decoded config rather than
+		// rebuilding it, so a post-decode pin would miss it.
+		{name: "rejected auto-accept section",
+			body: "[escalations.auto_accept]\napproval = \"-3m\"\n", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := Load(writeConfig(t, tc.body))
+			if tc.wantErr && err == nil {
+				t.Fatal("want an error for this body")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatal(err)
+			}
+			got := cfg.ResolveProvider(TaskSource{})
+			if got.Name != ProviderLocalFS {
+				t.Errorf("provider = %q, want %q — an existing install's lists are files "+
+					"on disk and must stay there", got.Name, ProviderLocalFS)
+			}
+			if got.Remote() {
+				t.Error("a pinned local_fs provider must not be remote")
+			}
+			if cfg.AnyNonDefaultProvider() {
+				t.Error("a pinned install must not grow a provider column either")
+			}
+		})
+	}
+}
+
+// TestAZeroConfigStillResolvesLocally pins ResolveProvider's own fallback: a
+// Config assembled in memory never went through Load or Default, and the
+// file-backed posture is the one that needs no store handle and no node id.
+func TestAZeroConfigStillResolvesLocally(t *testing.T) {
+	got := Config{}.ResolveProvider(TaskSource{})
+	if got.Name != ProviderLocalFS {
+		t.Errorf("provider = %q, want %q", got.Name, ProviderLocalFS)
+	}
+	if (Config{}).AnyNonDefaultProvider() {
+		t.Error("AnyNonDefaultProvider must be false for a zero config")
 	}
 }
 
@@ -234,8 +297,37 @@ func TestAnyNonDefaultProviderDetectsEitherLevel(t *testing.T) {
 				TaskSourceProvider: TaskSourceProvider{Provider: ProviderGitHubGist},
 				TaskSources:        []TaskSource{{Provider: ProviderLocalFS}},
 			},
-			// Still true: the DEFAULT is remote, so a newly minted source would be.
+			// Still true: the source's backend differs from the default, which
+			// is exactly when an operator needs to see which list is where.
 			true,
+		},
+		// The two postures an operator reaches without touching the setting —
+		// a fresh install on sqlite, an older one pinned to local_fs — must
+		// both stay quiet, or every default install grows a provider column.
+		{"uniform sqlite default", Config{TaskSourceProvider: TaskSourceProvider{Provider: ProviderSQLite}}, false},
+		{
+			"sqlite default with inheriting sources",
+			Config{
+				TaskSourceProvider: TaskSourceProvider{Provider: ProviderSQLite},
+				TaskSources:        []TaskSource{{Agent: "a"}, {Agent: "b"}},
+			},
+			false,
+		},
+		{
+			"sqlite default, one source kept on files",
+			Config{
+				TaskSourceProvider: TaskSourceProvider{Provider: ProviderSQLite},
+				TaskSources:        []TaskSource{{Agent: "a"}, {Agent: "b", Provider: ProviderLocalFS}},
+			},
+			true,
+		},
+		{
+			"an explicit spelling of the default is not a difference",
+			Config{
+				TaskSourceProvider: TaskSourceProvider{Provider: ProviderSQLite},
+				TaskSources:        []TaskSource{{Agent: "a", Provider: ProviderSQLite}},
+			},
+			false,
 		},
 	}
 	for _, tc := range cases {
@@ -282,8 +374,20 @@ func TestTaskSourceProviderRoundTripsThroughSave(t *testing.T) {
 			t.Errorf("an untouched local config must not grow [task_source_provider.github_gist]:\n%s", saved)
 		}
 		if !strings.Contains(saved, `provider = "local_fs"`) {
-			t.Errorf("the default provider is materialized so a saved config names the posture "+
-				"it runs under:\n%s", saved)
+			t.Errorf("the provider is materialized so a saved config names the posture "+
+				"it runs under — and for an install that predates the default flip that "+
+				"posture is local_fs, written out so the pin survives one save:\n%s", saved)
+		}
+	})
+
+	t.Run("a fresh config saves the sqlite posture", func(t *testing.T) {
+		// The counterpart to the case above, and the reason it is not vacuous:
+		// the pin is what makes an EXISTING file save local_fs, while a config
+		// that never had a file names the new default.
+		path := filepath.Join(t.TempDir(), "hap.toml")
+		saved := saveAndRead(t, path, loadConfig(t, path))
+		if !strings.Contains(saved, `provider = "sqlite"`) {
+			t.Errorf("a fresh install must save the sqlite posture:\n%s", saved)
 		}
 	})
 

--- a/internal/frontend/append_target_test.go
+++ b/internal/frontend/append_target_test.go
@@ -62,7 +62,7 @@ func TestAppendTargetPrecedenceSurvivesTheStoreRewrite(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			app, st := testApp(t)
+			app, st := localFSApp(t)
 			app.Herdr = &fakeHerdr{}
 			dir := t.TempDir()
 			app.StateDir = dir

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -3939,7 +3939,7 @@ func resolveTaskSourceFor(cfg config.Config, agent string) (config.TaskSource, i
 			// source 0 happens to be agent-scoped.
 			return config.TaskSource{}, 0, fmt.Errorf("no task source is scoped to agent %q; workspace-scoped sources exist but aren't addressable by name — address one by its index, e.g. `hap task %d list` (`hap config task-source list` shows each source's index)", agent, workspaceIdx[0])
 		}
-		return config.TaskSource{}, 0, fmt.Errorf("no task source for agent %q; add one first: hap config task-source add --agent %s <checklist.md>", agent, agent)
+		return config.TaskSource{}, 0, fmt.Errorf("no task source for agent %q; add one first: hap config task-source add --agent %s", agent, agent)
 	default:
 		return config.TaskSource{}, 0, fmt.Errorf("agent %q matches %d task sources (indexes %s); address one by its index, e.g. `hap task %d list`", agent, len(matches), joinInts(matchIdx), matchIdx[0])
 	}

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -42,6 +42,29 @@ func testApp(t *testing.T) (*frontend.App, *store.Store) {
 	}, st
 }
 
+// localFSApp is testApp for a test whose lists are FILES on disk: it seeds a
+// config declaring the local_fs provider, the posture an install that predates
+// the sqlite default runs under.
+//
+// It is a separate helper rather than a change to testApp on purpose. Making
+// testApp local would mean no CLI or frontend test exercises the DEFAULT task
+// store at all, which is the failure this repo keeps rediscovering — every
+// test running on a local file, where a locator IS a path, is the single
+// reason the locator-is-not-a-path bugs kept shipping green.
+func localFSApp(t *testing.T) (*frontend.App, *store.Store) {
+	t.Helper()
+	app, st := testApp(t)
+	seedLocalFSConfig(t, app.ConfigPath)
+	return app, st
+}
+
+func seedLocalFSConfig(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("[task_source_provider]\nprovider = \"local_fs\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // fakeEmbedder is a canned embedder for the standalone re-embed path.
 type fakeEmbedder struct {
 	fail bool
@@ -570,7 +593,7 @@ func TestConfirmGeneratedTaskWritesSourceAndSends(t *testing.T) {
 	// Confirming an idle task suggestion writes a per-agent tasks.md (single
 	// in-progress "[-]" item), registers a matching [[task_sources]] entry,
 	// records the correction, and sends the task to the agent.
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	// Route the tasks file into a known state dir.
@@ -644,7 +667,7 @@ func TestConfirmGeneratedTaskWithoutSendStillWritesSource(t *testing.T) {
 	// must leave the first item "[ ]" so the daemon's idle flow can hand it
 	// out later. Regression for issue #156: the item used to be pre-marked
 	// "[-]" at write time, which suppressed the idle resend forever.
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -683,7 +706,7 @@ func TestConfirmGeneratedMultipleTasksWritesChecklist(t *testing.T) {
 	// A multiline suggestion (a Markdown checklist from the LLM) is normalized:
 	// ONLY the first task is sent to the agent, so after the send it reads
 	// in-progress "[-]" (reserved at delivery) and the rest stay pending "[ ]".
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -738,7 +761,7 @@ func TestConfirmGeneratedMultipleListsWritesOnlyLastList(t *testing.T) {
 	// LAST list is real work, so only its items reach the checklist and only its
 	// first item is sent. The daemon validated the same raw text with the same
 	// parser, so the two sides cannot disagree about which list won.
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -826,7 +849,7 @@ func TestConfirmGeneratedTaskSendFailureRollsBackToPending(t *testing.T) {
 	// A failed --send delivery must roll the reserved item back to "[ ]" so
 	// the daemon's idle flow can retry it — mirroring SendTaskToAgent. Before
 	// issue #156 the item stayed "[-]" and was stranded forever.
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{sendErr: errors.New("pane vanished")}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -859,7 +882,7 @@ func TestConfirmRepeatedGenerationPreservesMarkers(t *testing.T) {
 	// duplicate raised before the first confirm registered the source) must
 	// not rewrite the file: resetting a delivered item's "[-]" back to "[ ]"
 	// would re-arm the daemon to send it a second time.
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -926,7 +949,7 @@ func TestConfirmRegenerationCarriesOverMarkers(t *testing.T) {
 	// A later generation carrying a DIFFERENT task list rewrites the file, but
 	// items it re-lists keep their progress markers: resetting a delivered
 	// "[-]" to "[ ]" would re-arm the daemon for a duplicate send.
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -973,7 +996,7 @@ func TestConfirmRegenerationAppendsKeepingReservedMarker(t *testing.T) {
 	// its position, and the new task lands at the end pending — never reordered
 	// ahead of it, and never reset to "[ ]" (which would re-arm the daemon for a
 	// duplicate send).
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -1024,7 +1047,7 @@ func TestConfirmRegenerationAppendsKeepingCompletedMarker(t *testing.T) {
 	// Same for FINISHED work: an item the agent completed ("[x]", e.g. via
 	// `hap task done`) stays done and in place when a later generation appends
 	// new work — it is never re-queued (issue #183).
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -1082,7 +1105,7 @@ func TestConfirmGeneratedTaskAddOnlyWhileAgentWorking(t *testing.T) {
 	// escalation is resolved (accepted). The daemon delivers the item on the
 	// agent's next idle. This is the "a: add to list" path — the staleness
 	// refusal only applies to a send (issue #180).
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{agents: []domain.AgentTransition{{AgentID: "w5:p5", Status: "working"}}}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -1136,7 +1159,9 @@ func TestConfirmGeneratedTaskAddOnlyWhileAgentWorking(t *testing.T) {
 // store, fake herdr, the agent's short name, and the absolute source path.
 func declaredSourceApp(t *testing.T, agentID, content string) (*frontend.App, *store.Store, *fakeHerdr, string, string) {
 	t.Helper()
-	app, st := testApp(t)
+	// Its declared source is a real file on disk, so it declares the file
+	// backend rather than riding on whatever the default happens to be.
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	app.StateDir = t.TempDir()
@@ -1410,7 +1435,7 @@ func TestConfirmGeneratedTaskBootstrapRespectsMaxTasks(t *testing.T) {
 	// max_tasks cap: a file already holding DefaultMaxTasks items refuses one
 	// more generated task instead of growing an unbounded list. Regression for
 	// the gap where only the append + `task add` paths enforced the cap.
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -1624,7 +1649,7 @@ func TestConfirmGeneratedTaskUsesSourceTemplate(t *testing.T) {
 	// The append path renders the outbound prompt through the SOURCE's own
 	// next_task_template, like any declared-task send — not the built-in
 	// default the bootstrap path uses.
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	app.StateDir = t.TempDir()
@@ -1652,7 +1677,7 @@ func TestConfirmGeneratedTaskUsesSourceTemplate(t *testing.T) {
 func TestConfirmGeneratedTaskAppendCreatesMissingDeclaredFile(t *testing.T) {
 	// A declared source whose file does not exist yet still receives the
 	// tasks at ITS path — never a second bootstrap source.
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	app.StateDir = t.TempDir()
@@ -1699,7 +1724,7 @@ func TestConfirmGeneratedTaskAppendMatchesDaemonSelectors(t *testing.T) {
 	// just the short name, or an id-/type-selected declared source would be
 	// bypassed and bootstrapped into a duplicate.
 	t.Run("agent id selector", func(t *testing.T) {
-		app, st := testApp(t)
+		app, st := localFSApp(t)
 		fake := &fakeHerdr{}
 		app.Herdr = fake
 		app.StateDir = t.TempDir()
@@ -1719,7 +1744,7 @@ func TestConfirmGeneratedTaskAppendMatchesDaemonSelectors(t *testing.T) {
 		}
 	})
 	t.Run("agent type selector", func(t *testing.T) {
-		app, st := testApp(t)
+		app, st := localFSApp(t)
 		fake := &fakeHerdr{}
 		app.Herdr = fake
 		app.StateDir = t.TempDir()
@@ -1746,7 +1771,7 @@ func TestConfirmGeneratedTaskAppendMatchesDaemonSelectors(t *testing.T) {
 		}
 	})
 	t.Run("workspace name selector via locator", func(t *testing.T) {
-		app, st := testApp(t)
+		app, st := localFSApp(t)
 		fake := &locatorHerdr{
 			fakeHerdr:  &fakeHerdr{agents: []domain.AgentTransition{{AgentID: "w1:p1", Status: "idle", WorkspaceID: "ws-1"}}},
 			workspaces: []domain.WorkspaceInfo{{ID: "ws-1", Label: "codex-main"}},
@@ -1780,7 +1805,7 @@ func TestConfirmGeneratedTaskAppendMatchesDaemonSelectors(t *testing.T) {
 		}
 	})
 	t.Run("workspace raw id fallback without locator", func(t *testing.T) {
-		app, st := testApp(t)
+		app, st := localFSApp(t)
 		fake := &fakeHerdr{agents: []domain.AgentTransition{{AgentID: "w1:p1", Status: "idle", WorkspaceID: "ws-1"}}}
 		app.Herdr = fake
 		app.StateDir = t.TempDir()
@@ -1807,7 +1832,7 @@ func TestConfirmGeneratedTaskPrefersSourceWithPendingWork(t *testing.T) {
 	// With several matching sources, the append lands on the one the daemon
 	// would reason about: a source with a pending "[ ]" item beats a fully
 	// completed one, regardless of config order.
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	app.StateDir = t.TempDir()
@@ -1846,7 +1871,7 @@ func TestConfirmGeneratedTaskRefusesDuplicateAgentSource(t *testing.T) {
 	// to a workspace the confirm cannot match falls through to the bootstrap
 	// path — which must REFUSE to register a second source for the same agent
 	// selector (that duplicate is exactly the `hap task` ambiguity of #157).
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	app.StateDir = t.TempDir()
@@ -2680,7 +2705,7 @@ func TestSplitCommand(t *testing.T) {
 }
 
 func TestRemoveByIndexIsValueVerified(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	app.AddNeverAutoPattern(ctx, `(?i)one`)
 	app.AddNeverAutoPattern(ctx, `(?i)two`)
@@ -2820,7 +2845,7 @@ func TestRenameAgentThroughApp(t *testing.T) {
 // TestCLIParityWithSharedLayer proves FR-022: every CLI verb operates on the
 // same shared state the TUI reads.
 func TestCLIParityWithSharedLayer(t *testing.T) {
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	ctx := context.Background()
 
 	run := func(verb string, args ...string) string {
@@ -3953,7 +3978,7 @@ func TestAddTaskMultiline(t *testing.T) {
 // (freshness guard), rendered through the source's template — stored `\n`
 // decoded to real newlines — and delivered to the agent's pane.
 func TestSendTaskToAgent(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	h := &sendCaptureHerdr{agents: idleAt("w1:p2")}
 	app.Herdr = h
 	ctx := context.Background()
@@ -4155,7 +4180,7 @@ func TestSendTaskToAgentRollbackIsClaimScoped(t *testing.T) {
 // differently depending on who sent it.
 func TestSendTaskToAgentRendersCwd(t *testing.T) {
 	ctx := context.Background()
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	path := filepath.Join(t.TempDir(), "tasks.md")
 	if err := os.WriteFile(path, []byte("- [ ] work\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -4177,7 +4202,7 @@ func TestSendTaskToAgentRendersCwd(t *testing.T) {
 		t.Errorf("{cwd} should render the foreground cwd, got %v", h.sent)
 	}
 	// An adapter without the optional inspector still sends, with {cwd} empty.
-	app2, _ := testApp(t)
+	app2, _ := localFSApp(t)
 	plain := &sendCaptureHerdr{agents: idleAt("w1:p2")}
 	app2.Herdr = plain
 	path2 := filepath.Join(t.TempDir(), "tasks.md")
@@ -4410,7 +4435,7 @@ func TestANeverPublishedRosterIsNotAnEmptyHerd(t *testing.T) {
 // on the bootstrap path that registers a generated task list by itself, which
 // no operator ever opted in for.
 func TestAddTaskSourceAutoSendWhenIdleOption(t *testing.T) {
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	app.Herdr = &fakeHerdr{}
 	app.StateDir = t.TempDir()
 	ctx := context.Background()
@@ -4477,7 +4502,7 @@ func TestAddTaskSourceAutoSendWhenIdleOption(t *testing.T) {
 // distinguishable from "never decided" on disk), and an add that names neither
 // flag lands with review off — the default.
 func TestAddTaskSourceReviewOption(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	dir := t.TempDir()
 	plain := filepath.Join(dir, "plain.md")
@@ -4520,7 +4545,7 @@ func TestAddTaskSourceReviewOption(t *testing.T) {
 // switched itself off. The review is now a pre-delivery filter that never
 // escalates, so every write surface must ACCEPT the pair, in either order.
 func TestTaskSourceReviewAndAutoSendCompose(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	dir := t.TempDir()
 
@@ -4584,7 +4609,7 @@ func TestTaskSourceReviewAndAutoSendCompose(t *testing.T) {
 // living in updateTaskSource: an edit that touches neither delivery-gate flag
 // must never be refused because of them.
 func TestSetTaskSourceMaxTasksIsUngated(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "tasks.md")
 	if err := app.AddTaskSource(ctx, "handout", "", path, "", frontend.AutoSendWhenIdle()); err != nil {
@@ -4610,7 +4635,7 @@ func TestSetTaskSourceMaxTasksIsUngated(t *testing.T) {
 // `x` advertises: removing a source retires the config entry only. Source
 // files are often hand-written docs hap never created and could not restore.
 func TestRemoveTaskSourceKeepsChecklistFile(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "tasks.md")
 	if err := os.WriteFile(path, []byte("- [ ] keep me\n"), 0o644); err != nil {
@@ -4652,7 +4677,7 @@ func TestRemoveTaskSourceKeepsChecklistFile(t *testing.T) {
 // must refuse 0 — on disk 0 means "unset", so accepting it would silently mean
 // the default rather than the "no cap" an operator typing 0 expects.
 func TestSetTaskSourceSettings(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	dir := t.TempDir()
 	first := filepath.Join(dir, "first.md")
@@ -4743,7 +4768,7 @@ func TestSetTaskSourceSettings(t *testing.T) {
 // than retire the wrong agent's source — and the entry the operator DID name
 // is still removable by its new index.
 func TestRemoveTaskSourceDuplicatePathReordered(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	shared := filepath.Join(t.TempDir(), "shared.md")
 	if err := os.WriteFile(shared, []byte("- [ ] a\n"), 0o644); err != nil {
@@ -5589,7 +5614,7 @@ func TestSignaturesBatchAndFallbackAgree(t *testing.T) {
 // on the daemon's first hand-out, which cannot happen until the list holds a
 // task.
 func TestAddTaskCreatesAMissingConfiguredList(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	// A configured source in a directory that does not exist either, so the
 	// create has to build the whole path the way the bootstrap does.
 	path := filepath.Join(t.TempDir(), "nested", "tasks.md")
@@ -5645,7 +5670,7 @@ func TestAddTaskPathTargetStillRefusesAMissingFile(t *testing.T) {
 // failed" while the source had in fact been added, so an operator could
 // re-run it and double-add.
 func TestConfigWriteSucceedsWithNoDaemonListening(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	// A control path that nothing is listening on, which is exactly what a
 	// stopped daemon leaves behind.
 	app.ControlPath = filepath.Join(t.TempDir(), "control.sock")
@@ -5804,7 +5829,7 @@ func TestSetFieldReportsWhetherADaemonTookTheReload(t *testing.T) {
 // operator to this feature. The gate is therefore "this locator belongs to a
 // configured source", which both surfaces satisfy.
 func TestAddTaskCreatesFromTheTUIsLocatorShapedCall(t *testing.T) {
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	// The registry names the agent: for a DERIVED source that is the evidence
 	// the selector is an agent rather than an agent type.
 	if _, err := st.EnsureAgentName(context.Background(), "w1:p1"); err != nil {
@@ -5911,7 +5936,7 @@ func TestTaskGroupsResolvesWhenTheNameRegistryCouldNotBeRead(t *testing.T) {
 // the TUI's locator-shaped call and the cap lookup did not — so a TUI add read
 // max_tasks as UNCAPPED, silently ignoring a limit the operator had set.
 func TestTaskCapAppliesToALocatorShapedAdd(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	path := filepath.Join(t.TempDir(), "tasks.md")
 	if err := os.WriteFile(path, []byte("- [ ] one\n- [ ] two\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -5938,7 +5963,7 @@ func TestTaskCapAppliesToALocatorShapedAdd(t *testing.T) {
 // the TUI Config tab) and the generated-task bootstrap (accepting an LLM task
 // suggestion, which registers a source as a side effect).
 func TestAddingATaskSourceNeverRenumbersTheExistingOnes(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 	dir := t.TempDir()
 
@@ -5985,7 +6010,7 @@ func TestAddingATaskSourceNeverRenumbersTheExistingOnes(t *testing.T) {
 // triggers without naming a source at all — so it is the likeliest place for
 // an insert to creep in. It must append like every other surface.
 func TestAcceptingAGeneratedTaskAppendsItsSource(t *testing.T) {
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	ctx := context.Background()
 	dir := t.TempDir()
 

--- a/internal/frontend/generated_task_append_test.go
+++ b/internal/frontend/generated_task_append_test.go
@@ -15,7 +15,7 @@ import (
 // lists only NEW tasks (not re-listing the existing ones) must APPEND to the
 // agent's bootstrapped list, never replace it (issue #183).
 func TestConfirmGeneratedTaskAppendsToBootstrapList(t *testing.T) {
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -56,7 +56,7 @@ func TestConfirmGeneratedTaskAppendsToBootstrapList(t *testing.T) {
 // (send=false, busy agent) also appends — existing tasks survive and the new
 // ones are added, with nothing delivered to the busy pane (issue #180 + #183).
 func TestConfirmGeneratedTaskAppendsWhileAgentBusy(t *testing.T) {
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -100,7 +100,7 @@ func TestConfirmGeneratedTaskAppendsWhileAgentBusy(t *testing.T) {
 // position, not #1) — the completed item stays "[x]" and the new one is
 // delivered and marked "[-]" (issue #183 reservation-position fix).
 func TestConfirmGeneratedTaskSendAppendsAndReservesNewItem(t *testing.T) {
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -156,7 +156,7 @@ func TestConfirmGeneratedTaskSendAppendsAndReservesNewItem(t *testing.T) {
 // name that same rendered text, not the raw "1. Foo", or it fails spuriously
 // after the escalation is claimed (issue #183 reservation-text fix).
 func TestConfirmGeneratedTaskSendReservesNumberedFirstTask(t *testing.T) {
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{agents: []domain.AgentTransition{{AgentID: "w9:p9", Status: "idle"}}}
 	app.Herdr = fake
 	stateDir := t.TempDir()
@@ -203,7 +203,7 @@ func TestConfirmGeneratedTaskCollapsesDuplicateKeepingAdvancedMark(t *testing.T)
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			app, st := testApp(t)
+			app, st := localFSApp(t)
 			fake := &fakeHerdr{}
 			app.Herdr = fake
 			stateDir := t.TempDir()

--- a/internal/frontend/generated_task_automated_test.go
+++ b/internal/frontend/generated_task_automated_test.go
@@ -46,7 +46,7 @@ func seedClaimedGeneratedTask(t *testing.T, st interface {
 // suggestions it exists to act on. A fake seam in the daemon tests can never
 // catch this, which is why the assertion lives here, against the real code.
 func TestAutomatedGeneratedTaskAcceptsAClaimedRow(t *testing.T) {
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	app.Herdr = &fakeHerdr{}
 	stateDir := t.TempDir()
 	app.StateDir = stateDir
@@ -275,7 +275,7 @@ func TestAutomatedGeneratedTaskReleasesTheReservationOnAFailedSend(t *testing.T)
 // the callback. A template can frame a benign task into something the operator's
 // rules refuse, and the raw task text cannot show that.
 func TestAutomatedGeneratedTaskScreensTheSourceTemplatePrompt(t *testing.T) {
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	fake := &fakeHerdr{}
 	app.Herdr = fake
 	app.StateDir = t.TempDir()

--- a/internal/frontend/generated_task_bootstrap_provider_test.go
+++ b/internal/frontend/generated_task_bootstrap_provider_test.go
@@ -22,7 +22,7 @@ import (
 // it registers must resolve to the same list.
 func TestBootstrapWritesWhereItRegisters(t *testing.T) {
 	t.Run("local default writes the state-dir file and registers it", func(t *testing.T) {
-		app, st := testApp(t)
+		app, st := localFSApp(t)
 		app.Herdr = &fakeHerdr{}
 		stateDir := t.TempDir()
 		app.StateDir = stateDir
@@ -55,7 +55,7 @@ func TestBootstrapWritesWhereItRegisters(t *testing.T) {
 	})
 
 	t.Run("remote default registers the store file, not the state-dir path", func(t *testing.T) {
-		app, st := testApp(t)
+		app, st := localFSApp(t)
 		app.Herdr = &fakeHerdr{}
 		stateDir := t.TempDir()
 		app.StateDir = stateDir
@@ -92,6 +92,54 @@ func TestBootstrapWritesWhereItRegisters(t *testing.T) {
 		// And it must NOT have written the local bootstrap file.
 		if _, statErr := os.Stat(filepath.Join(stateDir, "tasks", name+".md")); statErr == nil {
 			t.Error("the confirm wrote a local bootstrap file under a remote provider")
+		}
+	})
+
+	t.Run("the sqlite default registers a db locator and writes no file", func(t *testing.T) {
+		// The DEFAULT posture for a fresh install, and the shape this whole
+		// class of bug lives in: a locator is not a path, so a confirm that
+		// still reaches for the filesystem writes the tasks somewhere the
+		// registered source can never read them.
+		app, st := testApp(t)
+		app.Herdr = &fakeHerdr{}
+		stateDir := t.TempDir()
+		app.StateDir = stateDir
+		ctx := context.Background()
+
+		name, _ := st.EnsureAgentName(ctx, "w3:p3")
+		id, _ := st.AppendAudit(ctx, domain.AuditRecord{
+			AgentID: "w3:p3", SituationType: domain.SituationIdle, Trigger: "t",
+			Action: "escalated", Status: "escalated",
+			Suggestion: domain.SuggestTaskPrefix + "Task A", CreatedAt: time.Now(),
+		})
+		if err := confirmGeneratedTask(app, ctx, id, false); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(filepath.Join(stateDir, "tasks", name+".md")); err == nil {
+			t.Error("the confirm wrote a local bootstrap file under the sqlite provider")
+		}
+		cfg, err := config.Load(app.ConfigPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(cfg.TaskSources) != 1 {
+			t.Fatalf("got %d sources, want 1", len(cfg.TaskSources))
+		}
+		src := cfg.TaskSources[0]
+		if src.Path != name+".md" {
+			t.Errorf("registered path = %q, want the store file name %q", src.Path, name+".md")
+		}
+		if src.Provider != "" {
+			t.Errorf("provider = %q, want the inherited default left empty", src.Provider)
+		}
+		// And the tasks are readable back through the store, which is the only
+		// thing that proves the write and the registration agree.
+		items, err := app.ListTasks(name, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 1 || !strings.Contains(items[0].Text, "Task A") {
+			t.Errorf("items = %+v, want the confirmed task readable through the store", items)
 		}
 	})
 }

--- a/internal/frontend/generated_task_seed_test.go
+++ b/internal/frontend/generated_task_seed_test.go
@@ -29,7 +29,7 @@ import (
 // the finished list — is the point: the finished list is non-blank either way,
 // which is why this shipped.
 func TestBootstrapSeedsTheListWithItsHeaderNotBlank(t *testing.T) {
-	app, st := testApp(t)
+	app, st := localFSApp(t)
 	app.Herdr = &fakeHerdr{}
 	stateDir := t.TempDir()
 	app.StateDir = stateDir

--- a/internal/frontend/notasksource.go
+++ b/internal/frontend/notasksource.go
@@ -78,7 +78,8 @@ func (n *NoTaskSourceNotice) Guidance() string {
 	}
 
 	b.WriteString("\nOr give the agent its own checklist:\n")
-	b.WriteString("  hap config task-source add --agent <name> ./docs/tasks.md\n")
+	b.WriteString("  hap config task-source add --agent <name>\n")
+	b.WriteString("  (for a markdown file on disk instead: add --provider local_fs ./docs/tasks.md)\n")
 
 	fmt.Fprintf(&b, "\nNothing to do about this one? Drop it with:\n  hap dismiss %d", n.AuditID)
 	return b.String()

--- a/internal/frontend/symlinked_source_test.go
+++ b/internal/frontend/symlinked_source_test.go
@@ -18,7 +18,7 @@ import (
 // the other, the lookup silently missed and the source ran UNCAPPED — the cap
 // simply stopped applying, with nothing reporting it.
 func TestSymlinkedSourcePathStillMatchesItsConfigEntry(t *testing.T) {
-	app, _ := testApp(t)
+	app, _ := localFSApp(t)
 	ctx := context.Background()
 
 	dir := t.TempDir()

--- a/internal/frontend/taskstoreprovider_fields_test.go
+++ b/internal/frontend/taskstoreprovider_fields_test.go
@@ -134,7 +134,13 @@ func TestProviderFieldValueNeverRendersEmpty(t *testing.T) {
 			}
 		}
 	}
-	if got := frontend.FieldValue(config.Default(), "task_source_provider.provider"); got != config.ProviderLocalFS {
-		t.Errorf("the default provider must render as %q, got %q", config.ProviderLocalFS, got)
+	if got := frontend.FieldValue(config.Default(), "task_source_provider.provider"); got != config.ProviderSQLite {
+		t.Errorf("the default provider must render as %q, got %q", config.ProviderSQLite, got)
+	}
+	// A Config assembled in memory never went through Load or Default, and
+	// ResolveProvider answers local_fs there — the posture that needs neither a
+	// store handle nor a node id.
+	if got := frontend.FieldValue(config.Config{}, "task_source_provider.provider"); got != config.ProviderLocalFS {
+		t.Errorf("a zero config must render as %q, got %q", config.ProviderLocalFS, got)
 	}
 }

--- a/internal/privacy/privacy_test.go
+++ b/internal/privacy/privacy_test.go
@@ -10,7 +10,8 @@
 //     the operator owns, with a token the operator supplies. No pane content,
 //     no learned rules, no audit history. A source uses it only when
 //     [task_source_provider] (or that source's own `provider`) selects it, and
-//     the default is local_fs.
+//     it is never the default — a new install gets sqlite (hap's own database)
+//     and an older one local_fs, and neither makes an outbound call.
 //  3. internal/store/turso/turso.go — the turso store engine, which syncs the
 //     WHOLE store (agents, escalations with their pane excerpts, audit, learned
 //     rules) with a Turso Cloud database the operator owns, with a token the

--- a/internal/tasklocator/locator_symlink_test.go
+++ b/internal/tasklocator/locator_symlink_test.go
@@ -28,7 +28,7 @@ func TestLocalLocatorIsNotSymlinkResolved(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := tasklocator.Resolve(config.Default(),
+	res, err := tasklocator.Resolve(localCfg(),
 		config.TaskSource{Agent: "a", Path: viaLink}, "a", "")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/tasklocator/tasklocator_test.go
+++ b/internal/tasklocator/tasklocator_test.go
@@ -156,6 +156,13 @@ func TestGistLocatorRoundTripsThroughParse(t *testing.T) {
 	}
 }
 
+// localCfg is the file-backed posture, named explicitly. config.Default() is
+// no longer it: a fresh install defaults to the sqlite provider, so a test
+// that means "a list that is a file on disk" has to say so.
+func localCfg() config.Config {
+	return config.Config{TaskSourceProvider: config.TaskSourceProvider{Provider: config.ProviderLocalFS}}
+}
+
 func remoteCfg(gistID string) config.Config {
 	return config.Config{TaskSourceProvider: config.TaskSourceProvider{
 		Provider:   config.ProviderGitHubGist,
@@ -177,12 +184,12 @@ func TestResolveAppliesProviderDefaultsAndOverrides(t *testing.T) {
 	}{
 		{
 			name: "local source keeps its canonical path",
-			cfg:  config.Default(), src: config.TaskSource{Path: local},
+			cfg:  localCfg(), src: config.TaskSource{Path: local},
 			agent: "brave-otter", want: tasklocator.Canonical(local),
 		},
 		{
 			name: "local source ignores the agent name",
-			cfg:  config.Default(), src: config.TaskSource{Path: local},
+			cfg:  localCfg(), src: config.TaskSource{Path: local},
 			agent: "", want: tasklocator.Canonical(local),
 		},
 		{
@@ -223,7 +230,7 @@ func TestResolveAppliesProviderDefaultsAndOverrides(t *testing.T) {
 		},
 		{
 			name: "a local source with no path is refused",
-			cfg:  config.Default(), src: config.TaskSource{},
+			cfg:  localCfg(), src: config.TaskSource{},
 			agent: "brave-otter", wantErr: "no path",
 		},
 		{

--- a/internal/tui/correct_test.go
+++ b/internal/tui/correct_test.go
@@ -85,7 +85,7 @@ func correctTestModel(t *testing.T) (Model, *store.Store, *fakeHerdrTUI) {
 	app := &frontend.App{
 		Store:      st,
 		Herdr:      fh,
-		ConfigPath: filepath.Join(dir, "config.toml"),
+		ConfigPath: seedLocalFSConfigIn(t, dir),
 		Author:     "operator",
 		StateDir:   dir,
 		DaemonInfo: func() (bool, int, string) { return true, os.Getpid(), buildinfo.Version },

--- a/internal/tui/fsp_test.go
+++ b/internal/tui/fsp_test.go
@@ -28,7 +28,7 @@ func fspTestApp(t *testing.T) *frontend.App {
 	t.Cleanup(func() { st.Close() })
 	app := &frontend.App{
 		Store:      st,
-		ConfigPath: filepath.Join(dir, "config.toml"),
+		ConfigPath: seedLocalFSConfigIn(t, dir),
 		Author:     "operator",
 	}
 	ctx := context.Background()

--- a/internal/tui/idlepoll_test.go
+++ b/internal/tui/idlepoll_test.go
@@ -151,7 +151,7 @@ func TestKeypressRestoresTheFastPoll(t *testing.T) {
 	}
 	t.Cleanup(func() { st.Close() })
 	ctx := context.Background()
-	app := &frontend.App{Store: st, ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	app := &frontend.App{Store: st, ConfigPath: seedLocalFSConfigIn(t, dir), Author: "op"}
 
 	m := New(ctx, app)
 	m.width, m.height = 100, 30

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -1211,7 +1211,7 @@ func TestFilteredSelectionConfirms(t *testing.T) {
 	}
 	t.Cleanup(func() { st.Close() })
 	h := &captureHerdr{}
-	app := &frontend.App{Store: st, Herdr: h, ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	app := &frontend.App{Store: st, Herdr: h, ConfigPath: seedLocalFSConfigIn(t, dir), Author: "op"}
 	makeDaemonLive(t, app, dir)
 	startStandInDrain(t, st, h.record)
 	ctx := context.Background()

--- a/internal/tui/llmpreset_prompt_test.go
+++ b/internal/tui/llmpreset_prompt_test.go
@@ -23,7 +23,7 @@ func presetModel(t *testing.T) (Model, *frontend.App) {
 	}
 	t.Cleanup(func() { st.Close() })
 	app := &frontend.App{Store: st, Herdr: &captureHerdr{},
-		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+		ConfigPath: seedLocalFSConfigIn(t, dir), Author: "operator"}
 	m := New(context.Background(), app)
 	m.width, m.height = 100, 30
 	m.tab = tabConfig

--- a/internal/tui/remoteagents_test.go
+++ b/internal/tui/remoteagents_test.go
@@ -337,7 +337,7 @@ func TestRemoteFocusSaysWhoseViewMoved(t *testing.T) {
 	t.Cleanup(func() { st.Close() })
 
 	m := fleetModel(t, 0, 1, 30)
-	m.app = &frontend.App{Store: st, ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+	m.app = &frontend.App{Store: st, ConfigPath: seedLocalFSConfigIn(t, dir), Author: "operator"}
 	m.ctx = context.Background()
 	m.cursors[tabAgents] = 1
 

--- a/internal/tui/seedrule_test.go
+++ b/internal/tui/seedrule_test.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -129,7 +128,7 @@ func TestEscalationsHelpAdvertisesBuiltinKeyOnlyWhenOneMatched(t *testing.T) {
 func TestDisableMatchedSeedRuleWritesOnlyThatRule(t *testing.T) {
 	rule := aSeedRule(t)
 	dir := t.TempDir()
-	app := &frontend.App{ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	app := &frontend.App{ConfigPath: seedLocalFSConfigIn(t, dir), Author: "op"}
 	m := escModelWith(t, config.Default(), []domain.AuditRecord{seedRuleEscalation(7, rule, domain.NeverAutoSeed)})
 	m.ctx = context.Background()
 	m.app = app
@@ -370,7 +369,7 @@ func TestDisableMatchedSeedRuleIsEscalationsOnly(t *testing.T) {
 func TestDisableMatchedSeedRuleCancelChangesNothing(t *testing.T) {
 	rule := aSeedRule(t)
 	dir := t.TempDir()
-	app := &frontend.App{ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	app := &frontend.App{ConfigPath: seedLocalFSConfigIn(t, dir), Author: "op"}
 	m := escModelWith(t, config.Default(), []domain.AuditRecord{seedRuleEscalation(1, rule, domain.NeverAutoSeed)})
 	m.ctx = context.Background()
 	m.app = app

--- a/internal/tui/signal_test.go
+++ b/internal/tui/signal_test.go
@@ -41,7 +41,7 @@ func runTestApp(t *testing.T) *frontend.App {
 	return &frontend.App{
 		Store:      st,
 		Herdr:      &captureHerdr{},
-		ConfigPath: filepath.Join(dir, "config.toml"),
+		ConfigPath: seedLocalFSConfigIn(t, dir),
 		StateDir:   dir,
 		Author:     "operator",
 	}

--- a/internal/tui/task_source_prompt_test.go
+++ b/internal/tui/task_source_prompt_test.go
@@ -25,7 +25,7 @@ func sourcePromptModel(t *testing.T) (Model, *frontend.App, string) {
 	}
 	t.Cleanup(func() { st.Close() })
 	app := &frontend.App{Store: st, Herdr: &captureHerdr{},
-		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+		ConfigPath: seedLocalFSConfigIn(t, dir), Author: "operator"}
 	path := filepath.Join(dir, "tasks.md")
 	if err := os.WriteFile(path, []byte("- [ ] alpha\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -318,7 +318,7 @@ func TestConfigTabEditsTaskSourceSettings(t *testing.T) {
 // edit, resolved through MaxTasksLimit so a config written before the cap was
 // filled in still shows the number the daemon enforces.
 func TestConfigTabSourceRowShowsMaxTasks(t *testing.T) {
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{
 		{Agent: "a1", Path: "/tmp/one.md"},              // unset → default
 		{Agent: "a2", Path: "/tmp/two.md", MaxTasks: 3}, // explicit
@@ -352,7 +352,7 @@ func dupSourceModel(t *testing.T) (Model, *frontend.App, string) {
 	}
 	t.Cleanup(func() { st.Close() })
 	app := &frontend.App{Store: st, Herdr: &captureHerdr{},
-		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+		ConfigPath: seedLocalFSConfigIn(t, dir), Author: "operator"}
 	shared := filepath.Join(dir, "shared.md")
 	if err := os.WriteFile(shared, []byte("- [ ] a\n"), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/tui/task_source_prompt_test.go
+++ b/internal/tui/task_source_prompt_test.go
@@ -117,7 +117,11 @@ func TestTUIAddTaskSourcePromptRejectsBadInput(t *testing.T) {
 		"/tmp/tasks.md --auto-send-when-idle=true",
 		"/tmp/tasks.md -auto-send-when-idle",
 		"/tmp/tasks.md --auto-send-when-idl",
-		"/tmp/tasks.md --agent brave-otter",
+		// --agent is real now, but naming the agent twice is not: whichever
+		// one lost would be a selector the operator believes is set.
+		"/tmp/tasks.md brave-otter --agent calm-badger",
+		"/tmp/tasks.md --agent",
+		"/tmp/tasks.md --provider linear",
 	} {
 		m, app, _ := sourcePromptModel(t)
 		msg := submitSourcePrompt(t, m, input)
@@ -836,5 +840,118 @@ func TestTUIAddTaskSourceAcceptsReviewWithAutoSend(t *testing.T) {
 	src := cfg.TaskSources[0]
 	if !src.ReviewBeforeAutoSendEnabled() || !src.EnableAutoSendTaskWhenIdle {
 		t.Errorf("both flags must survive the add: %+v", src)
+	}
+}
+
+// freshSourcePromptModel is sourcePromptModel on a FRESH install: no config
+// file at all, so the sqlite default is in force and a list is a name inside
+// hap's database rather than a path. sourcePromptModel seeds local_fs, which
+// is why it cannot see any of this.
+func freshSourcePromptModel(t *testing.T) (Model, *frontend.App) {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	app := &frontend.App{Store: st, Herdr: &captureHerdr{},
+		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+	m := New(context.Background(), app)
+	m.width, m.height = 100, 30
+	return m, app
+}
+
+// TestTUIAddPathlessSourceOnAFreshInstall: the pathless per-agent form is the
+// documented default, and the prompt used to have no way to express it —
+// positionally the checklist comes first, so an operator with no path to give
+// had nothing to type in its place, an empty input was refused, and a
+// filesystem path is refused by the sqlite provider. --agent is the way in.
+func TestTUIAddPathlessSourceOnAFreshInstall(t *testing.T) {
+	m, app := freshSourcePromptModel(t)
+	msg := submitSourcePrompt(t, m, "--agent brave-otter")
+	if msg.err != nil {
+		t.Fatalf("a pathless source must be creatable on a fresh install: %v", msg.err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 1 {
+		t.Fatalf("got %d sources, want 1", len(cfg.TaskSources))
+	}
+	src := cfg.TaskSources[0]
+	if src.Agent != "brave-otter" {
+		t.Errorf("agent = %q, want brave-otter", src.Agent)
+	}
+	if src.Path != "" {
+		t.Errorf("path = %q, want it left empty so the list name derives per agent", src.Path)
+	}
+	// The inheritance is a live link: writing the resolved provider into the
+	// entry would freeze it, so changing the default would move nothing.
+	if src.Provider != "" {
+		t.Errorf("provider = %q, want the inheritance left empty", src.Provider)
+	}
+	if got := cfg.ResolveProvider(src).Name; got != config.ProviderSQLite {
+		t.Errorf("resolved provider = %q, want %q", got, config.ProviderSQLite)
+	}
+}
+
+// TestTUIAddLocalFileSourceOnAFreshInstall is the symmetric hole: with sqlite
+// the default, a filesystem path is refused, so without --provider the TUI
+// could no longer create a file-backed source at all.
+func TestTUIAddLocalFileSourceOnAFreshInstall(t *testing.T) {
+	m, _ := freshSourcePromptModel(t)
+	path := filepath.Join(t.TempDir(), "tasks.md")
+	if err := os.WriteFile(path, []byte("- [ ] alpha\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Without --provider this is refused by the sqlite provider's store-file
+	// rule, and the refusal must name the way out rather than only the fault.
+	msg := submitSourcePrompt(t, m, path+" brave-otter")
+	if msg.err == nil {
+		t.Fatal("a filesystem path under the sqlite default must be refused")
+	}
+	if !strings.Contains(msg.err.Error(), config.ProviderLocalFS) {
+		t.Errorf("the refusal must name local_fs, got %v", msg.err)
+	}
+
+	m, app := freshSourcePromptModel(t)
+	if msg := submitSourcePrompt(t, m, path+" brave-otter --provider local_fs"); msg.err != nil {
+		t.Fatalf("--provider local_fs must make a file-backed source creatable: %v", msg.err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 1 {
+		t.Fatalf("got %d sources, want 1", len(cfg.TaskSources))
+	}
+	if got := cfg.TaskSources[0].Provider; got != config.ProviderLocalFS {
+		t.Errorf("provider = %q, want the explicit override recorded", got)
+	}
+	if got := cfg.TaskSources[0].Path; got != path {
+		t.Errorf("path = %q, want %q", got, path)
+	}
+}
+
+// TestTUIPathlessAddIsStillRefusedUnderLocalFS: the checklist stays REQUIRED
+// where there is nothing to derive, so the relaxation follows the provider
+// rather than being a blanket "path is optional now".
+func TestTUIPathlessAddIsStillRefusedUnderLocalFS(t *testing.T) {
+	m, app, _ := sourcePromptModel(t) // seeds local_fs
+	msg := submitSourcePrompt(t, m, "--agent brave-otter")
+	if msg.err == nil {
+		t.Fatal("a pathless source under local_fs must be refused")
+	}
+	if !strings.Contains(msg.err.Error(), "required") {
+		t.Errorf("the refusal must say a path is required, got %v", msg.err)
+	}
+	cfg, err := app.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.TaskSources) != 0 {
+		t.Errorf("a refused add must write nothing, got %+v", cfg.TaskSources)
 	}
 }

--- a/internal/tui/tasks_test.go
+++ b/internal/tui/tasks_test.go
@@ -27,7 +27,7 @@ import (
 // in-progress items) and an unreadable one.
 func taskModel(t *testing.T) Model {
 	t.Helper()
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{
 		{Agent: "brave-otter", Path: "/work/tasks.md"},
 		{Agent: "codex", Path: "/work/missing.md"},
@@ -153,7 +153,7 @@ func TestTasksTabSearchKeepsGroupHeaders(t *testing.T) {
 // scroll/viewport tests.
 func tasksListModel(t *testing.T, n, height int) Model {
 	t.Helper()
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{{Agent: "claude", Path: "/work/tasks.md"}}
 	group := frontend.TaskGroup{Source: cfg.TaskSources[0]}
 	for i := 0; i < n; i++ {
@@ -203,7 +203,7 @@ func TestRefreshDataPopulatesTasks(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { st.Close() })
-	app := &frontend.App{Store: st, ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+	app := &frontend.App{Store: st, ConfigPath: seedLocalFSConfigIn(t, dir), Author: "operator"}
 	ctx := context.Background()
 
 	good := filepath.Join(dir, "tasks.md")
@@ -237,6 +237,27 @@ func TestRefreshDataPopulatesTasks(t *testing.T) {
 // exercise the same read-modify-write path the CLI uses. Returns the model
 // on the Tasks tab (rows: header, #1, #2, #3), the App, and the checklist
 // path.
+// seedLocalFSConfigIn writes a config declaring the local_fs provider into dir
+// and returns its path, for a fixture whose checklist is a FILE on disk. The
+// package default is the sqlite provider, under which a filesystem path is not
+// a legal list name at all — so a fixture that writes a .md and points a source
+// at it has to say which backend it means.
+func seedLocalFSConfigIn(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte("[task_source_provider]\nprovider = \"local_fs\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// localFSCfg is config.Default() for a fixture whose sources are files on disk.
+func localFSCfg() config.Config {
+	cfg := config.Default()
+	cfg.TaskSourceProvider.Provider = config.ProviderLocalFS
+	return cfg
+}
+
 func taskAppModel(t *testing.T) (Model, *frontend.App, string) {
 	t.Helper()
 	dir := t.TempDir()
@@ -246,7 +267,7 @@ func taskAppModel(t *testing.T) (Model, *frontend.App, string) {
 	}
 	t.Cleanup(func() { st.Close() })
 	app := &frontend.App{Store: st, Herdr: &captureHerdr{},
-		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+		ConfigPath: seedLocalFSConfigIn(t, dir), Author: "operator"}
 	ctx := context.Background()
 	// A daemon that looked and found nothing — "no agent matches this source",
 	// as opposed to an unpublished roster's "nobody has looked". Only the
@@ -863,7 +884,7 @@ func TestTaskRowCountsNestedDetailAndDetailShowsIt(t *testing.T) {
 		"- [ ] flat task\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{{Agent: "brave-otter", Path: path}}
 	m := Model{width: 100, height: 30}
 	upd, _ := m.Update(refreshMsg{
@@ -916,7 +937,7 @@ func TestTaskRowDetailMarkerSurvivesNarrowPane(t *testing.T) {
 			"    - it renders\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{{Agent: "brave-otter", Path: path}}
 	for _, w := range []int{40, 60, 80, 92, 120} {
 		m := Model{width: w, height: 30}
@@ -1423,7 +1444,7 @@ func TestTaskDetailFocusAction(t *testing.T) {
 
 func TestTasksHeaderPathTruncatedKeepsBase(t *testing.T) {
 	longDir := "/very/long/path/segments/that/will/never/fit/on/one/line/of/the/header"
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{{Agent: "claude", Path: longDir + "/checklist.md"}}
 	m := Model{width: 200, height: 30}
 	upd, _ := m.Update(refreshMsg{cfg: cfg, tasks: []frontend.TaskGroup{
@@ -1516,7 +1537,7 @@ func sendTaskModel(t *testing.T) (Model, *captureHerdr, string) {
 		[]byte(`- [ ] write the parser\nstart with the lexer`+"\n- [x] done thing\n- [-] wip thing\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{
 		{Agent: "brave-otter", Path: path, NextTaskTemplate: "DO: {next_task_content} ({agent_name})"},
 		{Agent: "codex", Path: "/work/missing.md"},
@@ -1807,7 +1828,7 @@ func TestTasksMarksPrunedOnRefresh(t *testing.T) {
 // on the group's header row.
 func removeSourceModel(t *testing.T, items []domain.ChecklistItem, groupErr string) Model {
 	t.Helper()
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{{Agent: "brave-otter", Path: "/work/tasks.md"}}
 	m := Model{width: 100, height: 30}
 	upd, _ := m.Update(refreshMsg{
@@ -2126,7 +2147,7 @@ func TestTasksReorderCursorNudgeWithTwoGroups(t *testing.T) {
 	}
 	t.Cleanup(func() { st.Close() })
 	app := &frontend.App{Store: st, Herdr: &captureHerdr{},
-		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+		ConfigPath: seedLocalFSConfigIn(t, dir), Author: "operator"}
 	ctx := context.Background()
 	if err := app.AddTaskSource(ctx, "a1", "", first, ""); err != nil {
 		t.Fatal(err)
@@ -2316,7 +2337,7 @@ func TestSendTaskRowRefusesARegroupedDerivedSource(t *testing.T) {
 // one-list-per-agent shape, which reads as an unconfigured source. It must
 // name where the list actually lives, as `hap config task-source list` does.
 func TestConfigTabTaskSourceRowNamesTheProvider(t *testing.T) {
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSourceProvider = config.TaskSourceProvider{
 		Provider:   config.ProviderGitHubGist,
 		EnvFile:    "/etc/hap/task.env",

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -6091,7 +6091,7 @@ func (m Model) addTaskSourcePrompt() (tea.Model, tea.Cmd) {
 	app, ctx := m.app, m.ctx
 	m.beginAction()
 	m.openPrompt(&prompt{
-		label: "add task source: <path> [agent] [workspace] [--auto-send-when-idle] [--enable-llm-review-before-auto-send] [--max-tasks N]",
+		label: "add task source: [<checklist>] [agent] [workspace] [--agent A] [--workspace W] [--provider P] [--auto-send-when-idle] [--enable-llm-review-before-auto-send] [--max-tasks N]",
 		onSubmit: func(input string) tea.Cmd {
 			return func() tea.Msg {
 				// Flags are spelled exactly like the CLI's and accepted in any
@@ -6105,6 +6105,7 @@ func (m Model) addTaskSourcePrompt() (tea.Model, tea.Cmd) {
 				fields := strings.Fields(input)
 				maxTasks := config.DefaultMaxTasks
 				llmReview := false
+				var flagAgent, flagWorkspace, provider string
 				for i := 0; i < len(fields); i++ {
 					f := fields[i]
 					if f == "--auto-send-when-idle" {
@@ -6117,7 +6118,7 @@ func (m Model) addTaskSourcePrompt() (tea.Model, tea.Cmd) {
 					}
 					// --max-tasks takes a value, written either way round:
 					// "--max-tasks 40" or "--max-tasks=40".
-					if value, ok := maxTasksFlagValue(fields, &i); ok {
+					if value, ok := valueFlag(fields, &i, "--max-tasks"); ok {
 						if value == "" {
 							return actionResultMsg{err: fmt.Errorf(
 								"--max-tasks needs a value (e.g. --max-tasks 40)")}
@@ -6131,31 +6132,85 @@ func (m Model) addTaskSourcePrompt() (tea.Model, tea.Cmd) {
 						maxTasks = n
 						continue
 					}
+					// --agent/--workspace name the selector WITHOUT a leading
+					// checklist, which is the only way to express the pathless
+					// per-agent form: positionally the path comes first, so an
+					// operator who wants the default provider to derive one
+					// list per agent has nothing to type in its place.
+					named, err := namedValueFlag(fields, &i, map[string]*string{
+						"--agent":     &flagAgent,
+						"--workspace": &flagWorkspace,
+						"--provider":  &provider,
+					})
+					if err != nil {
+						return actionResultMsg{err: err}
+					}
+					if named {
+						continue
+					}
 					if strings.HasPrefix(f, "-") {
 						return actionResultMsg{err: fmt.Errorf(
-							"unknown flag %q — this prompt takes --auto-send-when-idle and --enable-llm-review-before-auto-send (spelled exactly, no =value) and --max-tasks N (or --max-tasks=N); use the CLI for anything else", f)}
+							"unknown flag %q — this prompt takes --auto-send-when-idle and --enable-llm-review-before-auto-send (spelled exactly, no =value), --max-tasks N (or --max-tasks=N), and --agent A / --workspace W / --provider P (each also as --flag=value); use the CLI for anything else", f)}
 					}
 					parts = append(parts, f)
 				}
-				if len(parts) == 0 {
-					return actionResultMsg{err: fmt.Errorf("expected <path> [agent] [workspace] — no path given")}
-				}
 				if len(parts) > 3 {
 					return actionResultMsg{err: fmt.Errorf(
-						"expected <path> [agent] [workspace] — got %d fields (paths with spaces are not supported here; use the CLI)", len(parts))}
+						"expected [<checklist>] [agent] [workspace] — got %d fields (paths with spaces are not supported here; use the CLI)", len(parts))}
 				}
-				var agent, workspace string
+				if provider != "" && !slices.Contains(config.ValidTaskSourceProviders, provider) {
+					return actionResultMsg{err: fmt.Errorf("--provider must be one of %s, got %q",
+						strings.Join(config.ValidTaskSourceProviders, ", "), provider)}
+				}
+				var path, agent, workspace string
+				if len(parts) > 0 {
+					path = parts[0]
+				}
 				if len(parts) > 1 {
 					agent = parts[1]
 				}
 				if len(parts) > 2 {
 					workspace = parts[2]
 				}
+				// A flag and a positional naming the same field is refused
+				// rather than silently resolved: whichever one lost would be a
+				// selector the operator believes this source carries.
+				if flagAgent != "" {
+					if agent != "" {
+						return actionResultMsg{err: fmt.Errorf(
+							"agent given twice: --agent %s and the positional %q", flagAgent, agent)}
+					}
+					agent = flagAgent
+				}
+				if flagWorkspace != "" {
+					if workspace != "" {
+						return actionResultMsg{err: fmt.Errorf(
+							"workspace given twice: --workspace %s and the positional %q", flagWorkspace, workspace)}
+					}
+					workspace = flagWorkspace
+				}
+				// Whether the checklist is required depends on the provider
+				// this source will actually run under, which may be inherited
+				// — the same rule the CLI applies. Under local_fs it is a
+				// filesystem path and there is nothing to derive; under the
+				// others an empty one means "one list per matched agent".
+				cfg, err := app.Config()
+				if err != nil {
+					return actionResultMsg{err: err}
+				}
+				if path == "" && !cfg.ResolveProvider(config.TaskSource{Provider: provider}).Remote() {
+					return actionResultMsg{err: fmt.Errorf(
+						"a checklist path is required under provider=%s — give one, or pass --provider to a store-backed provider to derive one list per agent",
+						cfg.ResolveProvider(config.TaskSource{Provider: provider}).Name)}
+				}
+				if provider != "" {
+					opts = append(opts, frontend.Provider(provider))
+				}
 				// Passed unconditionally, like the CLI's --max-tasks: a new
 				// source records the review gate it actually runs under rather
 				// than leaving the key absent and the operator guessing.
 				opts = append(opts, frontend.ReviewBeforeAutoSend(llmReview))
-				if err := app.AddTaskSource(ctx, agent, workspace, parts[0], "", opts...); err != nil {
+				if err := app.AddTaskSource(ctx, agent, workspace, path, "", opts...); err != nil {
 					return actionResultMsg{err: err}
 				}
 				// Every setting is echoed back: an operator who typed a flag
@@ -6175,17 +6230,37 @@ func (m Model) addTaskSourcePrompt() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// maxTasksFlagValue recognizes the --max-tasks flag at fields[*i] in either
-// spelling ("--max-tasks 40" or "--max-tasks=40"), advancing *i past a
-// separate value word. A trailing "--max-tasks" with nothing after it returns
-// an empty value, which the caller reports as invalid rather than ignoring —
-// silently dropping it would create the source under the default cap.
-func maxTasksFlagValue(fields []string, i *int) (string, bool) {
+// namedValueFlag matches fields[*i] against any of the value-taking flags in
+// into, storing the value through its pointer. A flag with no value is an
+// error rather than a no-op, for the same reason valueFlag says: a silently
+// dropped --agent would create a source matching EVERY agent.
+func namedValueFlag(fields []string, i *int, into map[string]*string) (bool, error) {
+	for name, dst := range into {
+		value, ok := valueFlag(fields, i, name)
+		if !ok {
+			continue
+		}
+		if value == "" {
+			return false, fmt.Errorf("%s needs a value (e.g. %s brave-otter)", name, name)
+		}
+		*dst = value
+		return true, nil
+	}
+	return false, nil
+}
+
+// valueFlag recognizes a value-taking flag at fields[*i] in either spelling
+// ("--max-tasks 40" or "--max-tasks=40"), advancing *i past a separate value
+// word. A trailing flag with nothing after it returns an empty value, which
+// the caller reports as invalid rather than ignoring — silently dropping
+// --max-tasks would create the source under the default cap, and silently
+// dropping --agent would create one matching every agent.
+func valueFlag(fields []string, i *int, name string) (string, bool) {
 	f := fields[*i]
-	if value, ok := strings.CutPrefix(f, "--max-tasks="); ok {
+	if value, ok := strings.CutPrefix(f, name+"="); ok {
 		return value, true
 	}
-	if f != "--max-tasks" {
+	if f != name {
 		return "", false
 	}
 	if *i+1 < len(fields) {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -593,7 +593,7 @@ func TestAgentsListTaskColumn(t *testing.T) {
 	// "<total> (<pending>)" for the agent's own source; agents with no source
 	// read "-", and an unreadable source must not render a truthful-looking
 	// "0 (0)".
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{
 		{Agent: "brave-otter", Path: "/work/tasks.md"},
 		{Agent: "swift-hawk", Path: "/work/broken.md"},
@@ -705,7 +705,7 @@ func TestSeeAgentTasksFromAgentsListNoMatchIsNoop(t *testing.T) {
 // the cursor — a one-agent fixture would pass even if the cursor were ignored.
 func multiAgentTasksModel(t *testing.T) Model {
 	t.Helper()
-	cfg := config.Default()
+	cfg := localFSCfg()
 	cfg.TaskSources = []config.TaskSource{
 		{Agent: "alpha", Path: "/work/alpha.md"},
 		{Agent: "beta", Path: "/work/beta.md"},
@@ -1234,7 +1234,7 @@ func appModel(t *testing.T) (Model, *frontend.App, *store.Store) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { st.Close() })
-	app := &frontend.App{Store: st, ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+	app := &frontend.App{Store: st, ConfigPath: seedLocalFSConfigIn(t, dir), Author: "operator"}
 	ctx := context.Background()
 	now := time.Now()
 	st.UpsertSignature(ctx, domain.SignatureState{
@@ -1589,7 +1589,7 @@ func TestEscalationDetailEnterConfirmsAndCloses(t *testing.T) {
 	}
 	t.Cleanup(func() { st.Close() })
 	h := &captureHerdr{}
-	app := &frontend.App{Store: st, Herdr: h, ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	app := &frontend.App{Store: st, Herdr: h, ConfigPath: seedLocalFSConfigIn(t, dir), Author: "op"}
 	makeDaemonLive(t, app, dir)
 	startStandInDrain(t, st, h.record)
 	ctx := context.Background()
@@ -1657,7 +1657,7 @@ func TestEscalationDetailEnterConfirmsSnapshotNotClampedCursor(t *testing.T) {
 	}
 	t.Cleanup(func() { st.Close() })
 	h := &captureHerdr{}
-	app := &frontend.App{Store: st, Herdr: h, ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	app := &frontend.App{Store: st, Herdr: h, ConfigPath: seedLocalFSConfigIn(t, dir), Author: "op"}
 	makeDaemonLive(t, app, dir)
 	startStandInDrain(t, st, h.record)
 	ctx := context.Background()
@@ -2124,7 +2124,7 @@ func TestReembedKey(t *testing.T) {
 	t.Cleanup(func() { st.Close() })
 	app := &frontend.App{
 		Store:      st,
-		ConfigPath: filepath.Join(dir, "config.toml"),
+		ConfigPath: seedLocalFSConfigIn(t, dir),
 		DaemonInfo: func() (bool, int, string) { return false, 0, "" },
 	}
 	m = driftModel(t, frontend.EmbeddingDrift{Detected: true, Stale: 1, Total: 1})
@@ -2157,7 +2157,7 @@ func retryAppModel(t *testing.T) (Model, *store.Store, *frontend.App, int64) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { st.Close() })
-	app := &frontend.App{Store: st, Herdr: &captureHerdr{}, ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	app := &frontend.App{Store: st, Herdr: &captureHerdr{}, ConfigPath: seedLocalFSConfigIn(t, dir), Author: "op"}
 	ctx := context.Background()
 	id, err := st.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: "w1:pA", SituationType: domain.SituationApproval, Trigger: "t",
@@ -2188,7 +2188,7 @@ func TestDetailViewRetriesFailedLearnFromUserRunOnAuditTab(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { st.Close() })
-	app := &frontend.App{Store: st, Herdr: &captureHerdr{}, ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	app := &frontend.App{Store: st, Herdr: &captureHerdr{}, ConfigPath: seedLocalFSConfigIn(t, dir), Author: "op"}
 	ctx := context.Background()
 	id, err := st.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: "w1:pA", AgentType: "claude", SituationType: domain.SituationApproval,
@@ -2261,7 +2261,7 @@ func TestRetryLLMListGatedForNonFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { st.Close() })
-	app := &frontend.App{Store: st, Herdr: &captureHerdr{}, ConfigPath: filepath.Join(dir, "config.toml"), Author: "op"}
+	app := &frontend.App{Store: st, Herdr: &captureHerdr{}, ConfigPath: seedLocalFSConfigIn(t, dir), Author: "op"}
 	ctx := context.Background()
 	st.AppendAudit(ctx, domain.AuditRecord{
 		AgentID: "w1:pA", SituationType: domain.SituationApproval, Trigger: "t",
@@ -2701,7 +2701,7 @@ func focusApp(t *testing.T) (*frontend.App, *store.Store) {
 		t.Fatal(err)
 	}
 	return &frontend.App{
-		Store: st, ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator",
+		Store: st, ConfigPath: seedLocalFSConfigIn(t, dir), Author: "operator",
 		StateDir:   dir,
 		DaemonInfo: func() (bool, int, string) { return true, os.Getpid(), buildinfo.Version },
 	}, st

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -624,11 +624,15 @@ sync_claude_session_name = false  # keep a claude agent's hap short name and its
 # change the value here and every inheriting source moves with it. hap never
 # writes the inherited value back into a source (that would freeze it).
 #
-# Values: "local_fs" (default) | "github_gist" | "sqlite"
+# Values: "sqlite" (default) | "local_fs" | "github_gist"
+#
+# The default applies to a config file that does not exist yet. An install that
+# already has one keeps "local_fs" — hap pins it on load — so no checklist you
+# already have changes where it lives.
 # [task_source_provider]
-# provider = "local_fs"
+# provider = "sqlite"
 
-# ── sqlite ──────────────────────────────────────────────────────────
+# ── sqlite (the default) ────────────────────────────────────────────
 # Keeps each list INSIDE hap's own database (the task_lists table) instead of a
 # file. Under the default engine nothing leaves this machine; under
 # [database] engine = "turso" the lists sync with everything else, so every
@@ -640,11 +644,19 @@ sync_claude_session_name = false  # keep a claude agent's hap short name and its
 # hands items out — so two machines' agents never share a queue.
 # provider = "sqlite"
 
+# ── local_fs ────────────────────────────────────────────────────────
+# Each list is a markdown FILE on this machine and `path` is a filesystem path.
+# This is the only provider where that is true: under sqlite and github_gist a
+# path-shaped value is refused rather than silently creating a list elsewhere.
+# Set it here to move every inheriting source, or per source with
+# `hap config task-source add --agent <name> --provider local_fs <checklist.md>`.
+# provider = "local_fs"
+
 # ── github_gist ─────────────────────────────────────────────────────
-# PRIVACY: this sends the task lists of the sources using it to GitHub. The
-# default ("local_fs") keeps every checklist on this machine and makes no
-# outbound call. Nothing else is ever sent: no pane content, no learned rules,
-# no audit log.
+# PRIVACY: this sends the task lists of the sources using it to GitHub. It is
+# the ONLY provider that makes an outbound call — the default ("sqlite") and
+# "local_fs" both keep every checklist on this machine. Nothing else is ever
+# sent: no pane content, no learned rules, no audit log.
 #
 # Every list is a FILE inside ONE gist you already own. hap NEVER creates the
 # gist: make a SECRET gist on github.com, copy the hex id out of its URL, and


### PR DESCRIPTION
Changes `[task_source_provider] provider` from `local_fs` to `sqlite` — for **new installs only**.

## What a fresh install gets

A checklist is a row in hap's own database (`task_lists`) rather than a markdown file: no file lock behind every read-modify-write, one list derived per matched agent instead of a hand-written path, and — under the turso engine — lists visible fleet-wide. It still makes no outbound call; `github_gist` remains the only provider that does.

- `hap config task-source add --agent x` no longer needs the positional `<checklist.md>`.
- A filesystem path is now **refused** under the default, and the message names both ways out: `--provider local_fs` for a file on disk, or omit the path.
- Locators render as `db_list=` rather than `path=`.

## Existing installs do not move

`Default()` names `sqlite`; `Load` pins `local_fs` the moment the config **file** exists — **before the decode**, so an explicit key still wins and *every* return carries the pin. That covers three exits, not two: the read error, the parse error, and the `AutoAccept.validate()` branch that keeps the partially decoded config rather than rebuilding it. A post-decode pin misses that third one silently — a typo in the config would move an install's storage backend.

`ResolveProvider`'s literal fallback stays `local_fs`: it is reached only by a `Config` assembled in memory, where the posture needing no store handle and no node id is the right answer.

## `AnyNonDefaultProvider`

It gates every "print the provider" branch in the CLI and TUI, and it could no longer be written as "anything but local_fs" — there are now **two** postures an operator reaches without touching the setting, and neither may grow a provider column. It now asks whether the config is **mixed**, and otherwise stays quiet on either local backend. `github_gist` is still always notable.

## Tests — and why `testApp` was left alone

88 `cli`/`frontend` tests failed on the flip. Every one of them means "a file on disk", so they now **declare** it (`localFSApp` / `localFSCfg` / `seedLocalFSConfigIn`), plus ~50 in `tui`.

`testApp` deliberately stays on the **default**. Seeding `local_fs` there would have made all 88 green by declaring that no CLI or frontend test exercises the new default — which is the failure `CLAUDE.md` names three times over ("every frontend test before it ran on a local file, which is the single reason all of this shipped green").

New coverage for the default path instead:

- `TestFreshInstallAddsAPathlessSourceAndRoundTripsItsTasks` — pathless add, list created on demand, full `hap task` round trip, inheritance left unmaterialized.
- `TestFreshInstallRefusalNamesTheWayOut`.
- `TestTaskSourceListIsQuietOnTheSQLiteDefault` — the other half of the byte-identical-output promise.
- A `sqlite` subtest of `TestBootstrapWritesWhereItRegisters` — the generated-task bootstrap is where the locator-is-not-a-path class historically bit; it asserts no file is written, the registered source is a store name, and the tasks read back through the store.
- `TestAFreshConfigDefaultsToSQLite` / `TestAnExistingConfigWithoutTheKeyStaysLocalFS` (writes a real file — a config built in memory cannot tell "no file yet" from "a file omitting the key", so it is the only shape that discriminates; covers all three exits) / `TestAZeroConfigStillResolvesLocally`.

## Docs

README, `sample/config.toml`, the in-binary `hap` skill, the architecture doc's NFR-007, the `privacy` package doc, `CLAUDE.md`, and `hap config task-source add --help` — whose `--provider` enum was already stale (it never listed `sqlite`).

## Release

Minor, so per `CLAUDE.md` the version is hand-written into `herdr-plugin.toml` (`0.9.0`) and `scripts/assemble-changelog.sh 0.9.0` was run in this PR.

**If another PR merges before this one**, rebase and re-run `bash scripts/assemble-changelog.sh 0.9.0` so its fragment is folded in too — the release refuses to tag while unassembled fragments remain.

## Verification

`go build`, `go vet`, `go test -tags "vectors cpu" ./... -count=1` and `golangci-lint run --build-tags "vectors,cpu"` (0 issues). The only failing test is `TestALockedMigrationStepLosesTheLeaseAndFailsClosed` in `internal/store/turso`, which fails identically on an untouched branch in this environment.

https://claude.ai/code/session_01QuzmZBxJZx86FAgdTWjvug