### PR TITLE
#0 perf: re-read the TUI's data only when it changed, lean rule listing, back the roster tick off

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -626,6 +626,16 @@ unstructured pane-tail and Guard 3 usually answers `heldStillUnevaluable` — th
     cannot establish the lease fails closed rather than migrating blind.
   - `fleetRun` runs every sync op off the loop and waits for it OR shutdown; `turso.DB.Close` waits a
     bounded time and refuses to close underneath an in-flight op.
+  - **A front end polls a change token, not the data** (`Store.Revision` → `ports.RevisionReporter`,
+    `frontend.App.ChangeKey`, `tui.Model.poll`). Under turso it is the executor's counter
+    (`sqlbridge.Executor.Revision`, a `rev` request over a POOLED connection), bumped AFTER every committed
+    write and every pull that `changed` — so sampling it before a read can only cost an extra refresh, never
+    miss one — and prefixed with an epoch because a restarted daemon counts from zero. Under sqlite it is
+    the file's and WAL's size+mtime. The key adds config.toml and local checklist files; a **gist** source
+    answers "cannot tell" (no local trace), as does a store without the port, and both keep the old
+    re-read-every-tick behaviour. What a refresh derives from the CLOCK is re-read on `refreshBackstop`, and
+    an open agent detail always re-reads (its permission mode comes from the PANE). The unconditional 2s
+    re-read was the TUI's whole idle cost and serving it most of the daemon's while one was open.
   - Config never enters the database. Front ends draw ids from the daemon with NO local fallback: two
     processes minting locally in one millisecond collide, so an insert with no id fails with the reason
     (`failedID`).
@@ -640,7 +650,12 @@ unstructured pane-tail and Guard 3 usually answers `heldStillUnevaluable` — th
     **recycled** id is never skipped — its row was DELETEd earlier in the same transaction, so `existing`
     describes a row that no longer exists, and the gate is on `recycledIDs` structurally rather than on the
     coincidence that `terminal_id` is in the compare set. Roster FRESHNESS is `roster_meta.published_at`
-    (`domain.RosterFresh`), never a per-row `seen_at`, which is why the stamp still happens every publish.
+    (`domain.RosterFresh`), never a per-row `seen_at` — and the stamp is itself a write, so a publish that
+    changed nothing re-stamps only once it is `domain.RosterRestampAfter` old, a constant bounded ABOVE by
+    the one-minute sweep so an unwatched herd's every sweep still stamps. A changed row stamps at once.
+  - **Only a transaction that WROTE reports a write** (`sqlbridge.Session.txWrote`) — COMMIT used to
+    report unconditionally, so every read-only transaction armed a push. Any successful Exec counts,
+    whatever it affected: DDL reports 0 rows and must still reach the other nodes.
   - **`domain.NodeHeartbeat` is a SEPARATE constant from `daemonhealth.HeartbeatInterval` — deliberately
     slower, but BOUNDED ABOVE by `daemon.actionStaleAfter`.** The file answers "is this daemon hung" and
     must be fast; the row answers "is this machine still out there", and no reader asks with more precision

