### PR TITLE
#0 perf: cut one-shot CLI cost — skip unused stats, remember the model id, read modes in parallel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -867,6 +867,14 @@ collision changed it; an unnamed one is sent `/rename <hap name>`.
     Turso Cloud plus a permanent "N rules need re-compute" nag. Unreadable falls back to the base name, never
     `""` (an empty id compares unequal to every row, so drift could never clear) — and that fallback is NOT
     cached, or an install whose model arrives later keeps the legacy scheme for the process's life.
+  - **The id is hashed once per MACHINE, not per process** (`embedder.SetModelIDCacheDir`, `<state>/model-ids.json`,
+    set by every hap process in `cmd/hap`): streaming the ~25 MB model through SHA-256 cost every
+    `hap status` / `hap agents` ~50ms on an idle devbox and several hundred ms on a busy one. An entry is trusted
+    only while size, mtime, inode, device AND ctime match what was hashed — ctime is the one fact user space cannot
+    set, so a model rewritten in place with its mtime restored (`cp -p`, `touch -r`) is still re-hashed at the next
+    process start; an id is persisted only if the file's facts held still across the hash. The in-process cache
+    still holds for the process's life; `rm <state>/model-ids.json` forces a re-hash. Best-effort: an unreadable
+    cache just hashes.
   - **Anything comparing a stored row's model must resolve the id the SAME way** — `frontend.embeddingDrift`
     calls `embedder.ModelIDFor` rather than taking the base name; the two drifting apart is silent and
     permanent. `EmbeddingDrift.ModelName` is DISPLAY only; `ModelID` is the comparison key.

--- a/changelog.d/perf-cli-cost.md
+++ b/changelog.d/perf-cli-cost.md
@@ -1,0 +1,3 @@
+- `hap status` and `hap agents` no longer hash the whole ~25 MB embedding model on every run: the model's id is remembered per machine and re-checked only when the file changes (tens of milliseconds on an idle machine, much more on a busy one)
+- The CLI verbs no longer ask the daemon for per-agent lifetime counters they never print (two full audit-log aggregations per `hap status`)
+- `hap agents` reads its agents' permission modes in parallel instead of one herdr call after another

