### PR TITLE
#0 perf: collect the index-rebuild burst tightly, shrink Turso's per-connection page cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,10 @@ golangci-lint run --build-tags "vectors,cpu"
 - Profiling (opt-in, any verb): `HAP_PROFILE_DIR=<dir> [HAP_PROFILE_SECONDS=60] hap daemon --restart` writes
   ROLLING `<verb>-<pid>.cpu.pprof` / `.heap.pprof` windows (`internal/profiling`) — the files are always the latest
   complete window, so an idle daemon hours in can be read with `go tool pprof -top bin/hap <file>`. The detached
-  daemon inherits the environment; nothing is written or listened on when the variable is unset.
+  daemon inherits the environment; nothing is written or listened on when the variable is unset. Each window also
+  writes `<verb>-<pid>.mem.txt` (Go memory classes, plus `/proc/self/status` on Linux): the heap profile sees only LIVE Go
+  objects, a few MB of a resident set mostly made of file-backed pages, freed-but-unreturned Go heap and native
+  memory (Turso engine, FAISS, llama.cpp) — "go resident" is what to subtract from RssAnon to find the native part.
 - Pipeline smoke test (fake herdr → real daemon → real LLM CLI):
   `go build -o /tmp/e2e ./e2e_harness && /tmp/e2e <short-dir> <hap-bin> <config-dir> <state-dir>`.
 
@@ -618,7 +621,12 @@ unstructured pane-tail and Guard 3 usually answers `heldStillUnevaluable` — th
   - The adapter gates the SDK (statements read-lock, Push/Pull/Checkpoint write-lock, transactions hold the
     lock, rows returned EAGERLY) over a FIXED pre-warmed pool, with sync ops on a background context —
     verified: unguarded they flood `database is locked`, and a Push cancelled mid-flight hangs the engine
-    for good.
+    for good. Every pooled connection gets `turso.PageCacheKiB` of page cache — at warm-up, and again whenever a
+    bridge session takes a connection (`sqlbridge.Executor.SetConnInit`), which is what reaches one database/sql
+    opened to replace a discarded one; a refusal is logged, never fatal. The engine default is
+    2000 KiB PER CONNECTION, kept for the daemon's life across the whole pool, duplicating the kernel's page
+    cache. The engine clamps anything under 200 pages up to 200 and reads it back as `200`, so the constant
+    sits at that floor.
   - **Schema DDL on a shared database is issued only by the SCHEMA LEASE holder**
     (`turso.PrepareSharedSchema` / `AcquireSchemaLease`), which must be RE-PROVEN between migration steps,
     failing closed with `ErrSchemaLeaseLost` — a background renewal alone is starved by a step's own write
@@ -843,6 +851,12 @@ collision changed it; an unnamed one is sent `/rename <hap name>`.
 
 ### Semantic matching
 
