### PR TITLE
#0 perf: subscribe herdr agent-status events only for agent panes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1091,10 +1091,15 @@ where the behaviour could revert.
   panes are replayed as `pane_created`.
 - **A status subscription costs herdr CPU per pane, so only AGENT panes are watched** (`Subscriber.agentPanes`,
   herdr 0.8.2): with 13 live panes (2 agents) the per-pane subscriptions were ~5.5 points of the server's CPU —
-  more than half its load with the daemon up — against ~2.7 for the agent panes alone, while the discovery stream
+  more than half its load with the daemon up — against ~2.8 for the agent panes alone, while the discovery stream
   and hap's CLI calls were negligible. The label comes from `pane.list` (authoritative; an agent that exited
   clears it) or `pane.agent_detected`, and a label newly attached to an existing pane resubscribes
-  (`upsertPane`). **Test trap:** `fakeherdr.AddPane` is a plain SHELL — a test pushing status must use
+  (`upsertPane`) — too late for ONE event by construction: herdr emits the detection and the agent's first status
+  in the same update, so a resubscribe that ADDS an agent pane replays its status from the `pane.list` snapshot
+  (`replayStatus`; not on the first subscribe, which the startup reconcile covers). **A listing that labels NO pane falls back to watching every pane** (and keeps discovery's
+  labels) — `min_herdr_version` is 0.7.0 and a herdr not reporting labels in `pane.list` would otherwise leave
+  every agent running at daemon start unwatched; a herd with no agents takes the same path, harmlessly.
+  **Test trap:** `fakeherdr.AddPane` is a plain SHELL — a test pushing status must use
   `AddAgentPane` (or `PushAgentDetected` first), exactly as real herdr only reports status for a detected agent.
 - Adding a pane makes the subscriber reconnect ("pane set changed", 1s backoff) — tests pushing transitions
   right after `AddPane` must wait past the resubscribe.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1089,6 +1089,13 @@ where the behaviour could revert.
   in case a build ships the caret binding, failing closed when the learned label matches no offered environment.
 - One `events.subscribe` per socket connection; status subscriptions require a concrete `pane_id`; existing
   panes are replayed as `pane_created`.
+- **A status subscription costs herdr CPU per pane, so only AGENT panes are watched** (`Subscriber.agentPanes`,
+  herdr 0.8.2): with 13 live panes (2 agents) the per-pane subscriptions were ~5.5 points of the server's CPU —
+  more than half its load with the daemon up — against ~2.7 for the agent panes alone, while the discovery stream
+  and hap's CLI calls were negligible. The label comes from `pane.list` (authoritative; an agent that exited
+  clears it) or `pane.agent_detected`, and a label newly attached to an existing pane resubscribes
+  (`upsertPane`). **Test trap:** `fakeherdr.AddPane` is a plain SHELL — a test pushing status must use
+  `AddAgentPane` (or `PushAgentDetected` first), exactly as real herdr only reports status for a detected agent.
 - Adding a pane makes the subscriber reconnect ("pane set changed", 1s backoff) — tests pushing transitions
   right after `AddPane` must wait past the resubscribe.
 - The herdr binary resolves via `HERDR_BIN_PATH` (fallback: `herdr` on PATH); the events socket via

--- a/changelog.d/perf-herdr-load.md
+++ b/changelog.d/perf-herdr-load.md
@@ -1,0 +1,1 @@
+- Cut the load the daemon puts on the herdr server: it now subscribes to agent-status events only for panes that host an agent, instead of every pane — with 13 panes open that was more than half of herdr's CPU

