### PR TITLE
#0 feat: show a cross-machine escalation answer the instant it is dispatched

### DIFF
--- a/changelog.d/feat-tui-inflight-remote-action.md
+++ b/changelog.d/feat-tui-inflight-remote-action.md
@@ -7,4 +7,5 @@
   nothing to tell "it is on its way" from "the key did not register".
 - Fixed a second press on a row already being answered queueing the work twice.
   It is now refused, saying the answer is already in flight. Covers every row
-  action: confirm+send, confirm-only, correct, retry LLM and delete.
+  action from both the list and the detail overlay: confirm+send, confirm-only,
+  correct, retry LLM and delete.

--- a/changelog.d/feat-tui-inflight-remote-action.md
+++ b/changelog.d/feat-tui-inflight-remote-action.md
@@ -1,0 +1,10 @@
+- Added immediate feedback on the Escalations tab when you answer a row. The
+  row dims and its first column shows `»` the instant you press the key, and
+  the banner names where the answer is going ("answering escalation #41 on node
+  laptop — queued for its daemon…"). Answering another machine's escalation
+  files the request for that node's daemon and waits up to 45s for its verdict,
+  and for that whole window the row used to look untouched — so there was
+  nothing to tell "it is on its way" from "the key did not register".
+- Fixed a second press on a row already being answered queueing the work twice.
+  It is now refused, saying the answer is already in flight. Covers every row
+  action: confirm+send, confirm-only, correct, retry LLM and delete.

--- a/internal/tui/correct_test.go
+++ b/internal/tui/correct_test.go
@@ -245,7 +245,21 @@ func runPromptSubmit(t *testing.T, m Model, input string) (Model, tea.Msg) {
 	if cmd == nil {
 		return m, nil
 	}
-	return m, cmd()
+	msg := cmd()
+	// An action dispatched from inside a prompt claims its rows first — a
+	// prompt's onSubmit returns a tea.Cmd and cannot mutate the model — and
+	// carries the real command as the claim's payload. Following that hop is
+	// exactly what the Bubble Tea runtime does, and it is what keeps every
+	// assertion below pointed at what the ACTION did rather than at the claim.
+	if bs, ok := msg.(beginSendingMsg); ok {
+		upd, _ := m.Update(bs)
+		m = upd.(Model)
+		if bs.run == nil {
+			return m, nil
+		}
+		msg = bs.run()
+	}
+	return m, msg
 }
 
 // TestCorrectLiveOpensSendPromptAndRecords: correcting a live escalation opens

--- a/internal/tui/inflight_test.go
+++ b/internal/tui/inflight_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -158,6 +159,82 @@ func TestARowThatLeavesTheQueueDropsItsClaim(t *testing.T) {
 	upd, _ = m.Update(data)
 	if upd.(Model).sending[oldID] {
 		t.Error("a row that left the queue kept its claim forever")
+	}
+}
+
+// A FAILED refresh carries no escalations at all, and "we could not read the
+// queue" is not "the row left it". Pruning there would drop every live claim,
+// un-dim the rows, and let a second press queue the same answer again — the
+// prune undoing exactly what the claim exists to do.
+func TestAFailedRefreshKeepsEveryClaim(t *testing.T) {
+	m, app, _, oldID, _ := escalationsModel(t)
+
+	upd, _ := m.confirmAuditID(oldID)
+	m = upd.(Model)
+	if !m.sending[oldID] {
+		t.Fatal("the row was not claimed")
+	}
+	// The shape a store or daemon read error produces: an error and no rows.
+	data := refreshData(context.Background(), app)
+	data.err = errors.New("store unavailable")
+	data.escalations = nil
+	upd, _ = m.Update(data)
+	if !upd.(Model).sending[oldID] {
+		t.Error("a failed refresh dropped a live claim — a second press would re-answer the row")
+	}
+}
+
+// The overlay's y and x are the list's y and x in another surface, so they need
+// the same guard. The claim lives in the FUNCTION rather than the key handler
+// for exactly this reason: a guard repeated per door is a guard that gets
+// missed at one of them.
+func TestTheDetailOverlayDoorsAreGuardedToo(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(Model, int64) (tea.Model, tea.Cmd)
+	}{
+		{"overlay y (confirm only)", func(m Model, id int64) (tea.Model, tea.Cmd) {
+			return m.confirmIDWithoutSend(id)
+		}},
+		{"overlay x (dismiss)", func(m Model, id int64) (tea.Model, tea.Cmd) {
+			return m.dismissByID(id)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _, _, oldID, _ := escalationsModel(t)
+
+			upd, cmd := tc.run(m, oldID)
+			got := upd.(Model)
+			if cmd == nil {
+				t.Fatalf("the first press raised no command: %q", got.message)
+			}
+			if !got.sending[oldID] {
+				t.Fatal("the overlay door took no claim")
+			}
+			upd, cmd = tc.run(got, oldID)
+			if cmd != nil {
+				t.Fatal("a row already in flight was answered a second time from the overlay")
+			}
+			if msg := upd.(Model).message; !strings.Contains(msg, "already being answered") {
+				t.Errorf("banner = %q, want the in-flight refusal", msg)
+			}
+		})
+	}
+}
+
+// And their results release the claim, like every other path.
+func TestTheDetailOverlayDoorsReleaseTheirClaims(t *testing.T) {
+	m, _, _, oldID, _ := escalationsModel(t)
+
+	upd, cmd := m.confirmIDWithoutSend(oldID)
+	m = upd.(Model)
+	res, ok := cmd().(actionResultMsg)
+	if !ok || len(res.sent) != 1 || res.sent[0] != oldID {
+		t.Fatalf("the overlay confirm must carry its own claim, got %+v", res)
+	}
+	upd, _ = m.Update(res)
+	if upd.(Model).sending[oldID] {
+		t.Error("the overlay confirm leaked its claim")
 	}
 }
 

