### PR TITLE
#1 chore: bump plugin version to 0.9.17 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.17
+
+- Added a recorded corpus of Antigravity CLI (agy) screens and a design for supporting it; hap's handling of agy is unchanged for now (every agy screen still reads as idle)
+
 ## 0.9.16
 
 - Added `HAP_ACTOR=orchestrator`, which marks everything a hap command does as the orchestrator's rather than the operator's — for an orchestrating agent hap did not start itself. It gets the same never-auto screening and pause refusal as commands run in the orchestrator's own pane. That pane is always the orchestrator whatever the variable says, and any value other than `orchestrator` or `operator` fails the command

--- a/changelog.d/docs-agy-phase1-corpus.md
+++ b/changelog.d/docs-agy-phase1-corpus.md
@@ -1,1 +1,0 @@
-- Added a recorded corpus of Antigravity CLI (agy) screens and a design for supporting it; hap's handling of agy is unchanged for now (every agy screen still reads as idle)

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.16"
+version = "0.9.17"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.17 is being released from this commit by the Auto Release workflow.