+- **A knowledge rebuild runs under `tightGC`** (`daemon/memory.go`) — loading every signature and building a
+  fresh index is the daemon's one large allocation burst (~40MB against a live heap of a few MB), and at the
+  default GC target it set the daemon's high-water mark and held ~80MB resident for its first minute. The
+  target is lowered only for the burst and the heap handed back at its end; a process-wide GOGC=25 was measured
+  at roughly double the idle daemon's CPU. It only ever LOWERS (an operator's tighter GOGC stays), overlapping
+  rebuilds nest, and GOGC=off is not touched at all.
 - **Semantic matching degrades, never blocks** — situations resolve via embedding + vector search over the
   MASKED salient (`daemon.resolveSignature`, `internal/match`, `internal/embedder`), falling back to
   normalized BM25, then exact hash. `SignatureResult.Raw` is the never-remapped content hash (the LLM drift

--- a/changelog.d/perf-daemon-memory.md
+++ b/changelog.d/perf-daemon-memory.md
@@ -1,0 +1,3 @@
+- Cut the daemon's memory: its startup peak no longer climbs to ~130MB while the semantic index is rebuilt (the burst is collected tightly and handed back to the OS at once), and each of the Turso engine's pooled connections keeps a far smaller page cache
+- The embed worker hands back its start-up garbage once the model has loaded
+- `HAP_PROFILE_DIR` now also writes a `<verb>-<pid>.mem.txt` beside each heap profile, splitting the Go runtime's memory from the process's resident set

--- a/internal/daemon/memory.go
+++ b/internal/daemon/memory.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"runtime/debug"
+	"runtime/metrics"
+	"sync"
+)
+
+// rebuildGCPercent is the GC target while the knowledge index is rebuilt.
+//
+// A rebuild is the daemon's one large allocation burst: loading every stored
+// signature and building a fresh bleve/FAISS index allocates ~40MB for a
+// 787-rule store in well under a second, against a live heap of a few MB. At
+// the default target the heap is allowed to grow to twice the live data in
+// between collections, which put the daemon's resident set at ~125MB for its
+// first minute and pinned its high-water mark there. Collecting more often for
+// that half-second costs a few milliseconds of CPU; doing it for the whole
+// process (GOGC=25) was measured at roughly double the idle daemon's CPU.
+const rebuildGCPercent = 25
+
+// rebuildGC is the process-wide GC setting shared by overlapping rebuilds (a
+// reload and a fleet pull can both be building); guarded by its mutex.
+var rebuildGC struct {
+	sync.Mutex
+	active    int
+	prev      int
+	tightened bool // the first burst lowered the target; restore it at the last
+	enabled   bool // GC was on, so handing memory back is meaningful
+}
+
+// tightGC lowers the GC target for an allocation burst and returns the
+// function that ends it. The last burst to end restores the previous target
+// and returns the freed heap to the OS at once — the runtime would otherwise
+// hand it back over the next minute or so. It only ever LOWERS: an operator's
+// tighter GOGC stays as it is, and GOGC=off is not touched at all (not even by
+// the handback, which would force a collection). Overlapping calls nest; the
+// returned function is safe to call twice.
+func tightGC() (release func()) {
+	rebuildGC.Lock()
+	if rebuildGC.active == 0 {
+		cur := gcPercent()
+		rebuildGC.prev, rebuildGC.enabled = cur, cur >= 0
+		rebuildGC.tightened = cur > rebuildGCPercent
+		if rebuildGC.tightened {
+			debug.SetGCPercent(rebuildGCPercent)
+		}
+	}
+	rebuildGC.active++
+	rebuildGC.Unlock()
+	return sync.OnceFunc(func() {
+		rebuildGC.Lock()
+		rebuildGC.active--
+		last := rebuildGC.active == 0
+		if last && rebuildGC.tightened {
+			debug.SetGCPercent(rebuildGC.prev)
+		}
+		handBack := last && rebuildGC.enabled
+		rebuildGC.Unlock()
+		if handBack {
+			debug.FreeOSMemory()
+		}
+	})
+}
+
+// gcPercent reads the current GC target without changing it (-1 = off).
+func gcPercent() int {
+	s := []metrics.Sample{{Name: "/gc/gogc:percent"}}
+	metrics.Read(s)
+	if s[0].Value.Kind() != metrics.KindUint64 {
+		return 100
+	}
+	v := int64(s[0].Value.Uint64())
+	if v < 0 || v > 1<<20 {
+		return -1
+	}
+	return int(v)
+}

--- a/internal/daemon/memory_test.go
+++ b/internal/daemon/memory_test.go
@@ -1,0 +1,59 @@
+package daemon
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+// TestTightGCOnlyLowersNestsAndRestores: overlapping rebuilds share one lowered
+// target, only the LAST to finish restores the previous one, and releasing
+// twice is harmless — otherwise one rebuild ending mid-way through another
+// would undo its setting, or leave the whole daemon collecting at the burst
+// rate. An operator's tighter GOGC is never raised, and GOGC=off never moves.
+func TestTightGCOnlyLowersNestsAndRestores(t *testing.T) {
+	rebuildGC.Lock()
+	active := rebuildGC.active
+	rebuildGC.Unlock()
+	if active != 0 {
+		t.Fatalf("%d rebuild(s) already hold the GC setting; this test needs it free", active)
+	}
+	orig := debug.SetGCPercent(100)
+	t.Cleanup(func() { debug.SetGCPercent(orig) })
+
+	outer := tightGC()
+	if got := gcPercent(); got != rebuildGCPercent {
+		t.Fatalf("during a rebuild GC percent = %d, want %d", got, rebuildGCPercent)
+	}
+	inner := tightGC()
+	inner()
+	inner()
+	if got := gcPercent(); got != rebuildGCPercent {
+		t.Fatalf("an inner rebuild ending restored %d while the outer still runs", got)
+	}
+	outer()
+	if got := gcPercent(); got != 100 {
+		t.Errorf("after the last rebuild GC percent = %d, want the previous 100", got)
+	}
+
+	// An operator already running tighter keeps their setting.
+	debug.SetGCPercent(10)
+	release := tightGC()
+	if got := gcPercent(); got != 10 {
+		t.Errorf("GOGC=10 became %d during a rebuild; it may only ever be lowered", got)
+	}
+	release()
+	if got := gcPercent(); got != 10 {
+		t.Errorf("GOGC=10 became %d after a rebuild", got)
+	}
+
+	// GOGC=off stays off throughout.
+	debug.SetGCPercent(-1)
+	release = tightGC()
+	if got := gcPercent(); got != -1 {
+		t.Errorf("GOGC=off became %d during a rebuild", got)
+	}
+	release()
+	if got := gcPercent(); got != -1 {
+		t.Errorf("GOGC=off became %d after a rebuild", got)
+	}
+}

