### PR TITLE
#0 feat: prune escalations across every node, and finish the Tasks tab's fleet view

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -209,7 +209,8 @@ hap confirm <id> --send               # the suggestion is right — accept and d
 hap resolve <id> --action TEXT --send # it is wrong — send the right answer instead
 hap resolve <id> --action @noop       # no reply was needed (never sends)
 hap dismiss <id> [<id>...]            # drop it; nothing sent or learned
-hap escalations prune [minutes]       # bulk-dismiss everything older (default 360)
+hap escalations prune [minutes]       # bulk-dismiss everything older, on EVERY node (default 360)
+hap escalations prune --node NODE     # …on one machine only
 hap escalations retry <id>            # re-invoke the LLM on a failed/timed-out consult
 ```
 

--- a/README.md
+++ b/README.md
@@ -848,11 +848,16 @@ appends the machine as the last field; escalations carry `node=<label>`.
 
 **What you can do from another machine.** Confirm, answer, correct, dismiss or
 retry an escalation raised there — the owning daemon executes it and the action
-reads `queued for node <label>` until it lands; curate learned rules, which are
+reads `queued for node <label>` until it lands; prune the aged ones on every
+machine at once (`X` on the Escalations tab, or `hap escalations prune`, which
+retires exactly the unified list it shows — `--node <label>` scopes it to one);
+rename, enable, disable, focus or capture a remote agent with `--node <label>`,
+which files the request for the owning daemon; curate learned rules, which are
 shared; pause or resume a machine (`hap pause --node laptop`); read and edit its
-`sqlite`-provider task lists (`hap task --node laptop <agent> list`). Renaming,
-enabling, disabling or focusing a remote agent is refused: those are the owning
-daemon's rows.
+`sqlite`-provider task lists (`hap task --node laptop <agent> list`), including
+reordering them from the TUI's Tasks tab. Changing a remote agent's permission
+MODE is still refused — that one reads the pane it is about to press into, so it
+belongs to the machine watching it.
 
 **How conflicts are avoided.** Every row a machine owns carries its node id
 (herdr pane ids repeat across machines), ids are allocated with node bits, and a

--- a/changelog.d/feat-fleet-wide-prune-and-tasks.md
+++ b/changelog.d/feat-fleet-wide-prune-and-tasks.md
@@ -1,0 +1,28 @@
+- Changed the Escalations tab's "prune old" (`X`) and `hap escalations prune` to
+  retire every machine's aged escalations, not just this one's. The list they
+  prune has always spanned the fleet under a shared `turso` database, so a
+  node-scoped prune cleared a fraction of what was on screen and reported the
+  count as though it had cleared all of it. Both surfaces now name the scope
+  ("across 3 nodes"), and `hap escalations prune --node <label|id>` prunes a
+  single machine.
+- Fixed `f` on another machine's task list saying "no live agent matches this
+  task source". It now focuses that node's agent, the way `f` on the Agents and
+  Escalations tabs already did; a list the owning node never named an agent for
+  says that instead.
+- Fixed `K`/`J` refusing to reorder another machine's task list with "this task
+  source is no longer loaded" — about a list that was on screen. Reordering
+  works on any node's list.
+- Fixed `x` on another machine's task-source header doing nothing at all. It now
+  explains that a task source lives in that machine's `config.toml`, which never
+  enters the shared database, and points at `hap config task-source remove`
+  there.
+- Fixed the README's fleet section still saying renaming, enabling, disabling or
+  focusing a remote agent is refused — `--node` has filed all four for the
+  owning daemon since the fleet view landed. Changing a remote agent's
+  permission mode is the one that really is refused.
+- Fixed `--node=` with no value being read as "no `--node` at all" on every verb
+  that takes the flag. It was a silent no-op there, and would have been the
+  wider action on the new fleet prune; it is now refused like the bare `--node`.
+- Fixed the Tasks tab treating a fleet task-list read FAILURE as another
+  machine's list: focus, send and source-removal named an empty node and
+  pointed at a machine that does not exist. They report the store error now.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1222,23 +1222,53 @@ func escalations(ctx context.Context, app *frontend.App, out io.Writer, args []s
 
 // escalationsPrune dismisses pending escalations older than the given age
 // in minutes (default 360). Audit rows are kept; nothing is sent or learned.
+//
+// Without --node it prunes EVERY node, matching the queue `hap escalations`
+// prints. --node scopes it to one machine.
 func escalationsPrune(ctx context.Context, app *frontend.App, out io.Writer, args []string) error {
-	minutes := frontend.DefaultPruneMinutes
-	if len(args) > 1 {
-		return fmt.Errorf("usage: escalations prune [minutes] (see: hap help escalations)")
-	}
-	if len(args) == 1 {
-		v, err := strconv.Atoi(args[0])
-		if err != nil || v <= 0 {
-			return fmt.Errorf("invalid age %q — whole minutes, e.g. escalations prune 120", args[0])
-		}
-		minutes = v
-	}
-	n, err := app.PruneEscalations(ctx, time.Duration(minutes)*time.Minute)
+	// Whether --node was SPELLED, which splitNodeFlag cannot answer on its own:
+	// it collapses `--node <this machine>` to an empty node id, the same value
+	// it returns when the flag is absent. For rename and friends those two are
+	// the same request; here they are opposites — one prunes this node, the
+	// other prunes the fleet.
+	scoped := slices.ContainsFunc(args, func(arg string) bool {
+		return arg == "--node" || strings.HasPrefix(arg, "--node=")
+	})
+	// splitNodeFlag, not nodeFlag: this verb takes a positional [minutes], and
+	// nodeFlag refuses any leftover argument.
+	rest, nodeID, label, err := splitNodeFlag(ctx, app, args)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "pruned %d escalation(s) older than %d minute(s); audit rows kept as dismissed\n", n, minutes)
+	minutes := frontend.DefaultPruneMinutes
+	if len(rest) > 1 {
+		return fmt.Errorf("usage: escalations prune [minutes] [--node <label|id>] (see: hap help escalations)")
+	}
+	if len(rest) == 1 {
+		v, err := strconv.Atoi(rest[0])
+		if err != nil || v <= 0 {
+			return fmt.Errorf("invalid age %q — whole minutes, e.g. escalations prune 120", rest[0])
+		}
+		minutes = v
+	}
+	var n int64
+	scope := ""
+	if scoped {
+		if label == "" {
+			label = " on this node"
+		}
+		scope = label
+		n, err = app.PruneEscalationsOn(ctx, time.Duration(minutes)*time.Minute, nodeID)
+	} else {
+		if nodes, e := app.Store.ListNodes(ctx); e == nil && len(nodes) > 1 {
+			scope = fmt.Sprintf(" across %d nodes", len(nodes))
+		}
+		n, err = app.PruneEscalations(ctx, time.Duration(minutes)*time.Minute)
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "pruned %d escalation(s)%s older than %d minute(s); audit rows kept as dismissed\n", n, scope, minutes)
 	PrintNextSteps(out, []Hint{
 		{Cmd: "hap escalations", Why: "what is still pending"},
 		{Cmd: "hap audit --limit 20", Why: "the pruned rows are kept here as dismissed"},

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -844,9 +844,80 @@ func TestEscalationsPruneCLI(t *testing.T) {
 		t.Errorf("2h-old escalation must fall to the 60-minute cutoff, got %q", rec.Status)
 	}
 
-	for _, args := range [][]string{{"prune", "0"}, {"prune", "-5"}, {"prune", "abc"}, {"prune", "60", "extra"}, {"bogus"}} {
+	for _, args := range [][]string{{"prune", "0"}, {"prune", "-5"}, {"prune", "abc"}, {"prune", "60", "extra"},
+		{"prune", "--node"}, {"prune", "--node="}, {"prune", "--node", "nosuchnode"}, {"bogus"}} {
 		if _, err := run(t, app, "escalations", args...); err == nil {
 			t.Errorf("escalations %v must fail", args)
+		}
+	}
+}
+
+// TestEscalationsPruneNodeFlag pins the two scopes the verb offers. The
+// positional [minutes] is what rules nodeFlag out — it refuses any leftover
+// argument — so this also proves the verb still reads the age after
+// splitNodeFlag has lifted the flag out from in front of it.
+func TestEscalationsPruneNodeFlag(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.db")
+	self, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { self.Close() })
+	other, err := store.OpenAs(path, "bbbbbbbbbbbbbbbb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { other.Close() })
+	app := &frontend.App{Store: self, ConfigPath: filepath.Join(dir, "config.toml"),
+		Author: "operator", StateDir: dir}
+
+	ctx := context.Background()
+	now := time.Now()
+	// Both machines announce themselves the way a running daemon does — the
+	// nodes table is what --node resolves against and what the fleet count
+	// reads.
+	for _, st := range []*store.Store{self, other} {
+		if err := st.UpsertNode(ctx, domain.NodeInfo{ID: st.NodeID(), Label: "node-" + st.NodeID()[:4],
+			StartedAt: now, LastSeen: now}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	aged := now.Add(-7 * time.Hour)
+	seed := func(st *store.Store) int64 {
+		t.Helper()
+		id, err := st.AppendAudit(ctx, domain.AuditRecord{SituationType: domain.SituationApproval,
+			Trigger: "old", Action: "escalated", Status: "escalated", CreatedAt: aged})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}
+	mine, theirs := seed(self), seed(other)
+
+	// --node names THIS machine: only its own row goes.
+	out, err := run(t, app, "escalations", "prune", "--node", self.NodeID(), "60")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "pruned 1 escalation(s) on this node older than 60 minute(s)") {
+		t.Errorf("scoped prune output:\n%s", out)
+	}
+	if rec, _ := self.GetAudit(ctx, theirs); rec.Status != "escalated" {
+		t.Errorf("--node <self> dismissed another node's escalation: %q", rec.Status)
+	}
+
+	// No flag: the fleet, which is what `hap escalations` lists.
+	out, err = run(t, app, "escalations", "prune", "60")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "pruned 1 escalation(s) across 2 nodes older than 60 minute(s)") {
+		t.Errorf("fleet prune output:\n%s", out)
+	}
+	for _, id := range []int64{mine, theirs} {
+		if rec, _ := self.GetAudit(ctx, id); rec.Status != "dismissed" {
+			t.Errorf("audit #%d after the fleet prune = %q, want dismissed", id, rec.Status)
 		}
 	}
 }

--- a/internal/cli/fleet_test.go
+++ b/internal/cli/fleet_test.go
@@ -180,6 +180,13 @@ func TestNodeFlagEqualsFormAndBareFlag(t *testing.T) {
 	if err := other.UpsertNode(ctx, domain.NodeInfo{Label: "laptop", LastSeen: time.Now()}); err != nil {
 		t.Fatal(err)
 	}
+	// An EMPTY value is the same mistake the bare flag makes and gets the same
+	// answer, on every verb that takes --node. Falling through as "no flag"
+	// reads as a silent no-op here, and as the WIDER action on a verb whose
+	// unflagged form spans the fleet (`hap escalations prune`).
+	if _, err := run(t, app, "pause", "--node="); err == nil {
+		t.Error("`--node=` with no value must be refused, like the bare `--node`")
+	}
 	out, err := run(t, app, "pause", "--node=laptop")
 	if err != nil || !strings.Contains(out, "automation paused on node laptop") {
 		t.Errorf("pause --node=laptop = %q %v", out, err)

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -423,14 +423,20 @@ func buildCommands() {
 			Summary: "list what is waiting for an answer; prune old ones",
 			Usage: []string{
 				"hap escalations",
-				"hap escalations prune [minutes]",
+				"hap escalations prune [minutes] [--node <label|id>]",
 				"hap escalations retry <audit-id>",
+			},
+			Flags: []FlagDoc{
+				{Name: "--node <label|id>", Desc: "prune only one machine's escalations (prune only; see `hap status` for the nodes sharing this store)"},
 			},
 			Details: "Each row is: #id, time, situation type, reason, agent, LLM confidence,\n" +
 				"the suggested answer, and the learned rule it matched (if any).\n" +
 				"Answer a row with `confirm` (accept the suggestion), `resolve` (supply the right\n" +
 				"answer), or `dismiss` (drop it). `prune` dismisses everything older than N minutes\n" +
 				"(default 360); audit rows are kept and nothing is sent or learned.\n" +
+				"Under a shared database (`[database] engine = \"turso\"`) the list spans every\n" +
+				"machine, and so does `prune` — it retires exactly what you are looking at.\n" +
+				"Pass `--node` to prune one machine instead.\n" +
 				"`retry` re-invokes the operator LLM on an escalation whose consult failed or\n" +
 				"timed out (and re-runs a failed learn-from-correction). It queues the request:\n" +
 				"the running daemon re-consults against the agent's LIVE pane, so the answer\n" +
