### PR TITLE
#1 chore: bump plugin version to 0.9.18 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.18
+
+- Added Antigravity CLI (`agy`) as a recognized agent: its approvals (shell commands, file access/creation, the trust-folder prompt, plan review), questions and errors now escalate as what they are instead of reading as an idle agent — which also stops an idle task hand-out from being typed into a standing agy prompt
+- agy's banner, model line and status bar are left out of its screen signatures, so a model or effort switch no longer splits one situation into several rules
+- hap does not send replies to agy prompts yet (they escalate as `reply_withheld`; answer them in the pane), and sign-in, terms, pickers and panels escalate as unclassifiable rather than being answered
+
 ## 0.9.17
 
 - Added a recorded corpus of Antigravity CLI (agy) screens and a design for supporting it; hap's handling of agy is unchanged for now (every agy screen still reads as idle)

--- a/changelog.d/feat-agy-first-class.md
+++ b/changelog.d/feat-agy-first-class.md
@@ -1,3 +1,0 @@
-- Added Antigravity CLI (`agy`) as a recognized agent: its approvals (shell commands, file access/creation, the trust-folder prompt, plan review), questions and errors now escalate as what they are instead of reading as an idle agent — which also stops an idle task hand-out from being typed into a standing agy prompt
-- agy's banner, model line and status bar are left out of its screen signatures, so a model or effort switch no longer splits one situation into several rules
-- hap does not send replies to agy prompts yet (they escalate as `reply_withheld`; answer them in the pane), and sign-in, terms, pickers and panels escalate as unclassifiable rather than being answered

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.17"
+version = "0.9.18"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.18 is being released from this commit by the Auto Release workflow.