### PR TITLE
#1 chore: bump plugin version to 0.9.9 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.9
+
+- Added `hap signatures search --screen`, which searches the captured pane instead of the rule's masked salient — the literal paths, commands and version numbers a salient replaces with `<path>`/`<num>` placeholders are findable again. It matches every term anywhere in the screen (quote a phrase to require it contiguous), reports how many screens it searched so an empty result tells you whether there was anything to search, and each result carries the text around its first hit.
+- Added ctrl+g on the TUI Rules tab, running that same screen search over the captured panes.
+- Changed `--limit` to bound a `--screen` search as well as a `--semantic` one; keyword search stays unbounded.
+- Fixed the `match=` excerpt on a screen search drifting away from the term it found when the screen contained characters that change byte width when lower-cased.
+- Fixed the suggested follow-up commands re-emitting a quoted search phrase as separate words, so pasting one searched for something wider than the original query.
+
 ## 0.9.8
 
 - Fixed the confirm-delivery integration tests, which could not pass since 0.8.0 and had silently switched off the guard on the send-content regression (that confirming a label reply selects the numbered menu digit rather than pasting the label).

--- a/changelog.d/feat-signatures-search-screen.md
+++ b/changelog.d/feat-signatures-search-screen.md
@@ -1,5 +1,0 @@
-- Added `hap signatures search --screen`, which searches the captured pane instead of the rule's masked salient — the literal paths, commands and version numbers a salient replaces with `<path>`/`<num>` placeholders are findable again. It matches every term anywhere in the screen (quote a phrase to require it contiguous), reports how many screens it searched so an empty result tells you whether there was anything to search, and each result carries the text around its first hit.
-- Added ctrl+g on the TUI Rules tab, running that same screen search over the captured panes.
-- Changed `--limit` to bound a `--screen` search as well as a `--semantic` one; keyword search stays unbounded.
-- Fixed the `match=` excerpt on a screen search drifting away from the term it found when the screen contained characters that change byte width when lower-cased.
-- Fixed the suggested follow-up commands re-emitting a quoted search phrase as separate words, so pasting one searched for something wider than the original query.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.8"
+version = "0.9.9"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.9 is being released from this commit by the Auto Release workflow.