### PR TITLE
#0 perf: keep re-rank verdicts across quiet pulls, add a profiling hook, trim idle daemon loops

### DIFF
--- a/.claude/skills/hap-development-local/SKILL.md
+++ b/.claude/skills/hap-development-local/SKILL.md
@@ -67,8 +67,25 @@ repo root. But repointing it means `hap status` / `hap daemon --ensure` in any
 shell hit your dev build, which is what you usually want.
 
 To go back to the released plugin later: `herdr plugin unlink herd-auto-prompter`
-then `herdr plugin install 0xGosu/herdr-auto-pilot` (and repoint or remove the
-symlink).
+then `herdr plugin install 0xGosu/herdr-auto-pilot --yes` (and repoint or remove
+the symlink).
+
+### GOTCHA: give the linked tree its embedding model
+
+`models/*.gguf` is gitignored and fetched only by `scripts/install.sh`, which
+`link` never runs — so a fresh checkout or worktree has **no `models/`**, and a
+daemon started from it runs with the embedder DEGRADED (text matching only, no
+vector index). Nothing fails loudly; `hap status` says so and the log repeats
+`embedder unavailable … stat <tree>/models/all-minilm-l6-v2-q8_0.gguf: no such
+file`. Any CPU or memory number taken that way is not comparable with a release.
+Borrow the installed copy before the first swap, and add it to the shared exclude
+(the `models/` ignore rule does not match a symlink):
+
+```bash
+ln -s ~/.config/herdr/plugins/github/herd-auto-prompter-*/models /workspaces/<tree>/models
+echo /models >> "$(git rev-parse --git-common-dir)/info/exclude"
+hap status | grep -i degraded   # must print nothing once the daemon restarted
+```
 
 ## the iteration loop (every code change)
 
@@ -249,6 +266,7 @@ classification. cross-check the shape:
 |---|---|
 | link working tree | `herdr plugin link /workspaces/herdr-auto-pilot` |
 | fix PATH symlink (once) | `ln -sf /workspaces/herdr-auto-pilot/bin/hap /usr/local/bin/hap` |
+| give the tree its model (once) | `ln -s ~/.config/herdr/plugins/github/herd-auto-prompter-*/models <tree>/models` |
 | rebuild | `go build -tags "vectors cpu" -o bin/hap ./cmd/hap` |
 | hot-swap daemon | `hap daemon --ensure` |
 | confirm swap | `hap status` → `running dev` |
@@ -263,3 +281,5 @@ classification. cross-check the shape:
 - **the daemon does not hot-reload** — always `hap daemon --ensure` after a rebuild.
 - **omitting `vectors cpu` breaks the build** — both tags always.
 - **`dev` is the tell** — a `dev` version = your local build; a `vX.Y.Z` version = a release.
+- **a linked tree has no embedding model** — symlink the installed `models/` in, or the dev
+  daemon runs DEGRADED and every measurement against a release is confounded.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,10 @@ golangci-lint run --build-tags "vectors,cpu"
 - Golden classifier fixtures: `internal/classify/testdata/`; regenerate with
   `UPDATE_GOLDEN=1 go test ./internal/classify/` and review the diff.
 - Run the full suite before every commit that touches Go code.
+- Profiling (opt-in, any verb): `HAP_PROFILE_DIR=<dir> [HAP_PROFILE_SECONDS=60] hap daemon --restart` writes
+  ROLLING `<verb>-<pid>.cpu.pprof` / `.heap.pprof` windows (`internal/profiling`) — the files are always the latest
+  complete window, so an idle daemon hours in can be read with `go tool pprof -top bin/hap <file>`. The detached
+  daemon inherits the environment; nothing is written or listened on when the variable is unset.
 - Pipeline smoke test (fake herdr → real daemon → real LLM CLI):
   `go build -o /tmp/e2e ./e2e_harness && /tmp/e2e <short-dir> <hap-bin> <config-dir> <state-dir>`.
 
@@ -951,9 +955,16 @@ above it is listed for a one-shot CLI returning `[{"id": n, "score": s}]` by rel
   does mean nothing to cancel.
 - **The verdict cache keys on the RENDERED listing, never the candidate signatures** — the listing carries each
   rule's `TopAction`/`Confidence`/`Mode`/`Decisions`, which is what makes the judge say "reuse this", and all
-  of those move under an UNCHANGED signature set every time a decision is recorded. Cleared on ANY reload and
-  on `RefreshKnowledge`, unconditionally — never gated on a section compare, or turning the judge off and on
-  again resurrects its old answers.
+  of those move under an UNCHANGED signature set every time a decision is recorded. Cleared on ANY reload
+  unconditionally — never gated on a section compare, or turning the judge off and on again resurrects its old
+  answers.
+- **A fleet pull retires verdicts only when the listing's INPUTS moved** (`invalidateRerankForKnowledge`). Under
+  turso nearly every pull reports a change, and bumping on each one retired almost every in-flight judge run — the
+  subprocess ran for nothing. The digest must cover EVERYTHING the listing reads: the candidate rows
+  (`SignatureEmbeddingsFingerprint`) AND the learned state (`RuleStateFingerprint`: mode, decision floor, decision
+  count + max id). This is not the forbidden "nothing to invalidate" fast path — that asks whether a verdict
+  EXISTS, this asks whether the QUESTION changed — and the compare and the bump share one hold of `mu`. Either
+  digest unknown invalidates. A change made on THIS node is caught by the next pull's digest, as before.
 
 `match.VectorCandidates` exists for this and re-expresses `MatchVector` rather than duplicating it:
 `MatchVector`'s "return the first accepted candidate" is sound only because the list is in descending cosine —
@@ -1088,6 +1099,7 @@ where the behaviour could revert.
 | `internal/selfpath` | resolves a live `hap` binary (an upgrade unlinks the running one) |
 | `internal/tuisession` | flock registry of live `hap tui` processes; closes the oldest past `[tui] max_instances` |
 | `internal/streamlog` | machine-local SQLite event log behind `hap stream orchestrator` (its own file, NOT a store table) |
+| `internal/profiling` | opt-in rolling CPU/heap profiles (`HAP_PROFILE_DIR`); files only, no listener |
 | `internal/updatecheck` | GitHub release check — one of exactly TWO `net/http` importers (NFR-007 allowlist) |
 | `internal/fakeherdr`, `e2e_harness/` | test fakes and the e2e driver |
 | `docs/architect/herd-auto-prompter-architecture.md` | consolidated architecture doc (FR-xxx / NFR-xxx ids used in comments) |

