### PR TITLE
#1 chore: bump plugin version to 0.9.15 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.15
+
+- `hap status` and `hap agents` no longer hash the whole ~25 MB embedding model on every run: the model's id is remembered per machine and re-checked only when the file changes (tens of milliseconds on an idle machine, much more on a busy one)
+- The CLI verbs no longer ask the daemon for per-agent lifetime counters they never print (two full audit-log aggregations per `hap status`)
+- `hap agents` reads its agents' permission modes in parallel instead of one herdr call after another
+
 ## 0.9.14
 
 - Cut the daemon's memory: its startup peak no longer climbs to ~130MB while the semantic index is rebuilt (the burst is collected tightly and handed back to the OS at once), and each of the Turso engine's pooled connections keeps a far smaller page cache

--- a/changelog.d/perf-cli-cost.md
+++ b/changelog.d/perf-cli-cost.md
@@ -1,3 +1,0 @@
-- `hap status` and `hap agents` no longer hash the whole ~25 MB embedding model on every run: the model's id is remembered per machine and re-checked only when the file changes (tens of milliseconds on an idle machine, much more on a busy one)
-- The CLI verbs no longer ask the daemon for per-agent lifetime counters they never print (two full audit-log aggregations per `hap status`)
-- `hap agents` reads its agents' permission modes in parallel instead of one herdr call after another

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.14"
+version = "0.9.15"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.15 is being released from this commit by the Auto Release workflow.