--- a/changelog.d/perf-tui-idle-cpu.md
+++ b/changelog.d/perf-tui-idle-cpu.md
@@ -1,0 +1,3 @@
+- Cut what an open `hap tui` costs: it now re-reads its data only when something changed (a store change token, the config file, local checklist files) instead of every two seconds, and the Rules tab's last-used lookup no longer pulls every rule's full audit row
+- The daemon's roster tick backs off (up to 15s) while the herd's listing is unchanged, and returns to 2s on any change or agent transition
+- A roster publish or read-only transaction that changed nothing no longer triggers a Turso push

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -459,6 +459,15 @@ type Daemon struct {
 	// listing is a subprocess with a budget in seconds and the tick fires
 	// every two, so without it a slow herdr accumulates listings.
 	rosterTickRunning bool
+	// rosterTickEvery / rosterTickNextAt pace the LOCAL roster tick's backoff
+	// and rosterTickDigest is the last listing it compared against; see
+	// rosterTickMaxInterval. rosterTickLevel is the demand the previous tick
+	// saw, so a TUI that has just opened restarts from the fast tick. All
+	// guarded by mu.
+	rosterTickEvery  time.Duration
+	rosterTickNextAt time.Time
+	rosterTickDigest string
+	rosterTickLevel  rosterDemandLevel
 
 	// rosterLocationsAt is when the workspace and tab labels were last
 	// published (guarded by mu). They cost two herdr subprocesses and name

--- a/internal/daemon/roster.go
+++ b/internal/daemon/roster.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -17,6 +18,17 @@ import (
 // what it used to see listing agents itself. It runs ONLY while a TUI is
 // registered — see rosterDemand.
 const rosterTickInterval = 2 * time.Second
+
+// rosterTickMaxInterval caps the local roster tick's backoff. A listing that
+// comes back unchanged doubles the wait before the next one (2s, 4s, 8s, then
+// this), and any change — in a listing, or an agent transition arriving as an
+// event — snaps it back to rosterTickInterval. Every tick is a herdr `agent
+// list` subprocess, and on a settled herd with a TUI open that was thirty a
+// minute answering "still the same". The events path already publishes every
+// status change the moment it happens; what only a listing sees — an agent
+// that vanished, a pane moved between tabs — reaches an open TUI at most this
+// late. Matches remoteRosterInterval: a remote watcher is paced the same way.
+const rosterTickMaxInterval = remoteRosterInterval
 
 // rosterCwdTTL is how long a published working directory is reused while
 // someone is watching.
@@ -152,6 +164,10 @@ func (d *Daemon) rosterShellOutTTLs() (cwd, locations time.Duration) {
 func (d *Daemon) startRosterTickPass(ctx context.Context) {
 	level := d.rosterDemandLevel()
 	if level == rosterDemandNone {
+		// Recorded, so a TUI opening later restarts from the fast tick.
+		d.mu.Lock()
+		d.rosterTickLevel = level
+		d.mu.Unlock()
 		return
 	}
 	now := d.opt.Clock.Now()
@@ -165,6 +181,20 @@ func (d *Daemon) startRosterTickPass(ctx context.Context) {
 		d.mu.Unlock()
 		return
 	}
+	// A local watcher is paced by the backoff (see rosterTickMaxInterval).
+	// A TUI that has just opened starts from the fast tick rather than
+	// inheriting a wait backed off before it was there.
+	if level == rosterDemandLocal {
+		if d.rosterTickLevel != rosterDemandLocal {
+			d.rosterTickEvery, d.rosterTickNextAt = 0, time.Time{}
+		}
+		if now.Before(d.rosterTickNextAt) {
+			d.rosterTickLevel = level
+			d.mu.Unlock()
+			return
+		}
+	}
+	d.rosterTickLevel = level
 	d.rosterRemoteAt = now
 	d.rosterTickRunning = true
 	d.mu.Unlock()
@@ -180,12 +210,54 @@ func (d *Daemon) startRosterTickPass(ctx context.Context) {
 			slog.Debug("roster tick: listing agents failed", "error", err)
 			return
 		}
+		d.noteRosterTickListing(agents, d.opt.Clock.Now())
 		d.publishRoster(ctx, agents)
 	}) {
 		d.mu.Lock()
 		d.rosterTickRunning = false
 		d.mu.Unlock()
 	}
+}
+
+// noteRosterTickListing schedules the next local roster tick from this one's
+// listing: unchanged doubles the wait up to rosterTickMaxInterval, changed
+// snaps it back to rosterTickInterval.
+func (d *Daemon) noteRosterTickListing(agents []domain.AgentTransition, now time.Time) {
+	digest := rosterListingDigest(agents)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	switch {
+	case digest != d.rosterTickDigest || d.rosterTickEvery == 0:
+		d.rosterTickEvery = rosterTickInterval
+	default:
+		d.rosterTickEvery = min(2*d.rosterTickEvery, rosterTickMaxInterval)
+	}
+	d.rosterTickDigest = digest
+	d.rosterTickNextAt = now.Add(d.rosterTickEvery)
+}
+
+// resetRosterTick returns the local roster tick to its fast cadence: an agent
+// transition means the herd is moving, and the next listing is the one most
+// likely to see something only a listing can.
+func (d *Daemon) resetRosterTick() {
+	d.mu.Lock()
+	d.rosterTickEvery, d.rosterTickNextAt = 0, time.Time{}
+	d.mu.Unlock()
+}
+
+// rosterListingDigest renders everything a publish stores from one listing, in
+// listing order (the order is published too).
+func rosterListingDigest(agents []domain.AgentTransition) string {
+	var b strings.Builder
+	for _, a := range agents {
+		b.WriteString(a.AgentID)
+		for _, f := range []string{a.PaneID, a.TabID, a.WorkspaceID, a.AgentType, a.Status, a.TerminalID} {
+			b.WriteByte(0)
+			b.WriteString(f)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
 }
 
 // publishRoster records the herd from a listing the caller already made.
@@ -447,6 +519,7 @@ func (d *Daemon) noteRosterTransition(ctx context.Context, tr domain.AgentTransi
 	if tr.Status == domain.AgentStatusDetected {
 		return
 	}
+	d.resetRosterTick()
 	if err := d.opt.Store.UpsertRosterAgent(ctx, domain.RosterAgentFrom(tr, d.opt.Clock.Now())); err != nil {
 		slog.Debug("roster: recording a transition failed", "agent", tr.AgentID, "error", err)
 	}

--- a/internal/daemon/roster.go
+++ b/internal/daemon/roster.go
@@ -163,38 +163,30 @@ func (d *Daemon) rosterShellOutTTLs() (cwd, locations time.Duration) {
 // refuses, or one shutdown race disables the tick for the life of the process.
 func (d *Daemon) startRosterTickPass(ctx context.Context) {
 	level := d.rosterDemandLevel()
-	if level == rosterDemandNone {
-		// Recorded, so a TUI opening later restarts from the fast tick.
-		d.mu.Lock()
-		d.rosterTickLevel = level
+	d.mu.Lock()
+	// A TUI that has just opened starts from the fast tick rather than
+	// inheriting a wait backed off before it was there. Recorded before ANY
+	// return below, or a tick that leaves early — nobody watching, a listing
+	// still running, a remote watcher's pacing — hides the transition.
+	if level == rosterDemandLocal && d.rosterTickLevel != rosterDemandLocal {
+		d.rosterTickEvery, d.rosterTickNextAt = 0, time.Time{}
+	}
+	d.rosterTickLevel = level
+	if level == rosterDemandNone || d.rosterTickRunning {
 		d.mu.Unlock()
 		return
 	}
 	now := d.opt.Clock.Now()
-	d.mu.Lock()
-	if d.rosterTickRunning {
-		d.mu.Unlock()
-		return
-	}
 	// A remote watcher gets a publish per sync interval, not per tick.
 	if level == rosterDemandRemote && !d.rosterRemoteAt.IsZero() && now.Sub(d.rosterRemoteAt) < remoteRosterInterval {
 		d.mu.Unlock()
 		return
 	}
 	// A local watcher is paced by the backoff (see rosterTickMaxInterval).
-	// A TUI that has just opened starts from the fast tick rather than
-	// inheriting a wait backed off before it was there.
-	if level == rosterDemandLocal {
-		if d.rosterTickLevel != rosterDemandLocal {
-			d.rosterTickEvery, d.rosterTickNextAt = 0, time.Time{}
-		}
-		if now.Before(d.rosterTickNextAt) {
-			d.rosterTickLevel = level
-			d.mu.Unlock()
-			return
-		}
+	if level == rosterDemandLocal && now.Before(d.rosterTickNextAt) {
+		d.mu.Unlock()
+		return
 	}
-	d.rosterTickLevel = level
 	d.rosterRemoteAt = now
 	d.rosterTickRunning = true
 	d.mu.Unlock()

--- a/internal/daemon/rosterbackoff_test.go
+++ b/internal/daemon/rosterbackoff_test.go
@@ -109,3 +109,76 @@ func TestASettledHerdBacksTheRosterTickOff(t *testing.T) {
 	t.Cleanup(session.Release)
 	expect(at+8.5, 10, "a TUI that just opened gets a listing before the old wait ran out")
 }
+
+// TestATUIReopenedUnderARemoteWatcherStartsFast: the fast-tick reset for a TUI
+// that has just opened must see a transition from ANY other demand, including
+// one whose ticks all left early — a remote watcher's pacing returns before a
+// listing, and a level recorded only on a listing kept reading "local" there.
+func TestATUIReopenedUnderARemoteWatcherStartsFast(t *testing.T) {
+	dir := t.TempDir()
+	session, err := tuisession.Register(dir)
+	if err != nil {
+		t.Skipf("cannot register a TUI session here: %v", err)
+	}
+	dbPath := filepath.Join(dir, "test.db")
+	raw, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { raw.Close() })
+	fh := &fakeHerdr{}
+	fh.setAgents([]domain.AgentTransition{{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"}})
+	start := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
+	clock := &stepClock{now: start}
+	d := &Daemon{opt: Options{StateDir: dir, Store: raw, Herdr: fh, Clock: clock}}
+	ctx := context.Background()
+	tickAt := func(sec float64) int {
+		t.Helper()
+		clock.set(start.Add(time.Duration(sec * float64(time.Second))))
+		d.startRosterTickPass(ctx)
+		waitFor(t, 2*time.Second, func() bool {
+			d.mu.Lock()
+			defer d.mu.Unlock()
+			return !d.rosterTickRunning
+		})
+		return fh.listAgentsCallCount()
+	}
+	// Backed off: listings at 0, 2, 6 — the next is due at 14.
+	for _, sec := range []float64{0, 2, 6} {
+		tickAt(sec)
+	}
+	if got := fh.listAgentsCallCount(); got != 3 {
+		t.Fatalf("%d listings while backing off, want 3", got)
+	}
+
+	// The local TUI closes while another node's TUI is watching.
+	session.Release()
+	other, err := store.OpenAs(dbPath, otherNodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { other.Close() })
+	if err := other.StampWatching(ctx, start.Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	expireRemoteWatchers(d)
+	if got := tickAt(7); got != 3 {
+		t.Fatalf("remote pacing listed again inside its interval (%d listings)", got)
+	}
+	d.mu.Lock()
+	level := d.rosterTickLevel
+	d.mu.Unlock()
+	if level != rosterDemandRemote {
+		t.Fatalf("the remote tick recorded demand %v, want remote", level)
+	}
+
+	// Reopened before the old wait (14) ran out: it must list at once.
+	session, err = tuisession.Register(dir)
+	if err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+	t.Cleanup(session.Release)
+	if got := tickAt(8); got != 4 {
+		t.Errorf("a TUI reopened under a remote watcher waited out the old backoff (%d listings, want 4)", got)
+	}
+}

--- a/internal/daemon/rosterbackoff_test.go
+++ b/internal/daemon/rosterbackoff_test.go
@@ -1,0 +1,111 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+	"github.com/0xGosu/herdr-auto-pilot/internal/tuisession"
+)
+
+// stepClock is a clock the test moves by hand.
+type stepClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *stepClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *stepClock) set(t time.Time) {
+	c.mu.Lock()
+	c.now = t
+	c.mu.Unlock()
+}
+
+// TestASettledHerdBacksTheRosterTickOff pins the local roster tick's pacing.
+// Every tick is a herdr `agent list` subprocess, and with a TUI open over a
+// settled herd that was thirty a minute answering "still the same" — so an
+// unchanged listing doubles the wait up to rosterTickMaxInterval. The controls
+// are what keep it from being a slower tick and nothing more: a changed
+// listing, an agent transition, and a TUI that has just opened each snap it
+// back to the fast cadence.
+func TestASettledHerdBacksTheRosterTickOff(t *testing.T) {
+	dir := t.TempDir()
+	session, err := tuisession.Register(dir)
+	if err != nil {
+		t.Skipf("cannot register a TUI session here: %v", err)
+	}
+	raw, err := store.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { raw.Close() })
+	fh := &fakeHerdr{}
+	agent := domain.AgentTransition{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude", Status: "idle"}
+	fh.setAgents([]domain.AgentTransition{agent})
+	start := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
+	clock := &stepClock{now: start}
+	d := &Daemon{opt: Options{StateDir: dir, Store: raw, Herdr: fh, Clock: clock}}
+	ctx := context.Background()
+
+	// tickAt runs one tick at start+sec and waits for its listing to finish.
+	tickAt := func(sec float64) int {
+		t.Helper()
+		clock.set(start.Add(time.Duration(sec * float64(time.Second))))
+		d.startRosterTickPass(ctx)
+		waitFor(t, 2*time.Second, func() bool {
+			d.mu.Lock()
+			defer d.mu.Unlock()
+			return !d.rosterTickRunning
+		})
+		return fh.listAgentsCallCount()
+	}
+	expect := func(sec float64, want int, why string) {
+		t.Helper()
+		if got := tickAt(sec); got != want {
+			t.Fatalf("t=%vs: %d listings, want %d — %s", sec, got, want, why)
+		}
+	}
+
+	expect(0, 1, "the first tick lists")
+	expect(1, 1, "waits the fast interval")
+	expect(2, 2, "lists at the fast interval")
+	expect(4, 2, "unchanged: the wait doubled to 4s")
+	expect(6, 3, "lists after 4s")
+	expect(12, 3, "unchanged: the wait doubled to 8s")
+	expect(14, 4, "lists after 8s")
+	expect(28, 4, "capped at rosterTickMaxInterval, not 16s")
+	expect(14+rosterTickMaxInterval.Seconds(), 5, "lists at the cap")
+
+	// A changed listing snaps back to the fast tick.
+	agent.Status = "working"
+	fh.setAgents([]domain.AgentTransition{agent})
+	at := 14 + 2*rosterTickMaxInterval.Seconds()
+	expect(at, 6, "lists at the cap")
+	expect(at+2, 7, "a changed listing returns to the fast tick")
+
+	// So does an agent transition arriving as an event.
+	d.noteRosterTransition(ctx, agent)
+	expect(at+3, 8, "a transition returns to the fast tick at once")
+
+	// And a TUI that has just opened starts fast rather than inheriting a
+	// wait backed off before it was there.
+	expect(at+5, 9, "fast tick")
+	expect(at+7, 9, "unchanged: the wait doubled to 4s, due at +9")
+	session.Release()
+	expect(at+8, 9, "nobody is watching: no tick at all")
+	session, err = tuisession.Register(dir)
+	if err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+	t.Cleanup(session.Release)
+	expect(at+8.5, 10, "a TUI that just opened gets a listing before the old wait ran out")
+}

--- a/internal/domain/agentroster.go
+++ b/internal/domain/agentroster.go
@@ -75,6 +75,17 @@ func RosterAgentFrom(tr AgentTransition, seenAt time.Time) RosterAgent {
 // looks authoritative.
 const RosterStaleAfter = 3 * time.Minute
 
+// RosterRestampAfter is how old roster_meta.published_at may grow before a
+// publish that changed NOTHING stamps it again.
+//
+// The stamp is the liveness proof RosterFresh reads, but it is also a write,
+// and every write arms a Turso push: stamped on every publish, a TUI's roster
+// tick sent a changeset to Turso Cloud for a herd where nothing had moved.
+// A publish that changed a row always stamps. Bounded ABOVE by the daemon's
+// one-minute sweep, so on an unwatched herd every sweep still stamps and the
+// stamp stays under two sweeps old — far inside RosterStaleAfter.
+const RosterRestampAfter = 30 * time.Second
+
 // RosterFresh reports whether a roster published at publishedAt can still be
 // trusted as of now. A zero publishedAt means no daemon has ever published,
 // which is UNKNOWN — never "no agents are running".

--- a/internal/frontend/changekey.go
+++ b/internal/frontend/changekey.go
@@ -1,0 +1,77 @@
+package frontend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/tasklocator"
+)
+
+// ChangeKey returns a token that moves whenever a TUI refresh could show
+// something different, and false when this App cannot tell — the caller then
+// refreshes as it always did.
+//
+// A refresh reads three kinds of source, and the key covers each:
+//
+//   - the store, through its change token (ports.RevisionReporter) — under
+//     turso that is one tiny request to the daemon instead of the few dozen
+//     queries a refresh makes, which is what a TUI's idle cost was;
+//   - config.toml, by size and modification time;
+//   - the checklist FILES among groups — the task groups the last refresh
+//     resolved — since an agent ticking off its list changes no store row.
+//     A db:// list lives in the store and is already covered.
+//
+// A gist list changes with no local trace at all, so a config reading one
+// answers false: under a gist source the TUI keeps re-reading every tick.
+// Anything else a refresh derives from the clock (roster freshness, the update
+// check's due time) is the caller's to re-read on a backstop.
+func (a *App) ChangeKey(ctx context.Context, groups []TaskGroup) (string, bool) {
+	rr, ok := a.Store.(ports.RevisionReporter)
+	if !ok {
+		return "", false
+	}
+	rev, err := rr.Revision(ctx)
+	if err != nil {
+		return "", false
+	}
+	var b strings.Builder
+	b.WriteString(rev)
+	if !stampFile(&b, a.ConfigPath) {
+		return "", false
+	}
+	for _, g := range groups {
+		switch tasklocator.Scheme(g.Locator) {
+		case tasklocator.DBScheme:
+		case "":
+			if g.Locator != "" && !stampFile(&b, g.Locator) {
+				return "", false
+			}
+		default:
+			return "", false
+		}
+	}
+	return b.String(), true
+}
+
+// stampFile appends path's size and modification time to b ("-" when it does
+// not exist, which is a state too), reporting false when it cannot be read.
+func stampFile(b *strings.Builder, path string) bool {
+	b.WriteString("|")
+	if path == "" {
+		return true
+	}
+	fi, err := os.Stat(path)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		b.WriteString("-")
+	case err != nil:
+		return false
+	default:
+		fmt.Fprintf(b, "%d:%d", fi.ModTime().UnixNano(), fi.Size())
+	}
+	return true
+}

--- a/internal/frontend/changekey_test.go
+++ b/internal/frontend/changekey_test.go
@@ -1,0 +1,102 @@
+package frontend
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/tasklocator"
+)
+
+// TestChangeKeyMovesWithEverySourceARefreshReads pins what lets the TUI skip a
+// re-read: the key holds still across reads and moves on a store write, a
+// config edit and a ticked checklist FILE — each a source a refresh reads.
+// Every case that moves it is the control for the stability check before it.
+func TestChangeKeyMovesWithEverySourceARefreshReads(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	list := filepath.Join(t.TempDir(), "tasks.md")
+	if err := os.WriteFile(list, []byte("- [ ] one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	groups := []TaskGroup{
+		{Locator: list},
+		// A db:// list lives in the store: nothing to stat, never a refusal.
+		{Locator: tasklocator.DBLocator(st.NodeID(), "agent.md")},
+		// An unresolved group has no locator at all.
+		{Err: "one list per matched agent"},
+	}
+	key := func() string {
+		t.Helper()
+		k, ok := app.ChangeKey(ctx, groups)
+		if !ok {
+			t.Fatal("ChangeKey could not tell over a sqlite store and local files")
+		}
+		return k
+	}
+	// Each write below lands at a distinct, later mtime: a coarse filesystem
+	// clock can otherwise give two writes in one test the same stamp.
+	bump := func(path string, at time.Time) {
+		t.Helper()
+		if err := os.Chtimes(path, at, at); err != nil {
+			t.Fatal(err)
+		}
+	}
+	base := time.Now().Add(time.Hour)
+
+	k0 := key()
+	if _, err := st.AuditLog(ctx, 10); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.GetStatus(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if got := key(); got != k0 {
+		t.Fatalf("reads moved the key %q → %q", k0, got)
+	}
+
+	seedEscalationRow(t, st)
+	k1 := key()
+	if k1 == k0 {
+		t.Error("a store write left the key where it was")
+	}
+
+	if err := os.WriteFile(app.ConfigPath, []byte("[tui]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bump(app.ConfigPath, base)
+	k2 := key()
+	if k2 == k1 {
+		t.Error("a config edit left the key where it was")
+	}
+
+	// Same size on purpose: ticking an item rewrites one byte.
+	if err := os.WriteFile(list, []byte("- [x] one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bump(list, base.Add(time.Second))
+	if got := key(); got == k2 {
+		t.Error("a ticked checklist file left the key where it was")
+	}
+}
+
+// TestChangeKeyRefusesWhatItCannotSee: a gist list changes with no local trace
+// and a store without a change token cannot say anything, so both answer
+// false and the TUI keeps re-reading every tick, exactly as before.
+func TestChangeKeyRefusesWhatItCannotSee(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	if _, ok := app.ChangeKey(ctx, []TaskGroup{{Locator: tasklocator.GistLocator("abc123", "tasks.md")}}); ok {
+		t.Error("a gist list produced a change key")
+	}
+	bare := &App{Store: struct{ ports.StorePort }{st}, ConfigPath: app.ConfigPath} // hides Revision
+	if _, ok := bare.ChangeKey(ctx, nil); ok {
+		t.Error("a store without a change token produced a key")
+	}
+	if _, ok := app.ChangeKey(ctx, nil); !ok {
+		t.Error("control: the sqlite store with no groups should produce a key")
+	}
+}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -5263,7 +5263,10 @@ type SignatureRow struct {
 	// confirmation meant to prevent it: a reset rule has Decisions == 0 while
 	// still carrying history, and a long-lived rule outgrows any read window.
 	TotalDecisions int
-	LastAudit      *domain.AuditRecord
+	// LastAudit is the rule's newest audit row. From Signatures it is the
+	// listing subset (ports.StorePort.LatestAuditsForSignatures: id, status,
+	// action, time); SignatureDetail fills the whole row.
+	LastAudit *domain.AuditRecord
 	// PaneExcerpt is the pane snapshot the signature was first seen with
 	// (rule provenance); "" for rules learned before snapshots existed.
 	PaneExcerpt string

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -150,6 +150,14 @@ type RuleStateFingerprinter interface {
 	RuleStateFingerprint(ctx context.Context) (string, error)
 }
 
+// RevisionReporter is implemented by stores that can report an opaque change
+// token: equal tokens mean a read would return the same rows. The TUI polls it
+// and re-reads its data only when it moves. Optional: absent — or on an error —
+// the TUI re-reads on every tick, as it always did.
+type RevisionReporter interface {
+	Revision(ctx context.Context) (string, error)
+}
+
 // VisiblePaneReader is implemented by Herdr adapters that can read the pane's
 // current on-screen content (as opposed to ReadPane's consuming "recent"
 // delta). Used to recover a standing numbered menu when delivering an
@@ -956,6 +964,9 @@ type ReadStore interface {
 	// LatestAuditsForSignatures returns the newest audit row per signature
 	// (keyed by signature) for all signatures with audit history — one batched
 	// query replacing N LatestAuditForSignature calls in the Rules listing.
+	// Each record carries only ID, NodeID, Signature, Status, Action and
+	// CreatedAt: it runs for every rule on each TUI refresh, and the full rows
+	// (pane excerpts, LLM output) were most of that refresh's cost.
 	LatestAuditsForSignatures(ctx context.Context) (map[string]*domain.AuditRecord, error)
 	// ListSignatureEmbeddings returns every stored semantic identity row
 	// (all models), for rebuilding the in-memory match index.

--- a/internal/store/agentroster.go
+++ b/internal/store/agentroster.go
@@ -23,7 +23,8 @@ const rosterColumns = `node_id, agent_id, pane_id, tab_id, workspace_id, agent_t
 const rosterSeqUnknown = 1 << 30
 
 // PublishRoster replaces the live roster with the agents herdr currently
-// reports, in ONE transaction, and stamps roster_meta.
+// reports, in ONE transaction, and stamps roster_meta — when a row changed or
+// the stamp is older than domain.RosterRestampAfter.
 //
 // Everything not in the set is marked gone rather than deleted, and an agent
 // whose terminal_id CHANGED is replaced rather than merged: herdr recycles
@@ -71,6 +72,9 @@ func (s *Store) PublishRoster(ctx context.Context, agents []domain.RosterAgent, 
 			return err
 		}
 
+		// changed records whether this publish wrote any roster row; only a
+		// publish that did, or a stamp gone stale, re-stamps roster_meta.
+		changed := false
 		live := make(map[string]bool, len(agents))
 		var recycled []any
 		recycledIDs := map[string]bool{}
@@ -92,6 +96,7 @@ func (s *Store) PublishRoster(ctx context.Context, agents []domain.RosterAgent, 
 				append([]any{s.self}, recycled...)...); err != nil {
 				return err
 			}
+			changed = true
 		}
 		for i, a := range agents {
 			// An agent whose stored row already says exactly what this publish
@@ -112,6 +117,7 @@ func (s *Store) PublishRoster(ctx context.Context, agents []domain.RosterAgent, 
 			if err := s.upsertRosterRow(ctx, tx, a, i, true); err != nil {
 				return err
 			}
+			changed = true
 		}
 		// Everything of ours not in the listing is marked gone, in one statement.
 		var absent []string
@@ -155,6 +161,27 @@ func (s *Store) PublishRoster(ctx context.Context, agents []domain.RosterAgent, 
 					terminal_id = excluded.terminal_id,
 					retired_at = excluded.retired_at`, tombstones...); err != nil {
 				return err
+			}
+			changed = true
+		}
+		// The stamp is the liveness proof (domain.RosterFresh) — and a write,
+		// which under turso arms a push. A publish that changed nothing leaves
+		// a recent stamp alone (domain.RosterRestampAfter), so a TUI's roster
+		// tick over a settled herd commits a read-only transaction.
+		if !changed {
+			var stampedAt int64
+			err := tx.QueryRowContext(ctx,
+				`SELECT published_at FROM roster_meta WHERE node_id = ?`, s.self).Scan(&stampedAt)
+			switch {
+			case errors.Is(err, sql.ErrNoRows):
+			case err != nil:
+				return err
+			default:
+				// An age below zero is a clock that stepped back: stamp, so
+				// the proof is re-based on the clock readers compare against.
+				if age := now.Sub(fromUnix(stampedAt)); stampedAt != 0 && age >= 0 && age < domain.RosterRestampAfter {
+					return nil
+				}
 			}
 		}
 		_, err = tx.ExecContext(ctx, `

--- a/internal/store/rosterdirty_test.go
+++ b/internal/store/rosterdirty_test.go
@@ -70,14 +70,82 @@ func TestRepublishingASettledHerdWritesNothing(t *testing.T) {
 		}
 	}
 
-	// roster_meta still stamps: it is the liveness proof (domain.RosterFresh),
-	// and skipping it would make a settled herd read as "no daemon publishing".
-	_, publishedAt, err := s.LiveRoster(ctx)
+	// Nor is roster_meta: a stamp this recent is still the liveness proof, and
+	// re-stamping it would be the one write left in a settled publish — under
+	// turso, a push to Turso Cloud every tick. TestASettledHerdIsRestamped
+	// covers the stamp ageing out.
+	if got := rosterStampedAt(t, s); !got.Equal(first.Truncate(time.Millisecond)) {
+		t.Errorf("roster_meta.published_at = %v, want it left at the first publish %v", got, first)
+	}
+}
+
+// rosterStampedAt reads this node's roster_meta stamp.
+func rosterStampedAt(t *testing.T, s *Store) time.Time {
+	t.Helper()
+	_, publishedAt, err := s.LiveRoster(context.Background())
 	if err != nil {
 		t.Fatalf("live roster: %v", err)
 	}
-	if !publishedAt.Equal(second.Truncate(time.Millisecond)) && publishedAt.Unix() != second.Unix() {
-		t.Errorf("roster_meta.published_at = %v, want the second publish at %v", publishedAt, second)
+	return publishedAt
+}
+
+// TestASettledHerdIsRestamped is the other half of leaving the stamp alone: a
+// settled herd must never read as "no daemon publishing". The stamp moves once
+// it is domain.RosterRestampAfter old, and immediately whenever a publish
+// changed something — a status, or an agent vanishing.
+func TestASettledHerdIsRestamped(t *testing.T) {
+	if domain.RosterRestampAfter*4 > domain.RosterStaleAfter {
+		t.Fatalf("RosterRestampAfter %v leaves too little margin under RosterStaleAfter %v",
+			domain.RosterRestampAfter, domain.RosterStaleAfter)
+	}
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+	t0 := time.Now().Truncate(time.Millisecond)
+	agents := []domain.RosterAgent{
+		{AgentID: "pane-1", PaneID: "pane-1", TabID: "t1", WorkspaceID: "w1",
+			AgentType: "claude", Status: "idle", TerminalID: "term-1", SeenAt: t0},
+		{AgentID: "pane-2", PaneID: "pane-2", TabID: "t1", WorkspaceID: "w1",
+			AgentType: "codex", Status: "idle", TerminalID: "term-2", SeenAt: t0},
+	}
+	publish := func(at time.Time, herd []domain.RosterAgent) {
+		t.Helper()
+		if err := s.PublishRoster(ctx, herd, at); err != nil {
+			t.Fatalf("publish at %v: %v", at, err)
+		}
+	}
+	publish(t0, agents)
+
+	almost := t0.Add(domain.RosterRestampAfter - time.Second)
+	publish(almost, agents)
+	if got := rosterStampedAt(t, s); !got.Equal(t0) {
+		t.Fatalf("stamp moved to %v before it aged out; want %v", got, t0)
+	}
+
+	aged := t0.Add(domain.RosterRestampAfter)
+	publish(aged, agents)
+	if got := rosterStampedAt(t, s); !got.Equal(aged) {
+		t.Fatalf("stamp = %v once it aged out, want %v", got, aged)
+	}
+
+	moved := aged.Add(time.Second)
+	agents[0].Status = "working"
+	publish(moved, agents)
+	if got := rosterStampedAt(t, s); !got.Equal(moved) {
+		t.Errorf("stamp = %v after a status change, want %v", got, moved)
+	}
+
+	vanished := moved.Add(time.Second)
+	publish(vanished, agents[:1])
+	if got := rosterStampedAt(t, s); !got.Equal(vanished) {
+		t.Errorf("stamp = %v after an agent vanished, want %v", got, vanished)
+	}
+
+	// A clock that stepped back re-bases the proof rather than trusting a
+	// stamp from the future forever.
+	back := t0.Add(-time.Minute)
+	publish(back, agents[:1])
+	if got := rosterStampedAt(t, s); !got.Equal(back) {
+		t.Errorf("stamp = %v after the clock stepped back, want %v", got, back)
 	}
 }
 
@@ -209,5 +277,46 @@ func TestAReorderedHerdIsRepublished(t *testing.T) {
 	}
 	if len(live) != 2 || live[0].AgentID != "pane-2" {
 		t.Fatalf("herdr's order was not republished: %+v", live)
+	}
+}
+
+// TestRevisionMovesOnAWriteAndHoldsAcrossReads pins the change token the TUI
+// polls in place of a full re-read, in every store mode: the sqlite file stamp,
+// the socket, and the daemon's in-process executor. A settled roster publish is
+// the read-only case that matters most — the TUI's own roster tick used to move
+// it every two seconds.
+func TestRevisionMovesOnAWriteAndHoldsAcrossReads(t *testing.T) {
+	s, _ := openTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	agents := []domain.RosterAgent{{AgentID: "pane-1", PaneID: "pane-1", TabID: "t1",
+		WorkspaceID: "w1", AgentType: "claude", Status: "idle", TerminalID: "term-1", SeenAt: now}}
+	if err := s.PublishRoster(ctx, agents, now); err != nil {
+		t.Fatal(err)
+	}
+	rev := func() string {
+		t.Helper()
+		r, err := s.Revision(ctx)
+		if err != nil {
+			t.Fatalf("revision: %v", err)
+		}
+		return r
+	}
+	before := rev()
+	if _, _, err := s.LiveRoster(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PublishRoster(ctx, agents, now.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if got := rev(); got != before {
+		t.Errorf("reads and a settled publish moved the revision %q → %q", before, got)
+	}
+	agents[0].Status = "working"
+	if err := s.PublishRoster(ctx, agents, now.Add(4*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if got := rev(); got == before {
+		t.Errorf("a changed publish left the revision at %q", got)
 	}
 }

--- a/internal/store/sqlbridge/client.go
+++ b/internal/store/sqlbridge/client.go
@@ -175,6 +175,19 @@ func (s *remoteSession) roundTrip(ctx context.Context, req request) (response, e
 	return resp, nil
 }
 
+// Revision asks the daemon for its change token. A daemon predating the request
+// answers with a statement error, which leaves the connection usable.
+func (s *remoteSession) Revision(ctx context.Context) (string, error) {
+	resp, err := s.roundTrip(ctx, request{Kind: kindRev})
+	if err != nil {
+		return "", err
+	}
+	if resp.Rev == "" {
+		return "", ErrNoRevision
+	}
+	return resp.Rev, nil
+}
+
 func (s *remoteSession) transport(ctx context.Context, err error) error {
 	if ctx.Err() != nil {
 		return &transportError{err: ctx.Err()}

--- a/internal/store/sqlbridge/driver.go
+++ b/internal/store/sqlbridge/driver.go
@@ -29,6 +29,41 @@ type freshnessChecker interface {
 	Fresh(ctx context.Context) bool
 }
 
+// revisioner is a backend that can report the executor's change token.
+type revisioner interface {
+	Revision(ctx context.Context) (string, error)
+}
+
+// ErrNoRevision: the handle cannot report a change token — it is not a bridge,
+// or the daemon behind it predates the request.
+var ErrNoRevision = errors.New("sqlbridge: this handle reports no revision")
+
+// Revision returns the change token (Executor.Revision) of the executor behind
+// db, over one of db's OWN pooled connections — no dial, no new server session.
+// ErrNoRevision when db is not a bridge handle.
+func Revision(ctx context.Context, db *sql.DB) (string, error) {
+	c, err := db.Conn(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer c.Close()
+	var rev string
+	err = c.Raw(func(dc any) error {
+		bc, ok := dc.(*conn)
+		if !ok {
+			return ErrNoRevision
+		}
+		r, ok := bc.b.(revisioner)
+		if !ok {
+			return ErrNoRevision
+		}
+		var err error
+		rev, err = r.Revision(ctx)
+		return bc.wrap(err)
+	})
+	return rev, err
+}
+
 // Connector is a driver.Connector whose connections run in-process through an
 // Executor — the daemon's own path to the gated database.
 type Connector struct{ e *Executor }

--- a/internal/store/sqlbridge/executor.go
+++ b/internal/store/sqlbridge/executor.go
@@ -26,7 +26,10 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"strconv"
 	"sync"
+	"sync/atomic"
+	"time"
 )
 
 // Executor runs statements against a *sql.DB behind the sync gate.
@@ -38,12 +41,31 @@ type Executor struct {
 	// loop debounces a push on it. Statements inside a transaction report at
 	// COMMIT, since nothing is durable before it.
 	onWrite func()
+	// rev counts every change a reader could observe — a committed write, a
+	// pull that brought rows in — and epoch names this executor, since a
+	// restarted daemon counts from zero again. Together they are Revision.
+	rev   atomic.Uint64
+	epoch int64
 }
 
 // NewExecutor wraps db. onWrite may be nil.
 func NewExecutor(db *sql.DB, onWrite func()) *Executor {
-	return &Executor{db: db, onWrite: onWrite}
+	return &Executor{db: db, onWrite: onWrite, epoch: time.Now().UnixNano()}
 }
+
+// Revision is an opaque token that changes whenever a read could return
+// something different. A front end compares it between polls instead of
+// re-reading everything: the TUI used to pull its whole data set through the
+// socket every two seconds, and serving that was most of the daemon's CPU while
+// one was open. It is bumped AFTER a change lands, so a reader that samples it
+// before reading can only see a change twice, never miss one.
+func (e *Executor) Revision() string {
+	return strconv.FormatInt(e.epoch, 36) + "." + strconv.FormatUint(e.rev.Load(), 10)
+}
+
+// NoteChanged records a change that is not a local write — a sync pull that
+// brought rows in — so Revision moves without arming a push.
+func (e *Executor) NoteChanged() { e.rev.Add(1) }
 
 // DB is the wrapped handle.
 func (e *Executor) DB() *sql.DB { return e.db }
@@ -55,6 +77,7 @@ func (e *Executor) Lock() { e.gate.Lock() }
 func (e *Executor) Unlock() { e.gate.Unlock() }
 
 func (e *Executor) noteWrite() {
+	e.rev.Add(1)
 	if e.onWrite != nil {
 		e.onWrite()
 	}
@@ -66,7 +89,12 @@ type Session struct {
 	e    *Executor
 	conn *sql.Conn
 	tx   *sql.Tx
-	mu   sync.Mutex
+	// txWrote records that the open transaction ran an Exec, so COMMIT
+	// reports a write only when there is one. Every commit used to count:
+	// under turso that armed a push for each read-only transaction, and a
+	// roster publish that found nothing to change still cost a changeset.
+	txWrote bool
+	mu      sync.Mutex
 }
 
 // Session opens a dedicated connection.
@@ -114,8 +142,12 @@ func (s *Session) Exec(ctx context.Context, query string, args []any) (lastID, a
 	}
 	lastID, _ = res.LastInsertId()
 	affected, _ = res.RowsAffected()
+	// Any successful Exec counts, whatever it affected: DDL reports 0 rows
+	// and must still reach the other nodes.
 	if s.tx == nil {
 		s.e.noteWrite()
+	} else {
+		s.txWrote = true
 	}
 	return lastID, affected, nil
 }
@@ -194,9 +226,10 @@ func (s *Session) Commit(ctx context.Context) error {
 		return errNoTx
 	}
 	err := s.tx.Commit()
-	s.tx = nil
+	wrote := s.txWrote
+	s.tx, s.txWrote = nil, false
 	s.e.gate.RUnlock()
-	if err == nil {
+	if err == nil && wrote {
 		s.e.noteWrite()
 	}
 	return err
@@ -210,7 +243,7 @@ func (s *Session) Rollback(ctx context.Context) error {
 		return errNoTx
 	}
 	err := s.tx.Rollback()
-	s.tx = nil
+	s.tx, s.txWrote = nil, false
 	s.e.gate.RUnlock()
 	return err
 }
@@ -224,13 +257,17 @@ func (s *Session) Ping(ctx context.Context) error {
 	return s.conn.PingContext(ctx)
 }
 
+// Revision is the executor's change token (see Executor.Revision). It takes
+// no connection and no gate: it describes the database, not a statement.
+func (s *Session) Revision(context.Context) (string, error) { return s.e.Revision(), nil }
+
 // Close rolls back any open transaction and returns the connection.
 func (s *Session) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.tx != nil {
 		_ = s.tx.Rollback()
-		s.tx = nil
+		s.tx, s.txWrote = nil, false
 		s.e.gate.RUnlock()
 	}
 	return s.conn.Close()

--- a/internal/store/sqlbridge/server.go
+++ b/internal/store/sqlbridge/server.go
@@ -200,6 +200,8 @@ func (s *Server) handle(ctx context.Context, sess *Session, req request) respons
 			return fail(errors.New("sqlbridge: this daemon allocates no ids"))
 		}
 		return response{Kind: kindOK, LastID: strconv.FormatInt(s.opts.NextID(), 10)}
+	case kindRev:
+		return response{Kind: kindOK, Rev: s.e.Revision()}
 	default:
 		return fail(errors.New("sqlbridge: unknown request kind " + strconv.Quote(req.Kind)))
 	}

--- a/internal/store/sqlbridge/sqlbridge_test.go
+++ b/internal/store/sqlbridge/sqlbridge_test.go
@@ -375,3 +375,133 @@ func TestNextIDComesFromTheDaemonsAllocator(t *testing.T) {
 		t.Fatal("a missing socket must be an error, not an id")
 	}
 }
+
+// TestOnlyATransactionThatWroteReportsAWrite pins the push trigger to real
+// writes. Every commit used to count, so under turso a read-only transaction
+// — a roster publish that found nothing to change, a status snapshot — armed a
+// push to Turso Cloud. The writing half is the control: without it the test
+// passes for a Commit that never reports anything.
+func TestOnlyATransactionThatWroteReportsAWrite(t *testing.T) {
+	var writes atomic.Int32
+	e := NewExecutor(openBacking(t), func() { writes.Add(1) })
+	local, remote, _ := bridges(t, e)
+	for name, db := range map[string]*sql.DB{"local": local, "remote": remote} {
+		t.Run(name, func(t *testing.T) {
+			writes.Store(0)
+			tx, err := db.Begin()
+			if err != nil {
+				t.Fatal(err)
+			}
+			var n int
+			if err := tx.QueryRow(`SELECT COUNT(*) FROM t`).Scan(&n); err != nil {
+				t.Fatal(err)
+			}
+			if err := tx.Commit(); err != nil {
+				t.Fatal(err)
+			}
+			if got := writes.Load(); got != 0 {
+				t.Errorf("a read-only commit reported %d writes, want 0", got)
+			}
+
+			// A rolled-back write reports nothing either, and must not leak
+			// its flag into the next transaction on the same session.
+			tx, err = db.Begin()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tx.Exec(`INSERT INTO t (txt) VALUES ('rolled back')`); err != nil {
+				t.Fatal(err)
+			}
+			if err := tx.Rollback(); err != nil {
+				t.Fatal(err)
+			}
+			tx, err = db.Begin()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := tx.Commit(); err != nil {
+				t.Fatal(err)
+			}
+			if got := writes.Load(); got != 0 {
+				t.Errorf("rollback then an empty commit reported %d writes, want 0", got)
+			}
+
+			tx, err = db.Begin()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tx.Exec(`INSERT INTO t (txt) VALUES ('kept')`); err != nil {
+				t.Fatal(err)
+			}
+			if got := writes.Load(); got != 0 {
+				t.Errorf("an uncommitted write reported %d writes, want 0 before COMMIT", got)
+			}
+			if err := tx.Commit(); err != nil {
+				t.Fatal(err)
+			}
+			if got := writes.Load(); got != 1 {
+				t.Errorf("a writing commit reported %d writes, want 1", got)
+			}
+		})
+	}
+}
+
+// TestRevisionMovesOnEveryObservableChange pins the change token a front end
+// polls instead of re-reading its data: it moves on a committed write and on a
+// NoteChanged (a pull), holds still across reads and read-only transactions,
+// and reads the same over the in-process driver and the socket. A plain
+// sqlite handle is not a bridge and says so.
+func TestRevisionMovesOnEveryObservableChange(t *testing.T) {
+	e := NewExecutor(openBacking(t), nil)
+	local, remote, _ := bridges(t, e)
+	ctx := context.Background()
+	rev := func(db *sql.DB) string {
+		t.Helper()
+		r, err := Revision(ctx, db)
+		if err != nil {
+			t.Fatalf("revision: %v", err)
+		}
+		return r
+	}
+	start := rev(remote)
+	if got := rev(local); got != start {
+		t.Fatalf("in-process %q and socket %q disagree", got, start)
+	}
+	var n int
+	if err := remote.QueryRow(`SELECT COUNT(*) FROM t`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := remote.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if got := rev(remote); got != start {
+		t.Errorf("reads moved the revision %q → %q", start, got)
+	}
+
+	if _, err := local.Exec(`INSERT INTO t (txt) VALUES ('a')`); err != nil {
+		t.Fatal(err)
+	}
+	afterWrite := rev(remote)
+	if afterWrite == start {
+		t.Errorf("a committed write left the revision at %q", start)
+	}
+	e.NoteChanged()
+	if got := rev(remote); got == afterWrite {
+		t.Errorf("a pull left the revision at %q", got)
+	}
+
+	// Another executor — a restarted daemon — never reads as "unchanged",
+	// even at the same count.
+	if other := NewExecutor(openBacking(t), nil); other.Revision() == NewExecutor(openBacking(t), nil).Revision() {
+		t.Errorf("two executors share a revision token %q", other.Revision())
+	}
+
+	plain := openBacking(t)
+	if _, err := Revision(ctx, plain); !errors.Is(err, ErrNoRevision) {
+		t.Errorf("a plain handle: %v, want ErrNoRevision", err)
+	}
+}

--- a/internal/store/sqlbridge/wire.go
+++ b/internal/store/sqlbridge/wire.go
@@ -15,6 +15,7 @@ import (
 //	→ {"id":N,"k":"exec"|"query","q":"<sql>","a":[<value>…]}
 //	→ {"id":N,"k":"begin"|"commit"|"rollback"|"ping"}
 //	→ {"id":N,"k":"nextid"}                      ← {"id":N,"k":"ok","li":"<int64>"}
+//	→ {"id":N,"k":"rev"}                         ← {"id":N,"k":"ok","rv":"<token>"}
 //	← {"id":N,"k":"ok","li":"<int64>","ra":"<int64>"}
 //	← {"id":N,"k":"rows","c":["col"…],"r":[[<value>…]…]}
 //	← {"id":N,"k":"err","m":"<message>"}
@@ -37,6 +38,7 @@ type response struct {
 	Kind     string        `json:"k"`
 	LastID   string        `json:"li,omitempty"`
 	Affected string        `json:"ra,omitempty"`
+	Rev      string        `json:"rv,omitempty"`
 	Columns  []string      `json:"c,omitempty"`
 	Rows     [][]wireValue `json:"r,omitempty"`
 	Message  string        `json:"m,omitempty"`
@@ -56,9 +58,12 @@ const (
 	// processes on one machine from minting the same id in the same
 	// millisecond. The id rides in "li".
 	kindNextID = "nextid"
-	kindOK     = "ok"
-	kindRows   = "rows"
-	kindErr    = "err"
+	// kindRev asks for the executor's change token (Executor.Revision), so a
+	// front end can tell "nothing changed" without re-reading its data.
+	kindRev  = "rev"
+	kindOK   = "ok"
+	kindRows = "rows"
+	kindErr  = "err"
 )
 
 type wireValue struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -33,6 +33,7 @@ import (
 	_ "modernc.org/sqlite"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store/sqlbridge"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 )
@@ -78,6 +79,9 @@ type Store struct {
 	// onWrite is called after every committed write (nil-safe). The daemon's
 	// sync loop uses it to debounce a push.
 	onWrite func()
+	// path is the sqlite file, when the store was opened from one; Revision
+	// stats it. Empty for a handle passed to OpenDB.
+	path string
 }
 
 // Options configures OpenDB.
@@ -204,12 +208,17 @@ func Open(path string) (*Store, error) {
 	// BEGIN under busy_timeout instead of failing mid-transaction, so extra
 	// connections cost queueing rather than errors.
 	db.SetMaxOpenConns(sqlitePoolSize)
-	return OpenDB(db, Options{
+	st, err := OpenDB(db, Options{
 		NodeID:       nodeID,
 		Engine:       EngineSQLite,
 		Migrate:      true,
 		AgentLockDir: filepath.Join(dir, "agent-automation-locks"),
 	})
+	if err != nil {
+		return nil, err
+	}
+	st.path = path
+	return st, nil
 }
 
 // sqlitePoolSize is the modernc connection pool for every sqlite-engine open
@@ -226,11 +235,16 @@ func OpenAs(path, nodeID string) (*Store, error) {
 		return nil, fmt.Errorf("open sqlite: %w", err)
 	}
 	db.SetMaxOpenConns(sqlitePoolSize)
-	return OpenDB(db, Options{
+	st, err := OpenDB(db, Options{
 		NodeID:       nodeID,
 		Engine:       EngineSQLite,
 		AgentLockDir: filepath.Join(filepath.Dir(path), "agent-automation-locks-"+nodeID),
 	})
+	if err != nil {
+		return nil, err
+	}
+	st.path = path
+	return st, nil
 }
 
 // OpenDB wraps an already-open database handle. It is how the turso engine is
@@ -281,6 +295,40 @@ func (s *Store) MigrateWith(between func() error) error { return s.migrate(betwe
 // Ping reports whether the database answers — for a proxied store, whether the
 // daemon serving it is reachable.
 func (s *Store) Ping(ctx context.Context) error { return s.db.PingContext(ctx) }
+
+// ErrNoRevision: this store cannot report a change token (see Revision).
+var ErrNoRevision = errors.New("store: no revision for this handle")
+
+// Revision returns an opaque token that changes whenever a read of this store
+// could return something different, so a front end can skip re-reading data
+// that has not moved. Under turso it is the daemon's executor counter
+// (sqlbridge.Executor.Revision) — over the socket for a front end, in-process
+// for the daemon. Under sqlite it is the database file's and its WAL's size
+// and modification time: every committing process appends to the WAL, and a
+// checkpoint rewrites the file. Reads touch neither (only -shm). ErrNoRevision
+// when neither applies; callers then re-read as they always did.
+func (s *Store) Revision(ctx context.Context) (string, error) {
+	rev, err := sqlbridge.Revision(ctx, s.db)
+	if !errors.Is(err, sqlbridge.ErrNoRevision) {
+		return rev, err
+	}
+	if s.path == "" {
+		return "", ErrNoRevision
+	}
+	var b strings.Builder
+	for _, p := range []string{s.path, s.path + "-wal"} {
+		fi, err := os.Stat(p)
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			b.WriteString("-;")
+		case err != nil:
+			return "", err
+		default:
+			fmt.Fprintf(&b, "%d:%d;", fi.ModTime().UnixNano(), fi.Size())
+		}
+	}
+	return b.String(), nil
+}
 
 // noteWrite reports a committed write to the sync hook.
 func (s *Store) noteWrite() {
@@ -1776,22 +1824,31 @@ func (s *Store) LatestAuditForSignature(ctx context.Context, signature string) (
 // otherwise make on each ~2s refresh into one grouped query. The inner
 // MAX(id)-per-signature scan is index-served by idx_audit_signature.
 func (s *Store) LatestAuditsForSignatures(ctx context.Context) (map[string]*domain.AuditRecord, error) {
+	// A LISTING's columns only, never auditCols: the rest of a row — the pane
+	// excerpt, the LLM's output, the salient — is most of audit_log's bytes,
+	// and this runs for EVERY learned rule on each TUI refresh. Selecting the
+	// whole row moved ~30MB through the store proxy per refresh on a
+	// 787-rule store and was over half the TUI's CPU and most of the daemon's
+	// while a TUI was open. A view needing the full row reads it with
+	// LatestAuditForSignature, as the signature detail does.
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT `+auditCols+` FROM audit_log
+		`SELECT id, node_id, signature, status, action_or_escalation, created_at FROM audit_log
 		 WHERE id IN (SELECT MAX(id) FROM audit_log WHERE signature <> '' GROUP BY signature)`)
 	if err != nil {
 		return nil, err
 	}
-	audits, err := s.scanAudits(rows)
-	if err != nil {
-		return nil, err
-	}
-	out := make(map[string]*domain.AuditRecord, len(audits))
-	for i := range audits {
-		a := audits[i]
+	defer rows.Close()
+	out := map[string]*domain.AuditRecord{}
+	for rows.Next() {
+		var a domain.AuditRecord
+		var created int64
+		if err := rows.Scan(&a.ID, &a.NodeID, &a.Signature, &a.Status, &a.Action, &created); err != nil {
+			return nil, err
+		}
+		a.CreatedAt = fromUnix(created)
 		out[a.Signature] = &a
 	}
-	return out, nil
+	return out, rows.Err()
 }
 
 // LatestKillEvent returns the newest GLOBAL kill event row, or nil (read every

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1556,7 +1556,8 @@ func TestLatestAuditForSignature(t *testing.T) {
 	s.AppendAudit(ctx, domain.AuditRecord{Signature: "sig:x", Trigger: "old",
 		SituationType: domain.SituationApproval, Action: "1", CreatedAt: now.Add(-time.Minute)})
 	s.AppendAudit(ctx, domain.AuditRecord{Signature: "sig:x", Trigger: "new",
-		SituationType: domain.SituationApproval, Action: "2", CreatedAt: now})
+		SituationType: domain.SituationApproval, Action: "2", CreatedAt: now,
+		Status: "auto", PaneExcerpt: "a whole pane of text", Rationale: "why", LLMOutput: "llm said"})
 	s.AppendAudit(ctx, domain.AuditRecord{Signature: "sig:other", Trigger: "other",
 		SituationType: domain.SituationApproval, Action: "3", CreatedAt: now})
 	a, err := s.LatestAuditForSignature(ctx, "sig:x")
@@ -1585,7 +1586,8 @@ func TestLatestAuditsForSignatures(t *testing.T) {
 	s.AppendAudit(ctx, domain.AuditRecord{Signature: "sig:x", Trigger: "old",
 		SituationType: domain.SituationApproval, Action: "1", CreatedAt: now.Add(-time.Minute)})
 	s.AppendAudit(ctx, domain.AuditRecord{Signature: "sig:x", Trigger: "new",
-		SituationType: domain.SituationApproval, Action: "2", CreatedAt: now})
+		SituationType: domain.SituationApproval, Action: "2", CreatedAt: now,
+		Status: "auto", PaneExcerpt: "a whole pane of text", Rationale: "why", LLMOutput: "llm said"})
 	s.AppendAudit(ctx, domain.AuditRecord{Signature: "sig:other", Trigger: "other",
 		SituationType: domain.SituationApproval, Action: "3", CreatedAt: now})
 	// A signature-less row (e.g. an unclassifiable escalation) must not appear.
@@ -1599,11 +1601,22 @@ func TestLatestAuditsForSignatures(t *testing.T) {
 	if len(m) != 2 {
 		t.Fatalf("expected one row per non-empty signature (2), got %d: %v", len(m), m)
 	}
-	if m["sig:x"] == nil || m["sig:x"].Trigger != "new" {
+	if m["sig:x"] == nil || m["sig:x"].Action != "2" {
 		t.Errorf("sig:x should map to its NEWEST audit, got %+v", m["sig:x"])
 	}
-	if m["sig:other"] == nil || m["sig:other"].Trigger != "other" {
+	if m["sig:other"] == nil || m["sig:other"].Action != "3" {
 		t.Errorf("sig:other missing or wrong: %+v", m["sig:other"])
+	}
+	// A LISTING's subset only: the heavy columns are what made this query most
+	// of a TUI refresh's cost, so carrying them again must fail here.
+	if x := m["sig:x"]; x != nil {
+		if x.PaneExcerpt != "" || x.LLMOutput != "" || x.Rationale != "" {
+			t.Errorf("the listing carried heavy columns: excerpt=%q llm=%q rationale=%q",
+				x.PaneExcerpt, x.LLMOutput, x.Rationale)
+		}
+		if x.CreatedAt.Unix() != now.Unix() || x.Status != "auto" {
+			t.Errorf("the listing lost what it renders: created=%v status=%q", x.CreatedAt, x.Status)
+		}
 	}
 	if _, ok := m[""]; ok {
 		t.Errorf("signature-less rows must be excluded from the map")

--- a/internal/store/turso/sync_test.go
+++ b/internal/store/turso/sync_test.go
@@ -331,3 +331,43 @@ func TestSchemaLeaseIsExclusiveBetweenTwoNodes(t *testing.T) {
 		t.Fatalf("%d nodes believe they hold the schema lease, want exactly 1", owners)
 	}
 }
+
+// TestAPullThatBroughtRowsMovesTheRevision covers the one change a front end's
+// poll cannot see as a local write: rows another node pushed, arriving through
+// this node's pull. The TUI skips its re-read while the store's revision holds
+// still, so a pull that changed rows without moving it would leave another
+// machine's escalation off the screen until the backstop.
+func TestAPullThatBroughtRowsMovesTheRevision(t *testing.T) {
+	url := startLocalSyncServer(t)
+	a := openNode(t, url, "aaaaaaaaaaaaaaaa")
+	a.sync(t)
+	b := openNode(t, url, "bbbbbbbbbbbbbbbb")
+	b.sync(t)
+	ctx := context.Background()
+	before, err := b.st.Revision(ctx)
+	if err != nil {
+		t.Fatalf("revision: %v", err)
+	}
+	if _, err := a.st.AppendAudit(ctx, domain.AuditRecord{AgentID: "1", AgentType: "claude", Trigger: "t",
+		SituationType: domain.SituationApproval, Action: domain.AuditActionEscalated, Status: "escalated",
+		CreatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.db.Push(); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := b.db.Pull()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("B's pull after A's push reported nothing new")
+	}
+	after, err := b.st.Revision(ctx)
+	if err != nil {
+		t.Fatalf("revision: %v", err)
+	}
+	if after == before {
+		t.Errorf("a pull that brought rows left the revision at %q", after)
+	}
+}

--- a/internal/store/turso/turso.go
+++ b/internal/store/turso/turso.go
@@ -167,7 +167,13 @@ func (d *DB) Pull() (changed bool, err error) {
 	defer d.ops.Done()
 	d.exec.Lock()
 	defer d.exec.Unlock()
-	return d.sdb.Pull(context.Background())
+	changed, err = d.sdb.Pull(context.Background())
+	if changed {
+		// Before the gate opens: a reader that gets in next already sees
+		// the moved revision.
+		d.exec.NoteChanged()
+	}
+	return changed, err
 }
 
 // Push sends local changes to the remote.

--- a/internal/tui/probe_test.go
+++ b/internal/tui/probe_test.go
@@ -1,0 +1,120 @@
+package tui
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// probeModel is a model over a real sqlite store that has taken its first,
+// full refresh — the state every later tick starts from.
+func probeModel(t *testing.T, st ports.StorePort) (Model, *store.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	raw, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { raw.Close() })
+	if st == nil {
+		st = raw
+	}
+	app := &frontend.App{Store: st, ConfigPath: seedLocalFSConfigIn(t, dir), Author: "op", StateDir: dir}
+	m := New(context.Background(), app)
+	m.width, m.height = 100, 30
+	first, ok := m.refresh()().(refreshMsg)
+	if !ok || first.err != nil {
+		t.Fatalf("first refresh: %#v", first.err)
+	}
+	mm, _ := m.Update(first)
+	return mm.(Model), raw
+}
+
+// TestAnUnchangedStoreIsProbedNotReRead pins the TUI's idle cost: a tick over
+// data that has not moved asks for the change key and re-reads NOTHING, while
+// a write is picked up on the very next tick. Serving the old unconditional
+// 2s re-read was most of the daemon's CPU while a TUI was open.
+func TestAnUnchangedStoreIsProbedNotReRead(t *testing.T) {
+	m, st := probeModel(t, nil)
+	if m.lastChangeKey == "" {
+		t.Fatal("a refresh over a sqlite store recorded no change key")
+	}
+	poll := func(at time.Time) tea.Msg { return m.poll(at)() }
+
+	if got, ok := poll(time.Now()).(probeMsg); !ok {
+		t.Fatalf("a tick over unchanged data produced %T, want probeMsg", got)
+	}
+
+	// The control: a write must be a full refresh that carries it.
+	id, err := st.AppendAudit(context.Background(), domain.AuditRecord{
+		AgentID: "a1", SituationType: domain.SituationApproval, Trigger: "t",
+		Action: "escalated", Status: "escalated", CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := poll(time.Now()).(refreshMsg)
+	if !ok {
+		t.Fatalf("a tick after a store write produced %T, want refreshMsg", poll(time.Now()))
+	}
+	if len(got.escalations) != 1 || got.escalations[0].ID != id {
+		t.Errorf("the refresh after the write carried %v, want escalation %d", got.escalations, id)
+	}
+	mm, _ := m.Update(got)
+	m = mm.(Model)
+	if _, ok := poll(time.Now()).(probeMsg); !ok {
+		t.Error("the tick after that refresh re-read again; the key did not settle")
+	}
+
+	// What a refresh derives from the clock is re-read on the backstop.
+	if _, ok := poll(time.Now().Add(refreshBackstop)).(refreshMsg); !ok {
+		t.Error("the backstop did not force a full refresh")
+	}
+}
+
+// TestAProbeRefreshesHealthButIsNotActivity: a probe still carries what a poll
+// reads besides the data, and finding nothing changed is exactly the quiet the
+// idle backoff waits for — it must not reset the idle clock.
+func TestAProbeRefreshesHealthButIsNotActivity(t *testing.T) {
+	m, _ := probeModel(t, nil)
+	quietSince := time.Now().Add(-time.Hour)
+	m.lastActivity = quietSince
+	health := frontend.DaemonHealth{Running: true, PID: 4242}
+	mm, cmd := m.Update(probeMsg{health: health})
+	m = mm.(Model)
+	if cmd != nil {
+		t.Errorf("a probe scheduled %T; it must not trigger more work", cmd())
+	}
+	if m.data.daemonHealth.PID != 4242 {
+		t.Errorf("daemon health = %+v, want the probe's", m.data.daemonHealth)
+	}
+	if !m.lastActivity.Equal(quietSince) {
+		t.Error("a probe that found nothing reset the idle clock")
+	}
+}
+
+// TestAStoreWithoutAChangeKeyIsReReadEveryTick is the fallback: a store that
+// cannot report a change token gets the old behaviour, never a stale screen.
+func TestAStoreWithoutAChangeKeyIsReReadEveryTick(t *testing.T) {
+	dir := t.TempDir()
+	raw, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { raw.Close() })
+	m, _ := probeModel(t, struct{ ports.StorePort }{raw})
+	if m.lastChangeKey != "" {
+		t.Fatalf("a store without a change token recorded key %q", m.lastChangeKey)
+	}
+	if got, ok := m.poll(time.Now())().(refreshMsg); !ok {
+		t.Errorf("a tick without a change key produced %T, want refreshMsg", got)
+	}
+}

--- a/internal/tui/probe_test.go
+++ b/internal/tui/probe_test.go
@@ -118,3 +118,88 @@ func TestAStoreWithoutAChangeKeyIsReReadEveryTick(t *testing.T) {
 		t.Errorf("a tick without a change key produced %T, want refreshMsg", got)
 	}
 }
+
+// TestTheBackstopIsMeasuredFromTheAsk pins the backstop to the moment a refresh
+// was asked for: the next tick is timed from that moment, so measuring from
+// the refresh's ARRIVAL left every other slow tick a probe — a 30s backstop
+// that was really 60s on an idle TUI.
+func TestTheBackstopIsMeasuredFromTheAsk(t *testing.T) {
+	m, _ := probeModel(t, nil)
+	asked := m.lastFullRefresh.Add(refreshBackstop)
+	got, ok := m.poll(asked)().(refreshMsg)
+	if !ok {
+		t.Fatalf("the backstop tick produced %T, want refreshMsg", got)
+	}
+	mm, _ := m.Update(got)
+	m = mm.(Model)
+	if !m.lastFullRefresh.Equal(asked) {
+		t.Errorf("lastFullRefresh = %v, want the ask %v", m.lastFullRefresh, asked)
+	}
+	if _, ok := m.poll(asked.Add(refreshBackstop))().(refreshMsg); !ok {
+		t.Error("the next slow tick, one backstop after the ask, probed instead of re-reading")
+	}
+}
+
+// lateWriteStore lands a write in the middle of a refresh — after the
+// escalations were read — the race the key's sample-before-read order exists
+// for. Revision is promoted from the embedded store.
+type lateWriteStore struct {
+	*store.Store
+	armed bool
+	id    int64
+}
+
+func (s *lateWriteStore) KillEvents(ctx context.Context, limit int) ([]domain.KillEvent, error) {
+	if s.armed {
+		s.armed = false
+		id, err := s.AppendAudit(ctx, domain.AuditRecord{AgentID: "a1", SituationType: domain.SituationApproval,
+			Trigger: "t", Action: "escalated", Status: "escalated", CreatedAt: time.Now()})
+		if err != nil {
+			return nil, err
+		}
+		s.id = id
+	}
+	return s.Store.KillEvents(ctx, limit)
+}
+
+// TestAWriteDuringARefreshIsNotLost: the key is sampled BEFORE the read, so a
+// write that lands mid-refresh leaves the recorded key stale and the next tick
+// re-reads. Sampled after, the key would already include the write while the
+// data does not, and the screen would miss it until the backstop.
+func TestAWriteDuringARefreshIsNotLost(t *testing.T) {
+	dir := t.TempDir()
+	raw, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { raw.Close() })
+	st := &lateWriteStore{Store: raw}
+	m, _ := probeModel(t, st)
+	st.armed = true
+	now := m.lastFullRefresh.Add(refreshBackstop)
+	mid, ok := m.poll(now)().(refreshMsg)
+	if !ok {
+		t.Fatalf("the backstop tick produced %T, want refreshMsg", mid)
+	}
+	if st.id == 0 {
+		t.Fatal("the late write did not happen")
+	}
+	for _, e := range mid.escalations {
+		if e.ID == st.id {
+			t.Fatal("the escalations were read after the late write; the test no longer lands it mid-refresh")
+		}
+	}
+	mm, _ := m.Update(mid)
+	m = mm.(Model)
+	next, ok := m.poll(now.Add(fastPollInterval))().(refreshMsg)
+	if !ok {
+		t.Fatalf("the tick after a mid-refresh write produced %T, want refreshMsg", next)
+	}
+	found := false
+	for _, e := range next.escalations {
+		found = found || e.ID == st.id
+	}
+	if !found {
+		t.Errorf("the mid-refresh write never reached the screen: %v", next.escalations)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -94,7 +94,19 @@ type refreshMsg struct {
 	// updateDue is true when that cached result has aged out, so the tick
 	// handler knows to fire a background check.
 	updateDue bool
+	// changeKey is frontend.App.ChangeKey sampled BEFORE this refresh read
+	// anything, "" when the App cannot tell. Sampling first means a change
+	// landing mid-read costs one extra refresh, never a missed one.
+	changeKey string
 	err       error
+}
+
+// probeMsg is a poll that found nothing changed (frontend.App.ChangeKey held
+// still), so none of the data was re-read: only what a poll reads besides it —
+// daemon health and the instance-limit sweep — comes back.
+type probeMsg struct {
+	health   frontend.DaemonHealth
+	tuiLimit frontend.TUILimitSweep
 }
 
 // updateCheckedMsg reports that a background release check finished; the
@@ -970,6 +982,12 @@ type Model struct {
 	// lastFingerprint is the previous refresh's activityFingerprint, the
 	// change signal lastActivity is driven from. Empty before the first one.
 	lastFingerprint string
+	// lastChangeKey is the change key the last successful refresh sampled
+	// ("" when there was none or the App cannot tell), and lastFullRefresh
+	// when it landed. A tick whose key still matches skips the re-read — see
+	// poll.
+	lastChangeKey   string
+	lastFullRefresh time.Time
 	// slowPoll records whether the LAST tick was scheduled at the slow
 	// interval, so a return to activity can refresh immediately instead of
 	// waiting out a long timer that is already in flight.
@@ -1742,7 +1760,47 @@ func (m Model) refresh() tea.Cmd {
 	// the 2s tick meant N subprocesses every two seconds to paint a row that is
 	// usually not on screen.
 	modeFor := m.detailAgentID()
-	return func() tea.Msg { return refreshData(ctx, app, modeFor) }
+	groups := m.data.tasks
+	return func() tea.Msg {
+		key, ok := app.ChangeKey(ctx, groups)
+		msg := refreshData(ctx, app, modeFor)
+		if ok {
+			msg.changeKey = key
+		}
+		return msg
+	}
+}
+
+// refreshBackstop bounds how long a TUI trusts an unchanged change key. What a
+// refresh derives from the CLOCK rather than from stored data — roster
+// freshness, the update check's due time, the model file's presence — moves
+// with no write to key on, so it is re-read on this schedule. It matches the
+// idle poll, so a backed-off TUI re-reads on every tick exactly as before.
+const refreshBackstop = slowPollInterval
+
+// poll is the tick's refresh. It re-reads everything only when something may
+// have changed: the change key moved, the App cannot tell, the backstop is
+// due, or an agent detail is open — that overlay renders a permission mode
+// read from the PANE, which no key covers. Otherwise it is a probe: one change
+// token from the store and a few stats. Re-reading unconditionally every two
+// seconds was the TUI's whole idle cost, and serving it was most of the
+// daemon's while a TUI was open.
+func (m Model) poll(now time.Time) tea.Cmd {
+	if m.lastChangeKey == "" || m.detailAgentID() != "" || now.Sub(m.lastFullRefresh) >= refreshBackstop {
+		return m.refresh()
+	}
+	app, ctx, groups, last := m.app, m.ctx, m.data.tasks, m.lastChangeKey
+	return func() tea.Msg {
+		key, ok := app.ChangeKey(ctx, groups)
+		if ok && key == last {
+			return probeMsg{health: app.AssessDaemonHealth(), tuiLimit: enforceTUILimit(app)}
+		}
+		msg := refreshData(ctx, app)
+		if ok {
+			msg.changeKey = key
+		}
+		return msg
+	}
 }
 
 // detailAgentID returns the agent id an agents-tab detail overlay is currently
@@ -1772,18 +1830,7 @@ func refreshData(ctx context.Context, app *frontend.App, modeFor ...string) refr
 	// Daemon health is read from local state files (never errors), so assess it
 	// first — it stays meaningful even when GetStatus fails (e.g. daemon down).
 	msg.daemonHealth = app.AssessDaemonHealth()
-	// Keep only the newest few TUIs alive: every extra one re-runs this whole
-	// refresh on its own 2s tick. Throttled inside the App, and deliberately
-	// not allowed to fail the refresh — an unenforceable limit is a slow TUI,
-	// not a broken one.
-	if sweep, err := app.EnforceTUISessionLimit(); err != nil {
-		// Once per process: refreshData runs on a 2s tick, so a registry error
-		// that persists (an unwritable state dir, a stale lock) would otherwise
-		// write 43,200 identical lines a day into the daemon's log file.
-		logging.WarnOnce("tui-session-limit", "TUI instance limit not enforced", "error", err)
-	} else {
-		msg.tuiLimit = sweep
-	}
+	msg.tuiLimit = enforceTUILimit(app)
 	msg.status, msg.err = app.GetStatus(ctx)
 	if msg.err != nil {
 		return msg
@@ -1846,6 +1893,36 @@ func refreshData(ctx context.Context, app *frontend.App, modeFor ...string) refr
 	msg.update = app.UpdateStatus(msg.cfg)
 	msg.updateDue = app.UpdateCheckDue(msg.cfg)
 	return msg
+}
+
+// enforceTUILimit keeps only the newest few TUIs alive: every extra one runs
+// its own poll. Throttled inside the App, and deliberately not allowed to fail
+// the poll — an unenforceable limit is a slow TUI, not a broken one.
+func enforceTUILimit(app *frontend.App) frontend.TUILimitSweep {
+	sweep, err := app.EnforceTUISessionLimit()
+	if err != nil {
+		// Once per process: this runs on a 2s tick, so a registry error that
+		// persists (an unwritable state dir, a stale lock) would otherwise
+		// write 43,200 identical lines a day into the daemon's log file.
+		logging.WarnOnce("tui-session-limit", "TUI instance limit not enforced", "error", err)
+	}
+	return sweep
+}
+
+// takeTUILimit records a sweep that closed older TUIs as the note to show, and
+// shows a pending one. Never over an error the operator is reading: a failed
+// action they just triggered is the one they need. It is held rather than
+// dropped, because no later sweep will re-report it — a peer already asked to
+// close is skipped for its whole grace, and gone after that — and a pane that
+// vanished with no explanation is the thing this note exists to prevent.
+func (m *Model) takeTUILimit(sweep frontend.TUILimitSweep) {
+	if len(sweep.Closed) > 0 {
+		m.pendingTUINote = closedTUINote(sweep)
+	}
+	if m.pendingTUINote != "" && (m.status == nil || !m.status.err) {
+		m.status = &statusNote{text: m.pendingTUINote, at: time.Now()}
+		m.pendingTUINote = ""
+	}
 }
 
 // closedTUINote explains a sweep that closed older TUIs, naming the setting to
@@ -2102,19 +2179,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Say so when this instance closed older ones: from the operator's side
 		// a pane they left open simply disappeared, and the reason (a limit they
 		// can raise) is only knowable from here.
-		// Never over an error the operator is reading: a failed action they
-		// just triggered is the one they need. It is held rather than dropped,
-		// because no later sweep will re-report it — a peer already asked to
-		// close is skipped for its whole grace, and gone after that — and a
-		// pane that vanished with no explanation is the thing this note exists
-		// to prevent.
-		if len(msg.tuiLimit.Closed) > 0 {
-			m.pendingTUINote = closedTUINote(msg.tuiLimit)
-		}
-		if m.pendingTUINote != "" && (m.status == nil || !m.status.err) {
-			m.status = &statusNote{text: m.pendingTUINote, at: time.Now()}
-			m.pendingTUINote = ""
-		}
+		m.takeTUILimit(msg.tuiLimit)
 		// A failed refresh returns before the update fields are filled, so
 		// carry the last known ones forward — the hint must not blink out of
 		// the header for every frame a store read happens to fail.
@@ -2126,6 +2191,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// keyboard. A failed refresh is not evidence of quiet either — it would
 		// otherwise let a broken store back the poll off — so it also refreshes
 		// the stamp without pretending to know the fingerprint.
+		if msg.err != nil {
+			m.lastChangeKey = ""
+		} else {
+			m.lastChangeKey, m.lastFullRefresh = msg.changeKey, time.Now()
+		}
 		if msg.err != nil {
 			m.lastActivity = time.Now()
 		} else if fp := activityFingerprint(msg); fp != m.lastFingerprint {
@@ -2270,10 +2340,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, msg.run
 	case openTaskSourceFieldMsg:
 		return m.openTaskSourceFieldPrompt(msg)
+	case probeMsg:
+		// Nothing changed, so nothing is re-derived and the idle clock is
+		// left alone: a probe that finds no change IS the quiet the backoff
+		// waits for.
+		m.data.daemonHealth = msg.health
+		m.takeTUILimit(msg.tuiLimit)
+		return m, nil
 	case tickMsg:
 		now := time.Now()
 		m.slowPoll = m.idle(now)
-		cmds := []tea.Cmd{m.refresh(), tick(m.refreshInterval(now))}
+		cmds := []tea.Cmd{m.poll(now), tick(m.refreshInterval(now))}
 		if m.updateCheckAllowed(time.Now()) {
 			m.updateChecking = true
 			m.lastUpdateCheck = time.Now()

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -98,7 +98,12 @@ type refreshMsg struct {
 	// anything, "" when the App cannot tell. Sampling first means a change
 	// landing mid-read costs one extra refresh, never a missed one.
 	changeKey string
-	err       error
+	// polledAt is the tick (or keypress) that asked for this refresh — what
+	// the backstop measures from, since the next tick is scheduled from the
+	// same moment. Stamping arrival instead made every other slow tick a
+	// probe: the next one lands 30s after the ask, under 30s after arrival.
+	polledAt time.Time
+	err      error
 }
 
 // probeMsg is a poll that found nothing changed (frontend.App.ChangeKey held
@@ -1751,7 +1756,10 @@ func (m Model) clockInterval(now time.Time) time.Duration {
 	return fastClockInterval
 }
 
-func (m Model) refresh() tea.Cmd {
+func (m Model) refresh() tea.Cmd { return m.refreshAt(time.Now()) }
+
+// refreshAt is refresh for a poll asked for at now.
+func (m Model) refreshAt(now time.Time) tea.Cmd {
 	app, ctx := m.app, m.ctx
 	// Only the agent whose detail overlay is OPEN needs its permission mode: it
 	// is the sole place the TUI renders one, and reading it costs a `herdr pane
@@ -1767,6 +1775,7 @@ func (m Model) refresh() tea.Cmd {
 		if ok {
 			msg.changeKey = key
 		}
+		msg.polledAt = now
 		return msg
 	}
 }
@@ -1775,7 +1784,9 @@ func (m Model) refresh() tea.Cmd {
 // refresh derives from the CLOCK rather than from stored data — roster
 // freshness, the update check's due time, the model file's presence — moves
 // with no write to key on, so it is re-read on this schedule. It matches the
-// idle poll, so a backed-off TUI re-reads on every tick exactly as before.
+// idle poll, so a backed-off TUI re-reads on every tick exactly as before —
+// which holds because it is measured from when each refresh was ASKED for
+// (refreshMsg.polledAt), the same moment the next tick is timed from.
 const refreshBackstop = slowPollInterval
 
 // poll is the tick's refresh. It re-reads everything only when something may
@@ -1787,7 +1798,7 @@ const refreshBackstop = slowPollInterval
 // daemon's while a TUI was open.
 func (m Model) poll(now time.Time) tea.Cmd {
 	if m.lastChangeKey == "" || m.detailAgentID() != "" || now.Sub(m.lastFullRefresh) >= refreshBackstop {
-		return m.refresh()
+		return m.refreshAt(now)
 	}
 	app, ctx, groups, last := m.app, m.ctx, m.data.tasks, m.lastChangeKey
 	return func() tea.Msg {
@@ -1799,6 +1810,7 @@ func (m Model) poll(now time.Time) tea.Cmd {
 		if ok {
 			msg.changeKey = key
 		}
+		msg.polledAt = now
 		return msg
 	}
 }
@@ -2194,7 +2206,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.lastChangeKey = ""
 		} else {
-			m.lastChangeKey, m.lastFullRefresh = msg.changeKey, time.Now()
+			m.lastChangeKey, m.lastFullRefresh = msg.changeKey, msg.polledAt
+			if m.lastFullRefresh.IsZero() {
+				m.lastFullRefresh = time.Now()
+			}
 		}
 		if msg.err != nil {
 			m.lastActivity = time.Now()


### PR DESCRIPTION
## Why

With #437/#439 merged, an open `hap tui` was the biggest idle cost left. Profiled live (`HAP_PROFILE_DIR`, one TUI, 120s window):

- **daemon** — ~76% of its CPU was the store socket serving the TUI's queries (turso row stepping + JSON encoding); the 2s roster tick itself was ~0.4%.
- **TUI** — 72% in its 2s `refreshData`, and 55% of all of it in one call: `App.Signatures` → `Store.LatestAuditsForSignatures`, which pulled the latest **full** audit row (pane excerpt, LLM output, salient…) for every one of 787 rules on every tick — ~30MB allocated per refresh, 4.8GB per 120s. Rendering (`View`) was ~1%.

## What

- **The TUI re-reads only when something changed.** New optional `ports.RevisionReporter` / `Store.Revision`: under turso the daemon's executor counter (`sqlbridge.Executor.Revision`, bumped after every committed write and every pull that changed rows, prefixed with an epoch so a restarted daemon never reads as "unchanged"), fetched with one tiny `rev` request over a pooled connection; under sqlite the db file's and WAL's size+mtime. `frontend.App.ChangeKey` adds config.toml and local checklist files. `tui.Model.poll` does a full refresh only when the key moved, an agent detail is open (its permission mode comes from the pane), or a 30s backstop is due (clock-derived state: roster freshness, update-check due); otherwise a probe refreshes daemon health and the instance-limit sweep only. The key is sampled **before** the read, so a change landing mid-read costs an extra refresh, never a missed one. A gist task source, or a store without the port, keeps the old every-tick re-read.
- **The Rules listing's last-used lookup is lean** — `LatestAuditsForSignatures` selects only id/node/signature/status/action/time (the only fields a listing renders); the signature detail still reads the full row.
- **Read-only work no longer arms a Turso push** — a bridge transaction reports a write at COMMIT only if it ran an Exec (it used to report every commit), and `PublishRoster` re-stamps `roster_meta` only when a row changed or the stamp is `domain.RosterRestampAfter` (30s) old — bounded above by the one-minute sweep, far inside `RosterStaleAfter` (3min).
- **The roster tick backs off** while herdr's listing is unchanged: 2s → 4s → 8s → 15s, back to 2s on a changed listing, any agent transition event, or a TUI that has just opened. Status changes still publish instantly through the event path; only vanish/move detection waits up to 15s.

## Before / after — live, same devbox and herd, model loaded, one TUI open

Same method both runs: plugin linked to the build, `hap daemon --ensure`, no DEGRADED line, TUI started in a scratch pane, 120 one-second `top` samples from ~1.5 min after start, then 60s of `strace -e execve` on the daemon.

| one TUI open | before (main after #439) | after (this PR) |
|---|---|---|
| daemon CPU, avg of 120×1s | 14.23% | **3.55%** |
| daemon CPU, max 1s sample | 35.0% | **21.8%** |
| `hap tui` CPU, avg of 120×1s | 8.69% | **2.84%** |
| `hap tui` CPU, max 1s sample | 53.3% | **9.0%** |
| `hap tui` RSS / high-water | 61 / 65 MB | **41 / 42 MB** |
| daemon RSS | 144 MB | 125 MB |
| daemon subprocesses / 60s | 39 (31 `herdr agent list`) | **13 (5 `herdr agent list`)** |

TUI memory: the live heap was only ~2.5MB in both; the RSS was garbage churn from the ~30MB each refresh allocated decoding full audit rows (4.8GB allocated per 120s), which the lean listing and the skipped re-reads remove.

CPU profile of one steady-state 120s window each (`HAP_PROFILE_DIR`, same TUI pane, ~4–6 min after start):

| per 120s window | before | after |
|---|---|---|
| daemon, whole process | 15.86s | **3.13s** |
| daemon, store socket serving the TUI | 12.08s | **2.27s** |
| TUI, whole process | 8.42s | **1.85s** |
| TUI, full re-reads (`refreshData`) | 6.02s | **0.76s** |
| TUI, `LatestAuditsForSignatures` | 3.95s | **0.12s** |
| TUI, change-key probes (`ChangeKey`) | — | 0.03s |
| TUI, bytes allocated | 4.8 GB | **0.5 GB** |

What is left is the full re-reads that still happen when the store really moved — under turso a fleet pull that brings rows bumps the revision too — and the daemon's own sync loop.

## Tests

- `sqlbridge`: a read-only / rolled-back transaction reports no write, a writing commit reports one (local + socket); the revision moves on a write and a pull, holds across reads, agrees over both drivers, differs across executors, and a plain handle says `ErrNoRevision`.
- `store` (sqlite / proxy / turso): a settled publish leaves the stamp alone; it is re-stamped once `RosterRestampAfter` old, at once on a change or a vanished agent, and after a clock step back; the revision holds across reads and a settled publish and moves on a changed one; the listing's audit rows carry no heavy columns.
- `frontend`: the change key holds across reads and moves on a store write, a config edit and a same-size checklist edit; a gist list and a store without the port answer "cannot tell".
- `tui`: an unchanged store is probed, not re-read; a write is picked up on the next tick and the key settles again; the backstop forces a refresh and is measured from when the refresh was asked for (so the idle poll still re-reads every tick); a write landing mid-refresh is picked up by the next tick (the key is sampled before the read); a probe updates health without resetting the idle clock; a store without the port is re-read every tick.
- `daemon`: the tick backs off 2→4→8→15s on an unchanged listing and snaps back on a changed listing, a transition, and a newly opened TUI — including one reopened while another node's TUI is watching; no tick without a TUI.
- `turso` (two real nodes over a local `tursodb` sync server): a pull that brought another node's rows moves the revision.
- Mutation-checked, 15/15 caught: commit reporting every transaction, a settled publish always stamping, a stamp that never ages out, a poll that always re-reads, no backstop, no backoff, no reset on a transition or a newly opened TUI, a write that does not bump the revision, config missing from the key, a gist list accepted, heavy columns back in the listing, the demand level recorded on only some tick paths, the backstop stamped on arrival, the key sampled after the read.
- Full suite green, plus the store suite under `HAP_STORE_TEST_MODE=proxy` and `turso`.