--- a/internal/fakeherdr/fakeherdr.go
+++ b/internal/fakeherdr/fakeherdr.go
@@ -48,6 +48,11 @@ type Server struct {
 	// agents is each pane's detected agent label, reported by pane.list the
 	// way real herdr reports it; a pane absent here is a plain shell.
 	agents map[string]string
+	// statuses is each agent pane's current status, reported by pane.list.
+	statuses map[string]string
+	// omitAgentLabels makes pane.list carry no agent field at all, like a
+	// herdr that does not report labels there (see SetPaneListLabels).
+	omitAgentLabels bool
 
 	// notifications records every notification.show request; notifyShown /
 	// notifyReason are the canned result, defaulting to a displayed toast.
@@ -72,6 +77,7 @@ func NewServer(dir string) (*Server, error) {
 		conns:        map[net.Conn]*clientConn{},
 		panes:        map[string]string{},
 		agents:       map[string]string{},
+		statuses:     map[string]string{},
 		notifyShown:  true,
 		notifyReason: "shown",
 	}
@@ -135,8 +141,12 @@ func (s *Server) serve(conn net.Conn) {
 			var panes []map[string]any
 			for paneID, wsID := range s.panes {
 				p := map[string]any{"pane_id": paneID, "workspace_id": wsID}
-				if label := s.agents[paneID]; label != "" {
+				if label := s.agents[paneID]; label != "" && !s.omitAgentLabels {
 					p["agent"] = label
+				}
+				p["agent_status"] = "unknown"
+				if st := s.statuses[paneID]; st != "" {
+					p["agent_status"] = st
 				}
 				panes = append(panes, p)
 			}
@@ -258,6 +268,15 @@ func (s *Server) AddAgentPane(paneID, workspaceID, agentLabel string) {
 	s.AddPane(paneID, workspaceID)
 }
 
+// SetPaneListLabels controls whether pane.list reports agent labels (the
+// default, as herdr 0.8.2 does). Off, labels still arrive through
+// pane.agent_detected, the way a herdr without them in pane.list behaves.
+func (s *Server) SetPaneListLabels(on bool) {
+	s.mu.Lock()
+	s.omitAgentLabels = !on
+	s.mu.Unlock()
+}
+
 // ClearAgent drops a pane's agent label, as when the agent exits back to its
 // shell: pane.list then reports the pane with no agent.
 func (s *Server) ClearAgent(paneID string) {
@@ -297,9 +316,21 @@ func (s *Server) PushAgentDetected(paneID, workspaceID, agentLabel string) {
 	}, "")
 }
 
+// PushAgentStarted is an agent starting in a pane the way herdr 0.8.2 reports
+// it: ONE state update that emits pane.agent_detected and, straight after, the
+// agent's first pane.agent_status_changed — before any subscriber can react to
+// the detection by subscribing the pane.
+func (s *Server) PushAgentStarted(paneID, workspaceID, agentLabel, status string) {
+	s.PushAgentDetected(paneID, workspaceID, agentLabel)
+	s.PushTransition(paneID, workspaceID, agentLabel, status)
+}
+
 // PushTransition pushes a pane.agent_status_changed event to subscribers
 // whose pane filter matches.
 func (s *Server) PushTransition(paneID, workspaceID, agentLabel, status string) {
+	s.mu.Lock()
+	s.statuses[paneID] = status
+	s.mu.Unlock()
 	s.broadcast("pane.agent_status_changed", map[string]any{
 		"pane_id": paneID, "workspace_id": workspaceID,
 		"agent": agentLabel, "agent_status": status,
@@ -332,6 +363,7 @@ func (s *Server) RemovePaneSilently(paneID string) {
 	s.mu.Lock()
 	delete(s.panes, paneID)
 	delete(s.agents, paneID)
+	delete(s.statuses, paneID)
 	s.mu.Unlock()
 }
 

--- a/internal/fakeherdr/fakeherdr.go
+++ b/internal/fakeherdr/fakeherdr.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -44,6 +45,9 @@ type Server struct {
 	mu    sync.Mutex
 	conns map[net.Conn]*clientConn
 	panes map[string]string // paneID → workspaceID (replayed on subscribe)
+	// agents is each pane's detected agent label, reported by pane.list the
+	// way real herdr reports it; a pane absent here is a plain shell.
+	agents map[string]string
 
 	// notifications records every notification.show request; notifyShown /
 	// notifyReason are the canned result, defaulting to a displayed toast.
@@ -67,6 +71,7 @@ func NewServer(dir string) (*Server, error) {
 		SocketPath: path, ln: ln,
 		conns:        map[net.Conn]*clientConn{},
 		panes:        map[string]string{},
+		agents:       map[string]string{},
 		notifyShown:  true,
 		notifyReason: "shown",
 	}
@@ -129,7 +134,11 @@ func (s *Server) serve(conn net.Conn) {
 			s.mu.Lock()
 			var panes []map[string]any
 			for paneID, wsID := range s.panes {
-				panes = append(panes, map[string]any{"pane_id": paneID, "workspace_id": wsID})
+				p := map[string]any{"pane_id": paneID, "workspace_id": wsID}
+				if label := s.agents[paneID]; label != "" {
+					p["agent"] = label
+				}
+				panes = append(panes, p)
 			}
 			s.mu.Unlock()
 			resp, _ := json.Marshal(map[string]any{
@@ -239,12 +248,48 @@ func (s *Server) AddPane(paneID, workspaceID string) {
 	}, "")
 }
 
+// AddAgentPane registers a pane that already hosts a detected agent — what
+// real herdr reports for a pane running claude or codex: pane.list carries
+// its label, so a subscriber watches its status from the first subscribe.
+func (s *Server) AddAgentPane(paneID, workspaceID, agentLabel string) {
+	s.mu.Lock()
+	s.agents[paneID] = agentLabel
+	s.mu.Unlock()
+	s.AddPane(paneID, workspaceID)
+}
+
+// ClearAgent drops a pane's agent label, as when the agent exits back to its
+// shell: pane.list then reports the pane with no agent.
+func (s *Server) ClearAgent(paneID string) {
+	s.mu.Lock()
+	delete(s.agents, paneID)
+	s.mu.Unlock()
+}
+
+// StatusSubscriptions lists the panes live connections are subscribed to for
+// pane.agent_status_changed, sorted.
+func (s *Server) StatusSubscriptions() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []string
+	for _, cc := range s.conns {
+		for _, sub := range cc.subs {
+			if sub.Type == "pane.agent_status_changed" {
+				out = append(out, sub.PaneID)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 // PushAgentDetected announces an agent label for a pane.
 func (s *Server) PushAgentDetected(paneID, workspaceID, agentLabel string) {
 	s.mu.Lock()
 	if _, ok := s.panes[paneID]; !ok {
 		s.panes[paneID] = workspaceID
 	}
+	s.agents[paneID] = agentLabel
 	s.mu.Unlock()
 	s.broadcast("pane.agent_detected", map[string]any{
 		"type": "pane_agent_detected", "pane_id": paneID,
@@ -286,6 +331,7 @@ func (s *Server) broadcast(eventType string, data map[string]any, paneID string)
 func (s *Server) RemovePaneSilently(paneID string) {
 	s.mu.Lock()
 	delete(s.panes, paneID)
+	delete(s.agents, paneID)
 	s.mu.Unlock()
 }
 

--- a/internal/herdr/events.go
+++ b/internal/herdr/events.go
@@ -38,12 +38,22 @@ type Subscriber struct {
 	mu    sync.Mutex
 	panes map[string]paneInfo // monitored pane set (FR-001)
 	dirty chan struct{}       // signals a pane-set change to the status loop
+
+	// watched is the pane set the status stream last subscribed, each with
+	// the agent label it carried then ("" for a shell), and subscribed
+	// whether it ever has; both are owned by the status loop alone
+	// (runStatus), so they need no lock. See runStatus.
+	watched    map[string]string
+	subscribed bool
 }
 
 type paneInfo struct {
 	workspaceID string
 	tabID       string
 	agentLabel  string
+	// status is the agent status pane.list last reported, used to replay a
+	// newly watched agent's current state (see runStatus).
+	status string
 }
 
 // NewSubscriber creates a subscriber for the given Herdr socket path.
@@ -245,21 +255,59 @@ func (s *Subscriber) runDiscovery(ctx context.Context, out chan<- domain.AgentTr
 // Only panes carrying a detected agent label are watched. A status
 // subscription is not free for herdr: measured on herdr 0.8.2, holding one for
 // each of 13 live panes (2 of them agents) was ~5.5 points of the server's CPU
-// — more than half its load with the daemon up — against ~2.7 for the two
+// — more than half its load with the daemon up — against ~2.8 for the two
 // agent panes alone, and a plain shell never reports an agent status to
 // watch. A shell that STARTS an agent is announced by pane.agent_detected,
-// which labels it and resubscribes (upsertPane); the one thing given up is a
-// status change landing in the milliseconds between that detection and the
-// resubscribe, which the minute sweep's reconcile covers.
+// which labels it and resubscribes (upsertPane).
+//
+// That resubscribe always comes too late for one event: herdr emits the
+// detection and the agent's first status change in the SAME update, so the
+// status is sent while the pane is still unwatched. It is not a race to win.
+// So a resubscribe that adds an agent pane — or finds a label on one it
+// watched as a shell, whose stream the label's own resubscribe tore down
+// mid-update — replays that pane's current status from the pane.list
+// snapshot it just took — once, and only on a resubscribe:
+// the first subscribe is the daemon starting, which its startup reconcile
+// already covers. A duplicate (the event did arrive) is harmless, since the
+// daemon coalesces captures per pane.
+//
+// The filter needs pane.list to REPORT agent labels (herdr 0.8.2 does). A
+// listing that carries none at all — a herdr that does not report them, or a
+// herd with no agent running — subscribes every pane, exactly as before:
+// filtering on labels that are never reported would leave an agent that was
+// already running when the daemon started with no status subscription at all.
 func (s *Subscriber) runStatus(ctx context.Context, out chan<- domain.AgentTransition) error {
-	allPanes, err := s.listPanes(ctx)
+	allPanes, labelled, err := s.listPanes(ctx)
 	if err != nil {
 		// Not wrapped with the method name: call()'s errors already carry it.
 		return err
 	}
-	paneIDs := s.agentPanes(allPanes)
+	paneIDs := allPanes
+	if labelled {
+		paneIDs = s.agentPanes(allPanes)
+	}
+	labels := s.labels(paneIDs)
+	var fresh []string
+	if s.subscribed {
+		for _, id := range paneIDs {
+			// New to the stream, or watched before only as a shell: either
+			// way the detection's status update was not seen as an agent's.
+			if prev, ok := s.watched[id]; labels[id] != "" && (!ok || prev == "") {
+				fresh = append(fresh, id)
+			}
+		}
+	}
+	s.watched = labels
+	s.subscribed = true
+	for _, tr := range s.replayStatus(fresh) {
+		select {
+		case out <- tr:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 	if len(paneIDs) == 0 {
-		// Nothing to watch yet: wait for discovery to find panes.
+		// Nothing to watch yet: wait for discovery to find agent panes.
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -418,6 +466,41 @@ func (s *Subscriber) upsertPane(paneID, workspaceID, tabID, agentLabel string) {
 	}
 }
 
+// labels snapshots the agent label of each pane ("" for a shell).
+func (s *Subscriber) labels(ids []string) map[string]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[string]string, len(ids))
+	for _, id := range ids {
+		label := s.panes[id].agentLabel
+		if domain.IsPlaceholderAgent(label, "") {
+			label = ""
+		}
+		out[id] = label
+	}
+	return out
+}
+
+// replayStatus builds a transition from pane.list's snapshot for each newly
+// watched pane that reported a real agent and status (see runStatus).
+func (s *Subscriber) replayStatus(ids []string) []domain.AgentTransition {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []domain.AgentTransition
+	for _, id := range ids {
+		info := s.panes[id]
+		if info.agentLabel == "" || domain.IsPlaceholderAgent("", info.status) {
+			continue
+		}
+		out = append(out, domain.AgentTransition{
+			AgentID: id, AgentType: info.agentLabel, PaneID: id,
+			TabID: info.tabID, WorkspaceID: info.workspaceID,
+			Status: info.status, At: time.Now(),
+		})
+	}
+	return out
+}
+
 // agentPanes keeps the panes that host a detected agent — the only ones the
 // status subscription watches (see runStatus).
 func (s *Subscriber) agentPanes(ids []string) []string {
@@ -533,20 +616,28 @@ func call(ctx context.Context, dial func(context.Context) (net.Conn, error),
 	return nil
 }
 
-// listPanes queries the live pane set over a short-lived connection.
-func (s *Subscriber) listPanes(ctx context.Context) ([]string, error) {
+// listPanes queries the live pane set over a short-lived connection, and
+// reports whether the listing labelled any pane with its agent (see runStatus).
+func (s *Subscriber) listPanes(ctx context.Context) (ids []string, labelled bool, err error) {
 	var result struct {
 		Panes []struct {
 			PaneID      string `json:"pane_id"`
 			TabID       string `json:"tab_id"`
 			WorkspaceID string `json:"workspace_id"`
 			Agent       string `json:"agent"`
+			AgentStatus string `json:"agent_status"`
 		} `json:"panes"`
 	}
 	if err := call(ctx, s.Dial, "hap_pane_list", "pane.list", map[string]any{}, &result); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	ids := make([]string, 0, len(result.Panes))
+	for _, p := range result.Panes {
+		if !domain.IsPlaceholderAgent(p.Agent, "") {
+			labelled = true
+			break
+		}
+	}
+	ids = make([]string, 0, len(result.Panes))
 	s.mu.Lock()
 	live := map[string]bool{}
 	for _, p := range result.Panes {
@@ -559,12 +650,15 @@ func (s *Subscriber) listPanes(ctx context.Context) ([]string, error) {
 		if p.TabID != "" {
 			info.tabID = p.TabID
 		}
-		// pane.list is the authoritative snapshot: a pane it reports with no
-		// agent has none now (the agent exited back to its shell), so the
-		// label is cleared rather than kept watching a plain shell.
+		info.status = p.AgentStatus
+		// A listing that labels agents is the authoritative snapshot: a pane
+		// it reports with no agent has none now (the agent exited back to its
+		// shell), so the label is cleared rather than kept watching a plain
+		// shell. One that labels nothing says nothing about agents, so the
+		// labels pane.agent_detected attached are kept.
 		if !domain.IsPlaceholderAgent(p.Agent, "") {
 			info.agentLabel = p.Agent
-		} else {
+		} else if labelled {
 			info.agentLabel = ""
 		}
 		s.panes[p.PaneID] = info
@@ -577,7 +671,7 @@ func (s *Subscriber) listPanes(ctx context.Context) ([]string, error) {
 	}
 	s.mu.Unlock()
 	sort.Strings(ids)
-	return ids, nil
+	return ids, labelled, nil
 }
 
 func (s *Subscriber) agentLabel(paneID string) string {

--- a/internal/herdr/events.go
+++ b/internal/herdr/events.go
@@ -235,18 +235,29 @@ func (s *Subscriber) runDiscovery(ctx context.Context, out chan<- domain.AgentTr
 	})
 }
 
-// runStatus subscribes to pane.agent_status_changed for every live pane;
+// runStatus subscribes to pane.agent_status_changed for every live AGENT pane;
 // it returns (to be re-run by loop) whenever the pane set changes. The pane
 // set is fetched authoritatively via pane.list on every (re)subscribe —
 // discovery events only trigger the refresh — so a pane that exited during
 // a reconnect window can never wedge the subscription (herdr rejects
 // subscriptions naming dead panes).
+//
+// Only panes carrying a detected agent label are watched. A status
+// subscription is not free for herdr: measured on herdr 0.8.2, holding one for
+// each of 13 live panes (2 of them agents) was ~5.5 points of the server's CPU
+// — more than half its load with the daemon up — against ~2.7 for the two
+// agent panes alone, and a plain shell never reports an agent status to
+// watch. A shell that STARTS an agent is announced by pane.agent_detected,
+// which labels it and resubscribes (upsertPane); the one thing given up is a
+// status change landing in the milliseconds between that detection and the
+// resubscribe, which the minute sweep's reconcile covers.
 func (s *Subscriber) runStatus(ctx context.Context, out chan<- domain.AgentTransition) error {
-	paneIDs, err := s.listPanes(ctx)
+	allPanes, err := s.listPanes(ctx)
 	if err != nil {
 		// Not wrapped with the method name: call()'s errors already carry it.
 		return err
 	}
+	paneIDs := s.agentPanes(allPanes)
 	if len(paneIDs) == 0 {
 		// Nothing to watch yet: wait for discovery to find panes.
 		select {
@@ -396,12 +407,29 @@ func (s *Subscriber) upsertPane(paneID, workspaceID, tabID, agentLabel string) {
 	}
 	if agentLabel != "" && info.agentLabel != agentLabel {
 		info.agentLabel = agentLabel
+		// A pane that has just gained an agent joins the status
+		// subscription, which only watches agent panes (see runStatus).
+		changed = true
 	}
 	s.panes[paneID] = info
 	s.mu.Unlock()
 	if changed {
 		s.signalDirty()
 	}
+}
+
+// agentPanes keeps the panes that host a detected agent — the only ones the
+// status subscription watches (see runStatus).
+func (s *Subscriber) agentPanes(ids []string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if label := s.panes[id].agentLabel; label != "" && !domain.IsPlaceholderAgent(label, "") {
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 func (s *Subscriber) removePane(paneID string) {
@@ -531,8 +559,13 @@ func (s *Subscriber) listPanes(ctx context.Context) ([]string, error) {
 		if p.TabID != "" {
 			info.tabID = p.TabID
 		}
+		// pane.list is the authoritative snapshot: a pane it reports with no
+		// agent has none now (the agent exited back to its shell), so the
+		// label is cleared rather than kept watching a plain shell.
 		if !domain.IsPlaceholderAgent(p.Agent, "") {
 			info.agentLabel = p.Agent
+		} else {
+			info.agentLabel = ""
 		}
 		s.panes[p.PaneID] = info
 	}

--- a/internal/herdr/herdr_test.go
+++ b/internal/herdr/herdr_test.go
@@ -304,6 +304,13 @@ func TestSubscriberWatchesAPaneOnceAnAgentStartsInIt(t *testing.T) {
 	if got := waitStatusSubs(t, srv, []string{"w1:p1"}); !slices.Equal(got, []string{"w1:p1"}) {
 		t.Fatalf("before: status subscriptions = %v, want [w1:p1]", got)
 	}
+	// Settled, not merely reached: a resubscribe still pending from the
+	// pane.created replays would otherwise pick the label up from pane.list
+	// on its own and hide a missing resubscribe signal.
+	time.Sleep(300 * time.Millisecond)
+	if got := srv.StatusSubscriptions(); !slices.Equal(got, []string{"w1:p1"}) {
+		t.Fatalf("before, settled: status subscriptions = %v, want [w1:p1]", got)
+	}
 
 	srv.PushAgentDetected("w1:sh", "w1", "claude")
 	if got := waitStatusSubs(t, srv, []string{"w1:p1", "w1:sh"}); !slices.Equal(got, []string{"w1:p1", "w1:sh"}) {
@@ -347,6 +354,118 @@ func TestSubscriberStopsWatchingAPaneWhoseAgentExited(t *testing.T) {
 	srv.AddPane("w1:new", "w1") // any pane-set change resubscribes
 	if got := waitStatusSubs(t, srv, []string{"w1:p1"}); !slices.Equal(got, []string{"w1:p1"}) {
 		t.Errorf("after the agent exited: status subscriptions = %v, want [w1:p1]", got)
+	}
+}
+
+// TestSubscriberWatchesEveryPaneWhenPaneListCarriesNoLabels is the
+// compatibility floor: a herdr whose pane.list reports no agent labels would
+// otherwise leave an agent already running at daemon start with no status
+// subscription (discovery labels it, and a label-trusting listing would clear
+// it again). With no labels in the listing every pane is watched, as before,
+// and the agent's status flows.
+func TestSubscriberWatchesEveryPaneWhenPaneListCarriesNoLabels(t *testing.T) {
+	srv, err := fakeherdr.NewServer(testutil.SocketDir(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	srv.SetPaneListLabels(false)
+	srv.AddPane("w1:sh", "w1")
+	srv.AddAgentPane("w1:p1", "w1", "claude")
+
+	sub := NewSubscriber(srv.SocketPath)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := make(chan domain.AgentTransition, 64)
+	go sub.Subscribe(ctx, out)
+	want := []string{"w1:p1", "w1:sh"}
+	if got := waitStatusSubs(t, srv, want); !slices.Equal(got, want) {
+		t.Fatalf("status subscriptions = %v, want every pane %v", got, want)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		srv.PushTransition("w1:p1", "w1", "claude", "idle")
+		select {
+		case tr := <-out:
+			if tr.PaneID == "w1:p1" && tr.Status == "idle" {
+				return
+			}
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+	t.Fatal("the running agent's status never reached the subscriber")
+}
+
+// TestSubscriberDeliversANewAgentsFirstStatus: herdr sends an agent's
+// detection and its first status in ONE update, so the status is emitted
+// while the pane is still unwatched — not a race the resubscribe can win. The
+// resubscribe that adds the pane replays its current status from pane.list;
+// without that the new agent's first park waits for the minute sweep.
+func TestSubscriberDeliversANewAgentsFirstStatus(t *testing.T) {
+	srv, err := fakeherdr.NewServer(testutil.SocketDir(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	srv.AddPane("w1:sh", "w1")
+	srv.AddAgentPane("w1:p1", "w1", "claude")
+
+	sub := NewSubscriber(srv.SocketPath)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := make(chan domain.AgentTransition, 64)
+	go sub.Subscribe(ctx, out)
+	if got := waitStatusSubs(t, srv, []string{"w1:p1"}); !slices.Equal(got, []string{"w1:p1"}) {
+		t.Fatalf("before: status subscriptions = %v, want [w1:p1]", got)
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	srv.PushAgentStarted("w1:sh", "w1", "claude", "idle") // pushed ONCE
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case tr := <-out:
+			if tr.PaneID == "w1:sh" && tr.Status == "idle" && tr.AgentType == "claude" {
+				return
+			}
+		case <-deadline:
+			t.Fatal("the new agent's first status was lost with its detection")
+		}
+	}
+}
+
+// TestSubscriberWithOnlyShellsStillSeesAnAgentStart covers the idle end of the
+// fallback: a herd with no agent yet labels nothing, so every pane is watched
+// and the first agent's status arrives directly.
+func TestSubscriberWithOnlyShellsStillSeesAnAgentStart(t *testing.T) {
+	srv, err := fakeherdr.NewServer(testutil.SocketDir(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	srv.AddPane("w1:sh", "w1")
+	srv.AddPane("w1:sh2", "w1")
+
+	sub := NewSubscriber(srv.SocketPath)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := make(chan domain.AgentTransition, 64)
+	go sub.Subscribe(ctx, out)
+	want := []string{"w1:sh", "w1:sh2"}
+	if got := waitStatusSubs(t, srv, want); !slices.Equal(got, want) {
+		t.Fatalf("status subscriptions = %v, want every pane %v", got, want)
+	}
+	srv.PushAgentStarted("w1:sh2", "w1", "codex", "blocked")
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case tr := <-out:
+			if tr.PaneID == "w1:sh2" && tr.Status == "blocked" {
+				return
+			}
+		case <-deadline:
+			t.Fatal("the first agent's status never arrived")
+		}
 	}
 }
 

--- a/internal/herdr/herdr_test.go
+++ b/internal/herdr/herdr_test.go
@@ -20,9 +20,9 @@ func TestSubscriberReceivesTransitions(t *testing.T) {
 	}
 	defer srv.Close()
 
-	// A pane already exists before the subscriber connects: discovered via
-	// the pane.created replay, then watched for status changes (FR-001).
-	srv.AddPane("w1:p1", "w1")
+	// An agent pane already exists before the subscriber connects: discovered
+	// via the pane.created replay, then watched for status changes (FR-001).
+	srv.AddAgentPane("w1:p1", "w1", "claude")
 
 	sub := NewSubscriber(srv.SocketPath)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -52,7 +52,7 @@ func TestSubscriberIgnoresDoublePlaceholderAgents(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer srv.Close()
-	srv.AddPane("w1:p1", "w1")
+	srv.AddAgentPane("w1:p1", "w1", "claude")
 
 	sub := NewSubscriber(srv.SocketPath)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -177,7 +177,7 @@ func TestSubscriberReconnectsWithBackoff(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer srv.Close()
-	srv.AddPane("w1:p2", "w1")
+	srv.AddAgentPane("w1:p2", "w1", "claude")
 
 	sub := NewSubscriber(srv.SocketPath)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -214,8 +214,8 @@ func TestSubscriberRecoversFromSilentlyVanishedPane(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer srv.Close()
-	srv.AddPane("w1:p1", "w1")
-	srv.AddPane("w1:p9", "w1")
+	srv.AddAgentPane("w1:p1", "w1", "claude")
+	srv.AddAgentPane("w1:p9", "w1", "claude")
 
 	sub := NewSubscriber(srv.SocketPath)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -241,6 +241,113 @@ func TestSubscriberRecoversFromSilentlyVanishedPane(t *testing.T) {
 		}
 	}
 	t.Fatal("subscriber did not recover after a silently vanished pane")
+}
+
+// waitStatusSubs waits until the fake reports exactly want as the status
+// subscriptions held, returning the last observed set.
+func waitStatusSubs(t *testing.T, srv *fakeherdr.Server, want []string) []string {
+	t.Helper()
+	var got []string
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		got = srv.StatusSubscriptions()
+		if slices.Equal(got, want) {
+			return got
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return got
+}
+
+// TestSubscriberWatchesOnlyAgentPanes pins the herdr-side cost: a status
+// subscription is per pane and not free for the server (measured: holding one
+// for each of 13 panes was more than half of herdr's CPU with the daemon up),
+// and a plain shell never reports an agent status. The agent pane is the
+// control — without it the test passes for a subscriber that watches nothing.
+func TestSubscriberWatchesOnlyAgentPanes(t *testing.T) {
+	srv, err := fakeherdr.NewServer(testutil.SocketDir(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	srv.AddPane("w1:sh", "w1")
+	srv.AddPane("w1:sh2", "w1")
+	srv.AddAgentPane("w1:p1", "w1", "claude")
+
+	sub := NewSubscriber(srv.SocketPath)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sub.Subscribe(ctx, make(chan domain.AgentTransition, 16))
+
+	if got := waitStatusSubs(t, srv, []string{"w1:p1"}); !slices.Equal(got, []string{"w1:p1"}) {
+		t.Fatalf("status subscriptions = %v, want only the agent pane [w1:p1]", got)
+	}
+}
+
+// TestSubscriberWatchesAPaneOnceAnAgentStartsInIt: a shell that starts an
+// agent is announced by pane.agent_detected, and from then on its status must
+// flow — the case watching only agent panes could otherwise lose for good.
+func TestSubscriberWatchesAPaneOnceAnAgentStartsInIt(t *testing.T) {
+	srv, err := fakeherdr.NewServer(testutil.SocketDir(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	srv.AddPane("w1:sh", "w1")
+	srv.AddAgentPane("w1:p1", "w1", "claude")
+
+	sub := NewSubscriber(srv.SocketPath)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := make(chan domain.AgentTransition, 64)
+	go sub.Subscribe(ctx, out)
+	if got := waitStatusSubs(t, srv, []string{"w1:p1"}); !slices.Equal(got, []string{"w1:p1"}) {
+		t.Fatalf("before: status subscriptions = %v, want [w1:p1]", got)
+	}
+
+	srv.PushAgentDetected("w1:sh", "w1", "claude")
+	if got := waitStatusSubs(t, srv, []string{"w1:p1", "w1:sh"}); !slices.Equal(got, []string{"w1:p1", "w1:sh"}) {
+		t.Fatalf("after the agent started: status subscriptions = %v, want [w1:p1 w1:sh]", got)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		srv.PushTransition("w1:sh", "w1", "claude", "blocked")
+		select {
+		case tr := <-out:
+			if tr.PaneID == "w1:sh" && tr.Status == "blocked" {
+				return
+			}
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+	t.Fatal("the new agent's status never reached the subscriber")
+}
+
+// TestSubscriberStopsWatchingAPaneWhoseAgentExited: pane.list is the
+// authoritative snapshot, so a pane it reports with no agent (the agent quit
+// back to its shell) leaves the status subscription at the next resubscribe
+// rather than being watched as a plain shell forever.
+func TestSubscriberStopsWatchingAPaneWhoseAgentExited(t *testing.T) {
+	srv, err := fakeherdr.NewServer(testutil.SocketDir(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	srv.AddAgentPane("w1:p1", "w1", "claude")
+	srv.AddAgentPane("w1:p2", "w1", "codex")
+
+	sub := NewSubscriber(srv.SocketPath)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sub.Subscribe(ctx, make(chan domain.AgentTransition, 64))
+	if got := waitStatusSubs(t, srv, []string{"w1:p1", "w1:p2"}); !slices.Equal(got, []string{"w1:p1", "w1:p2"}) {
+		t.Fatalf("before: status subscriptions = %v", got)
+	}
+	srv.ClearAgent("w1:p2")
+	srv.AddPane("w1:new", "w1") // any pane-set change resubscribes
+	if got := waitStatusSubs(t, srv, []string{"w1:p1"}); !slices.Equal(got, []string{"w1:p1"}) {
+		t.Errorf("after the agent exited: status subscriptions = %v, want [w1:p1]", got)
+	}
 }
 
 func TestCLIExecutor(t *testing.T) {


### PR DESCRIPTION
## Why

Task: reduce the load hap puts on the herdr server (16–20% CPU at the v0.9.10 baseline; still ~15% on v0.9.12). Re-measured on a build with #441, herdr 0.8.2, 13 live panes of which 2 are agents, no TUI:

- **CLI calls are no longer the load**: the daemon started **1** `herdr` subprocess per minute (one `agent list`) — #441 took it from 39.
- **The daemon still accounts for more than half of herdr's CPU**: herdr server **~10%** with the daemon up vs **~4%** with it stopped (alternating 40s windows, every stop under a minute, back with `hap daemon --ensure`).
- **It is the per-pane status subscriptions.** The daemon holds one `pane.agent_status_changed` subscription for EVERY live pane. A bare process holding exactly the daemon's subscriptions, with the daemon stopped, reproduced the cost on its own:

| 40s window, herdr server CPU avg | |
|---|---|
| daemon running | 10.1–10.5% |
| daemon stopped | 4.1% |
| stopped + discovery stream only (`pane.created` / `agent_detected` / `exited`) | 4.1% |
| stopped + status subscriptions for all 13 panes | 9.55% |
| stopped + status subscriptions for the 2 agent panes | 6.83% |

A plain shell never reports an agent status, so 11 of those 13 subscriptions were pure cost.

## What

- `herdr.Subscriber` subscribes status only for panes carrying a detected agent label (`agentPanes`). The label comes from `pane.list` — authoritative: a pane reported with no agent (it exited back to its shell) is dropped — or `pane.agent_detected`, and a label newly attached to an existing pane resubscribes (`upsertPane`).
- **A new agent's first status is replayed, not lost.** herdr 0.8.2 emits an agent's detection and its first status in ONE state update, so the status is sent while the pane is still unwatched — not a race the resubscribe can win (found in review). A resubscribe that adds an agent pane, or finds a label on one it watched as a shell, replays that pane's current status from the `pane.list` snapshot it just took (`replayStatus`); not on the first subscribe, which the daemon's startup reconcile covers. A duplicate is harmless (captures coalesce per pane).
- **Older herdr compatibility** (`min_herdr_version` is 0.7.0): a `pane.list` that labels NO pane — a herdr that does not report labels there, or a herd with no agent — subscribes every pane exactly as before and keeps discovery's labels, so an agent already running when the daemon restarts is never left unwatched.
- The fake herdr now reports agent labels in `pane.list` like real herdr, with `AddAgentPane` / `ClearAgent` / `StatusSubscriptions`; `AddPane` is a plain shell (CLAUDE.md test trap).

## Before / after

**Live, on the built daemon** (herdr 0.8.2; by now 14 panes, 3 of them agents and working, so a busier and noisier herd than the diagnostic above; alternating 40s windows, every stop under a minute):

| herdr server CPU | daemon up (3 windows) | daemon stopped (2) | hap's share |
|---|---|---|---|
| main | 17.0 / 16.1 / 14.2 — avg 15.8% | 8.4 / 8.9 — avg 8.6% | ~7.2 pts |
| this PR | 11.9 / 13.3 / 14.3 — avg 13.2% | 6.0 / 8.4 — avg 7.2% | ~6.0 pts |

The live herd moves a few points between windows on its own (three agents working), so the controlled diagnostic above — same moment, only the subscription set varied: 9.55% for every pane vs 6.83% for the agent panes — is the cleaner measure of the change; the live run agrees in direction.

**Restart check on this build, with an agent already running** (a scratch `claude --model haiku` in its own workspace, started BEFORE the daemon restart, no TUI open so the roster tick is off and only status events can move `hap agents`):

```
[15:02:52] after restart: patient-quokka  wH:p1  claude  idle  enabled  /tmp  manual
[15:02:57] prompted the agent
  [15:02:58] hap agents: patient-quokka idle
  [15:03:00] hap agents: patient-quokka working      <- status event, 2s after the prompt
  [15:03:02] hap agents: patient-quokka done
  [15:03:13] PONG on the pane — the task was handed out and answered
daemon log:
  15:02:43 reconcile: re-driving parked agent  agent=wH:p1 status=idle
  15:03:11 automated action delivered  agent=wH:p1 situation=idle  "declared task from a source with enable_auto_send_task_when_idle"
```

The idle hand-out came from the attention event (9s after the park = the first-event capture delay), not the minute sweep. The temporary task source, its list and the scratch workspace were removed afterwards.

## Tests

- `herdr`: only agent panes are watched (plain shells beside the agent pane — the control); a shell that starts an agent is subscribed and its status flows; a pane whose agent exited is dropped at the next resubscribe; **an agent's first status, sent in the same update as its detection (`fakeherdr.PushAgentStarted`, pushed once), still arrives**; with only shells (no labels) every pane is watched and the first agent's status arrives; **a `pane.list` with no labels at all (`SetPaneListLabels(false)`) watches every pane**. The existing subscriber tests that push status now use agent panes, as real herdr only reports status for one.
- Mutation-checked: removing the filter, the resubscribe on a new label, the label clearing, the no-labels fallback, the replay, or the "watched only as a shell" replay case each fails a test.
- Full suite green; the e2e harness already labels its pane (`PushAgentDetected`) and waits past the resubscribe.
- **Real-agent integration suite** (`HAP_ITEST_CLAUDE=1 HAP_ITEST_CODEX=1 go test -tags "integration vectors cpu" ./test/integration/`, haiku): **17 passed, 2 failed, 2 skipped — and main's tree gives the identical result**, so nothing here is a regression:
  - `TestRealClaudeModeCycle` fails the same way on main: `modeApp` opens a scratch store no daemon ever publishes a roster to, and `SetAgentMode` has required one since #386 (the test predates it, #323) — broken since then, unnoticed because it only runs with `HAP_ITEST_CLAUDE=1`.
  - `TestRealShiftTabKeyNameIsStillBroken` is the tripwire firing on main too: herdr 0.8.2's `shift+tab` key name now WORKS, so `domain.ShiftTab`'s raw CSI Z / `CLI.SendChord` can be simplified — a follow-up, not a failure of this change.
  - Skipped: `TestRealClaudeConsult` (claude auto-approved instead of raising a menu), `TestRealCodexModeToggle` (codex was blocked at startup in this environment).