--- a/changelog.d/perf-daemon-idle-cpu.md
+++ b/changelog.d/perf-daemon-idle-cpu.md
@@ -1,0 +1,3 @@
+- Fixed the LLM re-rank judge's in-flight answers being thrown away on nearly every Turso pull: a pull now retires them only when it actually changed the rules, their learned state or their decision history, so under turso the judge's subprocess no longer mostly runs for nothing
+- Reduced the idle daemon's CPU further: the per-pull check for changed rules no longer reads every stored vector, and with no local TUI open the roster tick asks the store whether a remote TUI is watching at most once per 15s instead of every 2s
+- Added an opt-in profiling hook: set `HAP_PROFILE_DIR` (and optionally `HAP_PROFILE_SECONDS`, default 60) and any hap process writes rolling CPU and heap profiles there for `go tool pprof`; nothing is written or listened on when it is unset

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/logging"
 	"github.com/0xGosu/herdr-auto-pilot/internal/mcpserver"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/profiling"
 	"github.com/0xGosu/herdr-auto-pilot/internal/selfpath"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store/sqlbridge"
@@ -108,7 +109,13 @@ func main() {
 		return
 	}
 
-	if err := run(verb, args); err != nil {
+	// Opt-in (HAP_PROFILE_DIR); a no-op otherwise. Stopped by hand rather than
+	// deferred, because os.Exit below skips defers and the last window is the
+	// one a short command is profiled for.
+	stopProfile := profiling.FromEnv(verb)
+	err := run(verb, args)
+	stopProfile()
+	if err != nil {
 		// `hap status` on an unhealthy daemon already printed the human detail;
 		// exit non-zero for scripts without a redundant "error:" line.
 		if !errors.Is(err, cli.ErrUnhealthy) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -386,6 +386,10 @@ type Daemon struct {
 	rerankGen        uint64
 	rerankCache      map[string][]domain.RerankResult
 	rerankCacheOrder []string
+	// rerankKnowledge is the rule-knowledge digest (candidate rows plus learned
+	// state) at the last knowledge-driven invalidation ("" = unknown). A fleet
+	// pull invalidates only when it moved; see invalidateRerankForKnowledge.
+	rerankKnowledge string
 
 	// sweepInFlight dedupes the one live multi-tab form sweep per agent
 	// (guarded by mu); outcomes return through sweepResults.
@@ -465,6 +469,10 @@ type Daemon struct {
 	// rosterRemoteAt is when the roster was last published FOR A REMOTE
 	// watcher (guarded by mu); see remoteRosterInterval.
 	rosterRemoteAt time.Time
+	// rosterWatchersAt / rosterWatched cache the store's RemoteWatchers answer
+	// for remoteRosterInterval (see remoteWatched); guarded by mu.
+	rosterWatchersAt time.Time
+	rosterWatched    bool
 
 	// fleet is the sync loop's state for the health record (own mutex).
 	fleet fleetSyncState

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -658,6 +658,16 @@ func (s *failingStore) SignatureEmbeddingsFingerprint(ctx context.Context) (stri
 	return kf.SignatureEmbeddingsFingerprint(ctx)
 }
 
+// RuleStateFingerprint forwards ports.RuleStateFingerprinter likewise: without
+// it every refresh in the suite retires the in-flight re-rank verdicts.
+func (s *failingStore) RuleStateFingerprint(ctx context.Context) (string, error) {
+	rf, ok := s.StorePort.(ports.RuleStateFingerprinter)
+	if !ok {
+		return "", errors.New("wrapped store cannot fingerprint rule state")
+	}
+	return rf.RuleStateFingerprint(ctx)
+}
+
 // PruneAuditExcerpts, FreelistPages and Vacuum forward ports.RetentionPort for
 // the same reason. All three are needed together: the daemon asserts the
 // interface, not the methods.

--- a/internal/daemon/fleet_test.go
+++ b/internal/daemon/fleet_test.go
@@ -233,6 +233,13 @@ func TestRemoteWatcherRaisesRosterCadenceToTheSyncInterval(t *testing.T) {
 	if err := other.StampWatching(context.Background(), time.Now().Add(30*time.Second)); err != nil {
 		t.Fatal(err)
 	}
+	// The store is asked at most once per remoteRosterInterval — the 2s tick
+	// asks on the select loop — so inside it the cached answer stands...
+	if lvl := d.rosterDemandLevel(); lvl != rosterDemandNone {
+		t.Fatalf("demand inside the cache interval = %v, want the cached none", lvl)
+	}
+	// ...and once it lapses the remote watcher is seen.
+	expireRemoteWatchers(d)
 	if lvl := d.rosterDemandLevel(); lvl != rosterDemandRemote {
 		t.Fatalf("demand with a remote TUI watching = %v, want remote", lvl)
 	}
@@ -263,9 +270,18 @@ func TestRemoteWatcherRaisesRosterCadenceToTheSyncInterval(t *testing.T) {
 	if err := other.StampWatching(context.Background(), time.Now().Add(-time.Second)); err != nil {
 		t.Fatal(err)
 	}
+	expireRemoteWatchers(d)
 	if lvl := d.rosterDemandLevel(); lvl != rosterDemandNone {
 		t.Fatalf("demand with an expired remote stamp = %v, want none", lvl)
 	}
+}
+
+// expireRemoteWatchers lapses the cached RemoteWatchers answer, standing in
+// for remoteRosterInterval passing.
+func expireRemoteWatchers(d *Daemon) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.rosterWatchersAt = time.Time{}
 }
 
 // nudgeDaemon wakes the daemon over its control socket, the way a front end

--- a/internal/daemon/knowledge_test.go
+++ b/internal/daemon/knowledge_test.go
@@ -41,6 +41,18 @@ func (s fingerprintingStore) SignatureEmbeddingsFingerprint(ctx context.Context)
 	return s.StorePort.(ports.KnowledgeFingerprinter).SignatureEmbeddingsFingerprint(ctx)
 }
 
+func (s fingerprintingStore) RuleStateFingerprint(ctx context.Context) (string, error) {
+	return s.StorePort.(ports.RuleStateFingerprinter).RuleStateFingerprint(ctx)
+}
+
+// embeddingsOnlyStore offers the rebuild digest but not the rule-state one:
+// the control for the verdict gate.
+type embeddingsOnlyStore struct{ *countingEmbeddingsStore }
+
+func (s embeddingsOnlyStore) SignatureEmbeddingsFingerprint(ctx context.Context) (string, error) {
+	return s.StorePort.(ports.KnowledgeFingerprinter).SignatureEmbeddingsFingerprint(ctx)
+}
+
 // latchedEmbedder is an embedder whose failure latch has tripped: a degraded
 // build is the best it will do until a reload.
 type latchedEmbedder struct{ *fakeEmbedder }
@@ -48,9 +60,22 @@ type latchedEmbedder struct{ *fakeEmbedder }
 func (latchedEmbedder) Degraded() bool { return true }
 
 // knowledgeHarness is semanticHarness over a counting store; fingerprint
-// selects whether the store offers the optional digest. It returns once the
+// selects whether the store offers both optional digests. It returns once the
 // startup build has published (semanticReady is set after publishKnowledge).
 func knowledgeHarness(t *testing.T, emb ports.EmbedderPort, fingerprint bool) (*Daemon, *countingEmbeddingsStore) {
+	t.Helper()
+	return knowledgeHarnessWith(t, emb, func(c *countingEmbeddingsStore) ports.StorePort {
+		if fingerprint {
+			return fingerprintingStore{c}
+		}
+		return c
+	})
+}
+
+// knowledgeHarnessWith is knowledgeHarness with the store wrapper chosen by
+// the caller, for the capabilities between "both digests" and "neither".
+func knowledgeHarnessWith(t *testing.T, emb ports.EmbedderPort,
+	wrap func(*countingEmbeddingsStore) ports.StorePort) (*Daemon, *countingEmbeddingsStore) {
 	t.Helper()
 	dir := t.TempDir()
 	raw, err := store.Open(filepath.Join(dir, "test.db"))
@@ -59,10 +84,7 @@ func knowledgeHarness(t *testing.T, emb ports.EmbedderPort, fingerprint bool) (*
 	}
 	t.Cleanup(func() { raw.Close() })
 	counting := &countingEmbeddingsStore{StorePort: raw}
-	var st ports.StorePort = counting
-	if fingerprint {
-		st = fingerprintingStore{counting}
-	}
+	st := wrap(counting)
 	d, err := New(Options{
 		ConfigPath:        filepath.Join(dir, "config.toml"),
 		ControlSocketPath: filepath.Join(testutil.SocketDir(t), "c.sock"),
@@ -136,8 +158,8 @@ func matchable(t *testing.T, d *Daemon, e domain.SignatureEmbedding) bool {
 
 // TestRefreshKnowledgeSkipsTheRebuildWhenNoRuleMoved is the CPU regression
 // guard: under turso nearly every pull reports a change, and rebuilding the
-// whole index on each one kept an idle node busy. Invalidation must still run
-// every time — the verdict cache keys on rule STATE the digest does not cover.
+// whole index on each one kept an idle node busy. Nothing moved, so the
+// re-rank verdicts survive too (see rerankknowledge_test.go).
 func TestRefreshKnowledgeSkipsTheRebuildWhenNoRuleMoved(t *testing.T) {
 	d, st := knowledgeHarness(t, &fakeEmbedder{}, true)
 	peerRule(t, st, "deploy")
@@ -154,8 +176,8 @@ func TestRefreshKnowledgeSkipsTheRebuildWhenNoRuleMoved(t *testing.T) {
 	if got := st.loads.Load(); got != loads {
 		t.Errorf("index loaded %d more time(s) on refreshes that changed no rule", got-loads)
 	}
-	if got := currentRerankGen(d); got != rr+3 {
-		t.Errorf("rerank generation = %d, want %d: invalidation must not be gated on the digest", got, rr+3)
+	if got := currentRerankGen(d); got != rr {
+		t.Errorf("rerank generation moved %d → %d on refreshes that changed no rule", rr, got)
 	}
 }
 

--- a/internal/daemon/rerank.go
+++ b/internal/daemon/rerank.go
@@ -457,12 +457,13 @@ func (d *Daemon) storeRerankVerdictLocked(key string, v []domain.RerankResult) {
 // and cannot have this shape: it is keyed on one agent, and a missing entry
 // there really does mean there is nothing to cancel.
 //
-// It is called on ANY reload and on RefreshKnowledge, unconditionally — never
-// gated on a section comparison the way reloadEmbedder's port swap is on
-// prev.Embedding != next.Embedding. Turning the judge off and on again, editing
-// its prompt, changing the threshold, or pulling rules learned on another
-// machine all change what the judge would answer, and a verdict that survived
-// any of them would keep answering the old question.
+// It is called on ANY reload unconditionally — never gated on a section
+// comparison the way reloadEmbedder's port swap is on prev.Embedding !=
+// next.Embedding. Turning the judge off and on again, editing its prompt, or
+// changing the threshold all change what the judge would answer, and a verdict
+// that survived any of them would keep answering the old question. A fleet
+// pull goes through invalidateRerankForKnowledge instead, which bumps whenever
+// the rule knowledge a listing is rendered from has moved.
 //
 // The two halves are one operation on purpose. Clearing only the cache leaves
 // the hole open in its most confusing form: a run started under the old regime
@@ -478,11 +479,66 @@ func (d *Daemon) storeRerankVerdictLocked(key string, v []domain.RerankResult) {
 func (d *Daemon) invalidateRerank() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	d.invalidateRerankLocked()
+}
+
+// invalidateRerankLocked is invalidateRerank's body; the caller holds mu.
+func (d *Daemon) invalidateRerankLocked() {
 	if len(d.rerankCache) > 0 {
 		d.rerankCache = map[string][]domain.RerankResult{}
 		d.rerankCacheOrder = nil
 	}
 	d.rerankGen++
+}
+
+// invalidateRerankForKnowledge is RefreshKnowledge's invalidation. It retires
+// every verdict only when the rule knowledge a candidate listing is rendered
+// from has moved since the last time it did: the candidate rows (emb, the
+// signature_embeddings digest) or the learned state the listing describes them
+// by (state, see ports.RuleStateFingerprinter). Under turso nearly every pull
+// reports a change, so bumping on each one retired almost every in-flight
+// judge run — the subprocess ran for nothing and the herd got the cosine
+// answer anyway. Either digest unknown ("") invalidates, which is the old
+// behaviour.
+//
+// This is NOT the "nothing to invalidate" fast path invalidateRerank rules out.
+// That one asks whether any verdict EXISTS, which a verdict in transit
+// defeats; this asks whether the QUESTION changed, and a verdict judged
+// against unmoved knowledge answers the question it was asked. The comparison
+// and the bump share one hold of mu, like commitRerankVerdict.
+//
+// A change this node made itself (a decision recorded here) is caught by the
+// next pull's digest just the same — the digest covers every node's rows — so
+// no source of change is lost relative to invalidating on every pull; only
+// pulls that moved nothing stop costing verdicts.
+func (d *Daemon) invalidateRerankForKnowledge(emb, state string) {
+	known := emb != "" && state != ""
+	digest := emb + "\x00" + state
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if known && d.rerankKnowledge == digest {
+		return
+	}
+	d.rerankKnowledge = ""
+	if known {
+		d.rerankKnowledge = digest
+	}
+	d.invalidateRerankLocked()
+}
+
+// ruleStateFingerprint digests the learned rule state a candidate listing
+// renders, or "" when the store cannot say — which invalidates.
+func (d *Daemon) ruleStateFingerprint(ctx context.Context) string {
+	rf, ok := d.opt.Store.(ports.RuleStateFingerprinter)
+	if !ok {
+		return ""
+	}
+	fp, err := rf.RuleStateFingerprint(ctx)
+	if err != nil {
+		slog.Debug("rule-state fingerprint unavailable; invalidating re-rank verdicts", "error", err)
+		return ""
+	}
+	return fp
 }
 
 // commitRerankVerdict is the LINEARIZATION POINT this feature's invalidation

--- a/internal/daemon/rerankknowledge_test.go
+++ b/internal/daemon/rerankknowledge_test.go
@@ -1,0 +1,115 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+)
+
+// TestAPullThatMovedNoRuleKeepsInFlightVerdicts is the regression guard for the
+// wasted judge: under turso nearly every pull reports a change, and retiring
+// every in-flight verdict on each one meant the re-rank subprocess mostly ran
+// for nothing. A pull that moved nothing a listing reads must leave them be.
+func TestAPullThatMovedNoRuleKeepsInFlightVerdicts(t *testing.T) {
+	d, _ := knowledgeHarness(t, &fakeEmbedder{}, true)
+	d.RefreshKnowledge() // the first digest is unknown, so this one invalidates
+	gen := currentRerankGen(d)
+	for range 3 {
+		d.RefreshKnowledge()
+	}
+	if got := currentRerankGen(d); got != gen {
+		t.Errorf("rerank generation moved %d → %d on pulls that changed no rule", gen, got)
+	}
+	if !d.commitRerankVerdict(gen, "k", []domain.RerankResult{{ID: 1, Score: 1}}) {
+		t.Error("a verdict judged against unmoved knowledge was refused")
+	}
+}
+
+// TestAPullThatMovedRuleKnowledgeRetiresVerdicts: every input the candidate
+// listing renders — the candidate rows, a rule's mode, its decision history —
+// is a changed question, and a verdict judged before it must not commit. Each
+// change retires ONCE; the pull after it is quiet again.
+func TestAPullThatMovedRuleKnowledgeRetiresVerdicts(t *testing.T) {
+	ctx := context.Background()
+	at := time.Unix(1_700_000_000, 0)
+	rule := domain.SignatureState{
+		Signature: "approval:peer-graduate", SituationType: domain.SituationApproval,
+		AgentType: "claude", Mode: domain.Mode("shadow"), UpdatedAt: at,
+	}
+	for _, tc := range []struct {
+		name string
+		move func(t *testing.T, st ports.StorePort)
+	}{
+		{"a peer's rule arrives", func(t *testing.T, st ports.StorePort) { peerRule(t, st, "rotate the logs") }},
+		{"a decision is recorded", func(t *testing.T, st ports.StorePort) {
+			if _, err := st.RecordDecision(ctx, domain.DecisionRecord{
+				Signature: rule.Signature, SituationType: rule.SituationType, AgentType: rule.AgentType,
+				ChosenAction: "1", CreatedAt: at,
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"a rule graduates", func(t *testing.T, st ports.StorePort) {
+			grad := rule
+			grad.Mode = domain.Mode("autonomous")
+			if err := st.UpsertSignature(ctx, grad); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, st := knowledgeHarness(t, &fakeEmbedder{}, true)
+			if err := st.UpsertSignature(ctx, rule); err != nil {
+				t.Fatal(err)
+			}
+			d.RefreshKnowledge()
+			gen := currentRerankGen(d)
+
+			tc.move(t, st)
+			d.RefreshKnowledge()
+			if got := currentRerankGen(d); got != gen+1 {
+				t.Fatalf("rerank generation = %d, want %d: the question changed", got, gen+1)
+			}
+			if d.commitRerankVerdict(gen, "k", nil) {
+				t.Error("a verdict judged before the change was committed")
+			}
+			d.RefreshKnowledge()
+			if got := currentRerankGen(d); got != gen+1 {
+				t.Errorf("rerank generation = %d, want %d: the pull after the change moved nothing", got, gen+1)
+			}
+		})
+	}
+}
+
+// TestWithoutARuleStateDigestEveryPullRetiresVerdicts is the control: a store
+// that can digest the candidate rows but not the rule state keeps the old
+// behaviour, so the quiet pulls above are the gate's doing.
+func TestWithoutARuleStateDigestEveryPullRetiresVerdicts(t *testing.T) {
+	d, _ := knowledgeHarnessWith(t, &fakeEmbedder{}, func(c *countingEmbeddingsStore) ports.StorePort {
+		return embeddingsOnlyStore{c}
+	})
+	gen := currentRerankGen(d)
+	d.RefreshKnowledge()
+	d.RefreshKnowledge()
+	if got := currentRerankGen(d); got != gen+2 {
+		t.Errorf("rerank generation = %d, want %d: without a rule-state digest every pull must retire", got, gen+2)
+	}
+}
+
+// TestAReloadStillRetiresVerdictsOverUnmovedKnowledge: the gate belongs to
+// the PULL. A reload changes the judge's command, prompt or thresholds — a
+// different question over identical rules — and must retire regardless.
+func TestAReloadStillRetiresVerdictsOverUnmovedKnowledge(t *testing.T) {
+	d, _ := knowledgeHarness(t, &fakeEmbedder{}, true)
+	d.RefreshKnowledge()
+	gen := currentRerankGen(d)
+	if err := d.reloadWith(false); err != nil {
+		t.Fatal(err)
+	}
+	if got := currentRerankGen(d); got == gen {
+		t.Error("a reload did not retire the verdicts")
+	}
+}

--- a/internal/daemon/roster.go
+++ b/internal/daemon/roster.go
@@ -94,14 +94,33 @@ func (d *Daemon) rosterDemandLevel() rosterDemandLevel {
 			return rosterDemandLocal
 		}
 	}
-	// A read error is "nobody watching", as with the local registry: the
-	// event-driven path and the sweep still publish.
-	if d.opt.Store != nil && d.opt.Clock != nil {
-		if n, err := d.opt.Store.RemoteWatchers(context.Background(), d.opt.Clock.Now()); err == nil && n > 0 {
-			return rosterDemandRemote
-		}
+	if d.opt.Store != nil && d.opt.Clock != nil && d.remoteWatched(d.opt.Clock.Now()) {
+		return rosterDemandRemote
 	}
 	return rosterDemandNone
+}
+
+// remoteWatched reports whether another node's TUI watches the fleet, asking
+// the store at most once per remoteRosterInterval. The 2s roster tick asks on
+// the select loop, and with no local TUI — the common case — it used to run a
+// store query every tick for an answer that only paces a 15s publish: a remote
+// watcher is at most one interval late to be noticed, and its view arrives a
+// pull later anyway. A read error is "nobody watching", as with the local
+// registry: the event-driven path and the sweep still publish.
+func (d *Daemon) remoteWatched(now time.Time) bool {
+	d.mu.Lock()
+	if !d.rosterWatchersAt.IsZero() && now.Sub(d.rosterWatchersAt) < remoteRosterInterval {
+		watched := d.rosterWatched
+		d.mu.Unlock()
+		return watched
+	}
+	d.mu.Unlock()
+	n, err := d.opt.Store.RemoteWatchers(context.Background(), now)
+	watched := err == nil && n > 0
+	d.mu.Lock()
+	d.rosterWatchersAt, d.rosterWatched = now, watched
+	d.mu.Unlock()
+	return watched
 }
 
 // rosterShellOutTTLs returns the cwd and location TTLs for this pass.

--- a/internal/daemon/semantic.go
+++ b/internal/daemon/semantic.go
@@ -486,20 +486,22 @@ func remapAllowed(s domain.Situation, sig domain.SignatureResult, hit match.Hit)
 // input — the embedder's health at build time decides which of them get
 // vectors — so initSemantic records a digest only for a build that was
 // complete, or whose embedder is down for good (see embedderPermanentlyDown).
-// The verdict invalidation is NOT gated: the cache keys on rule STATE
-// (signatures, decisions), which the digest does not cover.
+// The verdict invalidation has a gate of its own over a WIDER digest — the
+// listing also reads rule state (signatures, decisions) — see
+// invalidateRerankForKnowledge.
 func (d *Daemon) RefreshKnowledge() {
 	if d.matcher == nil {
 		return
 	}
-	// Rules learned on other machines have just arrived, so the candidate set a
-	// verdict was judged against no longer describes what the matcher would
-	// return — and a rule the refresh DELETED may be the one a verdict names.
-	// Drop them all, in flight included, rather than reason about which are
-	// still answerable: a re-rank is one subprocess, a wrong reuse is a wrong
-	// rule.
-	d.invalidateRerank()
-	if d.knowledgeUnchanged(d.knowledgeFingerprint(d.shutdownCtx)) {
+	emb := d.knowledgeFingerprint(d.shutdownCtx)
+	// Rules learned on other machines may have just arrived, so the candidate
+	// set a verdict was judged against may no longer describe what the matcher
+	// would return — and a rule the refresh DELETED may be the one a verdict
+	// names. When anything a listing reads moved, drop every verdict, in flight
+	// included, rather than reason about which are still answerable: a re-rank
+	// is one subprocess, a wrong reuse is a wrong rule.
+	d.invalidateRerankForKnowledge(emb, d.ruleStateFingerprint(d.shutdownCtx))
+	if d.knowledgeUnchanged(emb) {
 		return
 	}
 	gen := d.semanticGen.Add(1)

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -139,6 +139,17 @@ type KnowledgeFingerprinter interface {
 	SignatureEmbeddingsFingerprint(ctx context.Context) (string, error)
 }
 
+// RuleStateFingerprinter is implemented by stores that can digest the learned
+// rule STATE a re-rank candidate listing renders (each rule's mode, decision
+// floor and decision history). With KnowledgeFingerprinter it lets the daemon
+// keep in-flight re-rank verdicts across a fleet pull that moved nothing a
+// listing reads. Optional, and separate so neither capability breaks a fake
+// implementing the other: absent — or on an error — every refresh invalidates,
+// as it always did.
+type RuleStateFingerprinter interface {
+	RuleStateFingerprint(ctx context.Context) (string, error)
+}
+
 // VisiblePaneReader is implemented by Herdr adapters that can read the pane's
 // current on-screen content (as opposed to ReadPane's consuming "recent"
 // delta). Used to recover a standing numbered menu when delivering an

--- a/internal/profiling/profiling.go
+++ b/internal/profiling/profiling.go
@@ -1,0 +1,183 @@
+// Package profiling is hap's opt-in CPU and heap profiling hook. Nothing here
+// runs unless the operator sets HAP_PROFILE_DIR, and it writes only to that
+// directory — no listener, no egress (net/http/pprof would be an HTTP server,
+// which internal/privacy bans for good reason).
+//
+// Profiles are ROLLING windows rather than one whole-process capture, because
+// the process worth profiling is usually a daemon that has been idle for
+// hours: every HAP_PROFILE_SECONDS the current CPU window is closed and
+// renamed into place, a heap snapshot is written beside it, and a new window
+// starts. The files on disk are therefore always the LATEST complete window,
+// and a process that exits finalizes the window it was in.
+//
+//	HAP_PROFILE_DIR=/tmp/hap-prof hap daemon --restart
+//	go tool pprof -top /tmp/hap-prof/daemon-<pid>.cpu.pprof
+package profiling
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// EnvDir switches profiling on and names the directory profiles go to.
+	EnvDir = "HAP_PROFILE_DIR"
+	// EnvWindow is the rolling window length in whole seconds.
+	EnvWindow = "HAP_PROFILE_SECONDS"
+	// DefaultWindow is the window when EnvWindow is unset.
+	DefaultWindow = 60 * time.Second
+)
+
+// FromEnv starts profiling for the process named name when HAP_PROFILE_DIR is
+// set, and returns the function that finalizes it; the function is a no-op
+// otherwise. A failure to start is reported on stderr and never fails the
+// command — profiling is a diagnostic, not a feature anything depends on.
+func FromEnv(name string) (stop func()) {
+	dir := os.Getenv(EnvDir)
+	if dir == "" {
+		return func() {}
+	}
+	window := DefaultWindow
+	if s := os.Getenv(EnvWindow); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil || n <= 0 {
+			fmt.Fprintf(os.Stderr, "hap: ignoring %s=%q (want whole seconds > 0); using %s\n", EnvWindow, s, window)
+		} else {
+			window = time.Duration(n) * time.Second
+		}
+	}
+	stop, err := Start(dir, name, window)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hap: profiling not started: %v\n", err)
+		return func() {}
+	}
+	return stop
+}
+
+// Start writes rolling CPU and heap profiles for this process into dir as
+// <name>-<pid>.cpu.pprof and <name>-<pid>.heap.pprof, closing a window every
+// window. The returned stop finalizes the current window; calling it more
+// than once is safe.
+func Start(dir, name string, window time.Duration) (stop func(), err error) {
+	if window <= 0 {
+		return nil, fmt.Errorf("profile window must be positive, got %s", window)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("profile dir: %w", err)
+	}
+	p := &profiler{base: filepath.Join(dir, fmt.Sprintf("%s-%d", fileSafe(name), os.Getpid()))}
+	if err := p.begin(); err != nil {
+		return nil, err
+	}
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		t := time.NewTicker(window)
+		defer t.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-t.C:
+				p.finish()
+				if err := p.begin(); err != nil {
+					slog.Warn("profiling: could not start the next CPU window; stopping", "error", err)
+					return
+				}
+			}
+		}
+	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			close(done)
+			<-finished
+			p.finish()
+		})
+	}, nil
+}
+
+// profiler owns one CPU window at a time. Only the rolling goroutine and, once
+// that goroutine has returned, stop ever touch it, so it needs no lock.
+type profiler struct {
+	base string
+	cpu  *os.File // the open window; nil between windows
+}
+
+func (p *profiler) begin() error {
+	f, err := os.Create(p.base + ".cpu.pprof.partial")
+	if err != nil {
+		return fmt.Errorf("create CPU profile: %w", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return fmt.Errorf("start CPU profile: %w", err)
+	}
+	p.cpu = f
+	return nil
+}
+
+// finish closes the open CPU window into place and writes a heap snapshot.
+// Errors are logged, never returned: a lost window must not end the process
+// or the next window.
+func (p *profiler) finish() {
+	if p.cpu != nil {
+		pprof.StopCPUProfile()
+		name := p.cpu.Name()
+		if err := p.cpu.Close(); err != nil {
+			slog.Warn("profiling: closing the CPU window failed", "error", err)
+		} else if err := os.Rename(name, p.base+".cpu.pprof"); err != nil {
+			slog.Warn("profiling: publishing the CPU window failed", "error", err)
+		}
+		p.cpu = nil
+	}
+	if err := writeHeap(p.base + ".heap.pprof"); err != nil {
+		slog.Warn("profiling: heap snapshot failed", "error", err)
+	}
+}
+
+// writeHeap snapshots the heap after a GC, so in-use figures describe what is
+// actually retained rather than garbage not yet collected, and renames the
+// file into place so a reader never sees a half-written snapshot.
+func writeHeap(path string) error {
+	runtime.GC()
+	tmp := path + ".partial"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	if err := pprof.Lookup("heap").WriteTo(f, 0); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// fileSafe keeps a process name usable as a file-name prefix: the verb comes
+// from the command line, so a separator in it must not escape the directory.
+func fileSafe(name string) string {
+	s := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		}
+		return '_'
+	}, name)
+	if s == "" {
+		return "hap"
+	}
+	return s
+}

--- a/internal/profiling/profiling_test.go
+++ b/internal/profiling/profiling_test.go
@@ -1,0 +1,121 @@
+package profiling
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"testing"
+	"time"
+)
+
+// CPU profiling is process-global, so none of these tests run in parallel.
+
+func burn(d time.Duration) {
+	x := 0
+	for end := time.Now().Add(d); time.Now().Before(end); {
+		x++
+	}
+	_ = x
+}
+
+// gzipped reports whether path holds a pprof file: gzip-compressed protobuf.
+func gzipped(t *testing.T, path string) bool {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(b) > 2 && bytes.Equal(b[:2], []byte{0x1f, 0x8b})
+}
+
+// cpuProfilingIdle reports whether nothing holds the process's CPU profiler.
+func cpuProfilingIdle() bool {
+	if err := pprof.StartCPUProfile(io.Discard); err != nil {
+		return false
+	}
+	pprof.StopCPUProfile()
+	return true
+}
+
+func TestFromEnvIsOffUnlessTheDirIsSet(t *testing.T) {
+	t.Setenv(EnvDir, "")
+	stop := FromEnv("daemon")
+	defer stop()
+	if !cpuProfilingIdle() {
+		t.Error("profiling started with HAP_PROFILE_DIR unset")
+	}
+}
+
+// TestStartWritesRollingWindows: a long-lived process must have a COMPLETE
+// window on disk while it is still running — that is the whole point of
+// rolling — and stop must finalize the one in progress and leave no partial
+// files behind.
+func TestStartWritesRollingWindows(t *testing.T) {
+	dir := t.TempDir()
+	stop, err := Start(dir, "daemon", 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := filepath.Join(dir, fmt.Sprintf("daemon-%d", os.Getpid()))
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		burn(20 * time.Millisecond)
+		if _, err := os.Stat(base + ".cpu.pprof"); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			stop()
+			t.Fatal("no completed CPU window appeared while the process ran")
+		}
+	}
+	stop()
+	stop() // idempotent
+
+	for _, p := range []string{base + ".cpu.pprof", base + ".heap.pprof"} {
+		if !gzipped(t, p) {
+			t.Errorf("%s is not a pprof file", p)
+		}
+	}
+	partials, _ := filepath.Glob(filepath.Join(dir, "*.partial"))
+	if len(partials) > 0 {
+		t.Errorf("stop left partial files behind: %v", partials)
+	}
+	if !cpuProfilingIdle() {
+		t.Error("stop did not release the CPU profiler")
+	}
+}
+
+// TestFromEnvDegradesWhenTheProfilerIsTaken: a second profiler in one process
+// (a test harness, a library) must cost the operator the profile, never the
+// command.
+func TestFromEnvDegradesWhenTheProfilerIsTaken(t *testing.T) {
+	if err := pprof.StartCPUProfile(io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	defer pprof.StopCPUProfile()
+	t.Setenv(EnvDir, t.TempDir())
+	stop := FromEnv("daemon")
+	stop()
+}
+
+func TestStartKeepsFilesInsideTheDir(t *testing.T) {
+	dir := t.TempDir()
+	stop, err := Start(dir, "../../escape", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop()
+	matches, _ := filepath.Glob(filepath.Join(dir, "*.pprof"))
+	if len(matches) != 2 {
+		t.Errorf("want the cpu and heap profile inside %s, got %v", dir, matches)
+	}
+}
+
+func TestStartRefusesANonPositiveWindow(t *testing.T) {
+	if _, err := Start(t.TempDir(), "daemon", 0); err == nil {
+		t.Error("a zero window was accepted")
+	}
+}

--- a/internal/store/rulestate_test.go
+++ b/internal/store/rulestate_test.go
@@ -1,0 +1,89 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// TestRuleStateFingerprintTracksWhatAListingReads: the daemon keeps in-flight
+// re-rank verdicts across a pull whose digest did not move, so every state a
+// candidate listing renders — a rule's mode, its decision floor, its decision
+// history — must move it, and state the listing never reads must not.
+func TestRuleStateFingerprintTracksWhatAListingReads(t *testing.T) {
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+	at := time.Unix(1_700_000_000, 0)
+	state := domain.SignatureState{
+		Signature: "approval:a", SituationType: domain.SituationApproval, AgentType: "claude",
+		Mode: domain.Mode("shadow"), UpdatedAt: at,
+	}
+	fp := func() string {
+		t.Helper()
+		got, err := s.RuleStateFingerprint(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got == "" {
+			t.Fatal("the digest must never be empty: the daemon reads \"\" as unknown")
+		}
+		return got
+	}
+	upsert := func(mut func(*domain.SignatureState)) {
+		t.Helper()
+		mut(&state)
+		if err := s.UpsertSignature(ctx, state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	decide := func() {
+		t.Helper()
+		if _, err := s.RecordDecision(ctx, domain.DecisionRecord{
+			Signature: state.Signature, SituationType: state.SituationType, AgentType: state.AgentType,
+			ChosenAction: "1", CreatedAt: at,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	prev := fp()
+	for _, st := range []struct {
+		name string
+		do   func()
+	}{
+		{"a rule is learned", func() { upsert(func(*domain.SignatureState) {}) }},
+		{"a decision is recorded", decide},
+		{"a second decision is recorded", decide},
+		{"the rule graduates", func() { upsert(func(s *domain.SignatureState) { s.Mode = domain.Mode("autonomous") }) }},
+		{"its history is reset", func() { upsert(func(s *domain.SignatureState) { s.DecisionFloorID = 99 }) }},
+		{"the rule is deleted", func() {
+			if _, err := s.DeleteSignature(ctx, state.Signature); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	} {
+		st.do()
+		got := fp()
+		if got == prev {
+			t.Fatalf("%s: the digest did not move — a verdict judged before it would survive", st.name)
+		}
+		if again := fp(); again != got {
+			t.Fatalf("%s: re-reading moved the digest — every pull would retire the verdicts", st.name)
+		}
+		prev = got
+	}
+
+	// The control: state no listing renders must not cost verdicts.
+	upsert(func(*domain.SignatureState) {})
+	base := fp()
+	upsert(func(s *domain.SignatureState) {
+		s.CachedConfidence = 0.42
+		s.ConsecutiveConfirmations = 7
+		s.UpdatedAt = at.Add(time.Hour)
+	})
+	if got := fp(); got != base {
+		t.Error("a change to columns the listing never reads moved the digest")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"log/slog"
 	"math"
 	"net/url"
@@ -756,48 +757,120 @@ func (s *Store) ListSignatureEmbeddings(ctx context.Context) ([]domain.Signature
 // SignatureEmbeddingsFingerprint digests every column of every row the
 // semantic index is built from, so the daemon can tell a fleet pull that moved
 // a rule apart from one that only moved bookkeeping (see
-// ports.KnowledgeFingerprinter). The vector BYTES are hashed too, not just
-// their length: the read costs a few milliseconds against a rebuild costing
-// hundreds, and "same length, different vector" is then never a question.
+// ports.KnowledgeFingerprinter).
+//
+// A vector contributes its length and its first 16 bytes (four float32s), not
+// its whole body. Reading every vector on every pull was measured at ~40% of
+// an idle turso daemon's CPU (1.2MB through the SDK every 5s for 785 rules),
+// and the whole body buys nothing the prefix does not: a row is only ever
+// re-embedded under a different model or dims — both in the digest — and a
+// vector that differs at all, even in float rounding between two machines'
+// builds, differs in its leading components.
 //
 // Each field is length-prefixed so no two different rows can serialize to the
 // same bytes, and the order is by signature, the primary key, so the digest
 // does not depend on insertion order.
 func (s *Store) SignatureEmbeddingsFingerprint(ctx context.Context) (string, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT signature, situation_type, agent_type, model, dims, vector, salient, created_at
+		SELECT signature, situation_type, agent_type, model, dims,
+			substr(vector, 1, 16), length(vector), salient, created_at
 		FROM signature_embeddings ORDER BY signature`)
 	if err != nil {
 		return "", err
 	}
 	defer rows.Close()
-	h := sha256.New()
-	var n [binary.MaxVarintLen64]byte
-	field := func(b []byte) {
-		h.Write(n[:binary.PutUvarint(n[:], uint64(len(b)))])
-		h.Write(b)
-	}
+	d := newFieldDigest()
 	for rows.Next() {
 		var sig, st, agent, model, salient string
 		var dims, created int64
-		var blob []byte
-		if err := rows.Scan(&sig, &st, &agent, &model, &dims, &blob, &salient, &created); err != nil {
+		var head []byte
+		var size sql.NullInt64
+		if err := rows.Scan(&sig, &st, &agent, &model, &dims, &head, &size, &salient, &created); err != nil {
 			return "", err
 		}
-		field([]byte(sig))
-		field([]byte(st))
-		field([]byte(agent))
-		field([]byte(model))
-		field(binary.AppendVarint(nil, dims))
-		field(blob)
-		field([]byte(salient))
-		field(binary.AppendVarint(nil, created))
+		d.str(sig)
+		d.str(st)
+		d.str(agent)
+		d.str(model)
+		d.int(dims)
+		d.bytes(head)
+		if size.Valid {
+			d.int(size.Int64)
+		} else {
+			d.int(-1) // NULL, distinct from an empty blob
+		}
+		d.str(salient)
+		d.int(created)
 	}
 	if err := rows.Err(); err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
+	return d.sum(), nil
 }
+
+// RuleStateFingerprint digests the learned STATE the re-rank judge is shown
+// about each rule: its mode and decision floor (signatures) and the decision
+// history its listed confidence is computed from. With
+// SignatureEmbeddingsFingerprint it covers everything the rendered candidate
+// listing reads, so the daemon can keep in-flight verdicts across a fleet pull
+// that moved none of it (see ports.RuleStateFingerprinter).
+//
+// Decisions are summarized by count and highest id rather than hashed row by
+// row. The table is append-only — a rule's rows leave only with the rule
+// itself, which the signatures half sees — and it is never swept, so it is the
+// one table here that grows without bound. Count catches a delete or a peer's
+// row carrying a lower id; the maximum catches an insert that a delete in the
+// same pull would otherwise cancel out.
+func (s *Store) RuleStateFingerprint(ctx context.Context) (string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT signature, mode, decision_floor_id FROM signatures ORDER BY signature`)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	d := newFieldDigest()
+	for rows.Next() {
+		var sig, mode string
+		var floor int64
+		if err := rows.Scan(&sig, &mode, &floor); err != nil {
+			return "", err
+		}
+		d.str(sig)
+		d.str(mode)
+		d.int(floor)
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	var n, maxID int64
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*), COALESCE(MAX(id), 0) FROM decisions`).Scan(&n, &maxID); err != nil {
+		return "", err
+	}
+	d.int(n)
+	d.int(maxID)
+	return d.sum(), nil
+}
+
+// fieldDigest hashes a sequence of length-prefixed fields, so no two different
+// sequences serialize to the same bytes.
+type fieldDigest struct {
+	h hash.Hash
+	n [binary.MaxVarintLen64]byte
+}
+
+func newFieldDigest() *fieldDigest { return &fieldDigest{h: sha256.New()} }
+
+func (d *fieldDigest) bytes(b []byte) {
+	d.h.Write(d.n[:binary.PutUvarint(d.n[:], uint64(len(b)))])
+	d.h.Write(b)
+}
+
+func (d *fieldDigest) str(s string) { d.bytes([]byte(s)) }
+
+func (d *fieldDigest) int(v int64) { d.bytes(binary.AppendVarint(nil, v)) }
+
+func (d *fieldDigest) sum() string { return fmt.Sprintf("%x", d.h.Sum(nil)) }
 
 // CountSignatureEmbeddings reports how many semantic identity rows exist.
 func (s *Store) CountSignatureEmbeddings(ctx context.Context) (int64, error) {


### PR DESCRIPTION
## Why

Follow-up to #437. With the semantic-index rebuild storm gone, what an idle turso daemon still spends CPU on is its periodic loops — and one of them was wasting a feature outright: every fleet pull retired every in-flight LLM re-rank verdict, and under turso nearly every pull reports a change, so the judge subprocess mostly ran for nothing and the herd got the cosine answer anyway.

## What

- **Re-rank verdicts survive quiet pulls** — new optional `ports.RuleStateFingerprinter` (`Store.RuleStateFingerprint`: each rule's mode + decision floor, plus decision count and max id). `RefreshKnowledge` now calls `invalidateRerankForKnowledge`, which retires verdicts only when the candidate rows (`SignatureEmbeddingsFingerprint`) or the learned state moved; either digest unknown still invalidates. Reload invalidation stays unconditional. This is not the forbidden "nothing to invalidate" fast path (that asks whether a verdict EXISTS; this asks whether the question changed), and the compare + bump share one hold of `mu`.
- **Cheaper rebuild digest** — `SignatureEmbeddingsFingerprint` hashes a vector's length and first 16 bytes instead of its whole body (reading every vector every pull was ~40% of the idle daemon's CPU).
- **Roster tick** — with no local TUI, the 2s tick asked the store `RemoteWatchers` on the select loop every tick; the answer is now cached for `remoteRosterInterval` (15s). Said plainly: `nodes.watching_until` currently has no production writer (`StampWatching` is only called from tests), so today this caches a query whose answer is always 0 — the saving is the query itself, not work a real remote watcher would trigger. Wiring the writer is out of scope here.
- **Opt-in profiling hook** — `HAP_PROFILE_DIR=<dir> [HAP_PROFILE_SECONDS=60]` makes any hap process write rolling `<verb>-<pid>.cpu.pprof` / `.heap.pprof` windows (`internal/profiling`, `runtime/pprof` to files only — no listener, nothing when unset). The detached daemon inherits the environment, so `HAP_PROFILE_DIR=… hap daemon --restart` profiles a live daemon.
- **Docs** — CLAUDE.md (re-rank invalidation rules, profiling), and the `hap-development-local` skill now tells a linked tree to borrow the installed `models/` (a worktree has none, so a dev daemon silently runs DEGRADED and every measurement against a release is confounded — which is exactly what happened to #437's first table).

## Before / after — live, same devbox and herd, model loaded in every run

All three daemons: same herd (2 agents, no TUI, turso sync=5s, 786 signatures), `semantic matching ready (786 signatures, all-minilm-l6-v2-q8_0.gguf)`, no DEGRADED line; 120 one-second `top` samples from ~1.5 min after start.

| | A: v0.9.10 (baseline) | B: main after #437 | C: this PR |
|---|---|---|---|
| daemon CPU, avg of 120×1s | 1.86% | 0.42% | **0.33%** |
| daemon CPU, max 1s sample | 39% | 7% | **6%** |
| 1s samples ≥ 10% | 7 | 0 | **0** |
| index rebuilds / 120s | 6 | 0 | **0** |

CPU profile of one steady-state 120s window each (`HAP_PROFILE_DIR`, model loaded, ~4–6 min after start). B is main-after-#437 plus only the profiling hook (commit 94de0b3), built and swapped in the same way:

| per 120s window | B: #437 + hook | C: this PR |
|---|---|---|
| `SignatureEmbeddingsFingerprint` (every pull) | 310ms | **100ms** |
| roster tick `RemoteWatchers` (every 2s, on the select loop) | 30ms | **not sampled** |
| `RuleStateFingerprint` (new, every pull) | — | 20ms |
| whole process | 1.58s, of which 0.20s one rebuild for a newly minted rule | **0.30s** |

Per-function rows are the like-for-like comparison; the whole-process totals also move with how busy the herd was in each window.

The remaining ~100ms is the digest still transferring each row's salient text through the Turso SDK (~4ms per pull); the rest is `turso.Pull`/`Push` themselves.

## Tests

- `internal/daemon/rerankknowledge_test.go` — a quiet pull keeps in-flight verdicts (and one judged under it still commits); a peer rule, a recorded decision, or a graduation each retires once and the next pull is quiet; a store without the rule-state digest retires on every pull (control); a reload still retires over unmoved knowledge.
- `internal/store/rulestate_test.go` — every state a listing renders moves the digest; columns it never reads (cached confidence, streak, `updated_at`) do not (sqlite / proxy / turso).
- `internal/daemon/fleet_test.go` — the remote-watcher answer is cached inside the interval and seen once it lapses.
- `internal/profiling` — off by default, rolling windows complete while running, stop finalizes and leaves no partials, degrades when the profiler is taken, keeps files inside the dir.
- Mutation-checked: removing the verdict gate, dropping the rule-state half of the digest, or removing the watcher cache each fails a test.
- Full suite green apart from one load flake (`TestConsultIsNotGatedByTheDuplicateCheck`, consult-dedup, untouched here — 8/8 alone).

## Not in this PR

`hap tui` is now the biggest idle cost (its 2s poll through the store proxy plus the daemon's 2s roster tick, which also stamps `roster_meta` — and so arms a Turso push — on every publish). Next PR.