--- a/internal/daemon/semantic.go
+++ b/internal/daemon/semantic.go
@@ -28,6 +28,10 @@ func (d *Daemon) initSemantic(ctx context.Context, gen int64) {
 		return
 	}
 
+	// Loading every row and building a fresh index is the daemon's one large
+	// allocation burst; see tightGC.
+	defer tightGC()()
+
 	// Digest the rows BEFORE loading them: a rule landing between the two then
 	// costs one redundant rebuild on the next refresh, never a missed rule. (A
 	// Reconcile that rewrites rows below costs the same single extra rebuild.)

--- a/internal/embedder/worker.go
+++ b/internal/embedder/worker.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -120,6 +121,7 @@ func RunWorker(ctx context.Context, in io.Reader, out io.Writer) error {
 	bw := bufio.NewWriter(out)
 
 	requests := 0
+	freed := false
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -161,6 +163,15 @@ func RunWorker(ctx context.Context, in io.Reader, out io.Writer) error {
 		}
 		if err := bw.Flush(); err != nil {
 			return err
+		}
+		// The first successful embed is the model load. What the Go side
+		// allocated to get here — every package's init, the load itself —
+		// is garbage from now on; hand it back once rather than letting the
+		// runtime return it over the next minutes of a process that lives
+		// as long as the daemon.
+		if embErr == nil && !freed {
+			freed = true
+			debug.FreeOSMemory()
 		}
 	}
 }

--- a/internal/profiling/profiling.go
+++ b/internal/profiling/profiling.go
@@ -10,6 +10,13 @@
 // starts. The files on disk are therefore always the LATEST complete window,
 // and a process that exits finalizes the window it was in.
 //
+// Each heap snapshot gets a <name>-<pid>.mem.txt beside it: the Go runtime's
+// memory classes (runtime/metrics) and the process's own RSS lines. A heap
+// profile only sees live Go objects, and for hap those are a few MB of a
+// resident set several times larger — the rest is Go memory freed but not yet
+// returned to the OS, goroutine stacks, and the NATIVE side (llama.cpp, FAISS,
+// the Turso engine, malloc arenas). The file is what tells those apart.
+//
 //	HAP_PROFILE_DIR=/tmp/hap-prof hap daemon --restart
 //	go tool pprof -top /tmp/hap-prof/daemon-<pid>.cpu.pprof
 package profiling
@@ -20,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/metrics"
 	"runtime/pprof"
 	"strconv"
 	"strings"
