### PR TITLE
#1 chore: bump plugin version to 0.8.8 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.8.8
+
+- Fixed the TUI Audit tab and `hap audit` labelling another machine's rows with a local
+  agent's name: a herdr pane id repeats on every node sharing the store, so audit rows
+  now resolve the same `name@node` identity the Escalations tab already used — and an
+  audit row from another node no longer borrows a local agent's type
+- Added an `agent=` column to `hap audit`, which never had one; it is appended beside
+  `node=` so nothing parsing the existing tab-separated fields moves
+- Added the node to an audit/escalation detail view when the row came from another machine
+
 ## 0.8.7
 
 - Fixed `agent_roster` growing without bound: retired agents' rows are now deleted on the existing `[logging] row_retention_days` window, with a compact permanent tombstone left behind so a late transition cannot bring a dead agent back live

--- a/changelog.d/fix-audit-agent-name.md
+++ b/changelog.d/fix-audit-agent-name.md
@@ -1,7 +1,0 @@
-- Fixed the TUI Audit tab and `hap audit` labelling another machine's rows with a local
-  agent's name: a herdr pane id repeats on every node sharing the store, so audit rows
-  now resolve the same `name@node` identity the Escalations tab already used — and an
-  audit row from another node no longer borrows a local agent's type
-- Added an `agent=` column to `hap audit`, which never had one; it is appended beside
-  `node=` so nothing parsing the existing tab-separated fields moves
-- Added the node to an audit/escalation detail view when the row came from another machine

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.8.7"
+version = "0.8.8"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.8.8 is being released from this commit by the Auto Release workflow.