### PR TITLE
#1 chore: bump plugin version to 0.9.7 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.7
+
+- Changed the Claude session-name sync to leave you alone: it acts on a session only while the agent is parked, its composer untouched, and it has been sitting quietly — so a `/rename` no longer lands on a session you have just opened and are about to type into. In practice a name now settles a minute or two after an agent goes quiet, rather than seconds.
+- Changed those checks to run twice, the second time immediately before the keystroke and against the agent's live status rather than the status its capture carried, so an agent that went back to work in between is left alone.
+- Changed a refused rename to be retried about a minute later (backing off to fifteen), instead of waiting for an attention event a quiet pane may never produce.
+- Fixed a refused rename counting against the three-keystroke ceiling: being mid-draft three times used to disable the rename for that agent permanently.
+- Fixed a rename still landing on an agent that went back to work and parked again while the check was in flight: the quiet-enough test now runs against the agent's current parked spell, not the one its capture saw.
+- Fixed turning the setting on being silently ignored when a retry happened to be running: the enable is now remembered and the one-shot sync runs as soon as the retry finishes.
+
 ## 0.9.6
 
 - Added a loud TUI banner and `hap status` detail for a node whose shared-database sync has stopped working. A wedged sync engine used to be invisible: the daemon kept running, the herd looked quiet, and the Escalations and Agents tabs silently showed only this machine's rows while the other nodes' were never arriving — the failure was recorded at Warn level and nowhere else. It now says what it MEANS ("this machine is NOT exchanging rows with the other nodes") rather than what failed, and only after five minutes without a successful pull or push, so a passing network blip stays a quiet warning.

--- a/changelog.d/fix-session-sync-quiescence.md
+++ b/changelog.d/fix-session-sync-quiescence.md
@@ -1,6 +1,0 @@
-- Changed the Claude session-name sync to leave you alone: it acts on a session only while the agent is parked, its composer untouched, and it has been sitting quietly — so a `/rename` no longer lands on a session you have just opened and are about to type into. In practice a name now settles a minute or two after an agent goes quiet, rather than seconds.
-- Changed those checks to run twice, the second time immediately before the keystroke and against the agent's live status rather than the status its capture carried, so an agent that went back to work in between is left alone.
-- Changed a refused rename to be retried about a minute later (backing off to fifteen), instead of waiting for an attention event a quiet pane may never produce.
-- Fixed a refused rename counting against the three-keystroke ceiling: being mid-draft three times used to disable the rename for that agent permanently.
-- Fixed a rename still landing on an agent that went back to work and parked again while the check was in flight: the quiet-enough test now runs against the agent's current parked spell, not the one its capture saw.
-- Fixed turning the setting on being silently ignored when a retry happened to be running: the enable is now remembered and the one-shot sync runs as soon as the retry finishes.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.6"
+version = "0.9.7"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.7 is being released from this commit by the Auto Release workflow.