@@ -144,6 +152,66 @@ func (p *profiler) finish() {
 	if err := writeHeap(p.base + ".heap.pprof"); err != nil {
 		slog.Warn("profiling: heap snapshot failed", "error", err)
 	}
+	if err := writeMem(p.base + ".mem.txt"); err != nil {
+		slog.Warn("profiling: memory summary failed", "error", err)
+	}
+}
+
+// memClasses are the runtime/metrics memory classes worth reading against the
+// RSS. They are the large ones, not a partition (the mcache/mspan metadata and
+// profiling buckets are left out), so the lines need not add up to total;
+// "go resident" below is computed from total and released alone.
+var memClasses = []string{
+	"/memory/classes/total:bytes",
+	"/memory/classes/heap/objects:bytes",
+	"/memory/classes/heap/unused:bytes",
+	"/memory/classes/heap/free:bytes",
+	"/memory/classes/heap/released:bytes",
+	"/memory/classes/heap/stacks:bytes",
+	"/memory/classes/os-stacks:bytes",
+	"/memory/classes/metadata/other:bytes",
+	"/memory/classes/other:bytes",
+	"/gc/heap/goal:bytes",
+}
+
+// writeMem writes the Go memory classes and the process's resident-set lines
+// (Linux; elsewhere only the Go half), renamed into place like writeHeap.
+// "Go resident" is total minus released: what the Go runtime holds that the OS
+// counts; whatever RSS is beyond it and beyond file-backed pages is native.
+func writeMem(path string) error {
+	samples := make([]metrics.Sample, len(memClasses))
+	for i, name := range memClasses {
+		samples[i].Name = name
+	}
+	metrics.Read(samples)
+	var b strings.Builder
+	var total, released uint64
+	for _, s := range samples {
+		if s.Value.Kind() != metrics.KindUint64 {
+			continue
+		}
+		v := s.Value.Uint64()
+		switch s.Name {
+		case "/memory/classes/total:bytes":
+			total = v
+		case "/memory/classes/heap/released:bytes":
+			released = v
+		}
+		fmt.Fprintf(&b, "%-40s %8d kB\n", s.Name, v/1024)
+	}
+	fmt.Fprintf(&b, "%-40s %8d kB\n", "go resident (total - released)", (total-released)/1024)
+	if status, err := os.ReadFile("/proc/self/status"); err == nil {
+		for _, line := range strings.Split(string(status), "\n") {
+			if strings.HasPrefix(line, "Vm") || strings.HasPrefix(line, "Rss") || strings.HasPrefix(line, "Threads") {
+				b.WriteString(line + "\n")
+			}
+		}
+	}
+	tmp := path + ".partial"
+	if err := os.WriteFile(tmp, []byte(b.String()), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }
 
 // writeHeap snapshots the heap after a GC, so in-use figures describe what is

--- a/internal/store/sqlbridge/executor.go
+++ b/internal/store/sqlbridge/executor.go
@@ -26,6 +26,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"log/slog"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -46,7 +47,18 @@ type Executor struct {
 	// restarted daemon counts from zero again. Together they are Revision.
 	rev   atomic.Uint64
 	epoch int64
+	// connInit, when set, runs on a session's connection as it is taken (see
+	// SetConnInit).
+	connInit func(ctx context.Context, c *sql.Conn) error
 }
+
+// SetConnInit sets a per-connection setup run on every session's connection
+// as the session takes it — the only moment every connection in use passes
+// through, including one database/sql opened to replace a discarded one (a
+// transaction whose context was cancelled before COMMIT closes its connection).
+// A failure is logged and the session carries on: setup is tuning, never a
+// reason to refuse the store. Call before any session is opened.
+func (e *Executor) SetConnInit(fn func(ctx context.Context, c *sql.Conn) error) { e.connInit = fn }
 
 // NewExecutor wraps db. onWrite may be nil.
 func NewExecutor(db *sql.DB, onWrite func()) *Executor {
@@ -102,6 +114,14 @@ func (e *Executor) Session(ctx context.Context) (*Session, error) {
 	conn, err := e.db.Conn(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if e.connInit != nil {
+		e.gate.RLock()
+		err := e.connInit(ctx, conn)
+		e.gate.RUnlock()
+		if err != nil {
+			slog.Warn("store: connection setup failed; continuing without it", "error", err)
+		}
 	}
 	return &Session{e: e, conn: conn}, nil
 }

--- a/internal/store/sqlbridge/sqlbridge_test.go
+++ b/internal/store/sqlbridge/sqlbridge_test.go
@@ -505,3 +505,43 @@ func TestRevisionMovesOnEveryObservableChange(t *testing.T) {
 		t.Errorf("a plain handle: %v, want ErrNoRevision", err)
 	}
 }
+
+// TestConnInitRunsOnEverySessionAndNeverFailsIt: the per-connection setup is
+// what reaches a connection database/sql opens to replace a discarded one, so
+// it must run as each session takes its connection — and a setup that fails
+// is tuning lost, never a store refused.
+func TestConnInitRunsOnEverySessionAndNeverFailsIt(t *testing.T) {
+	ctx := context.Background()
+	e := NewExecutor(openBacking(t), nil)
+	var calls atomic.Int32
+	e.SetConnInit(func(ctx context.Context, c *sql.Conn) error {
+		calls.Add(1)
+		_, err := c.ExecContext(ctx, "PRAGMA cache_size = -800")
+		return err
+	})
+	for i := 0; i < 3; i++ {
+		s, err := e.Session(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, rows, err := s.Query(ctx, "PRAGMA cache_size", nil)
+		s.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rows) != 1 || rows[0][0] != int64(-800) {
+			t.Errorf("session %d: cache_size = %v, want -800", i, rows)
+		}
+	}
+	if got := calls.Load(); got != 3 {
+		t.Errorf("setup ran %d times for 3 sessions", got)
+	}
+
+	failing := NewExecutor(openBacking(t), nil)
+	failing.SetConnInit(func(context.Context, *sql.Conn) error { return errors.New("refused") })
+	s, err := failing.Session(ctx)
+	if err != nil {
+		t.Fatalf("a failed setup refused the session: %v", err)
+	}
+	s.Close()
+}

--- a/internal/store/turso/sync_test.go
+++ b/internal/store/turso/sync_test.go
@@ -2,6 +2,7 @@ package turso_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net"
 	"os"
@@ -60,6 +61,9 @@ func startLocalSyncServer(t *testing.T) string {
 	return ""
 }
 
+// testPoolConnections is openNode's pool size.
+const testPoolConnections = 4
+
 type node struct {
 	id  string
 	db  *turso.DB
@@ -74,7 +78,7 @@ func openNode(t *testing.T, url, id string) *node {
 	ctx := context.Background()
 	dir := t.TempDir()
 	db, err := turso.Open(ctx, turso.Options{Path: filepath.Join(dir, "hap.db"), RemoteURL: url,
-		AuthToken: os.Getenv("HAP_TURSO_TEST_TOKEN"), ClientName: "hap-" + id, Connections: 4})
+		AuthToken: os.Getenv("HAP_TURSO_TEST_TOKEN"), ClientName: "hap-" + id, Connections: testPoolConnections})
 	if err != nil {
 		t.Fatalf("%s: open: %v", id, err)
 	}
@@ -369,5 +373,40 @@ func TestAPullThatBroughtRowsMovesTheRevision(t *testing.T) {
 	}
 	if after == before {
 		t.Errorf("a pull that brought rows left the revision at %q", after)
+	}
+}
+
+// TestEveryPooledConnectionUsesTheSmallPageCache: the pool is warmed once and
+// kept for the daemon's life, so a connection that missed the pragma keeps the
+// engine's 2000 KiB default for good. Holding every connection at once is what
+// reaches each of them rather than whichever one the pool hands back first.
+func TestEveryPooledConnectionUsesTheSmallPageCache(t *testing.T) {
+	url := startLocalSyncServer(t)
+	n := openNode(t, url, "aaaaaaaaaaaaaaaa")
+	// The store's gated handle parks idle sessions on raw connections; hand
+	// them back so every pooled connection can be held below.
+	n.db.DB().SetMaxIdleConns(0)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	raw := n.db.Executor().DB()
+	var held []*sql.Conn
+	defer func() {
+		for _, c := range held {
+			c.Close()
+		}
+	}()
+	for i := 0; i < testPoolConnections; i++ {
+		c, err := raw.Conn(ctx)
+		if err != nil {
+			t.Fatalf("connection %d: %v", i, err)
+		}
+		held = append(held, c)
+		var kib int64
+		if err := c.QueryRowContext(ctx, "PRAGMA cache_size").Scan(&kib); err != nil {
+			t.Fatalf("connection %d: %v", i, err)
+		}
+		if kib != -turso.PageCacheKiB {
+			t.Errorf("connection %d: cache_size = %d, want %d", i, kib, -turso.PageCacheKiB)
+		}
 	}
 }

--- a/internal/store/turso/turso.go
+++ b/internal/store/turso/turso.go
@@ -21,6 +21,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -50,6 +51,25 @@ type Options struct {
 	Connections int
 	// OnWrite is reported after every committed write (the push debounce).
 	OnWrite func()
+}
+
+// PageCacheKiB is each pooled connection's page cache, in KiB (applied as
+// `PRAGMA cache_size = -PageCacheKiB` while the pool is warmed).
+//
+// The engine's default is 2000 KiB PER CONNECTION, and the pool holds
+// DefaultConnections of them for the life of the daemon, so a warm pool kept up
+// to ~24MB of pages — most of the daemon's native memory, for a database of
+// ~15MB that the kernel's page cache already holds. A miss costs a read from
+// that page cache, not the disk. 800 KiB is the ENGINE'S FLOOR: it clamps any
+// smaller setting to 200 pages (800 KiB at the 4 KiB page size — verified, and
+// it reads back as 200 rather than the value set), so asking for less changes
+// nothing but what the pragma reports.
+const PageCacheKiB = 800
+
+// setPageCache applies PageCacheKiB to one connection.
+func setPageCache(ctx context.Context, c *sql.Conn) error {
+	_, err := c.ExecContext(ctx, fmt.Sprintf("PRAGMA cache_size = -%d", PageCacheKiB))
+	return err
 }
 
 // DefaultConnections covers the daemon's own two plus the socket server's
@@ -115,6 +135,13 @@ func Open(ctx context.Context, opts Options) (*DB, error) {
 	conns := make([]*sql.Conn, 0, n)
 	for i := 0; i < n; i++ {
 		c, err := raw.Conn(ctx)
+		if err == nil {
+			// Tuning, not a precondition: an engine that refuses the pragma
+			// keeps its default cache and the daemon still starts.
+			if perr := setPageCache(ctx, c); perr != nil && i == 0 {
+				slog.Warn("turso: page cache not reduced; keeping the engine default", "error", perr)
+			}
+		}
 		if err != nil {
 			for _, c := range conns {
 				c.Close()
@@ -128,6 +155,9 @@ func Open(ctx context.Context, opts Options) (*DB, error) {
 		c.Close() // back to the pool, which keeps them
 	}
 	exec := sqlbridge.NewExecutor(raw, opts.OnWrite)
+	// Warming covers the pool as opened; this covers any connection
+	// database/sql opens later to replace one it discarded.
+	exec.SetConnInit(setPageCache)
 	d := &DB{sdb: sdb, raw: raw, exec: exec}
 	// The daemon's own handle: two connections, like the local store's.
 	d.db = sqlbridge.OpenGated(exec, 2)


### PR DESCRIPTION
## Why

Task: cut the hap daemon's memory. The orchestrator's baseline (v0.9.10) was daemon RSS ~218MB (HWM 244MB) + embed worker 72MB; most of that was the per-pull index rebuild storm #437 removed — v0.9.12 idles at ~85MB. This PR is what heap profiling found in what is left.

What the resident set actually is (live, 787 signatures, turso engine, model loaded; `HAP_PROFILE_DIR` + the new `.mem.txt`):

| daemon, steady | MB |
|---|---|
| file-backed pages (hap binary text, Turso/FAISS/BLAS libs, bleve segment mmaps) | ~46 |
| Go runtime (live heap only ~3MB; the rest is metadata, stacks, freed-but-unreturned spans) | ~14 |
| native (Turso engine page caches and buffers, FAISS) | ~22 |

- **The live Go heap is ~3MB.** There is no large retained cache, embedding copy or captured excerpt to drop: the rules, vectors and excerpts live in the store and on-disk index, not in Go memory.
- **The high-water mark is a startup burst.** `initSemantic` loads every signature and builds a fresh bleve/FAISS index — ~40MB allocated in under a second — and at the default GC target the heap doubled to hold it and stayed resident ~80MB for the first 60–90s.
- **The Turso engine keeps 2000 KiB of page cache PER pooled connection**, and the pool holds 12 of them for the daemon's life: up to ~24MB duplicating a ~15MB database the kernel's page cache already holds.
- Ruled out by measurement: glibc malloc arenas (`MALLOC_ARENA_MAX=2`: no change), a process-wide GOGC (=25 cut the HWM to 107MB but roughly doubled idle CPU), an idle-exit for the embed worker (its 50MB of file-backed RSS is the mmapped model and binary; its unique anon is ~25MB, and a cold reload would land on the daemon's select loop, which the `Dims()>0` gate exists to prevent).

## What

- **Tight GC only around a knowledge rebuild** (`daemon.tightGC`): GC target 25 for the burst, refcounted so overlapping rebuilds nest, previous target restored and the heap returned to the OS (`FreeOSMemory`) when the last one ends. It only ever lowers — an operator's tighter GOGC stays — and GOGC=off is not touched at all.
- **Turso page cache per pooled connection: 800 KiB** (`turso.PageCacheKiB`) — the engine's floor: it clamps anything under 200 pages up to 200 and reads it back as `200`. Applied at warm-up and again whenever a bridge session takes a connection (`sqlbridge.Executor.SetConnInit`), so a connection database/sql opens to replace a discarded one gets it too; a refusal is logged, never fatal.
- **Embed worker** returns its start-up garbage once after the model has loaded.
- **Profiling hook** also writes `<verb>-<pid>.mem.txt` (Go memory classes + `/proc/self/status`), because a heap profile alone only sees the ~3MB of live Go objects.

## Before / after

Same devbox and herd, model loaded, turso engine, ~788 signatures. Two ALTERNATING non-profiled pairs (before, after, before, after), each run: `hap daemon --restart` on the build, 1s `/proc/<pid>/status` samples for 240s, then 120s with one `hap tui` open. Before = main (#441 included), after = this branch. Herd activity (a consult, a newly minted rule) lands at random inside a 6-minute run, which is why each cell shows both runs.

| daemon, MB | before (run 1 / 2) | after (run 1 / 2) |
|---|---|---|
| anon at 2s — the index-rebuild burst | 70 / 86 | **32 / 47** |
| high-water mark, first 4 min | 126 / 131 | **125 / 114** |
| RSS at 240s, no TUI | 92 / 100 | 92 / 91 |
| RSS with a TUI open (360s) | 107 / 115 | **93 / 93** |
| anon with a TUI open (360s) | 62 / 71 | **47 / 48** |
| embed worker RSS | 74 / 74 | 72–77 / 73 |

- The startup burst is roughly halved, and the "~80MB for the first minute" tail is gone (the heap is handed back as the rebuild ends).
- The biggest steady-state effect is with a TUI open: its queries warm more of the pool's connections, and each one used to keep 2000 KiB of pages — now 800 KiB.
- Quiet steady state without a TUI is within noise: the engine's caches are mostly cold there anyway, and the live Go heap is only ~3MB.
- The embed worker's RSS is mostly the mmapped model and binary (file-backed); its unique anon memory is ~20–25MB.

For scale: the orchestrator's v0.9.10 baseline was 218MB RSS / 244MB HWM; the rebuild-storm fix (#437) already took the idle daemon to ~85MB.

## Tests

- `daemon`: `tightGC` nests (an inner rebuild ending leaves the target lowered), restores the previous target after the last, is idempotent, and leaves GOGC=off alone.
- `turso` (real `tursodb` sync server): every pooled connection — all held at once — reports the small page cache.
- `profiling`: existing suite.
- `sqlbridge`: the per-connection setup runs on every session and a failing setup never refuses the session.
- Reverting the page-cache pragma fails the turso test (-2000 ≠ -800); reverting `tightGC`'s nesting or its only-lower rule fails the daemon test.
- Full suite green, plus the store suite under `HAP_STORE_TEST_MODE=proxy` and `turso`; real-herdr integration suite (no agent CLI) 11 passed / 0 failed.
- **Real-agent integration suite** (`HAP_ITEST_CLAUDE=1 HAP_ITEST_CODEX=1 go test -tags "integration vectors cpu" ./test/integration/`, haiku): **17 passed, 2 failed, 2 skipped — and main's tree gives the identical result**, so nothing here is a regression:
  - `TestRealClaudeModeCycle` fails the same way on main: `modeApp` opens a scratch store no daemon ever publishes a roster to, and `SetAgentMode` has required one since #386 (the test predates it, #323) — broken since then, unnoticed because it only runs with `HAP_ITEST_CLAUDE=1`.
  - `TestRealShiftTabKeyNameIsStillBroken` is the tripwire firing on main too: herdr 0.8.2's `shift+tab` key name now WORKS, so `domain.ShiftTab`'s raw CSI Z / `CLI.SendChord` can be simplified — a follow-up, not a failure of this change.
  - Skipped: `TestRealClaudeConsult` (claude auto-approved instead of raising a menu), `TestRealCodexModeToggle` (codex was blocked at startup in this environment).