@@ -442,7 +448,8 @@ func buildCommands() {
 			},
 			Examples: []string{
 				"hap escalations", "hap confirm 42 --send",
-				"hap escalations prune 120", "hap escalations retry 42",
+				"hap escalations prune 120", "hap escalations prune 120 --node laptop",
+				"hap escalations retry 42",
 			},
 			SelfHints: true,
 			Handler:   escalations,
@@ -1453,7 +1460,16 @@ func splitNodeFlag(ctx context.Context, app *frontend.App, args []string) (rest 
 			ref = args[i+1]
 			i++
 		case strings.HasPrefix(args[i], "--node="):
+			// An EMPTY value is the same operator mistake the bare `--node`
+			// makes, and it must get the same answer. Falling through with
+			// ref == "" reads as "the flag was absent", which is a silent
+			// no-op for the verbs that then run locally — and, for a verb
+			// whose unflagged form is WIDER than its flagged one (the fleet
+			// prune), silently the broader action.
 			ref = strings.TrimPrefix(args[i], "--node=")
+			if ref == "" {
+				return nil, "", "", fmt.Errorf("--node requires a node (label or id)")
+			}
 		default:
 			rest = append(rest, args[i])
 		}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -2225,13 +2225,34 @@ func (a *App) HasPendingLLMConsultOn(ctx context.Context, nodeID, agentID string
 const DefaultPruneMinutes = 360
 
 // PruneEscalations dismisses every pending escalation older than the given
-// age, returning how many were dismissed. Like Dismiss, the audit rows are
-// kept and nothing is sent or learned.
+// age, on EVERY node, returning how many were dismissed. Like Dismiss, the
+// audit rows are kept and nothing is sent or learned.
+//
+// The scope matches the list it prunes: Escalations is a fleet read, so a
+// node-scoped prune retired a fraction of what the operator was looking at and
+// reported the count as though it had retired all of it. PruneEscalationsOn
+// prunes one machine.
+//
+// The reload nudge only reaches THIS node's daemon; another machine's picks the
+// dismissals up on its next pull, the same latency PauseNode already accepts.
 func (a *App) PruneEscalations(ctx context.Context, olderThan time.Duration) (int64, error) {
 	if olderThan <= 0 {
 		return 0, fmt.Errorf("prune age must be positive, got %s", olderThan)
 	}
 	n, err := a.Store.DismissEscalationsBefore(ctx, time.Now().Add(-olderThan))
+	if err != nil {
+		return 0, err
+	}
+	a.nudge(ctx, control.KindReload) // best-effort, as above
+	return n, nil
+}
+
+// PruneEscalationsOn is PruneEscalations scoped to one node (empty = this one).
+func (a *App) PruneEscalationsOn(ctx context.Context, olderThan time.Duration, nodeID string) (int64, error) {
+	if olderThan <= 0 {
+		return 0, fmt.Errorf("prune age must be positive, got %s", olderThan)
+	}
+	n, err := a.Store.DismissEscalationsBeforeOn(ctx, time.Now().Add(-olderThan), orSelf(a, nodeID))
 	if err != nil {
 		return 0, err
 	}
@@ -4726,6 +4747,14 @@ func (a *App) GetTask(agent, path string, index int) (domain.ChecklistItem, erro
 // that is not a managed task source is left uncapped. Matched by absolute path
 // so it applies to both agent- and path-addressed adds of a registered source.
 // A config read error also yields 0 (fail-open: never block an add on it).
+//
+// ANOTHER NODE's list is a third uncapped case, and it is a limit rather than a
+// bug: a `db://<node>/<name>` list the TUI's Tasks tab shows is registered as a
+// [[task_sources]] entry in THAT machine's config.toml, and config never enters
+// the shared database — so its max_tasks is not readable from here and
+// domain.StoredTaskList carries no copy of it. Adding to a remote list from the
+// unified view is therefore uncapped; the owning node's own surfaces still
+// enforce its cap, and so does its daemon's generation gate.
 func (a *App) taskSourceLimit(agent, locator string) int {
 	cfg, err := a.Config()
 	if err != nil {

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -2037,6 +2037,57 @@ func TestPruneEscalations(t *testing.T) {
 	if _, err := app.PruneEscalations(ctx, 0); err == nil {
 		t.Error("a non-positive prune age must be rejected")
 	}
+	if _, err := app.PruneEscalationsOn(ctx, 0, ""); err == nil {
+		t.Error("a non-positive prune age must be rejected on the scoped path too")
+	}
+}
+
+// TestPruneEscalationsAcrossNodes pins the scope of each prune from the App
+// seam: the plain one retires another machine's aged rows (the Escalations
+// surfaces are a fleet list, so it must), and the scoped one leaves them alone.
+func TestPruneEscalationsAcrossNodes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.db")
+	self, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { self.Close() })
+	// The same file as another machine sees it.
+	other, err := store.OpenAs(path, "bbbbbbbbbbbbbbbb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { other.Close() })
+	app := &frontend.App{Store: self, ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+
+	ctx := context.Background()
+	aged := time.Now().Add(-7 * time.Hour)
+	seed := func(st *store.Store) int64 {
+		t.Helper()
+		id, err := st.AppendAudit(ctx, domain.AuditRecord{SituationType: domain.SituationApproval,
+			Trigger: "old", Action: "escalated", Status: "escalated", CreatedAt: aged})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}
+	mine, theirs := seed(self), seed(other)
+
+	if n, err := app.PruneEscalationsOn(ctx, 6*time.Hour, ""); err != nil || n != 1 {
+		t.Fatalf("PruneEscalationsOn(self) = %d, %v; want 1, nil", n, err)
+	}
+	if rec, _ := self.GetAudit(ctx, theirs); rec == nil || rec.Status != "escalated" {
+		t.Errorf("a scoped prune dismissed another node's escalation: %+v", rec)
+	}
+	if n, err := app.PruneEscalations(ctx, 6*time.Hour); err != nil || n != 1 {
+		t.Fatalf("PruneEscalations = %d, %v; want 1 (the other node's row), nil", n, err)
+	}
+	for _, id := range []int64{mine, theirs} {
+		if rec, _ := self.GetAudit(ctx, id); rec == nil || rec.Status != "dismissed" {
+			t.Errorf("audit #%d after the fleet prune: %+v, want dismissed", id, rec)
+		}
+	}
 }
 
 func TestResolveUnknownAuditFails(t *testing.T) {

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -693,8 +693,12 @@ type FrontendStore interface {
 	// dismissed). Callers apply one-time side effects only on a true claim.
 	ResolveEscalation(ctx context.Context, auditID int64) (bool, error)
 	// DismissEscalationsBefore dismisses every pending escalation created
-	// before cutoff, returning how many were dismissed.
+	// before cutoff on EVERY node, returning how many were dismissed. It spans
+	// nodes because the queue it prunes does — the operator surfaces render the
+	// unified list, and dismissing one row by id already crosses machines.
 	DismissEscalationsBefore(ctx context.Context, cutoff time.Time) (int64, error)
+	// DismissEscalationsBeforeOn is DismissEscalationsBefore for one node.
+	DismissEscalationsBeforeOn(ctx context.Context, cutoff time.Time, nodeID string) (int64, error)
 	ClearLearnedData(ctx context.Context) error
 }
 

--- a/internal/store/nodescope_test.go
+++ b/internal/store/nodescope_test.go
@@ -63,6 +63,7 @@ var nodeScopeExemptions = map[string]string{
 	"GetAudit#1":                     "by id, returns node_id",
 	"CountPendingEscalations#1":      "fleet read: the unified pending count",
 	"PendingEscalations#1":           "fleet read: the unified queue, node_id per row",
+	"DismissEscalationsBefore#1":     "fleet write: the operator prunes the unified queue they are looking at",
 	"MarkLLMRetryProcessed#1":        "by id",
 	"RetireEscalationForRetry#1":     "by id",
 	"GetLLMRequest#1":                "by request_id",
@@ -360,8 +361,12 @@ func TestOperationalReadsNeverSeeAnotherNodesRows(t *testing.T) {
 	if rs, _ := a.OpenTaskReservations(ctx); len(rs) != 1 || rs[0].Restamps != 0 || !rs[0].ConfirmedAt.IsZero() {
 		t.Errorf("B's restart or a B pane going working touched A's hand-out: %+v", rs)
 	}
-	if n, _ := b.DismissEscalationsBefore(ctx, now.Add(time.Hour)); n != 0 {
-		t.Errorf("B's prune dismissed A's escalations: %d", n)
+	// The FLEET prune (DismissEscalationsBefore) deliberately spans nodes, so it
+	// is proved in TestFleetPruneDismissesEveryNodesAgedEscalations instead — it
+	// would dismiss the row every assertion below still needs. What belongs here
+	// is its node-scoped sibling, which is the one an operator points at B.
+	if n, _ := b.DismissEscalationsBeforeOn(ctx, now.Add(time.Hour), b.NodeID()); n != 0 {
+		t.Errorf("B's own-node prune dismissed A's escalations: %d", n)
 	}
 	if a2, _ := a.GetAudit(ctx, claimedID); a2.Status != domain.AuditStatusAutoAccepting {
 		t.Errorf("A's claim was disturbed: %q", a2.Status)
@@ -615,4 +620,81 @@ func indexExists(t *testing.T, db *sql.DB, name string) bool {
 		t.Fatal(err)
 	}
 	return n == 1
+}
+
+// TestFleetPruneDismissesEveryNodesAgedEscalations pins the one node-scoped
+// write that had to become fleet-wide: the operator's prune.
+//
+// The Escalations surfaces are a FLEET read — PendingEscalations has no node
+// filter and every row renders as name@node — so a prune that only touched
+// s.self retired a fraction of the list the operator was looking at and
+// reported the count as though it had retired all of it.
+//
+// The three assertions discriminate as a set. Without the `On` case the fleet
+// prune could be a prune of everything with no scoping left at all; without the
+// auto_accepting row a widened prune could reach a row another machine is
+// mid-claim on, which is the one hazard the status guard exists for.
+func TestFleetPruneDismissesEveryNodesAgedEscalations(t *testing.T) {
+	a, path := openTestStore(t)
+	b := openSecondNode(t, path, "bbbbbbbbbbbbbbbb")
+	ctx := context.Background()
+	now := time.Now()
+	old := now.Add(-2 * time.Hour)
+
+	seed := func(s *Store, status string, at time.Time) int64 {
+		t.Helper()
+		id, err := s.AppendAudit(ctx, domain.AuditRecord{AgentID: "1", AgentType: "claude",
+			Signature: "sig", Trigger: "t", SituationType: domain.SituationApproval,
+			Action: domain.AuditActionEscalated, Status: status, CreatedAt: at})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}
+	agedA := seed(a, "escalated", old)
+	agedB := seed(b, "escalated", old)
+	freshB := seed(b, "escalated", now)
+	// Mid-claim on B. It is older than the cutoff, so only the status guard
+	// keeps the prune off it.
+	claimedB := seed(b, domain.AuditStatusAutoAccepting, old)
+
+	statusOf := func(id int64) string {
+		t.Helper()
+		rec, err := a.GetAudit(ctx, id)
+		if err != nil || rec == nil {
+			t.Fatalf("GetAudit(%d): %v", id, err)
+		}
+		return rec.Status
+	}
+
+	// A's own-node prune leaves B's rows alone.
+	n, err := a.DismissEscalationsBeforeOn(ctx, now.Add(-time.Hour), a.NodeID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("DismissEscalationsBeforeOn(A) = %d, want 1 (only A's aged row)", n)
+	}
+	if got := statusOf(agedB); got != "escalated" {
+		t.Errorf("B's aged row after A's scoped prune = %q, want escalated", got)
+	}
+
+	// The fleet prune, run from A, retires B's aged row too.
+	n, err = a.DismissEscalationsBefore(ctx, now.Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("fleet prune = %d, want 1 (B's aged row; A's was already dismissed)", n)
+	}
+	for id, want := range map[int64]string{
+		agedA:    "dismissed",
+		agedB:    "dismissed",
+		freshB:   "escalated",
+		claimedB: domain.AuditStatusAutoAccepting,
+	} {
+		if got := statusOf(id); got != want {
+			t.Errorf("audit #%d = %q, want %q", id, got, want)
+		}
+	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1472,13 +1472,54 @@ func (s *Store) guardedStatus(ctx context.Context, auditID int64, from, to strin
 }
 
 // DismissEscalationsBefore dismisses every pending escalation created before
-// cutoff, returning how many were dismissed (the front-end prune).
+// cutoff, on EVERY node, returning how many were dismissed (the front-end
+// prune).
+//
+// It spans nodes because the queue it prunes does: PendingEscalations is a
+// fleet read, the TUI's Escalations tab and `hap escalations` render another
+// machine's rows as name@node, and dismissing one by id already works on any
+// node's escalation. A node-scoped prune under a fleet list dismissed a
+// fraction of what the operator was looking at and reported the count as if it
+// had pruned all of it.
+//
+// Nothing here reaches a pane or needs the owning node's config, so this is a
+// direct write rather than an agent_actions request: the case that most wants a
+// fleet prune is aged rows left behind by a machine whose daemon is gone, and a
+// queued action would need that daemon alive to run.
+//
+// Use DismissEscalationsBeforeOn for one node. The two statements are written
+// out separately on purpose — a single query with an optional predicate
+// (`WHERE (? = ” OR node_id = ?)`) would put node_id in the text that
+// TestEveryNodeOwnedStatementIsNodeScoped flattens, so a statement spanning
+// nodes would pass the guard silently.
 func (s *Store) DismissEscalationsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
 	var dismissed int64
 	err := s.tx(ctx, func(tx *sql.Tx) error {
 		res, err := tx.ExecContext(ctx,
+			`UPDATE audit_log SET status = 'dismissed' WHERE status = 'escalated' AND created_at < ?`,
+			unix(cutoff))
+		if err != nil {
+			return err
+		}
+		dismissed, err = res.RowsAffected()
+		return err
+	})
+	return dismissed, err
+}
+
+// DismissEscalationsBeforeOn is DismissEscalationsBefore for ONE node — the
+// `--node` prune, and the shape the daemon would need if it ever pruned its own
+// queue.
+//
+// The status guard is what keeps it off a row another writer holds: an
+// auto_accepting row is mid-claim on its own machine, and only an escalated one
+// is the operator's to retire.
+func (s *Store) DismissEscalationsBeforeOn(ctx context.Context, cutoff time.Time, nodeID string) (int64, error) {
+	var dismissed int64
+	err := s.tx(ctx, func(tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx,
 			`UPDATE audit_log SET status = 'dismissed' WHERE node_id = ? AND status = 'escalated' AND created_at < ?`,
-			s.self, unix(cutoff))
+			nodeID, unix(cutoff))
 		if err != nil {
 			return err
 		}

--- a/internal/tui/remotefocus_test.go
+++ b/internal/tui/remotefocus_test.go
@@ -1,11 +1,18 @@
 package tui
 
 import (
+	"context"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/config"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
 )
 
 const (
@@ -147,5 +154,264 @@ func TestFocusOnAVanishedRemoteAgentSaysSo(t *testing.T) {
 	}
 	if !strings.Contains(got.message, "laptop") || !strings.Contains(got.message, "may have exited") {
 		t.Errorf("banner = %q, want it to name the node and the likely cause", got.message)
+	}
+}
+
+// fleetTaskModel is collidingFleet with one list the OTHER node keeps in the
+// shared database, feeding the agent it names.
+func fleetTaskModel(t *testing.T) Model {
+	t.Helper()
+	m := collidingFleet(t)
+	m.tab = tabTasks
+	m.data.fleetTasks = []frontend.TaskGroup{{
+		Source:  config.TaskSource{Agent: "away-one"},
+		Index:   -1,
+		Locator: "db://" + otherNode + "/away-one.md",
+		Display: "away-one.md (hap database, node bbbbbbbb)",
+		NodeID:  otherNode, NodeLabel: "laptop",
+		Items: []domain.ChecklistItem{
+			{Index: 1, Mark: " ", Text: "remote one"},
+			{Index: 2, Mark: " ", Text: "remote two"},
+		},
+	}}
+	return m
+}
+
+// fleetTaskAppModel is the Tasks tab over a REAL store that another node keeps
+// a list in — the fixture for anything that has to run its command rather than
+// merely produce one.
+//
+// Distinct from fleetTaskModel, which hand-builds m.data over a nil App: that
+// one is right for the pure refusal paths (they never touch the store), and
+// wrong for anything that writes.
+func fleetTaskAppModel(t *testing.T) (Model, *frontend.App, *store.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.db")
+	st, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	remote, err := store.OpenAs(path, otherNode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { remote.Close() })
+
+	ctx := context.Background()
+	now := time.Now()
+	if err := remote.UpsertNode(ctx, domain.NodeInfo{ID: otherNode, Label: "laptop", LastSeen: now}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := remote.EnsureTaskList(ctx, otherNode, "away-one.md", "away-one",
+		"# Tasks for away-one\n\n- [ ] remote one\n- [ ] remote two\n", now); err != nil {
+		t.Fatal(err)
+	}
+	app := &frontend.App{Store: st, Herdr: &captureHerdr{},
+		ConfigPath: filepath.Join(dir, "config.toml"), Author: "operator"}
+	if err := st.PublishRoster(ctx, nil, now); err != nil {
+		t.Fatal(err)
+	}
+	m := New(ctx, app)
+	m.width, m.height = 120, 30
+	upd, _ := m.Update(refreshData(ctx, app))
+	m = upd.(Model)
+	m.tab = tabTasks
+	return m, app, remote
+}
+
+// fleetRowIndex is the cursor position of item n in the (single) fleet group,
+// found by walking the rendered rows rather than by counting them out by hand —
+// the configured sources in front of it are what set the offset, and a literal
+// index would silently address the wrong row if the fixture ever grows one.
+func (m Model) fleetRowIndex(t *testing.T, item int) int {
+	t.Helper()
+	for i, r := range m.taskRows() {
+		if r.item == item && r.group >= len(m.data.tasks) {
+			return i
+		}
+	}
+	t.Fatalf("no fleet row for item #%d in %d rows", item, len(m.taskRows()))
+	return 0
+}
+
+// f on another node's task list focuses that node's agent.
+//
+// MonitoredAgents is this machine's herd, so the row could never match it and
+// every fleet list answered "no live agent matches this task source" — about a
+// row that names both its node and its agent, while the Agents tab's own f had
+// reached a remote pane for releases.
+func TestFleetTaskFocusReachesTheOwningNodesAgent(t *testing.T) {
+	m := fleetTaskModel(t)
+	m.cursors[tabTasks] = 1 // the fleet header is row 0; row 1 is its first item
+
+	upd, cmd := m.focusSelectedTaskAgent()
+	got := upd.(Model)
+	if cmd == nil {
+		t.Fatalf("a fleet task row raised no focus request; it was refused with %q", got.message)
+	}
+	if got.message != "" {
+		t.Errorf("banner = %q, want the acting path to have cleared it", got.message)
+	}
+	// Aimed at the other machine's pane, not this one's — the pane ids collide.
+	if r := m.agentRowOn(otherNode, "1"); r == nil || r.TabID != "rt1" {
+		t.Errorf("the list's (node, agent) pair resolved to %+v, want the remote pane", r)
+	}
+}
+
+// The control for all of the above: a fleet group is addressed by an index PAST
+// every configured source, so the same list answers to a different number once
+// one is configured — and index 0 then belongs to the local source, which still
+// resolves through the selector match.
+//
+// Without this the fleet branch could be a redirect rather than an addition:
+// every assertion above runs on a model with no configured sources, where the
+// boundary is zero and any "is this remote" test passes.
+func TestFleetTaskGroupRespectsTheConfiguredSourceBoundary(t *testing.T) {
+	m := fleetTaskModel(t)
+	fleet := m.data.fleetTasks[0]
+	if g, ok := m.fleetTaskGroup(0); !ok || g.Locator != fleet.Locator {
+		t.Fatalf("with no configured source, group 0 = %+v (%v), want the fleet list", g, ok)
+	}
+
+	local := config.TaskSource{Agent: "here-one", Path: "/tmp/here.md"}
+	m.data.cfg.TaskSources = []config.TaskSource{local}
+	m.data.tasks = []frontend.TaskGroup{{Source: local, Index: 0}}
+	if _, ok := m.fleetTaskGroup(0); ok {
+		t.Error("group 0 must now be the configured source, not the fleet list")
+	}
+	if g, ok := m.fleetTaskGroup(1); !ok || g.Locator != fleet.Locator {
+		t.Errorf("group 1 = %+v (%v), want the fleet list shifted past the configured one", g, ok)
+	}
+	if g, ok := m.taskGroupAt(0); !ok || g.Source.Agent != "here-one" {
+		t.Errorf("taskGroupAt(0) = %+v (%v), want the configured source", g, ok)
+	}
+	// The local index goes through the selector match, and this node's agent
+	// "here-one" is what it finds.
+	if _, cmd := m.focusTaskGroupAgent(0); cmd == nil {
+		t.Error("a configured source feeding a live local agent must still focus it")
+	}
+}
+
+// A list the other node never named an agent for is refused with the fact that
+// is missing, not with a claim about this machine's herd.
+func TestFleetTaskFocusRefusesAnUnnamedList(t *testing.T) {
+	m := fleetTaskModel(t)
+	m.data.fleetTasks[0].Source.Agent = ""
+	m.cursors[tabTasks] = 1
+
+	upd, cmd := m.focusSelectedTaskAgent()
+	got := upd.(Model)
+	if cmd != nil {
+		t.Fatal("an unnamed remote list must not raise a focus")
+	}
+	if !strings.Contains(got.message, "does not say which agent") {
+		t.Errorf("banner = %q, want the unnamed-list refusal", got.message)
+	}
+}
+
+// x on another node's HEADER used to be a silent no-op — no message, no action,
+// indistinguishable from a broken key. A source is a [[task_sources]] entry in
+// that machine's config.toml, which never enters the shared database.
+func TestFleetTaskHeaderRemovalExplainsItself(t *testing.T) {
+	m := fleetTaskModel(t)
+	m.cursors[tabTasks] = 0 // the fleet header
+
+	upd, cmd := m.deleteTasksPrompt()
+	got := upd.(Model)
+	if cmd != nil || got.confirm != nil {
+		t.Fatal("removing another node's task source must not be attempted from here")
+	}
+	if !strings.Contains(got.message, "node laptop") ||
+		!strings.Contains(got.message, "hap config task-source remove") {
+		t.Errorf("banner = %q, want it to name the node and where the entry lives", got.message)
+	}
+}
+
+// K/J on another node's list reorders it — end to end, against a real store.
+//
+// Nothing under the old guard read the source's config (MoveTask addresses the
+// list by LOCATOR, which the store resolves to the owning node's task_lists
+// row), so the refusal cost an advertised key on every remote list and reported
+// "no longer loaded" about one that was on screen.
+//
+// It RUNS the command and reads the other node's list back, rather than
+// asserting a non-nil one. A model with no App can only prove that a command
+// was produced, and the locator-is-not-a-path bugs in this repo have all been
+// on the far side of that boundary.
+func TestFleetTaskReorderMovesTheRemoteList(t *testing.T) {
+	m, _, remote := fleetTaskAppModel(t)
+	ctx := context.Background()
+	m.cursors[tabTasks] = m.fleetRowIndex(t, 1)
+
+	upd, cmd := m.moveSelectedTask(1)
+	if cmd == nil {
+		t.Fatalf("a fleet task row raised no move; it was refused with %q", upd.(Model).message)
+	}
+	got, res := runAction(t, upd.(Model), cmd)
+	if res.err != nil {
+		t.Fatalf("the move failed: %v", res.err)
+	}
+	if strings.Contains(got.message, "no longer loaded") {
+		t.Errorf("banner = %q, want the stale-source refusal gone", got.message)
+	}
+	l, err := remote.ReadTaskList(ctx, otherNode, "away-one.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	one, two := strings.Index(l.Content, "remote one"), strings.Index(l.Content, "remote two")
+	if one < 0 || two < 0 || two > one {
+		t.Errorf("the other node's list was not reordered:\n%s", l.Content)
+	}
+}
+
+// The edges still refuse, which is what proves the items came from the FLEET
+// group rather than from an empty or a local one — a `group.Items` that read
+// the wrong slice would find no siblings and refuse BOTH directions.
+func TestFleetTaskReorderStillRefusesTheEnds(t *testing.T) {
+	m, _, _ := fleetTaskAppModel(t)
+	first, last := m.fleetRowIndex(t, 1), m.fleetRowIndex(t, 2)
+
+	m.cursors[tabTasks] = first
+	if _, cmd := m.moveSelectedTask(-1); cmd != nil {
+		t.Error("the first remote item must refuse to move up")
+	}
+	m.cursors[tabTasks] = last
+	if _, cmd := m.moveSelectedTask(1); cmd != nil {
+		t.Error("the last remote item must refuse to move down")
+	}
+}
+
+// A store the fleet lists cannot be read from renders as ONE synthetic group
+// carrying only an error (frontend.FleetTaskGroups). It names no node, no
+// locator and no agent, so an action that took it for another machine's list
+// answered about node "" and sent the operator to a machine that does not
+// exist. The refusal must be the error itself.
+func TestFleetTaskErrorGroupIsNotMistakenForAList(t *testing.T) {
+	m := fleetTaskModel(t)
+	m.data.fleetTasks = []frontend.TaskGroup{{Index: -1, Err: "fleet task lists: database is locked"}}
+
+	if _, ok := m.fleetTaskGroup(0); ok {
+		t.Error("an error group describes no list and must not resolve as one")
+	}
+	for _, tc := range []struct {
+		name string
+		run  func(Model) (tea.Model, tea.Cmd)
+	}{
+		{"focus", func(m Model) (tea.Model, tea.Cmd) { return m.focusTaskGroupAgent(0) }},
+		{"remove source", func(m Model) (tea.Model, tea.Cmd) { return m.removeTaskSourcePrompt(0) }},
+		{"send", func(m Model) (tea.Model, tea.Cmd) {
+			return m.sendTaskRow(taskRow{group: 0, item: 1, path: ""})
+		}},
+	} {
+		upd, cmd := tc.run(m)
+		got := upd.(Model)
+		if cmd != nil {
+			t.Errorf("%s: an unreadable fleet list must not act", tc.name)
+		}
+		if !strings.Contains(got.message, "database is locked") {
+			t.Errorf("%s: banner = %q, want the store error", tc.name, got.message)
+		}
 	}
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -3472,11 +3472,17 @@ func (m Model) deleteEscalations() (tea.Model, tea.Cmd) {
 // pruneEscalationsPrompt asks for an age in minutes (pre-filled with the
 // default, editable) and dismisses every pending escalation older than that.
 // Enter confirms, esc cancels.
+//
+// The prompt and the result NAME the scope when the store is shared, because
+// the prune spans every node the way this tab's list does: on a six-machine
+// fleet one keypress can go from retiring a dozen rows to retiring hundreds,
+// and a label that said only "prune escalations" would not have shown that.
+// On a single-node install pruneScope is empty and both lines read as before.
 func (m Model) pruneEscalationsPrompt() (tea.Model, tea.Cmd) {
-	app, ctx := m.app, m.ctx
+	app, ctx, scope := m.app, m.ctx, m.pruneScope()
 	m.beginAction()
 	m.openPrompt(&prompt{
-		label: "prune escalations older than N minutes — enter confirms, esc cancels",
+		label: "prune escalations" + scope + " older than N minutes — enter confirms, esc cancels",
 		input: strconv.Itoa(frontend.DefaultPruneMinutes),
 		onSubmit: func(input string) tea.Cmd {
 			return func() tea.Msg {
@@ -3489,11 +3495,24 @@ func (m Model) pruneEscalationsPrompt() (tea.Model, tea.Cmd) {
 					return actionResultMsg{err: err}
 				}
 				return actionResultMsg{message: fmt.Sprintf(
-					"pruned %d escalation(s) older than %d minute(s); audit rows kept as dismissed", n, minutes)}
+					"pruned %d escalation(s)%s older than %d minute(s); audit rows kept as dismissed",
+					n, scope, minutes)}
 			}
 		},
 	})
 	return m, nil
+}
+
+// pruneScope renders " across N nodes" when several machines share this store,
+// and "" when they do not. Status.Nodes is empty under the local engine, and
+// holds one row for a shared store nobody else has joined yet — neither is a
+// fleet, and saying "across 1 node" to an operator who has never heard of the
+// feature would be noise.
+func (m Model) pruneScope() string {
+	if n := len(m.data.status.Nodes); n > 1 {
+		return fmt.Sprintf(" across %d nodes", n)
+	}
+	return ""
 }
 
 // --- Tasks tab CRUD (mirrors `hap task` add/edit/done/undone/delete) ---
@@ -3818,6 +3837,20 @@ func (m Model) taskSourceRemovable(g frontend.TaskGroup) (string, bool) {
 // often hand-written docs hap did not create and could not restore, and
 // re-adding the source brings the list back untouched.
 func (m Model) removeTaskSourcePrompt(group int) (tea.Model, tea.Cmd) {
+	// Another machine's header. A task source is a [[task_sources]] entry in
+	// THAT node's config.toml, and config never enters the shared database, so
+	// there is nothing here to remove — but silence read as a broken key.
+	g, ok := m.fleetTaskGroup(group)
+	if ok {
+		m.message = fmt.Sprintf("this list belongs to node %s — a task source lives in that machine's "+
+			"config.toml, which never enters the shared database; remove it there with "+
+			"`hap config task-source remove`", g.NodeLabel)
+		return m, nil
+	}
+	if g.Err != "" {
+		m.message = g.Err
+		return m, nil
+	}
 	if group < 0 || group >= len(m.data.tasks) {
 		return m, nil
 	}
@@ -3918,6 +3951,8 @@ func (m Model) confirmDeleteTaskTargets(targets []taskTarget, clearsMarks bool) 
 // no source to consult at all.
 func (m Model) taskSourceLabel(r *taskRow) string {
 	if r.group >= len(m.data.tasks) {
+		// Another node's list, or a source that has gone: neither has a
+		// selector here to name it by, so the address is the label.
 		return truncatePathKeepBase(displayTaskAddress(r.path), taskPathDisplayWidth)
 	}
 	src := m.data.tasks[r.group].Source
@@ -4015,9 +4050,23 @@ func (m Model) focusSelectedTaskAgent() (tea.Model, tea.Cmd) {
 	return m.focusTaskGroupAgent(r.group)
 }
 
-// focusTaskGroupAgent focuses the first live agent whose selectors match the
-// given task source (config index) — shared by the list and detail `f`.
+// focusTaskGroupAgent focuses the live agent this task source feeds — shared by
+// the list and detail `f`.
+//
+// MonitoredAgents is THIS node's herd, so a fleet row can never match it: every
+// one of another machine's lists used to answer "no live agent matches this
+// task source", which is not what happened — the row names its node and the
+// agent that node keeps the list for, and the Agents tab's own `f` has reached
+// a remote pane since remoteagent.go landed.
 func (m Model) focusTaskGroupAgent(group int) (tea.Model, tea.Cmd) {
+	g, ok := m.fleetTaskGroup(group)
+	if ok {
+		return m.focusFleetTaskAgent(g)
+	}
+	if g.Err != "" {
+		m.message = g.Err
+		return m, nil
+	}
 	for _, a := range m.data.status.MonitoredAgents {
 		for _, idx := range m.agentTaskSourceMatches(m.localRow(a)) {
 			if idx == group {
@@ -4027,6 +4076,63 @@ func (m Model) focusTaskGroupAgent(group int) (tea.Model, tea.Cmd) {
 	}
 	m.message = "no live agent matches this task source"
 	return m, nil
+}
+
+// focusFleetTaskAgent focuses the agent another node keeps a list for.
+//
+// The list row carries the agent's NAME in that node's namespace, never a pane
+// id — pane ids repeat on every machine — so the roster is what turns it into
+// something focusable. An unnamed list is refused with the same sentence
+// sendRemoteTaskRow uses, since it is the same missing fact.
+func (m Model) focusFleetTaskAgent(g frontend.TaskGroup) (tea.Model, tea.Cmd) {
+	if g.Source.Agent == "" {
+		m.message = fmt.Sprintf("node %s does not say which agent this list belongs to", g.NodeLabel)
+		return m, nil
+	}
+	for _, r := range m.data.status.RemoteAgents {
+		if r.NodeID == g.NodeID && r.Name == g.Source.Agent {
+			return m.focusAgentOn(g.NodeID, r.AgentID)
+		}
+	}
+	m.message = fmt.Sprintf("no live agent %s on node %s — it may have exited",
+		g.Source.Agent, g.NodeLabel)
+	return m, nil
+}
+
+// fleetTaskGroup returns the OTHER node's list a row's group index addresses,
+// and whether the index names one at all.
+//
+// Fleet rows are laid out past every configured source (fleetTaskRows takes
+// len(m.data.tasks) as its base), so this boundary is the one thing that tells
+// another machine's list from this one's — and it was open-coded at every call
+// site, each having to get the arithmetic right on its own. A site that reads
+// only `>= len(m.data.tasks)` cannot tell a remote list from a source that has
+// gone, which is how a bare guard came to refuse a row that was on screen; a
+// site with no guard at all would index past the slice.
+// The ok is false for the SYNTHETIC error group FleetTaskGroups returns when
+// the store cannot be read (fleettasks.go: "a store that cannot be read is not
+// a fleet with no lists"). It renders, because silence would be worse — but it
+// describes no list at all: no node, no locator, no agent. An action that took
+// it for another machine's would name an empty node and send the operator to a
+// machine that does not exist. Its Err comes back either way, so a caller can
+// say what is actually wrong instead.
+func (m Model) fleetTaskGroup(group int) (frontend.TaskGroup, bool) {
+	k := group - len(m.data.tasks)
+	if k < 0 || k >= len(m.data.fleetTasks) {
+		return frontend.TaskGroup{}, false
+	}
+	g := m.data.fleetTasks[k]
+	return g, g.NodeID != ""
+}
+
+// taskGroupAt returns the group a row addresses, local or fleet — for the
+// actions that work the same either way, because they act on the LIST (through
+// a locator the store resolves per node) rather than on the source's config.
+func (m Model) taskGroupAt(group int) (frontend.TaskGroup, bool) {
+	if group >= 0 && group < len(m.data.tasks) {
+		return m.data.tasks[group], true
+	}
+	return m.fleetTaskGroup(group)
 }
 
 // taskGroupAgent resolves the first live agent whose selectors match the
@@ -4080,7 +4186,13 @@ func (m Model) moveSelectedTask(delta int) (tea.Model, tea.Cmd) {
 		m.message = "K/J reorders checklist items — move the cursor onto a task"
 		return m, nil
 	}
-	if r.group >= len(m.data.tasks) {
+	// Local or fleet: a reorder rewrites the LIST, and MoveTask addresses it by
+	// locator — which the store resolves to the owning node's task_lists row.
+	// Nothing below this point reads the source's config, so refusing a fleet
+	// row here left an advertised key dead on every remote list, and said
+	// "no longer loaded" about one that was on screen.
+	g, ok := m.taskGroupAt(r.group)
+	if !ok {
 		m.message = "this task source is no longer loaded — refreshing"
 		return m, nil
 	}
@@ -4098,7 +4210,7 @@ func (m Model) moveSelectedTask(delta int) (tea.Model, tea.Cmd) {
 	// first sub-task, and asking to swap those two is re-parenting, which
 	// MoveTask refuses. Stepping by position would make K/J fail on exactly the
 	// nested lists a subtree-carrying move exists for.
-	items := m.data.tasks[r.group].Items
+	items := g.Items
 	to := domain.SiblingPosition(items, r.item, delta)
 	// Refuse at the ends rather than clamping: a clamp would rewrite the file
 	// with identical content and report success, so holding the key at the top
@@ -4179,8 +4291,11 @@ func (m Model) sendTaskRow(r taskRow) (tea.Model, tea.Cmd) {
 	// is not in this herd, so nothing here can resolve a pane or a template for
 	// it — but the list row carries the agent's name in that node's namespace,
 	// which is the only identity the request needs.
-	if k := r.group - len(m.data.tasks); k >= 0 && k < len(m.data.fleetTasks) {
-		return m.sendRemoteTaskRow(r, m.data.fleetTasks[k])
+	if g, ok := m.fleetTaskGroup(r.group); ok {
+		return m.sendRemoteTaskRow(r, g)
+	} else if g.Err != "" {
+		m.message = g.Err
+		return m, nil
 	}
 	agent := m.taskGroupAgent(r.group)
 	if agent == nil {
@@ -4281,8 +4396,7 @@ func (m Model) taskDetailLines(r taskRow, width int) []string {
 		src := m.data.tasks[r.group].Source
 		lines = m.detailField(lines, w, "Agent selector", orDash(src.Agent))
 		lines = m.detailField(lines, w, "Workspace", orDash(src.Workspace))
-	} else if k := r.group - len(m.data.tasks); k >= 0 && k < len(m.data.fleetTasks) {
-		g := m.data.fleetTasks[k]
+	} else if g, ok := m.fleetTaskGroup(r.group); ok {
 		lines = m.detailField(lines, w, "Node", g.NodeLabel)
 		lines = m.detailField(lines, w, "Agent", orDash(g.Source.Agent))
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -4191,6 +4191,10 @@ func (m Model) moveSelectedTask(delta int) (tea.Model, tea.Cmd) {
 	// Nothing below this point reads the source's config, so refusing a fleet
 	// row here left an advertised key dead on every remote list, and said
 	// "no longer loaded" about one that was on screen.
+	// Unlike the other three fleet call sites, this one needs no branch for the
+	// synthetic error group FleetTaskGroups returns when the store cannot be
+	// read: its only rows are a header and an error line, both with item 0, so
+	// the guard above has already refused them.
 	g, ok := m.taskGroupAt(r.group)
 	if !ok {
 		m.message = "this task source is no longer loaded — refreshing"

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1862,6 +1862,25 @@ func TestAuditTabDeleteRefused(t *testing.T) {
 	}
 }
 
+// TestEscalationPruneNamesItsFleetScope: the prune spans every node the way
+// this tab's list does, so on a shared store one keypress can go from retiring
+// a dozen rows to retiring hundreds. The prompt and the result say so.
+func TestEscalationPruneNamesItsFleetScope(t *testing.T) {
+	m, _, _, _, _ := escalationsModel(t)
+	m.data.status.Nodes = []domain.NodeInfo{{ID: "aaaaaaaaaaaaaaaa"}, {ID: "bbbbbbbbbbbbbbbb"}}
+
+	m = press(t, m, "X")
+	if m.prompt == nil || !strings.Contains(m.prompt.label, "across 2 nodes") {
+		t.Fatalf("fleet prune prompt = %+v, want the scope named", m.prompt)
+	}
+	upd, cmd := m.Update(pressKeyMsg("enter"))
+	m = upd.(Model)
+	msg, ok := cmd().(actionResultMsg)
+	if !ok || msg.err != nil || !strings.Contains(msg.message, "across 2 nodes") {
+		t.Fatalf("result = %+v, want the scope named there too", msg)
+	}
+}
+
 func TestEscalationPrunePromptFlow(t *testing.T) {
 	m, _, st, oldID, freshID := escalationsModel(t)
 	ctx := context.Background()
@@ -1870,6 +1889,10 @@ func TestEscalationPrunePromptFlow(t *testing.T) {
 	m = press(t, m, "X")
 	if m.prompt == nil || m.prompt.input != "360" {
 		t.Fatalf("X should open the prune prompt pre-filled with 360, got %+v", m.prompt)
+	}
+	// On a single-node install the label says nothing about scope.
+	if strings.Contains(m.prompt.label, "across") {
+		t.Errorf("single-node prune prompt = %q, want no fleet scope", m.prompt.label)
 	}
 	// Enter with the default prunes only the 7h-old escalation.
 	upd, cmd := m.Update(pressKeyMsg("enter"))


### PR DESCRIPTION
## Why

Under `[database] engine = "turso"` several machines share one store, and the goal is one TUI that manages every machine's hap daemon. The Escalations tab has been a **fleet** view since the shared store landed — `PendingEscalations` has no node filter, every row renders as `name@node`, and `x` / `enter` / `c` / `l` / `f` all already act on another machine's row.

`X` (prune old) never followed. It dismissed only this node's aged rows while the prompt said "prune escalations older than N minutes" and the result said "pruned N escalation(s)" — telling the operator the queue they were looking at had been cleared.

The Tasks tab had the same shape of gap: its content edits already cross machines (`MutateTaskList` takes the node explicitly, fleet rows carry a `db://` locator), but three actions resolved through **this node's** `[[task_sources]]`, which never enters the shared database.

## What changed

**Fleet-wide prune**
- `Store.DismissEscalationsBefore` drops its `node_id` predicate; new `DismissEscalationsBeforeOn` keeps it. Written as **two separate inline literals** — one query with an optional predicate (`WHERE (? = '' OR node_id = ?)`) would put `node_id` in the text `TestEveryNodeOwnedStatementIsNodeScoped` flattens, so a fleet statement would pass the guard silently.
- Exemption added on the bare form only (the map is bidirectionally pinned).
- `App.PruneEscalations` / `PruneEscalationsOn`; TUI prompt and result say "across N nodes" on a shared store and read exactly as before on a single-node one; `hap escalations prune [minutes] [--node <label|id>]`.
- It is a **direct write, not a queued `agent_action`**: nothing here reaches a pane or needs the owning node's config, and the case that most wants a fleet prune is rows left behind by a machine whose daemon is gone — which a queued action would need alive to run.

**Tasks tab across machines** — one `fleetTaskGroup` / `taskGroupAt` pair replaces the boundary check four sites were open-coding:
- `f` focuses the owning node's agent instead of answering "no live agent matches this task source"
- `K` / `J` reorder a remote list instead of claiming it is "no longer loaded"
- `x` on a fleet header explains where the source lives instead of doing nothing
- and it closes a case **send** already had: a fleet task-list read *failure* renders as a synthetic group with no node, and was being reported as another machine's list

Adding to a remote list stays uncapped — the owning node's `max_tasks` is in its `config.toml` — documented on `taskSourceLimit`.

**Two adjacent fixes**
- `--node=` with no value was read as "no flag": a silent no-op on four verbs, and the *wider* action on the new prune. Refused like the bare `--node` now.
- The README still said renaming, enabling, disabling or focusing a remote agent is refused; `--node` has filed all four for the owning daemon for releases. Changing a remote agent's permission **mode** is the one that really is refused.

## Deliberately out of scope

`p`/`r` pause & resume are still local-only in the TUI even though `PauseNode`/`ResumeNode` exist — a fleet pause is one `kill_events` row per node, and a partially-applied safety control is worse than none, so it is its own change. `rr` (full self-prompting) and every Config-tab write are `config.toml`. The Pause/Kill tab shows every node's rows with no node column. Config `X` clear-data wipes *every* node's learned rules without saying so.

## Verification

Full suite, store suite in `sqlite`/`proxy`/`turso` modes, `gofmt`, `go vet`, `golangci-lint` (0 issues). Every behavioural fix proved by mutation.

New/changed tests: a two-node store case for both prune scopes (including that neither touches an `auto_accepting` row); the `nodescope_test.go` assertion switched to the `…On` variant rather than moved, since a fleet prune there destroys the row the rest of that test needs; frontend and CLI scope tests; and TUI tests over a **real store** — the reorder case runs its command and reads the other node's list back rather than asserting a non-nil `tea.Cmd`.

`TestALockedMigrationStepLosesTheLeaseAndFailsClosed` fails in a full `HAP_STORE_TEST_MODE=turso` package run and passes alone; verified pre-existing on `main` (that package is untouched here).