### PR TITLE
#0 fix: stop the daemon rebuilding its semantic index on every Turso pull

### DIFF
--- a/changelog.d/fix-daemon-rebuild-cpu.md
+++ b/changelog.d/fix-daemon-rebuild-cpu.md
@@ -1,0 +1,2 @@
+- Fixed the daemon rebuilding its whole semantic match index after every Turso pull, even when no learned rule had changed — on a fleet node that kept an idle daemon at ~20% CPU; it now rebuilds only when a rule is added, removed or re-embedded
+- Reduced `hap stream orchestrator`'s idle cost: a caught-up stream no longer re-reads the log's retained floor on every poll, and it polls every 2s instead of every 500ms after 30s without events (the first event restores the fast poll)

--- a/internal/cli/export_stream_test.go
+++ b/internal/cli/export_stream_test.go
@@ -1,0 +1,20 @@
+package cli
+
+import "time"
+
+// SetStreamIdlePolling overrides the idle back-off: the slower interval and how
+// long a stream must go without an event before using it. It returns a
+// function restoring both.
+func SetStreamIdlePolling(interval, after time.Duration) func() {
+	prevInterval, prevAfter := streamIdlePollInterval, streamIdleAfter
+	streamIdlePollInterval, streamIdleAfter = interval, after
+	return func() { streamIdlePollInterval, streamIdleAfter = prevInterval, prevAfter }
+}
+
+// SetStreamGapRecheck overrides how long a caught-up stream goes without
+// re-asking for the retained floor. It returns a function restoring it.
+func SetStreamGapRecheck(d time.Duration) func() {
+	prev := streamGapRecheck
+	streamGapRecheck = d
+	return func() { streamGapRecheck = prev }
+}

--- a/internal/cli/stream.go
+++ b/internal/cli/stream.go
@@ -12,9 +12,23 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
 )
 
-// streamPollInterval is how often a stream looks for new events. A variable so
-// tests can shorten it.
+// streamPollInterval is how often a stream looks for new events while they are
+// arriving. A variable so tests can shorten it.
 var streamPollInterval = 500 * time.Millisecond
+
+// streamIdlePollInterval is the cadence once nothing has arrived for
+// streamIdleAfter: an idle orchestrator stream is the common state, and it
+// used to poll at the fast rate forever. The first event read snaps the poll
+// back to fast, so at most one event per quiet spell waits the slower tick.
+// Variables so tests can shorten them.
+var (
+	streamIdlePollInterval = 2 * time.Second
+	streamIdleAfter        = 30 * time.Second
+)
+
+// streamGapRecheck bounds how long a caught-up stream goes without re-asking
+// for the retained floor (see the settled flag in streamOrchestrator).
+var streamGapRecheck = time.Minute
 
 // streamBatch is how many events one read returns; a full batch is followed by
 // another read at once rather than a poll wait, so a long replay is not paced.
@@ -73,19 +87,32 @@ func streamOrchestrator(ctx context.Context, app *frontend.App, out io.Writer, a
 	}
 
 	var lastErr string