--- a/internal/tui/inflight_test.go
+++ b/internal/tui/inflight_test.go
@@ -1,0 +1,291 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+)
+
+// Answering another machine's escalation is not a local write: the request is
+// filed in agent_actions for the owning node and this process waits for that
+// daemon's verdict, up to frontend.DefaultRemoteActionTimeout. For that whole
+// window the row used to look untouched — nothing told "it is on its way" from
+// "the key did not register", and a second press queued the work twice.
+//
+// The dispatch is what claims the row, so this asserts on the model returned by
+// the keypress itself, BEFORE the command runs.
+func TestConfirmClaimsTheRowAtTheKeypress(t *testing.T) {
+	m, _, _, oldID, _ := escalationsModel(t)
+
+	upd, cmd := m.confirmAuditID(oldID)
+	got := upd.(Model)
+	if cmd == nil {
+		t.Fatalf("confirm raised no command: %q", got.message)
+	}
+	if !got.sending[oldID] {
+		t.Fatalf("the row was not claimed at dispatch: %v", got.sending)
+	}
+	if got.message == "" {
+		t.Error("a dispatch must say something immediately — the wait is the whole reason")
+	}
+}
+
+// The claim is what a second press sees. Without it the operator has no signal
+// at all during the wait, so pressing again is the natural thing to do — and it
+// queued the answer twice.
+func TestASecondConfirmOnAClaimedRowIsRefused(t *testing.T) {
+	m, _, _, oldID, _ := escalationsModel(t)
+
+	upd, _ := m.confirmAuditID(oldID)
+	m = upd.(Model)
+	upd, cmd := m.confirmAuditID(oldID)
+	got := upd.(Model)
+	if cmd != nil {
+		t.Fatal("a row already being answered must not be dispatched again")
+	}
+	if !strings.Contains(got.message, "already being answered") {
+		t.Errorf("banner = %q, want it to say the answer is already in flight", got.message)
+	}
+}
+
+// The refusal is on the ids the action would ACT on, never on the marks:
+// confirmWithoutSend clears m.marked at dispatch, so a second press falls back
+// to the cursor row — and a guard that looked at marks would wave it through.
+func TestASecondConfirmWithoutSendFallsBackToTheCursorAndIsStillRefused(t *testing.T) {
+	m, _, _, oldID, _ := escalationsModel(t)
+	m.cursors[m.tab] = 0
+
+	upd, cmd := m.confirmWithoutSend()
+	m = upd.(Model)
+	if cmd == nil || !m.sending[oldID] {
+		t.Fatalf("the cursor row was not claimed: %v", m.sending)
+	}
+	if m.marked != nil {
+		t.Fatal("the fixture must reach the second press with no marks, as the dispatch leaves it")
+	}
+	upd, cmd = m.confirmWithoutSend()
+	if cmd != nil {
+		t.Fatal("the cursor row is still in flight and must not be dispatched again")
+	}
+	if got := upd.(Model).message; !strings.Contains(got, "already being answered") {
+		t.Errorf("banner = %q, want the in-flight refusal", got)
+	}
+}
+
+// Every terminal path releases the claim. A leak leaves the row dimmed and
+// unanswerable until something else resolves it.
+func TestTheActionsOwnResultReleasesItsClaim(t *testing.T) {
+	m, _, _, oldID, _ := escalationsModel(t)
+
+	upd, cmd := m.confirmAuditID(oldID)
+	m = upd.(Model)
+	res, ok := cmd().(actionResultMsg)
+	if !ok {
+		t.Fatalf("confirm produced %T, want an actionResultMsg", cmd())
+	}
+	if len(res.sent) != 1 || res.sent[0] != oldID {
+		t.Fatalf("the result must carry its own claim, got %v", res.sent)
+	}
+	upd, _ = m.Update(res)
+	if upd.(Model).sending[oldID] {
+		t.Error("the result did not release the claim")
+	}
+}
+
+// A confirm+send whose agent went busy ends as openAddPromptMsg, not as a
+// result — the second way that command can END, and the one a release keyed
+// only on actionResultMsg would leak.
+func TestTheBusyAgentPromptAlsoReleasesTheClaim(t *testing.T) {
+	m, _, _, oldID, _ := escalationsModel(t)
+
+	upd, _ := m.confirmAuditID(oldID)
+	m = upd.(Model)
+	if !m.sending[oldID] {
+		t.Fatal("the row was not claimed")
+	}
+	upd, _ = m.Update(openAddPromptMsg{id: oldID, sent: []int64{oldID}})
+	if upd.(Model).sending[oldID] {
+		t.Error("the busy-agent path leaked its claim")
+	}
+}
+
+// One action's result must release only its OWN rows: clearing the whole set
+// would let the first of two concurrent batches un-dim the second's, which is
+// the double-send the claim exists to prevent.
+func TestOneResultDoesNotReleaseAnotherActionsClaim(t *testing.T) {
+	m, _, _, oldID, freshID := escalationsModel(t)
+
+	upd, _ := m.confirmAuditID(oldID)
+	m = upd.(Model)
+	upd, _ = m.confirmAuditID(freshID)
+	m = upd.(Model)
+
+	upd, _ = m.Update(actionResultMsg{message: "done", sent: []int64{oldID}})
+	got := upd.(Model)
+	if got.sending[oldID] {
+		t.Error("the result did not release its own row")
+	}
+	if !got.sending[freshID] {
+		t.Error("the result released a row belonging to a different action")
+	}
+}
+
+// A row resolved by ANOTHER machine while our request is in flight simply
+// leaves the queue, so no result ever names it. Without the refresh prune its
+// claim would sit in the map for the life of the TUI.
+func TestARowThatLeavesTheQueueDropsItsClaim(t *testing.T) {
+	m, app, _, oldID, _ := escalationsModel(t)
+
+	upd, _ := m.confirmAuditID(oldID)
+	m = upd.(Model)
+	if !m.sending[oldID] {
+		t.Fatal("the row was not claimed")
+	}
+	// The refresh no longer carries it — the shape a remote resolve produces.
+	data := refreshData(context.Background(), app)
+	var rest []domain.AuditRecord
+	for _, e := range data.escalations {
+		if e.ID != oldID {
+			rest = append(rest, e)
+		}
+	}
+	data.escalations = rest
+	upd, _ = m.Update(data)
+	if upd.(Model).sending[oldID] {
+		t.Error("a row that left the queue kept its claim forever")
+	}
+}
+
+// A correction is dispatched from inside a PROMPT, which cannot mutate the
+// model — so the claim rides a message. It must be taken at the dispatch and
+// not at the keypress: `c` opens an editor the operator can still abandon.
+func TestCorrectClaimsAtDispatchNotAtTheKeypress(t *testing.T) {
+	m, st, _ := correctTestModel(t)
+	id := seedEscalation(t, st, "auto") // non-live: records without a send prompt
+
+	upd, _ := m.correctByID(id, false)
+	m = upd.(Model)
+	if m.prompt == nil {
+		t.Fatal("correct should open the action prompt")
+	}
+	if m.sending[id] {
+		t.Fatal("opening the prompt must not claim the row — esc would strand it")
+	}
+
+	m.prompt.input = "yes"
+	upd, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = upd.(Model)
+	claim, ok := cmd().(beginSendingMsg)
+	if !ok {
+		t.Fatalf("submitting produced %T, want the claim", cmd())
+	}
+	upd, run := m.Update(claim)
+	m = upd.(Model)
+	if !m.sending[id] {
+		t.Fatal("the claim was not applied at dispatch")
+	}
+	if run == nil {
+		t.Fatal("the claim must carry the action it stood in front of")
+	}
+	res, ok := run().(actionResultMsg)
+	if !ok {
+		t.Fatalf("the claimed action produced %T", run())
+	}
+	upd, _ = m.Update(res)
+	if upd.(Model).sending[id] {
+		t.Error("the correction leaked its claim")
+	}
+}
+
+// Esc on the correct prompt must leave nothing claimed — the case that makes
+// "claim at dispatch" different from "claim at the keypress".
+func TestAbandoningTheCorrectPromptClaimsNothing(t *testing.T) {
+	m, st, _ := correctTestModel(t)
+	id := seedEscalation(t, st, "escalated")
+
+	upd, _ := m.correctByID(id, true)
+	m = upd.(Model)
+	upd, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	got := upd.(Model)
+	if got.prompt != nil {
+		t.Fatal("esc should close the prompt")
+	}
+	if got.sending[id] {
+		t.Error("an abandoned correction left the row dimmed with nothing in flight")
+	}
+}
+
+// The glyph, not the colour, is what survives: lipgloss emits nothing without a
+// TTY, so on a plain pipe the mark column is the only thing left saying the row
+// is in flight. Sending outranks marked — a row whose answer is travelling is
+// no longer a selection the next key acts on.
+func TestEscalationMarkPrefersSendingOverMarked(t *testing.T) {
+	for _, tc := range []struct {
+		marked, sending bool
+		want            string
+	}{
+		{false, false, " "},
+		{true, false, "✓"},
+		{false, true, "»"},
+		{true, true, "»"},
+	} {
+		if got := escalationMark(tc.marked, tc.sending); got != tc.want {
+			t.Errorf("escalationMark(marked=%v, sending=%v) = %q, want %q",
+				tc.marked, tc.sending, got, tc.want)
+		}
+	}
+}
+
+// The style CHOICE is asserted directly, for the reason auditRowStyle is also a
+// pure function: lipgloss drops colour with no TTY, so an assertion on the
+// rendered escape sequence passes vacuously.
+func TestEscalationRowStyleSelectedOutranksSending(t *testing.T) {
+	// Compared by ROLE property, not by value: a lipgloss.Style holds funcs and
+	// is not comparable, which is why auditRowStyle's own test reads back a
+	// getter rather than the struct.
+	st := defaultStyles
+	if _, ok := escalationRowStyle(st, false, false); ok {
+		t.Error("an ordinary row must render plain")
+	}
+	got, ok := escalationRowStyle(st, true, false)
+	if !ok || !got.GetFaint() || got.GetReverse() {
+		t.Errorf("in-flight row: faint=%v reverse=%v, want the dimmed pending role",
+			got.GetFaint(), got.GetReverse())
+	}
+	got, ok = escalationRowStyle(st, true, true)
+	if !ok || !got.GetReverse() {
+		t.Errorf("selected row: reverse=%v, want selected to win — or the cursor "+
+			"vanishes on exactly the row you just answered", got.GetReverse())
+	}
+}
+
+// The banner names the NODE for another machine's row, because that is what
+// explains the wait.
+func TestTheDispatchNoticeNamesTheOwningNode(t *testing.T) {
+	m := collidingFleet(t)
+	m.tab = tabEscalations
+	m.data.escalations = []domain.AuditRecord{
+		{ID: 7, NodeID: otherNode, AgentID: "1", SituationType: domain.SituationApproval},
+		{ID: 8, NodeID: selfNode, AgentID: "1", SituationType: domain.SituationApproval},
+	}
+	if got := m.sendingNotice([]int64{7}); !strings.Contains(got, "node laptop") {
+		t.Errorf("remote notice = %q, want it to name the node", got)
+	}
+	if got := m.sendingNotice([]int64{8}); strings.Contains(got, "node") {
+		t.Errorf("local notice = %q, want no node — there is no wait to explain", got)
+	}
+}
+
+// A remote action's wait is bounded by frontend.DefaultRemoteActionTimeout,
+// which is what makes the claim worth having: it is long enough to press again.
+func TestRemoteWaitIsLongEnoughToInviteASecondPress(t *testing.T) {
+	if frontend.DefaultRemoteActionTimeout <= frontend.DefaultActionTimeout {
+		t.Errorf("a remote action (%s) is expected to outlast a local one (%s)",
+			frontend.DefaultRemoteActionTimeout, frontend.DefaultActionTimeout)
+	}
+}

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -111,6 +111,10 @@ type styles struct {
 	err         lipgloss.Style
 	ok          lipgloss.Style
 	warn        lipgloss.Style
+	// pending dims a row whose action has been dispatched and not yet
+	// answered. Faint only, no colour: it must read as "not yet actionable" in
+	// every theme, and a hue would compete with warn on the same row.
+	pending lipgloss.Style
 }
 
 func newStyles(p palette) styles {
@@ -131,6 +135,7 @@ func newStyles(p palette) styles {
 		err:         lipgloss.NewStyle().Foreground(p.err),
 		ok:          lipgloss.NewStyle().Foreground(p.ok),
 		warn:        lipgloss.NewStyle().Bold(true).Foreground(p.warn),
+		pending:     lipgloss.NewStyle().Faint(true),
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -147,6 +147,11 @@ type actionResultMsg struct {
 	// keypress stashed awaiting its own completion. Zero for the untagged
 	// majority; see doTagged.
 	token actionToken
+	// sent names the escalation rows this action claimed, so its own result
+	// releases exactly those. Clearing the whole set instead would let the
+	// first of two concurrent batches un-dim the second's rows, which is the
+	// double-send the dimming exists to prevent.
+	sent []int64
 	// taskLists carries the authoritative renumbered checklist a task
 	// mutation returned, keyed by canonical source path. Applying it
 	// directly updates the Tasks tab the moment the write lands, instead
@@ -172,6 +177,23 @@ type openSendPromptMsg struct {
 // prompt directly.
 type openAddPromptMsg struct {
 	id int64
+	// sent is the claim confirmAuditID took, released here: this is the second
+	// way that command can END, and a claim leaked on it would leave the row
+	// dimmed and unanswerable until something else resolved it.
+	sent []int64
+}
+
+// beginSendingMsg claims escalation rows for an action a PROMPT dispatched,
+// and then runs it.
+//
+// It exists for the same reason openSendPromptMsg does — a prompt's onSubmit
+// returns a tea.Cmd and cannot mutate the model directly — and the claim has to
+// be taken HERE rather than at the keypress that opened the prompt: `c` opens
+// an editor the operator can still abandon with esc, and a row dimmed at the
+// keypress would stay dimmed with nothing in flight.
+type beginSendingMsg struct {
+	ids []int64
+	run tea.Cmd
 }
 
 // openTaskSourceFieldMsg re-opens a prompt for the VALUE of the task-source
@@ -851,6 +873,23 @@ type Model struct {
 	// filtering with no explicit teardown. nil = never run / not applicable.
 	sigSemantic *semanticSigSearch
 	marked      map[int64]bool // Escalations tab multi-select (audit ids), space toggles
+	// sending holds the audit ids whose action has been DISPATCHED and whose
+	// result has not arrived. Set at dispatch, released by that same action's
+	// result, and pruned on refresh.
+	//
+	// It exists because answering another machine's escalation is not a local
+	// write: the request is filed in agent_actions for the owning node and this
+	// process then waits for that daemon's verdict — up to
+	// frontend.DefaultRemoteActionTimeout (45s), two sync intervals plus slack.
+	// For that whole window the row looked untouched, so there was nothing to
+	// tell "it is on its way" from "the key did not register", and a second
+	// press queued the work twice. Same reasoning as actionResultMsg.taskLists,
+	// which exists because a round trip "takes long enough that the old
+	// checkbox invites a second press".
+	//
+	// Not conditional on the row's node: a local action clears in milliseconds,
+	// and branching on the node would only add a case to get wrong.
+	sending map[int64]bool
 	// taskMarks is the Tasks tab multi-select, keyed by taskMarkKey
 	// (group index + item number). Space toggles; d/x consume the set.
 	taskMarks map[string]bool
@@ -2046,6 +2085,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+		// Same for claims: a result normally releases one, but not every row's
+		// fate is ours to observe — another machine's operator, or that node's
+		// own daemon, can resolve the escalation while our request is in
+		// flight, and then the row just leaves the queue.
+		m.pruneSending()
 		// Same for task marks: an item deleted (or renumbered away by an
 		// external edit) must not leave a mark pointing at nothing.
 		if len(m.taskMarks) > 0 {
@@ -2085,6 +2129,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return "automation resumed", nil
 		})
 	case actionResultMsg:
+		// Release before anything else can return early: every branch below is
+		// a way this result ENDS, and a claim leaked on one of them leaves the
+		// row dimmed and unanswerable until it resolves elsewhere.
+		m.releaseSending(msg.sent)
 		m.applyTaskLists(msg.taskLists)
 		if msg.pauseAction && (msg.err != nil || (msg.pauseNoChange && m.lastPaused)) {
 			// The pause request failed, or was a no-op on a pause this TUI
@@ -2144,7 +2192,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case openSendPromptMsg:
 		return m.openSendPrompt(msg.id, msg.action)
 	case openAddPromptMsg:
+		// The second way a confirm+send ends: the agent went busy, and the
+		// operator is about to be asked whether to queue the tasks instead.
+		m.releaseSending(msg.sent)
 		return m.openAddPrompt(msg.id)
+	case beginSendingMsg:
+		m.message = m.beginSending(msg.ids)
+		return m, msg.run
 	case openTaskSourceFieldMsg:
 		return m.openTaskSourceFieldPrompt(msg)
 	case tickMsg:
@@ -3078,8 +3132,16 @@ func (m Model) confirmSelected() (tea.Model, tea.Cmd) {
 // chains to an "add to the task list instead?" prompt (openAddPromptMsg) rather
 // than surfacing the error. Any other failure surfaces as-is.
 func (m Model) confirmAuditID(id int64) (tea.Model, tea.Cmd) {
+	ids := []int64{id}
+	if busy := m.sendingBlocked(ids); busy != "" {
+		m.message = busy
+		return m, nil
+	}
 	app, ctx, wg := m.app, m.ctx, m.inflight
 	m.beginAction()
+	// After beginAction, which clears the message area: the claim's notice is
+	// the immediate feedback, and beginAction would wipe it.
+	m.message = m.beginSending(ids)
 	if wg != nil {
 		wg.Add(1)
 	}
@@ -3089,12 +3151,12 @@ func (m Model) confirmAuditID(id int64) (tea.Model, tea.Cmd) {
 		}
 		err := app.Confirm(ctx, id, true)
 		if err == nil {
-			return actionResultMsg{message: fmt.Sprintf("confirmed #%d and sent", id)}
+			return actionResultMsg{message: fmt.Sprintf("confirmed #%d and sent", id), sent: ids}
 		}
 		if errors.Is(err, frontend.ErrSuggestionStaleAgentBusy) {
-			return openAddPromptMsg{id: id}
+			return openAddPromptMsg{id: id, sent: ids}
 		}
-		return actionResultMsg{err: err}
+		return actionResultMsg{err: err, sent: ids}
 	}
 }
 
@@ -3134,10 +3196,15 @@ func (m Model) confirmWithoutSend() (tea.Model, tea.Cmd) {
 	if len(ids) == 0 {
 		return m, nil
 	}
+	if busy := m.sendingBlocked(ids); busy != "" {
+		m.message = busy
+		return m, nil
+	}
 	app, ctx, wg := m.app, m.ctx, m.inflight
 	desc := describeEscalations(ids)
 	m.beginAction()
 	m.marked = nil
+	m.message = m.beginSending(ids)
 	if wg != nil {
 		wg.Add(1)
 	}
@@ -3169,7 +3236,7 @@ func (m Model) confirmWithoutSend() (tea.Model, tea.Cmd) {
 			confirmed++
 		}
 		if firstErr != nil {
-			return actionResultMsg{err: fmt.Errorf("confirmed %d, skipped %s: %w",
+			return actionResultMsg{sent: ids, err: fmt.Errorf("confirmed %d, skipped %s: %w",
 				confirmed, strings.Join(skipped, " "), firstErr)}
 		}
 		if firstNotice != nil {
@@ -3185,9 +3252,9 @@ func (m Model) confirmWithoutSend() (tea.Model, tea.Cmd) {
 				count = fmt.Sprintf("confirmed %d, skipped %s",
 					confirmed, strings.Join(skipped, " "))
 			}
-			return actionResultMsg{err: firstNotice, message: count}
+			return actionResultMsg{err: firstNotice, message: count, sent: ids}
 		}
-		return actionResultMsg{message: fmt.Sprintf(
+		return actionResultMsg{sent: ids, message: fmt.Sprintf(
 			"confirmed %s — learned, nothing sent (the agent is not answered)", desc)}
 	}
 }
@@ -3278,6 +3345,11 @@ func (m Model) correctSelected() (tea.Model, tea.Cmd) {
 // historical record (e.g. correcting a past auto decision) the correction is
 // recorded only, never sent.
 func (m Model) correctByID(id int64, live bool) (tea.Model, tea.Cmd) {
+	ids := []int64{id}
+	if busy := m.sendingBlocked(ids); busy != "" {
+		m.message = busy
+		return m, nil
+	}
 	app, ctx := m.app, m.ctx
 	m.beginAction()
 	m.openPrompt(&prompt{
@@ -3285,15 +3357,17 @@ func (m Model) correctByID(id int64, live bool) (tea.Model, tea.Cmd) {
 		onSubmit: func(input string) tea.Cmd {
 			if live {
 				// Defer recording to the send prompt so exactly one correction
-				// is written with the chosen send flag.
+				// is written with the chosen send flag — and, with it, the
+				// claim: nothing is dispatched on this branch.
 				return func() tea.Msg { return openSendPromptMsg{id: id, action: input} }
 			}
-			return func() tea.Msg {
+			run := func() tea.Msg {
 				if err := app.Resolve(ctx, id, input, false); err != nil {
-					return actionResultMsg{err: err}
+					return actionResultMsg{err: err, sent: ids}
 				}
-				return actionResultMsg{message: fmt.Sprintf("correction recorded for #%d", id)}
+				return actionResultMsg{message: fmt.Sprintf("correction recorded for #%d", id), sent: ids}
 			}
+			return func() tea.Msg { return beginSendingMsg{ids: ids, run: run} }
 		},
 	})
 	return m, nil
@@ -3311,15 +3385,17 @@ func (m Model) openSendPrompt(id int64, action string) (tea.Model, tea.Cmd) {
 		input: "n",
 		onSubmit: func(input string) tea.Cmd {
 			send := strings.HasPrefix(strings.ToLower(strings.TrimSpace(input)), "y")
-			return func() tea.Msg {
+			ids := []int64{id}
+			run := func() tea.Msg {
 				if err := app.Resolve(ctx, id, action, send); err != nil {
-					return actionResultMsg{err: err}
+					return actionResultMsg{err: err, sent: ids}
 				}
 				if send {
-					return actionResultMsg{message: fmt.Sprintf("correction recorded and sent for #%d", id)}
+					return actionResultMsg{message: fmt.Sprintf("correction recorded and sent for #%d", id), sent: ids}
 				}
-				return actionResultMsg{message: fmt.Sprintf("correction recorded for #%d (not sent)", id)}
+				return actionResultMsg{message: fmt.Sprintf("correction recorded for #%d (not sent)", id), sent: ids}
 			}
+			return func() tea.Msg { return beginSendingMsg{ids: ids, run: run} }
 		},
 	})
 	return m, nil
@@ -3336,10 +3412,30 @@ func (m Model) dismissByID(id int64) (tea.Model, tea.Cmd) {
 
 // retryByID re-invokes the LLM on one escalation by id (list and detail).
 func (m Model) retryByID(id int64) (tea.Model, tea.Cmd) {
+	ids := []int64{id}
+	if busy := m.sendingBlocked(ids); busy != "" {
+		m.message = busy
+		return m, nil
+	}
+	app, ctx, wg := m.app, m.ctx, m.inflight
 	m.beginAction()
-	return m, m.do(fmt.Sprintf("retry LLM queued for #%d", id), func(ctx context.Context) error {
-		return m.app.RetryLLM(ctx, id)
-	})
+	// Written out rather than routed through m.do, which builds its own result
+	// and so cannot carry the claim back. A retry files an llm_retries row
+	// under the escalation's OWN node, so on a remote row it waits the same way
+	// a confirm does.
+	m.message = m.beginSending(ids)
+	if wg != nil {
+		wg.Add(1)
+	}
+	return m, func() tea.Msg {
+		if wg != nil {
+			defer wg.Done()
+		}
+		if err := app.RetryLLM(ctx, id); err != nil {
+			return actionResultMsg{err: err, sent: ids}
+		}
+		return actionResultMsg{message: fmt.Sprintf("retry LLM queued for #%d", id), sent: ids}
+	}
 }
 
 // retrySelected re-invokes the LLM on the escalation under the cursor, with a
@@ -3416,6 +3512,106 @@ func (m Model) targetEscalationIDs() []int64 {
 	return ids
 }
 
+// beginSending claims rows for an action about to be dispatched, and returns
+// the notice naming what is happening and where it is going.
+//
+// Copy-on-write: a Bubble Tea Model is passed by value and copied constantly,
+// so mutating the map in place would reach every other copy holding it —
+// including one an earlier frame rendered from.
+func (m *Model) beginSending(ids []int64) string {
+	next := make(map[int64]bool, len(m.sending)+len(ids))
+	for id := range m.sending {
+		next[id] = true
+	}
+	for _, id := range ids {
+		next[id] = true
+	}
+	m.sending = next
+	return m.sendingNotice(ids)
+}
+
+// releaseSending drops the claims an action's own result carries.
+func (m *Model) releaseSending(ids []int64) {
+	if len(ids) == 0 || len(m.sending) == 0 {
+		return
+	}
+	next := make(map[int64]bool, len(m.sending))
+	for id := range m.sending {
+		next[id] = true
+	}
+	for _, id := range ids {
+		delete(next, id)
+	}
+	m.sending = next
+}
+
+// pruneSending drops claims for rows that are no longer pending.
+//
+// The result normally releases a claim, but not every row's fate is this
+// process's to observe: another machine's operator — or that node's own daemon
+// — can resolve the escalation while this request is in flight, and then the
+// row simply leaves the queue. Without this the id would sit in the map for the
+// life of the TUI. Called on every refresh, where the queue is re-read anyway.
+func (m *Model) pruneSending() {
+	if len(m.sending) == 0 {
+		return
+	}
+	next := make(map[int64]bool, len(m.sending))
+	for _, e := range m.data.escalations {
+		if m.sending[e.ID] {
+			next[e.ID] = true
+		}
+	}
+	m.sending = next
+}
+
+// sendingBlocked reports the refusal for ids already in flight, or "" when the
+// action may proceed.
+//
+// It answers on the ids the action would actually act on, never on the marks:
+// confirmWithoutSend clears m.marked at dispatch, so a second press falls back
+// to the cursor row — and a guard that looked at marks would wave it through.
+func (m Model) sendingBlocked(ids []int64) string {
+	var busy []int64
+	for _, id := range ids {
+		if m.sending[id] {
+			busy = append(busy, id)
+		}
+	}
+	if len(busy) == 0 {
+		return ""
+	}
+	if len(busy) == len(ids) {
+		return describeEscalations(busy) + " is already being answered — waiting for the result"
+	}
+	return describeEscalations(busy) + " is already being answered — clear the marks and retry the rest"
+}
+
+// sendingNotice is the banner a dispatch shows immediately. It names the NODE
+// for another machine's row, because that is what explains the wait: the
+// request travels on this node's next push and that node's next pull.
+func (m Model) sendingNotice(ids []int64) string {
+	nodes := map[string]bool{}
+	for _, e := range m.data.escalations {
+		for _, id := range ids {
+			if e.ID == id && !m.isSelfNode(e.NodeID) {
+				nodes[m.data.status.NodeLabel(e.NodeID)] = true
+			}
+		}
+	}
+	switch len(nodes) {
+	case 0:
+		return "answering " + describeEscalations(ids) + "…"
+	case 1:
+		for label := range nodes {
+			return fmt.Sprintf("answering %s on node %s — queued for its daemon…",
+				describeEscalations(ids), label)
+		}
+	}
+	return fmt.Sprintf("answering %s across %d nodes — queued for their daemons…",
+		describeEscalations(ids), len(nodes))
+}
+
 // describeEscalations names the action targets compactly: "escalation #41"
 // or "3 escalations (#41 #40 #39)", eliding a long id list.
 func describeEscalations(ids []int64) string {
@@ -3441,9 +3637,14 @@ func (m Model) deleteEscalations() (tea.Model, tea.Cmd) {
 	if len(ids) == 0 {
 		return m, nil
 	}
+	if busy := m.sendingBlocked(ids); busy != "" {
+		m.message = busy
+		return m, nil
+	}
 	app, ctx := m.app, m.ctx
 	desc := describeEscalations(ids)
 	m.beginAction()
+	m.message = m.beginSending(ids)
 	return m, func() tea.Msg {
 		// Skip-and-continue: a failed id usually means the row was
 		// resolved/confirmed concurrently; the rest still delete.
@@ -3461,10 +3662,10 @@ func (m Model) deleteEscalations() (tea.Model, tea.Cmd) {
 			deleted++
 		}
 		if firstErr != nil {
-			return actionResultMsg{err: fmt.Errorf("deleted %d, skipped %s: %w",
+			return actionResultMsg{sent: ids, err: fmt.Errorf("deleted %d, skipped %s: %w",
 				deleted, strings.Join(skipped, " "), firstErr)}
 		}
-		return actionResultMsg{message: fmt.Sprintf(
+		return actionResultMsg{sent: ids, message: fmt.Sprintf(
 			"deleted %s; audit rows kept as dismissed", desc)}
 	}
 }
@@ -7029,7 +7230,7 @@ func (m Model) helpLine() string {
 				seed = "  b: disable builtin rule"
 			}
 		}
-		return "enter: confirm+send  y: confirm only (marked)  c: correct (+send?)  l: retry LLM  f: focus in herdr  t: see rule" + seed + "  space: mark  x: delete  X: prune old  v: details  /: search  " + common
+		return "enter: confirm+send  y: confirm only (marked)  c: correct (+send?)  l: retry LLM  f: focus in herdr  t: see rule" + seed + "  space: mark  x: delete  X: prune old  v: details  /: search  (» = answer in flight)  " + common
 	case tabAudit:
 		return "c: correct decision  v: details  t: see rule  /: search  " + common
 	case tabSignatures:
@@ -7392,10 +7593,7 @@ func (m Model) renderEscalations(b *strings.Builder) {
 		// name@node for another machine's row: pane ids repeat across
 		// machines, so a local name lookup would mislabel it.
 		agent := m.data.status.RecordAgent(e)
-		mark := " "
-		if m.marked[e.ID] {
-			mark = "✓"
-		}
+		mark := escalationMark(m.marked[e.ID], m.sending[e.ID])
 		rWidth, sWidth := m.budget(escPrefix, e.Suggestion != "")
 		line := fmt.Sprintf(escRowFmt,
 			mark, shortAuditID(e.ID), humanizeWhen(e.CreatedAt, m.renderNow()), e.SituationType,
@@ -7405,12 +7603,53 @@ func (m Model) renderEscalations(b *strings.Builder) {
 		if e.Suggestion != "" {
 			line += "  → " + oneLine(e.Suggestion, sWidth)
 		}
-		if i == m.cursors[m.tab] {
-			line = m.styles().selected.Render(line)
+		if st, ok := escalationRowStyle(m.styles(), m.sending[e.ID], i == m.cursors[m.tab]); ok {
+			line = st.Render(line)
 		}
 		fmt.Fprintln(b, line)
 	}
 	m.renderMoreRows(b, len(esc)-end)
+}
+
+// escalationMark is the leftmost column: what this row is, in one cell.
+//
+// Sending outranks marked, and not only because a dispatch clears the marks —
+// a row whose answer is already travelling is no longer a selection the next
+// key would act on, and saying so is the point.
+//
+// It is a GLYPH rather than colour alone because colour is the half that
+// disappears: lipgloss emits nothing without a TTY, so on a plain pipe — and in
+// every test — the style is invisible and this cell is the only thing left
+// saying the row is in flight. Single-width on purpose; the column is %-1s, and
+// a double-width rune (⏳, →) shifts every column after it.
+func escalationMark(marked, sending bool) string {
+	switch {
+	case sending:
+		return "»"
+	case marked:
+		return "✓"
+	}
+	return " "
+}
+
+// escalationRowStyle picks the style for one Escalations row, or reports false
+// to leave it plain.
+//
+// A pure function for the same reason auditRowStyle is one: lipgloss drops
+// colour entirely with no TTY, so asserting on the rendered escape sequence
+// passes vacuously — the CHOICE has to be assertable on its own.
+//
+// Selected wins over sending, or the cursor vanishes the moment you answer the
+// row you are looking at. The glyph still marks it, which is why losing the dim
+// here costs nothing.
+func escalationRowStyle(st styles, sending, selected bool) (lipgloss.Style, bool) {
+	switch {
+	case selected:
+		return st.selected, true
+	case sending:
+		return st.pending, true
+	}
+	return lipgloss.Style{}, false
 }
 
 // auditRowStyle picks the style for one Audit row, or reports false to leave it

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -3291,9 +3291,33 @@ func (m *Model) openNoticeDetail(notice *frontend.NoTaskSourceNotice) {
 // detail overlay's y, acting on the record it snapshotted rather than the live
 // cursor (and never on the list's marks, which the overlay does not show).
 func (m Model) confirmIDWithoutSend(id int64) (tea.Model, tea.Cmd) {
+	// Claimed here rather than at the caller, the way confirmAuditID is: the
+	// overlay's y is the list's y in another surface, and a guard that lived in
+	// the key handler would have to be repeated at each door to the same action
+	// — which is how this one came to be the door with no guard on it.
+	ids := []int64{id}
+	if busy := m.sendingBlocked(ids); busy != "" {
+		m.message = busy
+		return m, nil
+	}
+	app, ctx, wg := m.app, m.ctx, m.inflight
 	m.beginAction()
-	return m, m.do(fmt.Sprintf("confirmed #%d — learned, nothing sent (the agent is not answered)", id),
-		func(ctx context.Context) error { return m.app.Confirm(ctx, id, false) })
+	// Written out rather than routed through m.do, which builds its own result
+	// and so cannot carry the claim back.
+	m.message = m.beginSending(ids)
+	if wg != nil {
+		wg.Add(1)
+	}
+	return m, func() tea.Msg {
+		if wg != nil {
+			defer wg.Done()
+		}
+		if err := app.Confirm(ctx, id, false); err != nil {
+			return actionResultMsg{err: err, sent: ids}
+		}
+		return actionResultMsg{sent: ids, message: fmt.Sprintf(
+			"confirmed #%d — learned, nothing sent (the agent is not answered)", id)}
+	}
 }
 
 // openAddPrompt asks whether to queue a stale generated-task suggestion onto the
@@ -3404,10 +3428,30 @@ func (m Model) openSendPrompt(id int64, action string) (tea.Model, tea.Cmd) {
 // dismissByID dismisses one escalation by id — used by the detail overlay.
 // The list uses deleteEscalations for its marked/cursor batch semantics.
 func (m Model) dismissByID(id int64) (tea.Model, tea.Cmd) {
+	// The overlay's x, and the same reasoning as confirmIDWithoutSend above:
+	// deleteEscalations guards the list's x, so leaving this door open means a
+	// row already in flight can still be dismissed out from under its own
+	// answer.
+	ids := []int64{id}
+	if busy := m.sendingBlocked(ids); busy != "" {
+		m.message = busy
+		return m, nil
+	}
+	app, ctx, wg := m.app, m.ctx, m.inflight
 	m.beginAction()
-	return m, m.do(fmt.Sprintf("dismissed #%d", id), func(ctx context.Context) error {
-		return m.app.Dismiss(ctx, id)
-	})
+	m.message = m.beginSending(ids)
+	if wg != nil {
+		wg.Add(1)
+	}
+	return m, func() tea.Msg {
+		if wg != nil {
+			defer wg.Done()
+		}
+		if err := app.Dismiss(ctx, id); err != nil {
+			return actionResultMsg{err: err, sent: ids}
+		}
+		return actionResultMsg{message: fmt.Sprintf("dismissed #%d", id), sent: ids}
+	}
 }
 
 // retryByID re-invokes the LLM on one escalation by id (list and detail).
@@ -3552,8 +3596,13 @@ func (m *Model) releaseSending(ids []int64) {
 // — can resolve the escalation while this request is in flight, and then the
 // row simply leaves the queue. Without this the id would sit in the map for the
 // life of the TUI. Called on every refresh, where the queue is re-read anyway.
+//
+// A FAILED refresh carries no escalations at all, and "we could not read the
+// queue" is not "the row left it": pruning there would drop every live claim,
+// un-dim the rows and let a second press queue the same answer again — exactly
+// what the claim exists to prevent.
 func (m *Model) pruneSending() {
-	if len(m.sending) == 0 {
+	if len(m.sending) == 0 || m.data.err != nil {
 		return
 	}
 	next := make(map[int64]bool, len(m.sending))


### PR DESCRIPTION
Stacked on #412.

## Why

Answering another machine's escalation is not a local write. The request is filed in `agent_actions` for the owning node and this process then **waits for that daemon's verdict** — up to `frontend.DefaultRemoteActionTimeout` (45s), documented as "two sync intervals plus slack".

For that whole window the row looked untouched. There was nothing to tell *"it is on its way"* from *"the key did not register"*, so pressing again is the natural thing to do — and it queued the answer twice.

This is the same failure mode `actionResultMsg.taskLists` already exists for, whose own comment says a round trip "takes long enough that the old checkbox invites a second press."

## What it does

A dispatch now **claims** its rows. Immediately, at the keypress:

- the row **dims**, and its first column shows `»`
- the banner names where the answer is going — `answering escalation #41 on node laptop — queued for its daemon…`
- a **second press on a claimed row is refused** instead of queued

Covers every Escalations row action: confirm+send (`enter`), confirm-only (`y`), correct (`c`), retry LLM (`l`), delete (`x`). Not conditional on the row's node — a local action clears in milliseconds, and branching on the node would only add a case to get wrong.

## Four bounds, each proved by mutation

- **Released by its OWN action's result**, never by clearing the set — otherwise the first of two concurrent batches un-dims the second's rows, which is the double-send the claim exists to prevent.
- **Every terminal path releases it.** A confirm+send whose agent went busy ends as `openAddPromptMsg`, *not* as a result; a claim leaked there leaves the row dimmed and unanswerable until something else resolves it.
- **A refresh prunes claims for rows that left the queue.** Another machine's operator — or that node's own daemon — can resolve the escalation mid-flight, and then no result ever names it.
- **A correction is claimed at DISPATCH, not at the keypress.** `c` opens a prompt the operator can still abandon with esc; a row dimmed at the keypress would stay dimmed with nothing in flight. Since a prompt's `onSubmit` returns a `tea.Cmd` and cannot mutate the model, the claim rides a message — the same reason `openSendPromptMsg` exists.

Two further details worth naming in review:

- The refusal reads the ids the action would **act on**, never the marks. `confirmWithoutSend` clears `m.marked` at dispatch, so a second press falls back to the cursor row — a mark-keyed guard would wave it straight through.
- The mark is a **glyph** as well as a dim, because colour is the half that disappears: lipgloss emits nothing without a TTY, so on a plain pipe the glyph is all that is left. Single-width, since the column is `%-1s` and a double-width rune (`⏳`, `→`) shifts every column after it. `escalationRowStyle` is a pure function for the same reason `auditRowStyle` is one — an assertion on the rendered escape sequence passes vacuously with no TTY, so the *choice* has to be assertable on its own.

## Verification

`internal/tui`, `internal/frontend`, `internal/cli`, `internal/store` all green; `gofmt`, `go vet`, `golangci-lint` (0 issues). Thirteen new tests; the four bounds above were each confirmed by reverting them and watching the matching test fail.

One test-helper change: `runPromptSubmit` now follows the claim hop through `Update`, exactly as the Bubble Tea runtime does, so the existing correction assertions stay pointed at what the action did rather than at the claim.

**Pre-existing, not from this change:** full-suite runs on this machine intermittently fail one `internal/daemon` test (a different one each run) and `TestALockedMigrationStepLosesTheLeaseAndFailsClosed` under `HAP_STORE_TEST_MODE=turso`. Both reproduce on the unmodified base branch, and `internal/daemon` has no dependency on `internal/tui`.

## Addressed from `/code-review low --fix 413`

- **A failed refresh dropped every live claim.** `m.data = msg` on a failed refresh carries no escalations at all, and `pruneSending` read that as "every row left the queue" — un-dimming the rows and letting a second press re-queue the same answer, the prune undoing exactly what the claim exists to do. "We could not read the queue" is not "the row left it".
- **The detail overlay was an unguarded second door.** Its `y` and `x` are the list's `y` and `x` in another surface (their own comments say so) but went straight to the store with no claim. The guard now lives in `confirmIDWithoutSend` and `dismissByID` themselves, the way it already does in `confirmAuditID` — a guard repeated per key handler is one that gets missed at a door, which is how these two were missed.

Both proved by mutation. CI note: the first run failed `TestEscalationAutoDismissesUnavailableAgentWithAudit` (`internal/daemon`); it passes ×5 in isolation, this diff is `internal/tui`-only, `internal/daemon` has no dependency on `internal/tui`, and the same test fails intermittently on unmodified `main` under full-suite load. Green on re-run.