--- a/cmd/hap/main.go
+++ b/cmd/hap/main.go
@@ -226,6 +226,10 @@ func run(verb string, args []string) error {
 	if err != nil {
 		return err
 	}
+	// Every process that reports or matches embeddings needs the model's id;
+	// hashing the ~25 MB file once per machine instead of once per process is
+	// most of a one-shot `hap status`.
+	embedder.SetModelIDCacheDir(paths.StateDir)
 
 	switch verb {
 	case "daemon":

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -930,7 +930,7 @@ func status(ctx context.Context, app *frontend.App, out io.Writer, args []string
 	if fs.NArg() > 0 {
 		return fmt.Errorf("unexpected argument %q (usage: hap status [--stderr])", fs.Arg(0))
 	}
-	st, err := app.GetStatus(ctx)
+	st, err := app.GetStatus(ctx, frontend.WithoutAgentStats())
 	if err != nil {
 		return err
 	}
@@ -1149,7 +1149,7 @@ func roundDuration(d time.Duration) string {
 }
 
 func agents(ctx context.Context, app *frontend.App, out io.Writer) error {
-	st, err := app.GetStatus(ctx)
+	st, err := app.GetStatus(ctx, frontend.WithoutAgentStats())
 	if err != nil {
 		return err
 	}
@@ -1264,7 +1264,7 @@ func escalations(ctx context.Context, app *frontend.App, out io.Writer, args []s
 	// The status snapshot carries every node's names, so a row another machine
 	// raised is labelled name@node rather than mislabelled with a local agent
 	// that happens to share its pane id.
-	st, err := app.GetStatus(ctx)
+	st, err := app.GetStatus(ctx, frontend.WithoutAgentStats())
 	if err != nil {
 		return err
 	}
@@ -1455,7 +1455,7 @@ func audit(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 	// The audit log is fleet-wide under a shared store, so each row names the
 	// machine it happened on — APPENDED, so every existing field keeps its
 	// position for the parsers reading this listing.
-	st, err := app.GetStatus(ctx)
+	st, err := app.GetStatus(ctx, frontend.WithoutAgentStats())
 	if err != nil {
 		return err
 	}
@@ -1597,7 +1597,7 @@ func killHistory(ctx context.Context, app *frontend.App, out io.Writer) error {
 	}
 	// Fleet-wide history: the node is appended so a pause landed on another
 	// machine (`hap pause --node`) reads as that machine's.
-	st, err := app.GetStatus(ctx)
+	st, err := app.GetStatus(ctx, frontend.WithoutAgentStats())
 	if err != nil {
 		return err
 	}
@@ -2038,7 +2038,7 @@ func splitAgentTypeFlag(args []string) (agentTypes string, rest []string, err er
 // refuses, and stays silent whenever the agent list could not be read — an
 // absent herdr must never read as "that type does not exist".
 func warnUnseenAgentTypes(ctx context.Context, app *frontend.App, out io.Writer, types []string) {
-	st, err := app.GetStatus(ctx)
+	st, err := app.GetStatus(ctx, frontend.WithoutAgentStats())
 	if err != nil || !st.AgentsKnown {
 		return
 	}
@@ -2914,7 +2914,7 @@ func taskSend(ctx context.Context, app *frontend.App, out io.Writer, agent, path
 	if it.Done {
 		return fmt.Errorf("task #%d is %q — only a pending [ ] task can be sent", idx, it.Mark)
 	}
-	status, err := app.GetStatus(ctx)
+	status, err := app.GetStatus(ctx, frontend.WithoutAgentStats())
 	if err != nil {
 		return err
 	}

--- a/internal/embedder/modelid.go
+++ b/internal/embedder/modelid.go
@@ -125,9 +125,16 @@ func persistModelID(path string, facts modelIDEntry, id string) {
 		return
 	}
 	file := filepath.Join(modelIDDir, modelIDFile)
-	all := map[string]modelIDEntry{}
+	var all map[string]modelIDEntry
 	if data, err := os.ReadFile(file); err == nil {
-		_ = json.Unmarshal(data, &all)
+		// A corrupt file — or a literal `null`, which decodes cleanly into a
+		// nil map — is replaced, never written into.
+		if json.Unmarshal(data, &all) != nil {
+			all = nil
+		}
+	}
+	if all == nil {
+		all = map[string]modelIDEntry{}
 	}
 	facts.ID = id
 	all[path] = facts

--- a/internal/embedder/modelid.go
+++ b/internal/embedder/modelid.go
@@ -3,6 +3,7 @@ package embedder
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -32,7 +33,118 @@ const modelIDDigestRunes = 16
 var (
 	modelIDMu    sync.Mutex
 	modelIDCache = map[string]string{}
+	// modelIDDir is where resolved ids persist across processes (see
+	// SetModelIDCacheDir); "" keeps them in memory only.
+	modelIDDir string
+	// modelHashFn is hashModel; tests count calls through it.
+	modelHashFn = hashModel
 )
+
+// modelIDFile is the cross-process cache inside the state dir.
+const modelIDFile = "model-ids.json"
+
+// SetModelIDCacheDir persists resolved model ids under dir, so a process does
+// not re-hash a model file whose identity an earlier one already computed.
+//
+// This is the one-shot CLI's cost: `hap status` and `hap agents` both report
+// embedding drift, which needs the id, and every one of them streamed the whole
+// ~25 MB model through SHA-256 — tens of milliseconds idle and far more on a
+// busy machine, for a verb whose useful work is a few store queries. An entry
+// is trusted only while the file's size, mtime, inode, device AND change time
+// all still match what was hashed. The change time is what makes that sound:
+// nothing in user space can set it, so any rewrite — in place, by rename, or
+// with its mtime put back (`cp -p`, `touch -r`) — is re-hashed at the next
+// process start, which the per-process cache alone never did. Deleting
+// <dir>/model-ids.json forces a re-hash. Best-effort throughout: an unreadable
+// or unwritable cache just hashes, exactly as before.
+func SetModelIDCacheDir(dir string) {
+	modelIDMu.Lock()
+	defer modelIDMu.Unlock()
+	modelIDDir = dir
+}
+
+// modelIDEntry is one persisted id with the file facts it was computed from.
+type modelIDEntry struct {
+	Size    int64  `json:"size"`
+	MtimeNs int64  `json:"mtime_ns"`
+	CtimeNs int64  `json:"ctime_ns,omitempty"`
+	Inode   uint64 `json:"inode,omitempty"`
+	Device  uint64 `json:"device,omitempty"`
+	ID      string `json:"id"`
+}
+
+// factsOf is what a persisted entry must still match.
+func factsOf(fi os.FileInfo) modelIDEntry {
+	e := modelIDEntry{Size: fi.Size(), MtimeNs: fi.ModTime().UnixNano()}
+	e.Inode, e.Device, e.CtimeNs = fileIdentity(fi)
+	return e
+}
+
+// sameFacts compares everything but the id.
+func sameFacts(a, b modelIDEntry) bool {
+	a.ID, b.ID = "", ""
+	return a == b
+}
+
+// modelFileFacts is what an entry must still match for path.
+func modelFileFacts(path string) (modelIDEntry, bool) {
+	fi, err := os.Stat(path)
+	if err != nil || !fi.Mode().IsRegular() {
+		return modelIDEntry{}, false
+	}
+	return factsOf(fi), true
+}
+
+// persistedModelID returns path's id from the cache file when its facts still
+// match. Caller holds modelIDMu.
+func persistedModelID(path string, facts modelIDEntry) (string, bool) {
+	if modelIDDir == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(filepath.Join(modelIDDir, modelIDFile))
+	if err != nil {
+		return "", false
+	}
+	var all map[string]modelIDEntry
+	if json.Unmarshal(data, &all) != nil {
+		return "", false
+	}
+	e, ok := all[path]
+	if !ok || e.ID == "" || !sameFacts(e, facts) {
+		return "", false
+	}
+	return e.ID, true
+}
+
+// persistModelID records path's id beside the facts it was computed from, by
+// write-and-rename so a concurrent reader never sees half a file. Two processes
+// racing can drop each other's entry for ANOTHER path; that only costs a hash.
+// Caller holds modelIDMu.
+func persistModelID(path string, facts modelIDEntry, id string) {
+	if modelIDDir == "" {
+		return
+	}
+	file := filepath.Join(modelIDDir, modelIDFile)
+	all := map[string]modelIDEntry{}
+	if data, err := os.ReadFile(file); err == nil {
+		_ = json.Unmarshal(data, &all)
+	}
+	facts.ID = id
+	all[path] = facts
+	data, err := json.Marshal(all)
+	if err != nil {
+		return
+	}
+	tmp, err := os.CreateTemp(modelIDDir, modelIDFile+".*")
+	if err != nil {
+		return
+	}
+	_, werr := tmp.Write(data)
+	cerr := tmp.Close()
+	if werr != nil || cerr != nil || os.Rename(tmp.Name(), file) != nil {
+		_ = os.Remove(tmp.Name())
+	}
+}
 
 // ModelIDFor returns the identity of the embedding model file at path, derived
 // from its CONTENT rather than its name.
@@ -65,38 +177,60 @@ var (
 // unaffected by this change.
 //
 // The first call for a path streams the file once (~25 MB for the bundled
-// MiniLM). In the daemon that first call is reembed.Reconcile's, on the
+// MiniLM) — once per MACHINE when SetModelIDCacheDir is set, which every hap
+// process does; later processes reuse it while the file is unchanged (its
+// change time included, so a replacement is always re-hashed). In the
+// daemon that first call is reembed.Reconcile's, on the
 // background semantic-init goroutine, never the select loop; the loop's own
 // caller (daemon.resolveSignature) reaches the cached value. Caching by path
-// also means a model replaced IN PLACE under the same name is not noticed until
-// the next process start or `[embedding]` reload — unchanged from the basename
-// scheme, and already documented on frontend.EmbeddingDrift.
+// also means a model replaced IN PLACE under the same name is not noticed by a
+// running process until its next start or `[embedding]` reload — documented on
+// frontend.EmbeddingDrift.
 func ModelIDFor(path string) string {
 	modelIDMu.Lock()
 	defer modelIDMu.Unlock()
 	if id, ok := modelIDCache[path]; ok {
 		return id
 	}
-	sum, err := modelDigest(path)
+	if facts, ok := modelFileFacts(path); ok {
+		if id, ok := persistedModelID(path, facts); ok {
+			modelIDCache[path] = id
+			return id
+		}
+	}
+	sum, facts, stable, err := modelHashFn(path)
 	if err != nil {
 		return filepath.Base(path)
 	}
 	id := modelIDPrefix + sum
 	modelIDCache[path] = id
+	if stable {
+		persistModelID(path, facts, id)
+	}
 	return id
 }
 
-// modelDigest streams path through SHA-256 and returns the leading
-// modelIDDigestRunes hex characters.
-func modelDigest(path string) (string, error) {
+// hashModel streams path through SHA-256 and returns the leading
+// modelIDDigestRunes hex characters, with the facts of the file it actually
+// hashed. stable is false when those facts moved during the hash (the file was
+// being replaced): the id is still returned, but must not be persisted against
+// facts that describe different bytes.
+func hashModel(path string) (sum string, facts modelIDEntry, stable bool, err error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return "", err
+		return "", modelIDEntry{}, false, err
 	}
 	defer f.Close()
+	before, berr := f.Stat()
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
-		return "", err
+		return "", modelIDEntry{}, false, err
 	}
-	return hex.EncodeToString(h.Sum(nil))[:modelIDDigestRunes], nil
+	sum = hex.EncodeToString(h.Sum(nil))[:modelIDDigestRunes]
+	after, aerr := os.Stat(path)
+	if berr != nil || aerr != nil || !before.Mode().IsRegular() {
+		return sum, modelIDEntry{}, false, nil
+	}
+	facts = factsOf(before)
+	return sum, facts, sameFacts(facts, factsOf(after)), nil
 }

--- a/internal/embedder/modelid_cache_test.go
+++ b/internal/embedder/modelid_cache_test.go
@@ -124,24 +124,30 @@ func TestModelIDWithoutACacheDirHashesEveryProcess(t *testing.T) {
 }
 
 // TestAnUnreadableModelIDCacheOnlyCostsAHash: a corrupt cache file is ignored,
-// the id is computed, and the file is rewritten usable.
+// the id is computed, and the file is rewritten usable. `null` is the sharp
+// case: it decodes WITHOUT error into a nil map, and writing into that map
+// panicked in every process that asked for the model id.
 func TestAnUnreadableModelIDCacheOnlyCostsAHash(t *testing.T) {
-	state := t.TempDir()
-	model := filepath.Join(t.TempDir(), "m.gguf")
-	if err := os.WriteFile(model, []byte("bytes"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(state, modelIDFile), []byte("{not json"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	hashed := freshProcess(t, state)
-	id := ModelIDFor(model)
-	if *hashed != 1 || id == "" {
-		t.Fatalf("corrupt cache: hashed %d, id %q", *hashed, id)
-	}
-	hashed = freshProcess(t, state)
-	if ModelIDFor(model) != id || *hashed != 0 {
-		t.Errorf("the cache was not rewritten usable (hashed %d)", *hashed)
+	for _, content := range []string{"{not json", "null", "[]", ""} {
+		t.Run(content, func(t *testing.T) {
+			state := t.TempDir()
+			model := filepath.Join(t.TempDir(), "m.gguf")
+			if err := os.WriteFile(model, []byte("bytes"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(state, modelIDFile), []byte(content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			hashed := freshProcess(t, state)
+			id := ModelIDFor(model)
+			if *hashed != 1 || id == "" {
+				t.Fatalf("cache %q: hashed %d, id %q", content, *hashed, id)
+			}
+			hashed = freshProcess(t, state)
+			if ModelIDFor(model) != id || *hashed != 0 {
+				t.Errorf("cache %q was not rewritten usable (hashed %d)", content, *hashed)
+			}
+		})
 	}
 }
 

--- a/internal/embedder/modelid_cache_test.go
+++ b/internal/embedder/modelid_cache_test.go
@@ -1,0 +1,155 @@
+package embedder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// freshProcess forgets the in-process ids, as a new hap process starts with,
+// and counts the digests computed from here on.
+func freshProcess(t *testing.T, dir string) *int {
+	t.Helper()
+	modelIDMu.Lock()
+	prevCache, prevDir, prevFn := modelIDCache, modelIDDir, modelHashFn
+	modelIDCache, modelIDDir = map[string]string{}, dir
+	n := new(int)
+	modelHashFn = func(p string) (string, modelIDEntry, bool, error) { *n++; return hashModel(p) }
+	modelIDMu.Unlock()
+	t.Cleanup(func() {
+		modelIDMu.Lock()
+		modelIDCache, modelIDDir, modelHashFn = prevCache, prevDir, prevFn
+		modelIDMu.Unlock()
+	})
+	return n
+}
+
+// TestModelIDIsHashedOncePerMachineNotPerProcess pins the one-shot CLI's
+// biggest cost: every `hap status` / `hap agents` streamed the whole model
+// through SHA-256 to report embedding drift. A later process reuses the id
+// while the file is unchanged — and re-hashes the moment it is not, which the
+// per-process cache alone never did for a model replaced in place.
+func TestModelIDIsHashedOncePerMachineNotPerProcess(t *testing.T) {
+	state, models := t.TempDir(), t.TempDir()
+	model := filepath.Join(models, "m.gguf")
+	if err := os.WriteFile(model, []byte("model bytes v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	hashed := freshProcess(t, state)
+	first := ModelIDFor(model)
+	if *hashed != 1 {
+		t.Fatalf("first process hashed %d times, want 1", *hashed)
+	}
+
+	hashed = freshProcess(t, state)
+	if got := ModelIDFor(model); got != first {
+		t.Fatalf("second process got %q, want the cached %q", got, first)
+	}
+	if *hashed != 0 {
+		t.Errorf("second process re-hashed an unchanged model (%d times)", *hashed)
+	}
+
+	// Replaced in place: same path, new content, later mtime.
+	if err := os.WriteFile(model, []byte("model bytes version 2"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	later := time.Now().Add(time.Hour)
+	if err := os.Chtimes(model, later, later); err != nil {
+		t.Fatal(err)
+	}
+	hashed = freshProcess(t, state)
+	second := ModelIDFor(model)
+	if *hashed != 1 || second == first {
+		t.Errorf("a replaced model: hashed %d times, id %q (first %q) — want one re-hash and a new id",
+			*hashed, second, first)
+	}
+
+	// Replaced by rename with identical size and mtime: only the inode tells.
+	other := filepath.Join(models, "other.gguf")
+	if err := os.WriteFile(other, []byte("model bytes version 3"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(other, later, later); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(other, model); err != nil {
+		t.Fatal(err)
+	}
+	hashed = freshProcess(t, state)
+	third := ModelIDFor(model)
+	if inode, _, _ := fileIdentity(mustStat(t, model)); inode != 0 {
+		if *hashed != 1 || third == second {
+			t.Errorf("a model swapped by rename: hashed %d times, id %q (was %q)", *hashed, third, second)
+		}
+	}
+
+	// Rewritten IN PLACE at the same size with its mtime put back — `cp -p`,
+	// `touch -r`, an archive tool storing whole seconds. Size, mtime, inode and
+	// device all survive; only the change time, which nothing in user space can
+	// set, says the bytes are different.
+	mtime := mustStat(t, model).ModTime()
+	// File timestamps come from the kernel's COARSE clock (a few ms per tick
+	// on Linux): a rewrite in the same tick as the rename above would share its
+	// ctime. A real replacement lands long after the hash it invalidates.
+	time.Sleep(50 * time.Millisecond)
+	if err := os.WriteFile(model, []byte("model bytes version 4"), 0o600); err != nil { // same length as v3
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(model, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	hashed = freshProcess(t, state)
+	if fourth := ModelIDFor(model); *hashed != 1 || fourth == third {
+		t.Errorf("a same-size rewrite with its mtime restored: hashed %d times, id %q (was %q) — a stale id would outlive the restart",
+			*hashed, fourth, third)
+	}
+}
+
+// TestModelIDWithoutACacheDirHashesEveryProcess is the control: without the
+// directory nothing persists, exactly the behaviour before.
+func TestModelIDWithoutACacheDirHashesEveryProcess(t *testing.T) {
+	model := filepath.Join(t.TempDir(), "m.gguf")
+	if err := os.WriteFile(model, []byte("bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		hashed := freshProcess(t, "")
+		ModelIDFor(model)
+		if *hashed != 1 {
+			t.Fatalf("process %d hashed %d times, want 1", i, *hashed)
+		}
+	}
+}
+
+// TestAnUnreadableModelIDCacheOnlyCostsAHash: a corrupt cache file is ignored,
+// the id is computed, and the file is rewritten usable.
+func TestAnUnreadableModelIDCacheOnlyCostsAHash(t *testing.T) {
+	state := t.TempDir()
+	model := filepath.Join(t.TempDir(), "m.gguf")
+	if err := os.WriteFile(model, []byte("bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(state, modelIDFile), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hashed := freshProcess(t, state)
+	id := ModelIDFor(model)
+	if *hashed != 1 || id == "" {
+		t.Fatalf("corrupt cache: hashed %d, id %q", *hashed, id)
+	}
+	hashed = freshProcess(t, state)
+	if ModelIDFor(model) != id || *hashed != 0 {
+		t.Errorf("the cache was not rewritten usable (hashed %d)", *hashed)
+	}
+}
+
+func mustStat(t *testing.T, p string) os.FileInfo {
+	t.Helper()
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fi
+}

--- a/internal/embedder/modelid_darwin.go
+++ b/internal/embedder/modelid_darwin.go
@@ -1,0 +1,17 @@
+//go:build darwin
+
+package embedder
+
+import (
+	"os"
+	"syscall"
+)
+
+// fileIdentity is the file's inode, device and change time; see the linux
+// twin for why the change time is the fact that matters.
+func fileIdentity(fi os.FileInfo) (inode, device uint64, ctimeNs int64) {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return st.Ino, uint64(st.Dev), st.Ctimespec.Nano()
+	}
+	return 0, 0, 0
+}

--- a/internal/embedder/modelid_linux.go
+++ b/internal/embedder/modelid_linux.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package embedder
+
+import (
+	"os"
+	"syscall"
+)
+
+// fileIdentity is the file's inode, device and change time. The change time
+// is the one fact user space cannot set: a model rewritten in place at the same
+// size with its mtime put back (`cp -p`, `touch -r`, an archive tool storing
+// whole seconds) keeps size, mtime and inode, and only ctime moves.
+func fileIdentity(fi os.FileInfo) (inode, device uint64, ctimeNs int64) {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return st.Ino, st.Dev, st.Ctim.Nano()
+	}
+	return 0, 0, 0
+}

--- a/internal/embedder/modelid_other.go
+++ b/internal/embedder/modelid_other.go
@@ -1,0 +1,9 @@
+//go:build !linux && !darwin
+
+package embedder
+
+import "os"
+
+// fileIdentity has no inode or change time to offer on this platform (hap
+// ships for linux and macOS); size and mtime still guard the entry.
+func fileIdentity(os.FileInfo) (inode, device uint64, ctimeNs int64) { return 0, 0, 0 }

--- a/internal/frontend/agentmode.go
+++ b/internal/frontend/agentmode.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
@@ -488,9 +489,16 @@ func joinModes(modes []domain.AgentMode) string {
 
 // modeFillBudget bounds ONE FillAgentModes pass end to end, for the same reason
 // cwdFillBudget bounds FillAgentCwds: each read is its own subprocess with a 15s
-// CLI budget and they run in sequence. A displayed mode is a nicety — whatever
-// resolves in the budget is what shows.
+// CLI budget. A displayed mode is a nicety — whatever resolves in the budget is
+// what shows.
 const modeFillBudget = 3 * time.Second
+
+// modeFillParallel is how many of those pane reads run at once. They used to
+// run in sequence, so a one-shot `hap agents` waited for every agent's
+// `herdr pane read` subprocess back to back — most of its wall time on a herd
+// of a few agents. Bounded rather than one per agent so a large herd does not
+// fork a burst of herdr processes at the server all at once.
+const modeFillParallel = 4
 
 // FillAgentModes populates st.AgentModes for the agents in st.MonitoredAgents,
 // or for just the agent ids named in only.
@@ -522,27 +530,42 @@ func (a *App) FillAgentModes(ctx context.Context, st *Status, only ...string) {
 	ctx, cancel := context.WithTimeout(ctx, modeFillBudget)
 	defer cancel()
 
+	var (
+		mu    sync.Mutex
+		wg    sync.WaitGroup
+		slots = make(chan struct{}, modeFillParallel)
+	)
 	for _, agent := range st.MonitoredAgents {
-		if ctx.Err() != nil {
-			return // budget spent: keep whatever resolved
-		}
 		if wanted != nil && !wanted[agent.AgentID] {
 			continue
 		}
 		if domain.AgentModesFor(agent.AgentType) == nil {
 			continue
 		}
-		pane, err := a.readModePane(ctx, panePreferred(agent))
-		if err != nil {
-			continue
-		}
-		mode, ok := domain.AgentModeFromPane(agent.AgentType, pane)
-		if !ok {
-			continue
-		}
-		if st.AgentModes == nil {
-			st.AgentModes = map[string]domain.AgentMode{}
-		}
-		st.AgentModes[agent.AgentID] = mode
+		wg.Add(1)
+		go func(agent domain.AgentTransition) {
+			defer wg.Done()
+			select {
+			case slots <- struct{}{}:
+			case <-ctx.Done():
+				return // budget spent: keep whatever resolved
+			}
+			defer func() { <-slots }()
+			pane, err := a.readModePane(ctx, panePreferred(agent))
+			if err != nil {
+				return
+			}
+			mode, ok := domain.AgentModeFromPane(agent.AgentType, pane)
+			if !ok {
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			if st.AgentModes == nil {
+				st.AgentModes = map[string]domain.AgentMode{}
+			}
+			st.AgentModes[agent.AgentID] = mode
+		}(agent)
 	}
+	wg.Wait()
 }

--- a/internal/frontend/agentmode_test.go
+++ b/internal/frontend/agentmode_test.go
@@ -3,8 +3,10 @@ package frontend_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -537,5 +539,95 @@ func TestSetAgentModeResolvesByShortName(t *testing.T) {
 	}
 	if chords, _ := fake.counts(); chords != 1 {
 		t.Errorf("delivered %d chords; want 1", chords)
+	}
+}
+
+// barrierHerdr blocks each pane read until `want` reads are in flight at
+// once (or the read's context ends), then renders like modeHerdr.
+type barrierHerdr struct {
+	*modeHerdr
+	want    int
+	arrived chan struct{}
+	release chan struct{}
+	// inFlight / maxInFlight record the most reads ever running at once.
+	inFlight, maxInFlight atomic.Int32
+}
+
+func (b *barrierHerdr) ReadPaneVisible(ctx context.Context, pane string, lines int) (string, error) {
+	n := b.inFlight.Add(1)
+	defer b.inFlight.Add(-1)
+	for {
+		m := b.maxInFlight.Load()
+		if n <= m || b.maxInFlight.CompareAndSwap(m, n) {
+			break
+		}
+	}
+	b.arrived <- struct{}{}
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+	return b.modeHerdr.ReadPaneVisible(ctx, pane, lines)
+}
+
+// TestFillAgentModesReadsPanesConcurrently: `hap agents` used to wait for each
+// agent's `herdr pane read` subprocess back to back. The barrier opens only
+// once all three reads are in flight together, so a sequential fill never gets
+// past the first read and resolves nothing inside the budget.
+func TestFillAgentModesReadsPanesConcurrently(t *testing.T) {
+	app, fake := claudeApp(t, domain.AgentModeAuto)
+	b := &barrierHerdr{modeHerdr: fake, want: 3, arrived: make(chan struct{}, 8), release: make(chan struct{})}
+	go func() {
+		for i := 0; i < b.want; i++ {
+			<-b.arrived
+		}
+		close(b.release)
+	}()
+	app.Herdr = b
+	st := frontend.Status{MonitoredAgents: []domain.AgentTransition{
+		{AgentID: "w1:p1", PaneID: "w1:p1", AgentType: "claude"},
+		{AgentID: "w1:p2", PaneID: "w1:p2", AgentType: "claude"},
+		{AgentID: "w1:p3", PaneID: "w1:p3", AgentType: "claude"},
+	}}
+	app.FillAgentModes(context.Background(), &st)
+	for _, id := range []string{"w1:p1", "w1:p2", "w1:p3"} {
+		if got := st.AgentMode(id); got != domain.AgentModeAuto {
+			t.Errorf("%s mode = %q, want %q — the reads did not run together", id, got, domain.AgentModeAuto)
+		}
+	}
+}
+
+// TestFillAgentModesCapsConcurrentReads: parallel, but bounded — each read is a
+// herdr subprocess, and a large herd must not fork one per agent at the server
+// at once. Six agents, a barrier that opens at four in flight: every mode still
+// resolves and no more than four reads ever overlap.
+func TestFillAgentModesCapsConcurrentReads(t *testing.T) {
+	app, fake := claudeApp(t, domain.AgentModeAuto)
+	b := &barrierHerdr{modeHerdr: fake, want: 4, arrived: make(chan struct{}, 16), release: make(chan struct{})}
+	go func() {
+		for i := 0; i < b.want; i++ {
+			<-b.arrived
+		}
+		close(b.release)
+		for range b.arrived { // later reads pass straight through
+		}
+	}()
+	defer close(b.arrived)
+	app.Herdr = b
+	var agents []domain.AgentTransition
+	for i := 1; i <= 6; i++ {
+		id := fmt.Sprintf("w1:p%d", i)
+		agents = append(agents, domain.AgentTransition{AgentID: id, PaneID: id, AgentType: "claude"})
+	}
+	st := frontend.Status{MonitoredAgents: agents}
+	app.FillAgentModes(context.Background(), &st)
+	for _, a := range agents {
+		if got := st.AgentMode(a.AgentID); got != domain.AgentModeAuto {
+			t.Errorf("%s mode = %q, want %q", a.AgentID, got, domain.AgentModeAuto)
+		}
+	}
+	if got := b.maxInFlight.Load(); got > 4 {
+		t.Errorf("%d pane reads ran at once; the cap is 4", got)
 	}
 }

--- a/internal/frontend/fleet.go
+++ b/internal/frontend/fleet.go
@@ -114,7 +114,7 @@ func (st Status) RemoteNodes(now time.Time) (total, stale int) {
 
 // fillFleet adds the other nodes' view to a Status. Best effort throughout:
 // under the local engine there is one node and every fleet read is empty.
-func (a *App) fillFleet(ctx context.Context, st *Status) {
+func (a *App) fillFleet(ctx context.Context, st *Status, o statusOptions) {
 	st.NodeID = a.Store.NodeID()
 	now := a.now()
 	nodes, err := a.Store.ListNodes(ctx)
@@ -138,7 +138,10 @@ func (a *App) fillFleet(ctx context.Context, st *Status) {
 		st.FleetNames = names
 	}
 	disabled, _ := a.Store.DisabledAgentsAll(ctx)
-	stats, _ := a.Store.FleetAgentStats(ctx)
+	var stats map[domain.NodeAgent]domain.AgentStats
+	if !o.skipStats {
+		stats, _ = a.Store.FleetAgentStats(ctx)
+	}
 	roster, published, err := a.Store.FleetRoster(ctx)
 	if err != nil {
 		return

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -243,8 +243,26 @@ type Status struct {
 	FleetNames map[domain.NodeAgent]string
 }
 
+// StatusOption narrows what GetStatus reads, for a caller that renders less.
+type StatusOption func(*statusOptions)
+
+type statusOptions struct {
+	skipStats bool
+}
+
+// WithoutAgentStats skips the per-agent lifetime counters (Status.StatsFor and
+// RemoteAgent.Stats). Only the TUI renders them, and they are the two most
+// expensive reads in a status snapshot — each aggregates the whole audit log
+// per agent, ~40ms of the daemon's time between them on a 787-rule store — so
+// the one-shot CLI verbs, which never show them, skip both.
+func WithoutAgentStats() StatusOption { return func(o *statusOptions) { o.skipStats = true } }
+
 // GetStatus returns the operator-facing status summary.
-func (a *App) GetStatus(ctx context.Context) (Status, error) {
+func (a *App) GetStatus(ctx context.Context, opts ...StatusOption) (Status, error) {
+	var o statusOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
 	var st Status
 	kill, err := a.Store.LatestKillEvent(ctx)
 	if err != nil {
@@ -301,8 +319,10 @@ func (a *App) GetStatus(ctx context.Context) (Status, error) {
 		st.DisabledAgents = disabled
 	}
 	// Best-effort, like AgentNames: a stats-query error just leaves it nil.
-	if stats, err := a.Store.AgentStats(ctx); err == nil {
-		st.AgentStats = stats
+	if !o.skipStats {
+		if stats, err := a.Store.AgentStats(ctx); err == nil {
+			st.AgentStats = stats
+		}
 	}
 	// One config load serves both embedding summaries so they cannot
 	// disagree about a mid-edit config within a single status snapshot.
@@ -332,7 +352,7 @@ func (a *App) GetStatus(ctx context.Context) (Status, error) {
 			st.AgentNames[agent.AgentID] = name
 		}
 	}
-	a.fillFleet(ctx, &st)
+	a.fillFleet(ctx, &st, o)
 	return st, nil
 }
 
@@ -430,10 +450,12 @@ func (a *App) embeddingStatus(ctx context.Context, cfg config.Config) string {
 // by a different model than the currently configured one. Detection is by
 // model id, which is a digest of the model FILE (embedder.ModelIDFor) — so
 // two different models installed under the same name no longer read as one.
-// The id is resolved once per path per process, so replacing the model file IN
-// PLACE is still not detected until the next start or `[embedding]` reload (a
-// dims change is caught by the daemon's reconcile at its next index init; a
-// same-dims in-place swap silently mixes vector spaces).
+// The id is resolved once per path per process and persisted per machine
+// (embedder.SetModelIDCacheDir, keyed on the file's size, mtime, inode, device
+// and ctime), so replacing the model file IN PLACE is detected at the next
+// process start or `[embedding]` reload, never by a running process (a dims
+// change is caught by the daemon's reconcile at its next index init; a
+// same-dims in-place swap silently mixes vector spaces until then).
 //
 // ModelID must be resolved the SAME way the embedder resolves its own, or every
 // stored row reads stale forever and no re-embed can clear it — the permanent

--- a/internal/frontend/statusopts_test.go
+++ b/internal/frontend/statusopts_test.go
@@ -1,0 +1,67 @@
+package frontend
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/store"
+)
+
+// statsCountingStore counts the two per-agent stats aggregations.
+type statsCountingStore struct {
+	*store.Store
+	agent, fleet atomic.Int32
+}
+
+func (s *statsCountingStore) AgentStats(ctx context.Context) (map[string]domain.AgentStats, error) {
+	s.agent.Add(1)
+	return s.Store.AgentStats(ctx)
+}
+
+func (s *statsCountingStore) FleetAgentStats(ctx context.Context) (map[domain.NodeAgent]domain.AgentStats, error) {
+	s.fleet.Add(1)
+	return s.Store.FleetAgentStats(ctx)
+}
+
+// TestWithoutAgentStatsSkipsBothAggregations: the per-agent counters are the
+// two most expensive reads in a status snapshot and only the TUI renders them,
+// so a CLI verb asking WithoutAgentStats must issue neither — local or fleet.
+// The default call is the control: without it the test passes for a GetStatus
+// that never reads stats at all, which would blank the TUI's Agents tab.
+func TestWithoutAgentStatsSkipsBothAggregations(t *testing.T) {
+	app, st := testApp(t)
+	ctx := context.Background()
+	now := time.Now()
+	// A second node makes GetStatus take the fleet branch.
+	if err := st.UpsertNode(ctx, domain.NodeInfo{Label: "here", LastSeen: now}); err != nil {
+		t.Fatal(err)
+	}
+	other, err := store.OpenAs(filepath.Join(app.StateDir, "t.db"), "bbbbbbbbbbbbbbbb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { other.Close() })
+	if err := other.UpsertNode(ctx, domain.NodeInfo{Label: "there", LastSeen: now}); err != nil {
+		t.Fatal(err)
+	}
+	counting := &statsCountingStore{Store: st}
+	app.Store = counting
+
+	if _, err := app.GetStatus(ctx, WithoutAgentStats()); err != nil {
+		t.Fatal(err)
+	}
+	if a, f := counting.agent.Load(), counting.fleet.Load(); a != 0 || f != 0 {
+		t.Errorf("WithoutAgentStats still aggregated stats: local %d, fleet %d", a, f)
+	}
+
+	if _, err := app.GetStatus(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if a, f := counting.agent.Load(), counting.fleet.Load(); a != 1 || f != 1 {
+		t.Errorf("the default GetStatus aggregated local %d, fleet %d times; want 1 each", a, f)
+	}
+}


### PR DESCRIPTION
## Why

Task: cut the wall time and max RSS of the one-shot verbs `hap status`, `hap agents`, `hap escalations`, `hap task <agent> list`. Traced on the current main build, on an otherwise idle 2-core devbox (turso engine, so a CLI verb talks to the daemon over `store.sock`):

- **Package init and process start are small**: ~25–33ms of Go package init (bleve/scorch 13ms, crypto/tls 10ms, `internal/domain` regexps 10ms); `hap escalations` and `hap task … list` complete in ~35–50ms end to end, and max RSS is ~34–36 MB for all four verbs — the binary and its native libraries, nothing retained.
- **`hap status` (~180ms) waits on the daemon for two queries it never prints**: the per-agent lifetime counters `AgentStats` and `FleetAgentStats`, each aggregating the whole audit log per agent — ~21ms and ~20ms of daemon time, the two slowest of the 20 statements a status makes. Only the TUI renders them.
- **`hap status` / `hap agents` hash the embedding model on every run**: embedding drift needs the model's id, and `embedder.ModelIDFor` streams the ~25 MB model through SHA-256 once per PROCESS — ~50ms idle, and it scales with load (0.7s measured while a test suite ran).
- **`hap agents` read each agent's pane in sequence** for the permission-mode column (one `herdr pane read` subprocess per agent).

## What

- **CLI verbs skip the per-agent stats** (`frontend.WithoutAgentStats()`, passed by every `GetStatus` in `internal/cli`); the TUI keeps the default.
- **The model id persists across processes** (`embedder.SetModelIDCacheDir`, `<state>/model-ids.json`): an entry is trusted only while the file's size, mtime, inode, device and ctime all match what was hashed, and the facts are the ones of the file actually hashed (persisted only if they held still across the hash). ctime is the fact user space cannot set, so a model replaced in place, by rename, or rewritten with its mtime restored (`cp -p`) is re-hashed at the next process start — which the per-process cache alone never did. `rm <state>/model-ids.json` forces a re-hash. Best-effort: an unreadable or corrupt cache just hashes, as before. Every hap process sets it.
- **`FillAgentModes` reads panes concurrently** (up to 4 at once) inside the same 3s budget, so `hap agents` waits for the slowest read instead of the sum (it matters as the herd grows; with three quick reads it is within noise).

## Before / after

Same devbox, idle apart from the herd, daemon up (turso engine), 2 ALTERNATING rounds of 9 runs per verb per build (`fork`+`wait4`, so max RSS is the child's own `ru_maxrss`). Before = main.

| verb | wall median, before (r1 / r2) | wall median, after (r1 / r2) | CPU median before → after | max RSS before → after |
|---|---|---|---|---|
| `hap status` | 155 / 162 ms | **69 / 78 ms** | 186 → ~100 ms | 36 → 36 MB |
| `hap agents` | 213 / 175 ms (fastest 150–160) | 182 / 179 ms (fastest **84–93**) | 193 → ~159 ms | 36 → 35–37 MB |
| `hap escalations` | 36 / 32 ms | 32 / 33 ms | ~50 ms | 33–34 → 34–36 MB |
| `hap task bold-dolphin list` | 45 / 42 ms | 53 / 45 ms | ~65 ms | 35 → 36 MB |

- `hap status` halves: the two stats aggregations and the model hash were most of what it waited for.
- `hap agents` now spends its time in the herdr `pane read` subprocesses for the mode column; running them together shows in the fastest runs, and the median is set by how quickly herdr answers.
- `hap escalations` (with nothing pending) and `hap task … list` were already ~35–50 ms end to end; they build no status and hash nothing, so they are unchanged — what is left is process start (~25–33 ms of package init) and one store round trip.
- Max RSS was never the problem (~34–37 MB is the binary plus its native libraries) and does not move.

## Tests

- `embedder`: a second process reuses the id without hashing; a model replaced in place, or swapped by rename with identical size and mtime, is re-hashed; no cache dir hashes every process (control); a corrupt cache costs one hash and is rewritten usable.
- `frontend`: a barrier that opens only when all three reads are in flight at once — a sequential fill resolves nothing.
- `embedder`: also a model rewritten IN PLACE at the same size with its mtime put back (`cp -p`) is re-hashed — only its ctime differs.
- `frontend`: `WithoutAgentStats` issues neither aggregation, local or fleet, while the default `GetStatus` issues each once (control); six agents never have more than four pane reads in flight.
- Mutation-checked: dropping ctime from the key, not skipping the stats, removing the concurrency cap, and reading sequentially each fail a test.
- Full suite green; golangci-lint (pinned toolchain) clean; `internal/frontend` passes under `-race`.