+	// settled means the previous read came back empty AND its gap check found
+	// nothing, so the cursor had reached the head. From there an empty read
+	// cannot hide a gap — only an event appended AND aged past the retention
+	// window between two polls could — so the floor query, a second statement
+	// on every idle tick, is skipped until a batch arrives, a read fails, or
+	// streamGapRecheck passes.
+	settled := false
+	var checkedAt time.Time
+	lastEventAt := time.Now()
 	for {
 		evs, err := app.Stream.Since(ctx, cursor, streamBatch)
-		if err == nil {
+		if err == nil && (!settled || len(evs) > 0 || time.Since(checkedAt) >= streamGapRecheck) {
 			// Asked AFTER the read: a prune landing between the floor above
 			// (or the previous batch) and this read removes events the cursor
 			// had not reached, and they must be reported, never skipped.
-			if last, ok := prunedUnder(ctx, app, cursor, evs); ok {
+			last, gap, checkErr := prunedUnder(ctx, app, cursor, evs)
+			if gap {
 				fmt.Fprintf(out, "# gap missed=%d..%d (pruned while you were reading — re-survey with hap)\n",
 					cursor+1, last)
 				cursor = last
 			}
+			checkedAt = time.Now()
+			settled = checkErr == nil && !gap && len(evs) == 0
 		}
 		if err != nil {
+			settled = false
 			if ctx.Err() != nil {
 				return nil
 			}
@@ -107,34 +134,41 @@ func streamOrchestrator(ctx context.Context, app *frontend.App, out io.Writer, a
 		if len(evs) == streamBatch {
 			continue
 		}
+		wait := streamPollInterval
+		if len(evs) > 0 {
+			lastEventAt = time.Now()
+		} else if time.Since(lastEventAt) >= streamIdleAfter {
+			wait = streamIdlePollInterval
+		}
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-time.After(streamPollInterval):
+		case <-time.After(wait):
 		}
 	}
 }
 
 // prunedUnder reports the last seq of events pruned beneath the cursor that
 // the reader never saw: everything from cursor+1 up to (not including) the
-// retained floor, and never past the first event the batch did return. ok is
-// false when nothing was lost — or when the floor could not be read, since a
-// failed read is not evidence of a gap.
-func prunedUnder(ctx context.Context, app *frontend.App, cursor int64, batch []domain.StreamEvent) (int64, bool) {
+// retained floor, and never past the first event the batch did return. gap is
+// false when nothing was lost — and when the floor could not be read (err),
+// since a failed read is not evidence of a gap; nor is it evidence of NONE,
+// which is why the caller keeps checking until a read succeeds.
+func prunedUnder(ctx context.Context, app *frontend.App, cursor int64, batch []domain.StreamEvent) (last int64, gap bool, err error) {
 	floor, err := app.Stream.Floor(ctx)
 	if err != nil {
-		return 0, false
+		return 0, false, err
 	}
 	if floor == 0 { // nothing retained: everything up to the head is gone
 		head, err := app.Stream.Head(ctx)
 		if err != nil {
-			return 0, false
+			return 0, false, err
 		}
 		floor = head + 1
 	}
-	last := floor - 1
+	last = floor - 1
 	if len(batch) > 0 && batch[0].Seq-1 < last {
 		last = batch[0].Seq - 1
 	}
-	return last, last > cursor
+	return last, last > cursor, nil
 }

--- a/internal/cli/stream_idle_test.go
+++ b/internal/cli/stream_idle_test.go
@@ -1,0 +1,196 @@
+package cli_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/cli"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/streamlog"
+)
+
+// queryCountingLog counts the two statements an idle stream can issue per
+// tick.
+type queryCountingLog struct {
+	*streamlog.Log
+	sinces atomic.Int32
+	floors atomic.Int32
+}
+
+func (l *queryCountingLog) Since(ctx context.Context, after int64, limit int) ([]domain.StreamEvent, error) {
+	l.sinces.Add(1)
+	return l.Log.Since(ctx, after, limit)
+}
+
+func (l *queryCountingLog) Floor(ctx context.Context) (int64, error) {
+	l.floors.Add(1)
+	return l.Log.Floor(ctx)
+}
+
+func waitForCount(t *testing.T, n *atomic.Int32, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for n.Load() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("count stuck at %d, want at least %d", n.Load(), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestStreamIdleReadsSkipTheFloorQuery: once a read comes back empty and its
+// gap check passes, the stream is caught up and later empty reads cannot hide
+// a gap — so an idle stream issues one statement per tick, not two. The
+// control half proves an event re-arms the check.
+func TestStreamIdleReadsSkipTheFloorQuery(t *testing.T) {
+	app, log := streamApp(t)
+	appendEvent(t, log, domain.StreamPauseOn, time.Now())
+	counting := &queryCountingLog{Log: log}
+	app.Stream = counting
+
+	out, _ := startStream(t, app)
+	waitForOutput(t, out, "# hap stream orchestrator head=1 floor=1\n")
+	// A third read has started, so the first read's gap check is done.
+	waitForCount(t, &counting.sinces, 3)
+	settledFloors := counting.floors.Load()
+	start := counting.sinces.Load()
+	waitForCount(t, &counting.sinces, start+20)
+	if got := counting.floors.Load(); got != settledFloors {
+		t.Errorf("%d floor queries over 20 idle reads, want 0", got-settledFloors)
+	}
+
+	appendEvent(t, log, domain.StreamFSPOn, time.Now())
+	waitForOutput(t, out, " fsp.on by=operator\n")
+	if got := counting.floors.Load(); got == settledFloors {
+		t.Error("a batch that arrived was not gap-checked")
+	}
+}
+
+// pruneWhileSettledLog, once armed, appends an event already past retention
+// and prunes it inside the next read — the one gap a caught-up stream's empty
+// reads cannot see, since the event is gone before it could be returned.
+type pruneWhileSettledLog struct {
+	*streamlog.Log
+	armed  atomic.Bool
+	fired  atomic.Bool
+	sinces atomic.Int32
+}
+
+func (l *pruneWhileSettledLog) Since(ctx context.Context, after int64, limit int) ([]domain.StreamEvent, error) {
+	l.sinces.Add(1)
+	if l.armed.CompareAndSwap(true, false) {
+		_, _ = l.Append(ctx, domain.StreamEvent{Kind: domain.StreamPauseOn, Author: "operator",
+			At: time.Now().Add(-30 * 24 * time.Hour)})
+		_, _ = l.Prune(ctx, time.Now().Add(-24*time.Hour))
+		l.fired.Store(true)
+	}
+	return l.Log.Since(ctx, after, limit)
+}
+
+// TestStreamGapRecheckBoundsASettledStream: skipping the floor query on idle
+// reads is safe only because it is re-asked every streamGapRecheck. With a
+// short recheck the gap is reported; with an hour it is not reported within
+// the same reads — the control showing the recheck, not some other path,
+// found it.
+func TestStreamGapRecheckBoundsASettledStream(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		recheck time.Duration
+		want    bool
+	}{
+		{"short recheck reports it", time.Millisecond, true},
+		{"hour-long recheck defers it", time.Hour, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(cli.SetStreamGapRecheck(tc.recheck))
+			app, log := streamApp(t)
+			wrapped := &pruneWhileSettledLog{Log: log}
+			app.Stream = wrapped
+
+			out, _ := startStream(t, app)
+			waitForOutput(t, out, "# hap stream orchestrator head=0 floor=0\n")
+			waitForCount(t, &wrapped.sinces, 3) // settled
+			wrapped.armed.Store(true)
+			waitFor(t, func() bool { return wrapped.fired.Load() })
+			waitForCount(t, &wrapped.sinces, wrapped.sinces.Load()+20)
+
+			got := strings.Contains(out.String(), "# gap missed=1..1 ")
+			if got != tc.want {
+				t.Errorf("gap reported = %v, want %v:\n%s", got, tc.want, out.String())
+			}
+		})
+	}
+}
+
+// failingEmptyCheckLog fails the floor query of the first EMPTY read, once.
+type failingEmptyCheckLog struct {
+	*streamlog.Log
+	lastEmpty atomic.Bool
+	failOnce  atomic.Bool
+	sinces    atomic.Int32
+	floors    atomic.Int32
+}
+
+func (l *failingEmptyCheckLog) Since(ctx context.Context, after int64, limit int) ([]domain.StreamEvent, error) {
+	l.sinces.Add(1)
+	evs, err := l.Log.Since(ctx, after, limit)
+	l.lastEmpty.Store(err == nil && len(evs) == 0)
+	return evs, err
+}
+
+func (l *failingEmptyCheckLog) Floor(ctx context.Context) (int64, error) {
+	l.floors.Add(1)
+	if l.lastEmpty.Load() && l.failOnce.CompareAndSwap(true, false) {
+		return 0, errors.New("induced floor failure")
+	}
+	return l.Log.Floor(ctx)
+}
+
+// TestStreamAFailedGapCheckIsNotSettled: a floor read that failed is not
+// evidence of NO gap, so the next empty read must ask again. Settling on it
+// would leave the stream skipping every check until the recheck interval.
+func TestStreamAFailedGapCheckIsNotSettled(t *testing.T) {
+	app, log := streamApp(t)
+	appendEvent(t, log, domain.StreamPauseOn, time.Now())
+	wrapped := &failingEmptyCheckLog{Log: log}
+	wrapped.failOnce.Store(true)
+	app.Stream = wrapped
+
+	out, _ := startStream(t, app)
+	waitForOutput(t, out, "# hap stream orchestrator head=1 floor=1\n")
+	waitForCount(t, &wrapped.sinces, 12)
+	// The header's floor, the failed check, the retry — then settled.
+	if got := wrapped.floors.Load(); got != 3 {
+		t.Errorf("floor queries = %d, want 3 (header, failed check, retry)", got)
+	}
+}
+
+// TestStreamIdleBackoffStillDeliversEvents: past streamIdleAfter the poll slows
+// down; an event arriving then must still be printed on the slower tick.
+func TestStreamIdleBackoffStillDeliversEvents(t *testing.T) {
+	t.Cleanup(cli.SetStreamIdlePolling(20*time.Millisecond, 0))
+	app, log := streamApp(t)
+	counting := &queryCountingLog{Log: log}
+	app.Stream = counting
+
+	out, _ := startStream(t, app)
+	waitForOutput(t, out, "# hap stream orchestrator head=0 floor=0\n")
+	waitForCount(t, &counting.sinces, 3)
+	appendEvent(t, log, domain.StreamPauseOn, time.Now())
+	waitForOutput(t, out, " pause.on by=operator\n")
+}
+
+func waitFor(t *testing.T, ok func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for !ok() {
+		if time.Now().After(deadline) {
+			t.Fatal("condition never held")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -261,6 +261,17 @@ type Daemon struct {
 	semanticReady atomic.Bool
 	semanticGen   atomic.Int64
 
+	// builtKnowledge is the signature_embeddings digest the PUBLISHED index was
+	// built from ("" = unknown, so the next refresh rebuilds). It lets
+	// RefreshKnowledge skip a rebuild when a fleet pull moved nothing the index
+	// reads — under turso nearly every pull reports a change (heartbeats,
+	// roster), and rebuilding on each one kept an idle node at ~20% CPU.
+	// knowledgeMu makes "the generation is still ours" and the write ONE step,
+	// and pairs reloadEmbedder's clear with its generation bump, so a
+	// superseded run can never record a digest over a newer run's index.
+	knowledgeMu    sync.Mutex
+	builtKnowledge string
+
 	// taskSnapshots caches REMOTE task lists so the main select loop never
 	// waits on a network read (see taskcache.go). A local store is never
 	// cached — it reads through exactly as it always has.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -647,6 +647,17 @@ func (s *failingStore) PruneAgedRows(ctx context.Context, now, cutoff time.Time)
 	return rp.PruneAgedRows(ctx, now, cutoff)
 }
 
+// SignatureEmbeddingsFingerprint forwards the OPTIONAL
+// ports.KnowledgeFingerprinter capability for the same reason: without it every
+// knowledge refresh in the suite silently rebuilds the index.
+func (s *failingStore) SignatureEmbeddingsFingerprint(ctx context.Context) (string, error) {
+	kf, ok := s.StorePort.(ports.KnowledgeFingerprinter)
+	if !ok {
+		return "", errors.New("wrapped store cannot fingerprint signature embeddings")
+	}
+	return kf.SignatureEmbeddingsFingerprint(ctx)
+}
+
 // PruneAuditExcerpts, FreelistPages and Vacuum forward ports.RetentionPort for
 // the same reason. All three are needed together: the daemon asserts the
 // interface, not the methods.

--- a/internal/daemon/knowledge_test.go
+++ b/internal/daemon/knowledge_test.go
@@ -1,0 +1,300 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/match"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
+)
+
+// countingEmbeddingsStore counts semantic-index loads (one per rebuild run)
+// and fails them on demand. It deliberately does NOT forward
+// ports.KnowledgeFingerprinter — that is the control; wrap it in
+// fingerprintingStore to switch the gate on.
+type countingEmbeddingsStore struct {
+	ports.StorePort
+	loads    atomic.Int32
+	failures atomic.Int32 // loads that took the failing branch
+	fail     atomic.Bool
+}
+
+func (s *countingEmbeddingsStore) ListSignatureEmbeddings(ctx context.Context) ([]domain.SignatureEmbedding, error) {
+	s.loads.Add(1)
+	if s.fail.Load() {
+		s.failures.Add(1)
+		return nil, errors.New("induced load failure")
+	}
+	return s.StorePort.ListSignatureEmbeddings(ctx)
+}
+
+type fingerprintingStore struct{ *countingEmbeddingsStore }
+
+func (s fingerprintingStore) SignatureEmbeddingsFingerprint(ctx context.Context) (string, error) {
+	return s.StorePort.(ports.KnowledgeFingerprinter).SignatureEmbeddingsFingerprint(ctx)
+}
+
+// latchedEmbedder is an embedder whose failure latch has tripped: a degraded
+// build is the best it will do until a reload.
+type latchedEmbedder struct{ *fakeEmbedder }
+
+func (latchedEmbedder) Degraded() bool { return true }
+
+// knowledgeHarness is semanticHarness over a counting store; fingerprint
+// selects whether the store offers the optional digest. It returns once the
+// startup build has published (semanticReady is set after publishKnowledge).
+func knowledgeHarness(t *testing.T, emb ports.EmbedderPort, fingerprint bool) (*Daemon, *countingEmbeddingsStore) {
+	t.Helper()
+	dir := t.TempDir()
+	raw, err := store.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { raw.Close() })
+	counting := &countingEmbeddingsStore{StorePort: raw}
+	var st ports.StorePort = counting
+	if fingerprint {
+		st = fingerprintingStore{counting}
+	}
+	d, err := New(Options{
+		ConfigPath:        filepath.Join(dir, "config.toml"),
+		ControlSocketPath: filepath.Join(testutil.SocketDir(t), "c.sock"),
+		Store:             st,
+		Herdr:             &fakeHerdr{},
+		Events:            &fakeEvents{ch: make(chan domain.AgentTransition, 4)},
+		Notify:            &fakeHerdr{},
+		Embedder:          emb,
+		MatchIndexDir:     filepath.Join(dir, "match-index"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if d.matcher != nil {
+			d.matcher.Close()
+		}
+	})
+	waitFor(t, 5*time.Second, func() bool { return d.semanticReady.Load() })
+	return d, counting
+}
+
+func builtKnowledge(d *Daemon) string {
+	d.knowledgeMu.Lock()
+	defer d.knowledgeMu.Unlock()
+	return d.builtKnowledge
+}
+
+func setEmbedFailure(emb *fakeEmbedder, fail bool) {
+	emb.mu.Lock()
+	defer emb.mu.Unlock()
+	emb.fail = fail
+}
+
+// peerRule stands in for a rule a fleet pull brought: already embedded by the
+// same model, and STRUCTURED so the embedding floor leaves it alone — so
+// Reconcile rewrites nothing and exactly one rebuild is owed.
+func peerRule(t *testing.T, st ports.StorePort, verb string) domain.SignatureEmbedding {
+	t.Helper()
+	e := domain.SignatureEmbedding{
+		Signature: "approval:peer-" + verb, SituationType: domain.SituationApproval, AgentType: "claude",
+		Model: "fake-model", Dims: 4, Vector: []float32{0, 1, 0, 0},
+		Salient: "permission:" + verb + " | options:no;yes", CreatedAt: time.Now(),
+	}
+	if err := st.UpsertSignatureEmbedding(context.Background(), e); err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+// waitPublished waits until the index built from the store's CURRENT rows has
+// published.
+func waitPublished(t *testing.T, d *Daemon, st *countingEmbeddingsStore) {
+	t.Helper()
+	fp, err := st.StorePort.(ports.KnowledgeFingerprinter).SignatureEmbeddingsFingerprint(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, 5*time.Second, func() bool { return builtKnowledge(d) == fp })
+}
+
+func matchable(t *testing.T, d *Daemon, e domain.SignatureEmbedding) bool {
+	t.Helper()
+	hit, ok, err := d.matcher.MatchText(context.Background(), e.Salient,
+		match.Scope{SituationType: e.SituationType, AgentType: e.AgentType}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ok && hit.Signature == e.Signature
+}
+
+// TestRefreshKnowledgeSkipsTheRebuildWhenNoRuleMoved is the CPU regression
+// guard: under turso nearly every pull reports a change, and rebuilding the
+// whole index on each one kept an idle node busy. Invalidation must still run
+// every time — the verdict cache keys on rule STATE the digest does not cover.
+func TestRefreshKnowledgeSkipsTheRebuildWhenNoRuleMoved(t *testing.T) {
+	d, st := knowledgeHarness(t, &fakeEmbedder{}, true)
+	peerRule(t, st, "deploy")
+	d.RefreshKnowledge()
+	waitPublished(t, d, st)
+
+	gen, loads, rr := d.semanticGen.Load(), st.loads.Load(), currentRerankGen(d)
+	for range 3 {
+		d.RefreshKnowledge()
+	}
+	if got := d.semanticGen.Load(); got != gen {
+		t.Errorf("semanticGen moved %d → %d on refreshes that changed no rule", gen, got)
+	}
+	if got := st.loads.Load(); got != loads {
+		t.Errorf("index loaded %d more time(s) on refreshes that changed no rule", got-loads)
+	}
+	if got := currentRerankGen(d); got != rr+3 {
+		t.Errorf("rerank generation = %d, want %d: invalidation must not be gated on the digest", got, rr+3)
+	}
+}
+
+// TestRefreshKnowledgeRebuildsWhenAPeerRuleArrives: the gate must never cost a
+// rule its matchability.
+func TestRefreshKnowledgeRebuildsWhenAPeerRuleArrives(t *testing.T) {
+	d, st := knowledgeHarness(t, &fakeEmbedder{}, true)
+	rule := peerRule(t, st, "restart the service")
+	if matchable(t, d, rule) {
+		t.Fatal("premise: the rule must not be in the index before the refresh")
+	}
+	gen := d.semanticGen.Load()
+	d.RefreshKnowledge()
+	if got := d.semanticGen.Load(); got != gen+1 {
+		t.Fatalf("semanticGen = %d, want %d: a new rule must rebuild", got, gen+1)
+	}
+	waitPublished(t, d, st)
+	if !matchable(t, d, rule) {
+		t.Error("the peer's rule is not matchable after the rebuild")
+	}
+	d.RefreshKnowledge()
+	if got := d.semanticGen.Load(); got != gen+1 {
+		t.Errorf("a second refresh with nothing new rebuilt again (gen %d)", got)
+	}
+}
+
+// TestRefreshKnowledgeRetriesAfterAFailedRebuild: the digest is recorded at
+// PUBLISH, so a failed run leaves the old one and the next pull tries again.
+// Recorded at pull time, the rule would never become matchable.
+func TestRefreshKnowledgeRetriesAfterAFailedRebuild(t *testing.T) {
+	d, st := knowledgeHarness(t, &fakeEmbedder{}, true)
+	rule := peerRule(t, st, "rotate the keys")
+	st.fail.Store(true)
+	d.RefreshKnowledge()
+	waitFor(t, 5*time.Second, func() bool { return st.failures.Load() > 0 })
+	st.fail.Store(false)
+
+	gen := d.semanticGen.Load()
+	d.RefreshKnowledge()
+	if got := d.semanticGen.Load(); got != gen+1 {
+		t.Fatalf("semanticGen = %d, want %d: a failed rebuild must not read as built", got, gen+1)
+	}
+	waitPublished(t, d, st)
+	if !matchable(t, d, rule) {
+		t.Error("the rule is not matchable after the retry")
+	}
+}
+
+// TestAReloadRebuildIsNeverSkippedByARefresh: a reload forgets the digest, so
+// while its rebuild is pending — or after it failed — a refresh over unchanged
+// rows still rebuilds instead of trusting an index built under the old config.
+func TestAReloadRebuildIsNeverSkippedByARefresh(t *testing.T) {
+	d, st := knowledgeHarness(t, &fakeEmbedder{}, true)
+	cfg, _, _ := d.snapshot()
+	st.fail.Store(true)
+	d.reloadEmbedder(cfg, cfg, false)
+	if got := builtKnowledge(d); got != "" {
+		t.Errorf("reload left the digest %q in place while its own rebuild is pending", got)
+	}
+	waitFor(t, 5*time.Second, func() bool { return st.failures.Load() > 0 })
+	st.fail.Store(false)
+
+	gen := d.semanticGen.Load()
+	d.RefreshKnowledge()
+	if got := d.semanticGen.Load(); got != gen+1 {
+		t.Fatalf("semanticGen = %d, want %d: a refresh after a failed reload rebuild must rebuild", got, gen+1)
+	}
+	waitPublished(t, d, st)
+}
+
+// TestAPublishFromASupersededGenerationIsRefused: a run the daemon has moved
+// past must not overwrite the digest a newer run recorded — or leave one
+// behind for an index a newer run is about to replace.
+func TestAPublishFromASupersededGenerationIsRefused(t *testing.T) {
+	d, _ := knowledgeHarness(t, &fakeEmbedder{}, true)
+	current := d.semanticGen.Load()
+	before := builtKnowledge(d)
+	if d.publishKnowledge(current-1, "stale") {
+		t.Error("a superseded generation was allowed to publish")
+	}
+	if got := builtKnowledge(d); got != before {
+		t.Errorf("a refused publish still wrote the digest: %q, want %q", got, before)
+	}
+	if !d.publishKnowledge(current, "fresh") || builtKnowledge(d) != "fresh" {
+		t.Error("the current generation could not publish")
+	}
+}
+
+// TestADegradedBuildKeepsRebuildingWhileTheEmbedderCanRecover: a build made
+// while the embedder is TRANSIENTLY failing is text-only where it should not
+// be, and nothing in the store changes to say so. Recording its digest would
+// make every later pull skip the rebuild that restores vector matching.
+func TestADegradedBuildKeepsRebuildingWhileTheEmbedderCanRecover(t *testing.T) {
+	emb := &fakeEmbedder{}
+	d, st := knowledgeHarness(t, emb, true)
+	peerRule(t, st, "migrate the schema")
+	setEmbedFailure(emb, true)
+	d.RefreshKnowledge()
+	waitFor(t, 5*time.Second, func() bool { return builtKnowledge(d) == "" })
+
+	gen := d.semanticGen.Load()
+	d.RefreshKnowledge()
+	if got := d.semanticGen.Load(); got != gen+1 {
+		t.Fatalf("semanticGen = %d, want %d: a degraded build must not be recorded as the index's state", got, gen+1)
+	}
+	waitFor(t, 5*time.Second, func() bool { return d.semanticReady.Load() })
+
+	setEmbedFailure(emb, false)
+	d.RefreshKnowledge()
+	waitPublished(t, d, st)
+}
+
+// TestADegradedBuildIsRecordedOnceTheEmbedderIsDownForGood is the other half:
+// with the failure latch tripped (or no embedder at all), retrying would
+// rebuild on every pull forever — the exact CPU cost the gate removes.
+func TestADegradedBuildIsRecordedOnceTheEmbedderIsDownForGood(t *testing.T) {
+	emb := latchedEmbedder{&fakeEmbedder{fail: true}}
+	d, st := knowledgeHarness(t, emb, true)
+	peerRule(t, st, "drain the node")
+	d.RefreshKnowledge()
+	waitPublished(t, d, st)
+
+	gen := d.semanticGen.Load()
+	d.RefreshKnowledge()
+	d.RefreshKnowledge()
+	if got := d.semanticGen.Load(); got != gen {
+		t.Errorf("semanticGen moved %d → %d: a latched embedder's build must be recorded", gen, got)
+	}
+}
+
+// TestRefreshKnowledgeWithoutAFingerprintAlwaysRebuilds is the control: a
+// store that cannot digest its rows keeps the old behaviour, so the skip in
+// the tests above is the gate's doing and not a harness that never rebuilds.
+func TestRefreshKnowledgeWithoutAFingerprintAlwaysRebuilds(t *testing.T) {
+	d, _ := knowledgeHarness(t, &fakeEmbedder{}, false)
+	gen := d.semanticGen.Load()
+	d.RefreshKnowledge()
+	d.RefreshKnowledge()
+	if got := d.semanticGen.Load(); got != gen+2 {
+		t.Errorf("semanticGen = %d, want %d: without a digest every refresh must rebuild", got, gen+2)
+	}
+}

--- a/internal/daemon/semantic.go
+++ b/internal/daemon/semantic.go
@@ -28,6 +28,11 @@ func (d *Daemon) initSemantic(ctx context.Context, gen int64) {
 		return
 	}
 
+	// Digest the rows BEFORE loading them: a rule landing between the two then
+	// costs one redundant rebuild on the next refresh, never a missed rule. (A
+	// Reconcile that rewrites rows below costs the same single extra rebuild.)
+	fp := d.knowledgeFingerprint(ctx)
+
 	// Warm the embedder and re-embed rows minted by another model (or with
 	// stale dims) from their stored salient text, so a model swap keeps
 	// every signature matchable. Warm failure is not fatal: the index still
@@ -53,7 +58,17 @@ func (d *Daemon) initSemantic(ctx context.Context, gen int64) {
 	if d.semanticGen.Load() != gen {
 		return // superseded by a newer reload; let its run own the index
 	}
-	if err := d.matcher.Rebuild(res.Rows, res.Dims); err != nil {
+	// A build degraded by a TRANSIENT embedder fault (a cold worker's warmup
+	// timing out, one row failing to embed) is text-only where it should not
+	// be, and the store does not change to say so — record its digest and
+	// every later refresh skips the rebuild that would have recovered it. A
+	// permanently absent or latched-degraded embedder is the opposite case:
+	// retrying would rebuild on every pull forever for nothing.
+	if (res.WarmErr != nil || res.Downgraded > 0) && !d.embedderPermanentlyDown() {
+		fp = ""
+	}
+	published, err := d.matcher.RebuildPublished(res.Rows, res.Dims)
+	if err != nil {
 		if !errors.Is(err, match.ErrCleanup) {
 			slog.Warn("semantic index rebuild failed; matching stays exact-hash", "error", err)
 			return
@@ -63,7 +78,13 @@ func (d *Daemon) initSemantic(ctx context.Context, gen int64) {
 		// semantic matching enabled.
 		slog.Warn("semantic index rebuilt; previous-generation cleanup failed", "error", err)
 	}
-	if d.semanticGen.Load() != gen {
+	if !published {
+		// A newer Rebuild owns the index. The matcher orders builds by when
+		// they STARTED and semanticGen by when they were SPAWNED, and the two
+		// can disagree — so this run cannot vouch for whatever index stands.
+		fp = ""
+	}
+	if !d.publishKnowledge(gen, fp) {
 		return // a newer reload raced past; it decides readiness
 	}
 	d.semanticReady.Store(true)
@@ -458,6 +479,15 @@ func remapAllowed(s domain.Situation, sig domain.SignatureResult, hit match.Hit)
 // store (rather than adding rows) is what also makes a rule DELETED elsewhere
 // disappear here. Superseded runs abort on the generation counter, so a burst
 // of pulls costs one rebuild.
+//
+// The REBUILD is skipped when signature_embeddings digests the same as when
+// the published index was built: a pull reports a change for any row at all,
+// and under turso that is nearly every pull. The rows are not the index's only
+// input — the embedder's health at build time decides which of them get
+// vectors — so initSemantic records a digest only for a build that was
+// complete, or whose embedder is down for good (see embedderPermanentlyDown).
+// The verdict invalidation is NOT gated: the cache keys on rule STATE
+// (signatures, decisions), which the digest does not cover.
 func (d *Daemon) RefreshKnowledge() {
 	if d.matcher == nil {
 		return
@@ -469,6 +499,9 @@ func (d *Daemon) RefreshKnowledge() {
 	// still answerable: a re-rank is one subprocess, a wrong reuse is a wrong
 	// rule.
 	d.invalidateRerank()
+	if d.knowledgeUnchanged(d.knowledgeFingerprint(d.shutdownCtx)) {
+		return
+	}
 	gen := d.semanticGen.Add(1)
 	d.spawn(func() {
 		_ = logging.Guard("semantic-refresh", func() error {
@@ -476,6 +509,60 @@ func (d *Daemon) RefreshKnowledge() {
 			return nil
 		})
 	})
+}
+
+// knowledgeFingerprint digests the rows the semantic index is built from, or
+// "" when the store cannot say — which every caller reads as "rebuild".
+func (d *Daemon) knowledgeFingerprint(ctx context.Context) string {
+	kf, ok := d.opt.Store.(ports.KnowledgeFingerprinter)
+	if !ok {
+		return ""
+	}
+	fp, err := kf.SignatureEmbeddingsFingerprint(ctx)
+	if err != nil {
+		slog.Debug("knowledge fingerprint unavailable; rebuilding the semantic index", "error", err)
+		return ""
+	}
+	return fp
+}
+
+// embedderPermanentlyDown reports whether a degraded index build is the best
+// this embedder will do until the next reload: none is configured (disabled,
+// crash-guard suppressed), or its failure latch has tripped. Anything else may
+// recover, so its degraded build must not be recorded as the index's state.
+func (d *Daemon) embedderPermanentlyDown() bool {
+	emb := d.embedderPort()
+	if emb == nil {
+		return true
+	}
+	dg, ok := emb.(interface{ Degraded() bool })
+	return ok && dg.Degraded()
+}
+
+// knowledgeUnchanged reports whether fp is known and is the digest the
+// published index was built from.
+func (d *Daemon) knowledgeUnchanged(fp string) bool {
+	if fp == "" {
+		return false
+	}
+	d.knowledgeMu.Lock()
+	defer d.knowledgeMu.Unlock()
+	return d.builtKnowledge == fp
+}
+
+// publishKnowledge records fp as the published index's digest, and reports
+// false without recording when gen is no longer current. It is called only
+// AFTER Matcher.Rebuild published: recording at pull time instead would mark a
+// failed or superseded rebuild as built, and a peer's new rule would then never
+// become matchable here.
+func (d *Daemon) publishKnowledge(gen int64, fp string) bool {
+	d.knowledgeMu.Lock()
+	defer d.knowledgeMu.Unlock()
+	if d.semanticGen.Load() != gen {
+		return false
+	}
+	d.builtKnowledge = fp
+	return true
 }
 
 // embedderPort returns the current embedder (rebuilt on reload when the
@@ -508,7 +595,12 @@ func (d *Daemon) reloadEmbedder(prev, next config.Config, first bool) {
 	}
 
 	d.semanticReady.Store(false)
+	// A reload always rebuilds, and until that run publishes no refresh may
+	// skip: forget the digest in the same step that supersedes older runs.
+	d.knowledgeMu.Lock()
+	d.builtKnowledge = ""
 	gen := d.semanticGen.Add(1)
+	d.knowledgeMu.Unlock()
 	// Tracked + rooted at shutdownCtx so daemon teardown cancels the reembed /
 	// index rebuild and awaits it before the matcher (and store) close.
 	d.spawn(func() {

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -148,6 +148,21 @@ func buildIndex(path string, dims int) (bleve.Index, error) {
 // abandoned index directory — a failed, superseded, or replaced build — is
 // removed, so the cache never leaks generations.
 func (m *Matcher) Rebuild(rows []domain.SignatureEmbedding, dims int) error {
+	return m.rebuild(rows, dims, nil)
+}
+
+// RebuildPublished is Rebuild that also reports whether THIS call's index is
+// the one now live. A superseded build returns (false, nil), which Rebuild
+// cannot tell apart from success — and a caller recording what the live index
+// was built from must not vouch for rows it just threw away. It is true
+// alongside ErrCleanup, where the new index did publish.
+func (m *Matcher) RebuildPublished(rows []domain.SignatureEmbedding, dims int) (bool, error) {
+	var published bool
+	err := m.rebuild(rows, dims, &published)
+	return published, err
+}
+
+func (m *Matcher) rebuild(rows []domain.SignatureEmbedding, dims int, published *bool) error {
 	if !vectorSearchSupported {
 		// No KNN engine is linked (built without the `vectors` tag), so the
 		// index must be text-only. Force dims to 0: a positive dims would make
@@ -217,6 +232,9 @@ func (m *Matcher) Rebuild(rows []domain.SignatureEmbedding, dims int) error {
 	old, oldDir := m.idx, m.idxDir
 	m.idx, m.idxDir, m.dims = idx, dir, dims
 	m.mu.Unlock()
+	if published != nil {
+		*published = true
+	}
 	if old != nil {
 		if cleanupErr := m.cleanupIndex(old.Close, oldDir); cleanupErr != nil {
 			// The new index is live and published; only reclaiming the previous

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -399,6 +399,47 @@ func TestRebuildStaleGenerationDoesNotClobber(t *testing.T) {
 	}
 }
 
+// TestRebuildPublishedReportsASupersededBuild: the daemon records what the
+// live index was built from only when RebuildPublished says this call's index
+// is live. The superseded build returns a nil error exactly like a success, so
+// without the flag it would vouch for rows it discarded. B (newer) publishes;
+// A (older) reaches publish last and must answer false.
+func TestRebuildPublishedReportsASupersededBuild(t *testing.T) {
+	m := New(t.TempDir())
+	defer m.Close()
+	alpha := []domain.SignatureEmbedding{
+		row("approval:alpha", domain.SituationApproval, "claude", "permission: alpha", nil),
+	}
+	bravo := []domain.SignatureEmbedding{
+		row("approval:bravo", domain.SituationApproval, "claude", "permission: bravo", nil),
+	}
+	bPublished := make(chan struct{})
+	m.publishBarrier = func(gen int) {
+		if gen == 1 {
+			<-bPublished
+		}
+	}
+
+	var aPublished bool
+	var aErr error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		aPublished, aErr = m.RebuildPublished(alpha, 0)
+	}()
+	waitForGen(t, m, 1)
+	bOK, bErr := m.RebuildPublished(bravo, 0)
+	close(bPublished)
+	<-done
+
+	if bErr != nil || !bOK {
+		t.Errorf("newer build: published=%v err=%v, want true, nil", bOK, bErr)
+	}
+	if aErr != nil || aPublished {
+		t.Errorf("superseded build: published=%v err=%v, want false, nil", aPublished, aErr)
+	}
+}
+
 // TestRebuildCleansUpSupersededDirectories: each successful Rebuild removes the
 // previous generation's directory, so a long-lived matcher never accumulates
 // stale index dirs.

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -130,6 +130,15 @@ type RowRetentionPort interface {
 	PruneAgedRows(ctx context.Context, now, cutoff time.Time) (domain.PruneCounts, error)
 }
 
+// KnowledgeFingerprinter is implemented by stores that can digest the rows
+// the semantic match index is built from (signature_embeddings), so the daemon
+// can skip a rebuild when a fleet pull moved nothing the index reads. Optional:
+// absent — or on an error — the daemon rebuilds on every refresh, as it always
+// did. Equal digests must mean identical rows; the value is otherwise opaque.
+type KnowledgeFingerprinter interface {
+	SignatureEmbeddingsFingerprint(ctx context.Context) (string, error)
+}
+
 // VisiblePaneReader is implemented by Herdr adapters that can read the pane's
 // current on-screen content (as opposed to ReadPane's consuming "recent"
 // delta). Used to recover a standing numbered menu when delivering an

--- a/internal/store/fingerprint_test.go
+++ b/internal/store/fingerprint_test.go
@@ -1,0 +1,129 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// TestSignatureEmbeddingsFingerprintTracksEveryIndexedColumn: the daemon skips
+// a semantic-index rebuild when this digest has not moved, so a change it
+// misses is a rule that never becomes matchable (or never stops matching).
+// Every mutation below must move it, and re-reading must not.
+func TestSignatureEmbeddingsFingerprintTracksEveryIndexedColumn(t *testing.T) {
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+	at := time.Unix(1_700_000_000, 0)
+	row := func(sig string, mut func(*domain.SignatureEmbedding)) domain.SignatureEmbedding {
+		e := domain.SignatureEmbedding{
+			Signature: sig, SituationType: domain.SituationApproval, AgentType: "claude",
+			Model: "m1", Dims: 2, Vector: []float32{0.5, 0.25},
+			Salient: "permission:" + sig + " | options:no;yes", CreatedAt: at,
+		}
+		if mut != nil {
+			mut(&e)
+		}
+		return e
+	}
+	fp := func() string {
+		t.Helper()
+		got, err := s.SignatureEmbeddingsFingerprint(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got == "" {
+			t.Fatal("the digest must never be empty: the daemon reads \"\" as unknown")
+		}
+		return got
+	}
+	upsert := func(e domain.SignatureEmbedding) {
+		t.Helper()
+		if err := s.UpsertSignatureEmbedding(ctx, e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	empty := fp()
+	prev := empty
+	steps := []struct {
+		name string
+		do   func()
+	}{
+		{"insert a row", func() { upsert(row("a", nil)) }},
+		{"insert a second row", func() { upsert(row("b", nil)) }},
+		{"re-embed under another model", func() { upsert(row("a", func(e *domain.SignatureEmbedding) { e.Model = "m2" })) }},
+		{"same-length vector, different values", func() {
+			upsert(row("a", func(e *domain.SignatureEmbedding) { e.Model = "m2"; e.Vector = []float32{0.5, 0.75} }))
+		}},
+		{"strip the vector", func() {
+			upsert(row("a", func(e *domain.SignatureEmbedding) { e.Model, e.Dims, e.Vector = "", 0, nil }))
+		}},
+		{"rewrite the salient", func() {
+			upsert(row("a", func(e *domain.SignatureEmbedding) {
+				e.Model, e.Dims, e.Vector = "", 0, nil
+				e.Salient = "permission:a | options:no;yes;always"
+			}))
+		}},
+		{"delete a row", func() {
+			dropEmbedding(t, s, "b")
+		}},
+	}
+	for _, st := range steps {
+		st.do()
+		got := fp()
+		if got == prev {
+			t.Fatalf("%s: the digest did not move — a rebuild would be skipped over a changed index", st.name)
+		}
+		if again := fp(); again != got {
+			t.Fatalf("%s: re-reading moved the digest (%s → %s) — every refresh would rebuild", st.name, got, again)
+		}
+		prev = got
+	}
+
+	dropEmbedding(t, s, "a")
+	if got := fp(); got != empty {
+		t.Errorf("an emptied table digests %s, want the empty table's %s", got, empty)
+	}
+}
+
+// dropEmbedding removes one semantic identity row the way a peer's rule
+// deletion arrives through a pull: the embedding row alone.
+func dropEmbedding(t *testing.T, s *Store, sig string) {
+	t.Helper()
+	if _, err := s.db.ExecContext(context.Background(),
+		`DELETE FROM signature_embeddings WHERE signature = ?`, sig); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSignatureEmbeddingsFingerprintIgnoresInsertionOrder: two nodes that
+// received the same rules in a different order hold the same index, so they
+// must not read each other's state as changed.
+func TestSignatureEmbeddingsFingerprintIgnoresInsertionOrder(t *testing.T) {
+	ctx := context.Background()
+	at := time.Unix(1_700_000_000, 0)
+	rows := []domain.SignatureEmbedding{
+		{Signature: "x", SituationType: domain.SituationChoice, AgentType: "codex", Salient: "options:no;yes", CreatedAt: at},
+		{Signature: "y", SituationType: domain.SituationApproval, AgentType: "claude", Model: "m", Dims: 1,
+			Vector: []float32{1}, Salient: "permission:y | options:", CreatedAt: at.Add(time.Second)},
+	}
+	digest := func(order ...int) string {
+		t.Helper()
+		s, _ := openTestStore(t)
+		for _, i := range order {
+			if err := s.UpsertSignatureEmbedding(ctx, rows[i]); err != nil {
+				t.Fatal(err)
+			}
+		}
+		fp, err := s.SignatureEmbeddingsFingerprint(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return fp
+	}
+	if a, b := digest(0, 1), digest(1, 0); a != b {
+		t.Errorf("insertion order moved the digest: %s vs %s", a, b)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -753,6 +753,52 @@ func (s *Store) ListSignatureEmbeddings(ctx context.Context) ([]domain.Signature
 	return out, rows.Err()
 }
 
+// SignatureEmbeddingsFingerprint digests every column of every row the
+// semantic index is built from, so the daemon can tell a fleet pull that moved
+// a rule apart from one that only moved bookkeeping (see
+// ports.KnowledgeFingerprinter). The vector BYTES are hashed too, not just
+// their length: the read costs a few milliseconds against a rebuild costing
+// hundreds, and "same length, different vector" is then never a question.
+//
+// Each field is length-prefixed so no two different rows can serialize to the
+// same bytes, and the order is by signature, the primary key, so the digest
+// does not depend on insertion order.
+func (s *Store) SignatureEmbeddingsFingerprint(ctx context.Context) (string, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT signature, situation_type, agent_type, model, dims, vector, salient, created_at
+		FROM signature_embeddings ORDER BY signature`)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	h := sha256.New()
+	var n [binary.MaxVarintLen64]byte
+	field := func(b []byte) {
+		h.Write(n[:binary.PutUvarint(n[:], uint64(len(b)))])
+		h.Write(b)
+	}
+	for rows.Next() {
+		var sig, st, agent, model, salient string
+		var dims, created int64
+		var blob []byte
+		if err := rows.Scan(&sig, &st, &agent, &model, &dims, &blob, &salient, &created); err != nil {
+			return "", err
+		}
+		field([]byte(sig))
+		field([]byte(st))
+		field([]byte(agent))
+		field([]byte(model))
+		field(binary.AppendVarint(nil, dims))
+		field(blob)
+		field([]byte(salient))
+		field(binary.AppendVarint(nil, created))
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
 // CountSignatureEmbeddings reports how many semantic identity rows exist.
 func (s *Store) CountSignatureEmbeddings(ctx context.Context) (int64, error) {
 	var n int64


### PR DESCRIPTION
## Why

Under `database.engine = "turso"` nearly every fleet pull reports a change (heartbeats, roster, echoed pushes), and `fleetPull` → `RefreshKnowledge` rebuilt the **whole** bleve+FAISS semantic index from the store on each one. On an idle devbox (sync=5s, ~785 signatures) the daemon logged `semantic matching ready` ~200 times in 17 minutes.

## What

- **Rebuild gate** — new optional `ports.KnowledgeFingerprinter` (`Store.SignatureEmbeddingsFingerprint`: sha256 over every `signature_embeddings` column incl. vector bytes, length-prefixed, PK order). `RefreshKnowledge` skips the rebuild when the digest equals the one the *published* index was built from.
  - Recorded only after `Matcher.RebuildPublished` confirms this build is the live one (a superseded `Rebuild` returns nil, indistinguishable from success).
  - Recorded only for a complete build, or when the embedder is down for good (nil / latched `Degraded()`); a transiently degraded text-only build keeps retrying.
  - Cleared by every reload, in the same critical section as the generation bump.
  - `invalidateRerank()` stays **unconditional** — the verdict cache keys on rule state this digest does not cover (follow-up below).
- **`hap stream orchestrator`** — a caught-up stream stops re-reading the log's floor on every empty poll (re-checked every 60s and after any batch or failed check), and backs off 500ms → 2s after 30s without events.

## Before / after — live A/B on the same devbox and herd

Same herd (2 agents, no TUI, turso sync=5s, 786 signatures), back-to-back, each daemon sampled with the same script: 120 one-second `top` samples starting ~1.5 min after start, **both with the embedding model loaded** (`semantic matching ready (786 signatures, all-minilm-l6-v2-q8_0.gguf)`, no DEGRADED line).

| | release v0.9.10 | this branch |
|---|---|---|
| daemon CPU, avg of 120×1s | 1.86% | **0.42%** |
| daemon CPU, max 1s sample | 39% | **7%** |
| 1s samples ≥ 10% (the 5s rebuild bursts) | 7 | **0** |
| semantic-index rebuilds in the 120s window | 6 | **0** |
| daemon RSS / HWM (fresh, ~3 min) | 146MB / 149MB | 87MB / 126MB |
| embed-worker RSS | 69MB | 71MB |

**Correction:** an earlier revision of this table showed an "after" RSS of 123MB and CPU of 0.4% taken from a linked dev worktree that had **no `models/`** (gitignored, fetched only by `install.sh`), so that daemon ran with the embedder DEGRADED and no vector index. Those numbers were confounded and are replaced by the A/B above. The baseline file's release figures (avg ~6–8%, ~30% bursts every 5s) were taken earlier under a busier herd.

With a `hap tui` open the daemon still sits much higher (its 2s poll through the store proxy plus the 2s roster tick) — untouched here, tracked separately.

## Tests

- `internal/daemon/knowledge_test.go` — skip on unchanged rows (and rerank still invalidated), rebuild on a peer rule, retry after a failed rebuild, reload never skipped, superseded generation refused, transient vs latched degraded embedder, no-port control.
- `internal/match` — `RebuildPublished` reports a superseded build.
- `internal/store/fingerprint_test.go` — every indexed column moves the digest; insertion order does not (sqlite / proxy / turso modes).
- `internal/cli/stream_idle_test.go` — idle reads skip the floor query; gap recheck bounds a settled stream (with an hour-long control); a failed check is not settled; back-off still delivers.
- Mutation-checked: removing the recheck clause, the `checkErr` clause, the publish generation check, or the degraded guard each fails a test.
- Full suite green; `TestALockedMigrationStepLosesTheLeaseAndFailsClosed` (turso schema lease, untouched package) flaked once under parallel load and passed 5/5 alone. Local integration suite: 10 pass, 10 skip, 0 fail.

## Follow-up

Every pull still invalidates in-flight LLM re-rank verdicts, so under turso the judge subprocess mostly runs for nothing — next PR gives the verdict cache its own fingerprint over `signatures`/`decisions`.
