### PR TITLE
#1 chore: bump plugin version to 0.9.12 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.12
+
+- Fixed the LLM re-rank judge's in-flight answers being thrown away on nearly every Turso pull: a pull now retires them only when it actually changed the rules, their learned state or their decision history, so under turso the judge's subprocess no longer mostly runs for nothing
+- Reduced the idle daemon's CPU further: the per-pull check for changed rules no longer reads every stored vector, and with no local TUI open the roster tick asks the store whether a remote TUI is watching at most once per 15s instead of every 2s
+- Added an opt-in profiling hook: set `HAP_PROFILE_DIR` (and optionally `HAP_PROFILE_SECONDS`, default 60) and any hap process writes rolling CPU and heap profiles there for `go tool pprof`; nothing is written or listened on when it is unset
+
 ## 0.9.11
 
 - Fixed the daemon rebuilding its whole semantic match index after every Turso pull, even when no learned rule had changed — on a fleet node that kept an idle daemon at ~20% CPU; it now rebuilds only when a rule is added, removed or re-embedded

--- a/changelog.d/perf-daemon-idle-cpu.md
+++ b/changelog.d/perf-daemon-idle-cpu.md
@@ -1,3 +1,0 @@
-- Fixed the LLM re-rank judge's in-flight answers being thrown away on nearly every Turso pull: a pull now retires them only when it actually changed the rules, their learned state or their decision history, so under turso the judge's subprocess no longer mostly runs for nothing
-- Reduced the idle daemon's CPU further: the per-pull check for changed rules no longer reads every stored vector, and with no local TUI open the roster tick asks the store whether a remote TUI is watching at most once per 15s instead of every 2s
-- Added an opt-in profiling hook: set `HAP_PROFILE_DIR` (and optionally `HAP_PROFILE_SECONDS`, default 60) and any hap process writes rolling CPU and heap profiles there for `go tool pprof`; nothing is written or listened on when it is unset

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.11"
+version = "0.9.12"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.12 is being released from this commit by the Auto Release workflow.