### PR TITLE
#0 feat: agy permission modes, conversation ids and skill install

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -192,6 +192,7 @@ hap mode backend-dev plan --yes       # rotate the agent into plan mode
 |---|---|
 | `claude` | `acceptEdits`, `plan`, `auto`, `manual` |
 | `codex` | `default`, `plan` |
+| `agy` | `default`, `acceptEdits`, `plan` (agy's `accept-edits` works too) |
 
 Other agent types have no toggle and report `-`.
 
@@ -212,7 +213,12 @@ itself reports the target mode, so:
   closes, rotates the agent **back to where it started**, and names the cycle
   it observed.
 - **`bypassPermissions`** (`--dangerously-skip-permissions`) is reported but
-  cannot be set — the cycle does not pass through it.
+  cannot be set — the cycle does not pass through it. agy's flag of the same
+  name paints no indicator, so such an agy reports whatever its cycle shows
+  (`default` at launch). Don't read agy's `default` as "asks before acting".
+- **agy is only pressed at an empty composer** — herdr reports agy idle under
+  every prompt and picker, so a draft, a form or agy's survey refuses the set
+  (the read still works while agy is working or holds a draft).
 - `--yes` skips the y/N prompt and is **required** when not on a terminal.
 
 ## escalations
@@ -1368,6 +1374,7 @@ The skill ships **inside the binary**, so no checkout is needed:
 ```bash
 hap skill                            # print it
 hap skill install claude codex       # → ~/.claude/skills/hap/, ~/.codex/skills/hap/
+hap skill install agy                # → ~/.gemini/antigravity-cli/skills/hap/
 hap skill install agents             # → ~/.agents/skills/hap/ (tools sharing ~/.agents)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Prefer these for how-to detail.
   hot-swap the daemon (`hap daemon --ensure`), live-test against a real agent.
 
 The hap skill also ships in the binary: `hap --skill` prints it,
-`hap skill install <claude|codex|agents>...` (or the TUI Config tab) installs it.
+`hap skill install <claude|codex|agy|agents>...` (or the TUI Config tab) installs it.
 
 ## Build, test, lint
 
@@ -810,6 +810,16 @@ read and an earlier form is always somewhere above.
   `IrreversibleScanContent` reads it raw alongside the 40-line pane tail, and `MaskVolatile` turns
   `of=/dev/sda` into `of=<path>` — the tail usually carries the raw command too, but a long
   wrapped command can push it out, and the verb is then the only raw copy.
+- **Modes (`default → acceptEdits → plan`) are read loosely and pressed strictly.** The READ
+  (`AgyAgentMode`) is not gated on an empty composer — a working agy or one holding a draft still
+  paints its mode, and `hap agents` should show it — but the PRESS gate (`ComposerReadyForMode`) is
+  `AgyComposerReady`. Two things the pane cannot say: `--dangerously-skip-permissions` paints no
+  indicator (such an agent reads `default` at launch), and a status bar with no model segment carries
+  no mode (UNKNOWN, never default). agy's `default` is its MOST restrictive mode, codex's its least.
+- **Session ids come from the print-mode JSON envelope only** (`llm.ExtractSessionID`): herdr reports
+  no `agent_session` for agy, and `--conversation` resumes an existing id rather than naming a new one,
+  so nothing is injected. The id is read from a line that DECODES as the envelope, never by searching
+  for the key, so an id quoted in the response (escaped inside the envelope) is never taken.
 
 ### Claude session-name sync
 
@@ -1104,7 +1114,9 @@ where the behaviour could revert.
   uniquely omits the cycle hint), so no line means the footer is not shown. **Matching is on the LABEL, never
   the glyph**: `accept edits on` and `auto mode on` both render `⏵⏵`. Codex is the mirror image — it appends a
   right-aligned `Plan mode` segment in Plan and nothing in Default, so "no segment" only means Default once the
-  footer itself is recognized.
+  footer itself is recognized. agy follows Codex (`domain.AgyAgentMode`): an `accept-edits · `/`plan · ` prefix on
+  the status bar's model segment, none for default — and the bar only counts DIRECTLY under the composer's rule,
+  because agy paints the same bar, mode prefix included, under every form and picker.
 - **The mode cycle is per-SESSION, not per-agent-type, so a set must detect a closed rotation** — verified live,
   a `--model haiku` Claude session offers three modes while a default-model session in the same build offers
   four, so `domain.AgentModesFor` is a SUPERSET, never a promise. `SetAgentMode` tracks the modes it has

--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ real ids filled in. Turn it off per invocation with `--no-hints`, per shell with
 these affect the help pages.
 
 `hap skill` prints the bundled agent skill document, and
-`hap skill install claude codex agents` writes it into those tools' skill
-directories — so a coding agent can drive hap without a repo checkout.
+`hap skill install claude codex agy agents` writes it into those tools' skill
+directories (agy's is `~/.gemini/antigravity-cli/skills`) — so a coding agent
+can drive hap without a repo checkout.
 
 Nearly everything the TUI does is also a CLI verb. The exceptions are two
 interactive-only conveniences: the `/usr/local/bin/hap` symlink shortcut and the
@@ -805,8 +806,11 @@ LLM-approved response may be sent.
 ### Permission modes
 
 The permission mode is what `shift+tab` cycles inside the agent's own TUI —
-`acceptEdits`, `plan`, `auto`, `manual` for claude; `default`, `plan` for codex.
-Other agent types have none.
+`acceptEdits`, `plan`, `auto`, `manual` for claude; `default`, `plan` for codex;
+`default`, `acceptEdits`, `plan` for agy (agy's own `accept-edits` spelling is
+accepted too). Other agent types have none. The shared names do not share a
+meaning: codex's `default` is its unrestricted mode, agy's is the one that asks
+before every edit and command.
 
 Setting works by pressing `shift+tab` and re-reading the pane until the agent
 itself reports the target, so it is **idempotent** (an agent already there gets
@@ -822,6 +826,13 @@ closed rotation, rotates the agent **back to where it started**, and names the
 cycle it observed. And an agent launched with `--dangerously-skip-permissions`
 reports `bypassPermissions`, which the cycle cannot leave, so hap refuses
 immediately.
+
+agy differs in two ways. Its `--dangerously-skip-permissions` paints no
+indicator at all, so such an agent reports whatever its cycle shows — `default`
+at launch — and hap cannot tell the two apart. And because herdr reports agy as
+idle under every prompt and picker, hap presses `shift+tab` into agy only at an
+EMPTY composer: a half-typed draft, a standing prompt or agy's survey refuses
+the set (reading the mode still works while agy is working or holds a draft).
 
 ## Never-auto patterns
 
@@ -1142,8 +1153,14 @@ the TUI's Audit tab.
 
 For `claude`, hap appends `--session-id {session_id}` automatically (writing
 `{session_id}` yourself turns that off, so it is never passed twice). `codex`
-mints its own and prints it in its startup banner, which hap reads back. For
-anything else nothing is added — hap does not guess a flag name.
+mints its own and prints it in its startup banner, which hap reads back. `agy`
+mints its own too and reports it as `conversation_id` only when the template
+already runs it with `--output-format json` (or `stream-json`); hap reads it
+back then, and it names `~/.gemini/antigravity-cli/conversations/<id>.db`. Plain
+text output carries no id, and switching an agy template to JSON output just for
+the id is not recommended: task generation, re-ranking and learn-from-user read
+the CLI's stdout and cannot see an answer wrapped in the envelope. For anything
+else nothing is added — hap does not guess a flag name.
 
 ### A separate environment per command
 

--- a/changelog.d/feat-agy-modes.md
+++ b/changelog.d/feat-agy-modes.md
@@ -1,0 +1,4 @@
+- `hap mode` and the `hap agents` MODE column now cover agy: its `default → acceptEdits → plan` cycle is read from agy's status bar and set with shift+tab (agy's own `accept-edits` spelling works too); hap presses into agy only at an empty composer, and a status bar with no model shows `-` rather than a guessed `default`
+- An agy launched with `--dangerously-skip-permissions` shows no mode indicator, so it reports whatever its cycle shows (`default` at launch); `hap help mode` and the README say so
+- An agy LLM command run with `--output-format json` now has its conversation id recorded on the audit row, like codex's session id
+- `hap skill install agy` (and the TUI's skill shortcut) installs the hap skill into agy's global skills directory, `~/.gemini/antigravity-cli/skills`

--- a/docs/designer/agy-support.md
+++ b/docs/designer/agy-support.md
@@ -736,4 +736,46 @@ What shipped, and where it deliberately departs from §4:
   - A never-auto seed for the trust prompt (§4.9). The seed list is scoped to major-risk remote
     operations, and Claude's own trust prompt is not seeded. The trust prompt is answered when a
     rule or the operator says so, like any approval.
-  - agy permission modes (phase 4).
+  - agy permission modes (phase 4, §11).
+
+## 11. Phase 4 as built (modes, session ids, the rest of the surface)
+
+- **Modes.** `domain.AgentModesFor("agy")` is `default, acceptEdits, plan` in cycle order. The
+  shared constants are reused, so `hap mode` prints `acceptEdits`, and `ParseAgentMode` folds
+  agy's own `accept-edits`. `AgyModePresses` is 6, one extra cycle as for the other agents.
+  Every per-type switch folds agy's aliases (`modeAgentKind`).
+  - **The read is `domain.AgyAgentMode`.** It uses the `accept-edits · ` / `plan · ` prefix on
+    the status bar's model segment, with no prefix meaning `default`. The bar counts only when
+    it is the last line and directly under the composer's bottom rule. agy paints the same bar,
+    prefix included, under every form, picker and popup, so those screens report unknown.
+  - A bar with no model segment (`error_agy_offline`) is unknown, never default.
+  - The read is not gated on an empty composer. A working agy (`working_agy_spinner` reads
+    `plan`) and one holding a draft still report their mode.
+  - **The press gate is `AgyComposerReady`** (`ComposerReadyForMode`), the same empty-composer
+    proof phase 3's deliveries use. A draft, a form or the survey refuses the set.
+  - `SetAgentMode`'s rotation detection and `restoreMode` apply unchanged.
+  - The whole corpus carries an explicit expectation (`TestAgyAgentModeOverEveryRecordedScreen`).
+- **`--dangerously-skip-permissions`**, checked live on agy 1.2.1: it paints no indicator of its
+  own. The cycle's prefixes still render under it (three presses went accept-edits, plan,
+  default), so reads and sets behave normally, and such an agent simply reads `default` at
+  launch. `hap help mode`, the README and the skill say so, and say that agy's `default` is its
+  most restrictive mode, while codex's is its least.
+- **Session id.** herdr still reports no `agent_session` for agy, and a live pane shows none, so
+  there is nothing per agent. agy prints `agy --conversation=<uuid>` only as it exits, when there
+  is no agent left to attach it to. For the LLM path, `agy -p … --output-format json` prints
+  `{"conversation_id":"<uuid>",…}`, verified live. `llm.ExtractSessionID("agy", …)` takes the id
+  from the first output line that decodes as that envelope, so an id quoted inside the escaped
+  `response` is never read. Plain text output carries none. Nothing is injected, because
+  `--conversation` resumes an existing id and cannot name a new one. The README does not
+  recommend JSON output for agy templates, because taskgen, rerank and learn-from-user read
+  stdout.
+- **Skill install.** `hap skill install agy` writes `~/.gemini/antigravity-cli/skills/hap/`. That
+  is the global directory agy's own `/skills` lists and loads, verified live with a probe
+  skill.
+  - `~/.gemini/config/skills`, named in agy's bundled migration guide, is not loaded.
+  - `~/.agents/skills` is read only per workspace.
+- **Display.** `hap agents`' MODE column and the TUI's agent detail both come from
+  `FillAgentModes`, which skips types with no toggle, so they show agy's mode with no
+  agy-specific code. The TUI's skill shortcut label names agy.
+- **fakeherdr.** It already carries any agent label verbatim (`AddAgentPane(pane, ws, "agy")`),
+  so only its comment changed.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -287,7 +287,7 @@ func modeNextSteps(out io.Writer, target string) {
 func modeReadError(r frontend.ModeReport, target string, err error) error {
 	switch {
 	case errors.Is(err, frontend.ErrModeUnsupported):
-		return fmt.Errorf("%s is a %q agent, which has no shift+tab mode toggle (claude and codex do)",
+		return fmt.Errorf("%s is a %q agent, which has no shift+tab mode toggle (claude, codex and agy do)",
 			r.Label(target), r.AgentType)
 	case errors.Is(err, frontend.ErrModeUnreadable):
 		return fmt.Errorf("could not read %s's mode: its pane is not showing the composer footer "+

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -188,13 +188,14 @@ func buildCommands() {
 			Aliases: []string{"--skill"},
 			Group:   groupCore,
 			Summary: "print the bundled hap agent skill document, or install it for coding agents",
-			Usage:   []string{"hap skill", "hap skill show", "hap --skill", "hap skill install <claude|codex|agents>..."},
+			Usage:   []string{"hap skill", "hap skill show", "hap --skill", "hap skill install <claude|codex|agy|agents>..."},
 			Details: "The SKILL.md that teaches a coding agent to drive hap ships inside the binary,\n" +
 				"so no repo checkout is needed. Without arguments (or with the explicit `show`)\n" +
 				"the document is printed to stdout. `install` writes it into the named agents'\n" +
 				"skill directories:\n" +
 				"  claude → ~/.claude/skills/hap/SKILL.md\n" +
 				"  codex  → ~/.codex/skills/hap/SKILL.md\n" +
+				"  agy    → ~/.gemini/antigravity-cli/skills/hap/SKILL.md\n" +
 				"  agents → ~/.agents/skills/hap/SKILL.md   (other tools sharing ~/.agents)\n" +
 				"The TUI's Config tab offers the same install as a quick shortcut.",
 			Examples: []string{"hap skill | less", "hap skill install claude codex"},
@@ -350,6 +351,7 @@ func buildCommands() {
 			Details: "With one argument it prints the mode alone, for scripts to capture:\n" +
 				"  claude: manual | acceptEdits | plan | auto\n" +
 				"  codex:  default | plan\n" +
+				"  agy:    default | acceptEdits | plan   (agy spells it accept-edits; both work)\n" +
 				"With two it presses shift+tab until the agent's own pane reports the mode you\n" +
 				"asked for — so it is idempotent: an agent already in that mode is left alone\n" +
 				"and no keystroke is sent.\n\n" +
@@ -359,7 +361,9 @@ func buildCommands() {
 				"fail with an explanation instead of pressing keys into a modal (inside one,\n" +
 				"shift+tab means \"approve\", not \"change mode\").\n\n" +
 				"Claude's launch-time bypass-permissions mode is reported but cannot be set —\n" +
-				"the shift+tab cycle does not pass through it.",
+				"the shift+tab cycle does not pass through it. agy's equivalent\n" +
+				"(--dangerously-skip-permissions) paints no indicator at all, so such an agy\n" +
+				"reports whatever its cycle shows, `default` at launch.",
 			Examples: []string{
 				"hap mode vivid-falcon",
 				"hap mode vivid-falcon plan --yes",

--- a/internal/domain/agentmode.go
+++ b/internal/domain/agentmode.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 )
 
-// An agent's PERMISSION MODE — how much the agent asks before acting. Both
-// Claude Code and Codex expose it as a rotating toggle bound to Shift+Tab, and
-// neither reports it over any API: herdr's `agent list` and `pane get` carry no
-// mode field (verified against herdr 0.7.5), so the ONLY source of truth is the
-// mode indicator the agent paints in its own composer footer.
+// An agent's PERMISSION MODE — how much the agent asks before acting. Claude
+// Code, Codex and agy all expose it as a rotating toggle bound to Shift+Tab, and
+// none reports it over any API: herdr's `agent list` and `pane get` carry no
+// mode field (verified against herdr 0.7.5 and 0.8.2), so the ONLY source of
+// truth is the mode indicator the agent paints in its own composer footer.
 //
 // That makes every function here a pure parser over captured pane text, and it
 // makes the read a SAFETY CONTROL rather than a display convenience: setting the
@@ -23,7 +23,8 @@ import (
 //     suggest renders nothing), so a capture with no line is a capture that does
 //     not show the footer, not an agent in manual mode.
 //   - A keystroke is only ever pressed over a pane that positively shows its
-//     ordinary composer (ClaudeComposerReady / CodexComposerReady). Shift+Tab is
+//     ordinary composer (ClaudeComposerReady / CodexComposerReady /
+//     AgyComposerReady). Shift+Tab is
 //     REBOUND inside Claude's modals — a standing plan approval renders
 //     "shift+tab to approve with this feedback" — so pressing it at a form
 //     approves the form. Requiring positive composer evidence, rather than
@@ -49,13 +50,18 @@ const (
 	// of "auto mode on".
 	AgentModeBypass AgentMode = "bypassPermissions"
 
-	// Codex's two Shift+Tab modes. Codex names its unrestricted mode "Default"
-	// rather than "manual", and its footer shows NO segment for it.
+	// AgentModeDefault is the mode whose footer shows NO segment, for both
+	// agents that have one. The name is shared, the meaning is not: Codex's
+	// "Default" is its unrestricted mode (it has no "manual"), while agy's
+	// "default" is its MOST restrictive — it asks before edits and commands.
+	// Codex cycles default/plan; agy default/acceptEdits/plan, and agy's own
+	// spelling "accept-edits" parses to AgentModeAcceptEdits (ParseAgentMode).
 	AgentModeDefault AgentMode = "default"
 )
 
 // ShiftTab is the raw terminal encoding of the Shift+Tab chord (CSI Z), which
-// is what actually rotates the mode in both agents.
+// is what actually rotates the mode in every agent here (agy too, verified live
+// against agy 1.2.1 under herdr 0.8.2).
 //
 // It is a literal escape sequence rather than a herdr key NAME on purpose.
 // Verified live (2026-08-09, herdr 0.7.5): `herdr pane send-keys <pane>
@@ -72,13 +78,24 @@ const (
 const ShiftTab = "\x1b[Z"
 
 // Press ceilings for the rotate-until-target loop, one full extra cycle beyond
-// what each agent needs (Claude has 4 modes, Codex 2). The loop exits as soon as
-// the pane reports the target, so these only bound a pane that is not rotating —
-// an agent build whose cycle differs, or a chord that is not landing.
+// what each agent needs (Claude has 4 modes, Codex 2, agy 3). The loop exits as
+// soon as the pane reports the target, so these only bound a pane that is not
+// rotating — an agent build whose cycle differs, or a chord that is not landing.
 const (
 	ClaudeModePresses = 8
 	CodexModePresses  = 4
+	AgyModePresses    = 6
 )
+
+// modeAgentKind folds an agent type for the per-type switches below: agy
+// reaches herdr under more than one label (CanonicalAgentType), the others
+// only by name.
+func modeAgentKind(agentType string) string {
+	if IsAgy(agentType) {
+		return AgentTypeAgy
+	}
+	return strings.ToLower(strings.TrimSpace(agentType))
+}
 
 // AgentModesFor returns the modes settable for an agent type, in cycle order,
 // or nil when the type has no Shift+Tab mode toggle. Callers use it both to
@@ -92,11 +109,13 @@ const (
 // still be unreachable, which is why the caller detects a closed rotation rather
 // than trusting the list (see frontend.SetAgentMode).
 func AgentModesFor(agentType string) []AgentMode {
-	switch strings.ToLower(strings.TrimSpace(agentType)) {
+	switch modeAgentKind(agentType) {
 	case "claude":
 		return []AgentMode{AgentModeAcceptEdits, AgentModePlan, AgentModeAuto, AgentModeManual}
 	case "codex":
 		return []AgentMode{AgentModeDefault, AgentModePlan}
+	case AgentTypeAgy:
+		return []AgentMode{AgentModeDefault, AgentModeAcceptEdits, AgentModePlan}
 	default:
 		return nil
 	}
@@ -105,11 +124,13 @@ func AgentModesFor(agentType string) []AgentMode {
 // ModePressCap returns how many Shift+Tab presses may be spent rotating an
 // agent of this type to a target, or 0 when the type has no mode toggle.
 func ModePressCap(agentType string) int {
-	switch strings.ToLower(strings.TrimSpace(agentType)) {
+	switch modeAgentKind(agentType) {
 	case "claude":
 		return ClaudeModePresses
 	case "codex":
 		return CodexModePresses
+	case AgentTypeAgy:
+		return AgyModePresses
 	default:
 		return 0
 	}
@@ -310,14 +331,53 @@ func codexFooterLine(pane string) (string, bool) {
 	return "", false
 }
 
+// AgyAgentMode reports the permission mode agy is painting in the given pane
+// capture. ok=false means the capture does not show agy's composer status bar
+// with its model segment, which is UNKNOWN rather than any mode.
+//
+// agy prefixes the right-aligned half of its status bar with "accept-edits · "
+// or "plan · " and shows NO prefix in default mode (verified live, agy 1.2.1).
+// So, as with Codex, "default" is concluded only from a bar positively
+// recognized, and the bar only counts directly under the composer's bottom rule:
+// under a form, a picker or the slash popup the line above it is a key hint,
+// and those screens report unknown. The read is deliberately NOT gated on an
+// empty composer (AgyComposerReady) — it sends nothing, and a working agy or
+// one holding a draft still paints its mode. A bar with no model segment (agy
+// could not load a model) carries no mode either, so it is unknown too.
+//
+// One mode is invisible: --dangerously-skip-permissions paints no indicator of
+// its own and leaves the cycle's segments as they are, so such an agent reads
+// as whatever its cycle shows — "default" at launch. Callers MUST gate this on
+// the agent type being agy.
+func AgyAgentMode(pane string) (AgentMode, bool) {
+	lines := trimTrailingBlank(strings.Split(strings.ReplaceAll(pane, "\r", ""), "\n"))
+	n := len(lines)
+	if n < 2 || !agyRuleLineRE.MatchString(strings.TrimSpace(lines[n-2])) {
+		return AgentModeUnknown, false
+	}
+	segment, ok := agyStatusBar(lines[n-1])
+	if !ok || segment == "" {
+		return AgentModeUnknown, false
+	}
+	switch {
+	case strings.HasPrefix(segment, "accept-edits · "):
+		return AgentModeAcceptEdits, true
+	case strings.HasPrefix(segment, "plan · "):
+		return AgentModePlan, true
+	}
+	return AgentModeDefault, true
+}
+
 // AgentModeFromPane dispatches to the right parser for an agent type. Types
 // with no mode toggle report unknown.
 func AgentModeFromPane(agentType, pane string) (AgentMode, bool) {
-	switch strings.ToLower(strings.TrimSpace(agentType)) {
+	switch modeAgentKind(agentType) {
 	case "claude":
 		return ClaudeAgentMode(pane)
 	case "codex":
 		return CodexAgentMode(pane)
+	case AgentTypeAgy:
+		return AgyAgentMode(pane)
 	default:
 		return AgentModeUnknown, false
 	}
@@ -407,12 +467,18 @@ func CodexComposerReady(pane string) bool {
 // pane. It fails CLOSED for every agent type with no known composer shape:
 // pressing an unrecognized chord into an unrecognized screen is the one
 // outcome this whole file exists to prevent.
+//
+// agy's gate is the stricter EMPTY-composer proof its deliveries use: herdr
+// reports every agy modal as idle, and a press over the survey or a draft is
+// not worth the difference.
 func ComposerReadyForMode(agentType, pane string) bool {
-	switch strings.ToLower(strings.TrimSpace(agentType)) {
+	switch modeAgentKind(agentType) {
 	case "claude":
 		return ClaudeComposerReady(pane)
 	case "codex":
 		return CodexComposerReady(pane)
+	case AgentTypeAgy:
+		return AgyComposerReady(pane)
 	default:
 		return false
 	}

--- a/internal/domain/agentmode_test.go
+++ b/internal/domain/agentmode_test.go
@@ -1,6 +1,8 @@
 package domain
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -293,7 +295,7 @@ func TestCodexComposerReadyAcceptsTheRealComposer(t *testing.T) {
 // TestComposerReadyForModeFailsClosedOnUnknownAgents: an agent type with no
 // known composer shape must never be pressed into.
 func TestComposerReadyForModeFailsClosedOnUnknownAgents(t *testing.T) {
-	for _, agentType := range []string{"", "unknown", "gemini", "agy"} {
+	for _, agentType := range []string{"", "unknown", "gemini"} {
 		if ComposerReadyForMode(agentType, claudeComposer+"  ⏸ manual mode on\n") {
 			t.Errorf("ComposerReadyForMode(%q) accepted a pane for an agent with no known mode toggle", agentType)
 		}
@@ -324,6 +326,13 @@ func TestParseAgentModeAcceptsOnlyTheTypesOwnModes(t *testing.T) {
 		{"codex", "plan", AgentModePlan, true},
 		{"codex", "manual", AgentModeUnknown, false},
 		{"codex", "auto", AgentModeUnknown, false},
+		// agy's own spelling of its middle mode, and its aliases.
+		{"agy", "default", AgentModeDefault, true},
+		{"agy", "accept-edits", AgentModeAcceptEdits, true},
+		{"agy", "acceptEdits", AgentModeAcceptEdits, true},
+		{"antigravity", "plan", AgentModePlan, true},
+		{"agy", "auto", AgentModeUnknown, false},
+		{"agy", "manual", AgentModeUnknown, false},
 		// bypassPermissions is reportable but never settable: it is entered at
 		// launch, so the Shift+Tab cycle can never reach it and the loop would
 		// spend its whole ceiling trying.
@@ -344,7 +353,7 @@ func TestParseAgentModeAcceptsOnlyTheTypesOwnModes(t *testing.T) {
 // TestModePressCapCoversAFullCycle: the ceiling must exceed the cycle length,
 // or a target one step "behind" the current mode is unreachable.
 func TestModePressCapCoversAFullCycle(t *testing.T) {
-	for _, agentType := range []string{"claude", "codex"} {
+	for _, agentType := range []string{"claude", "codex", "agy", "antigravity-cli"} {
 		modes := AgentModesFor(agentType)
 		if cap := ModePressCap(agentType); cap < len(modes) {
 			t.Errorf("ModePressCap(%q) = %d with %d modes — a full rotation cannot complete", agentType, cap, len(modes))
@@ -352,6 +361,110 @@ func TestModePressCapCoversAFullCycle(t *testing.T) {
 	}
 	if ModePressCap("gemini") != 0 || AgentModesFor("gemini") != nil {
 		t.Error("an agent type with no mode toggle must offer no modes and no presses")
+	}
+}
+
+// TestAgyAgentModeOverEveryRecordedScreen runs agy's mode read and its press
+// gate over every recorded agy screen. Each fixture carries an explicit
+// expectation, so a new capture must be classified here before it passes.
+//
+// The cases that discriminate: offline (a status bar with no model segment)
+// and every form, picker and popup (a key hint above the bar, not the
+// composer's rule) are UNKNOWN, never "default"; a working agy and one holding
+// a draft still report their mode, because a read sends nothing; and neither
+// of those two may be pressed into.
+func TestAgyAgentModeOverEveryRecordedScreen(t *testing.T) {
+	unknown := AgentModeUnknown
+	want := map[string]struct {
+		mode  AgentMode
+		ready bool
+	}{
+		"idle_agy_fresh":             {AgentModeDefault, true},
+		"idle_agy_after_turn":        {AgentModeDefault, true},
+		"idle_agy_declined":          {AgentModeDefault, true},
+		"idle_agy_mode_accept_edits": {AgentModeAcceptEdits, true},
+		"idle_agy_mode_plan":         {AgentModePlan, true},
+		"error_agy_interrupted":      {AgentModeDefault, true},
+		"error_agy_model_warning":    {AgentModeDefault, true},
+		"idle_agy_composer_draft":    {AgentModeDefault, false},
+		"working_agy_spinner":        {AgentModePlan, false},
+		// A bar with no model segment carries no mode; the press gate may
+		// accept the composer, but SetAgentMode refuses on the unknown read
+		// before any press.
+		"error_agy_offline":            {unknown, true},
+		"approval_agy_artifact_review": {unknown, false},
+		"approval_agy_file_access":     {unknown, false},
+		"approval_agy_file_create":     {unknown, false},
+		"approval_agy_shell":           {unknown, false},
+		"approval_agy_shell_amend":     {unknown, false},
+		"approval_agy_shell_plan_mode": {unknown, false},
+		"approval_agy_shell_recent":    {unknown, false},
+		"approval_agy_shell_wide":      {unknown, false},
+		"approval_agy_shell_wrapped":   {unknown, false},
+		"approval_agy_trust_folder":    {unknown, false},
+		"choice_agy_mcq":               {unknown, false},
+		"choice_agy_mcq_two":           {unknown, false},
+		"choice_agy_mcq_two_q2":        {unknown, false},
+		"choice_agy_mcq_two_recent":    {unknown, false},
+		"idle_agy_effort_picker":       {unknown, false},
+		"idle_agy_model_picker":        {unknown, false},
+		"idle_agy_shortcuts_overlay":   {unknown, false},
+		"idle_agy_signin_method":       {unknown, false},
+		"idle_agy_signin_url":          {unknown, false},
+		"idle_agy_slash_popup":         {unknown, false},
+		"idle_agy_terms":               {unknown, false},
+	}
+	files, err := filepath.Glob(filepath.Join("..", "classify", "testdata", "transcripts", "*_agy_*.txt"))
+	if err != nil || len(files) == 0 {
+		t.Fatalf("no agy fixtures found (%v)", err)
+	}
+	seen := map[string]bool{}
+	for _, f := range files {
+		name := strings.TrimSuffix(filepath.Base(f), ".txt")
+		seen[name] = true
+		t.Run(name, func(t *testing.T) {
+			w, ok := want[name]
+			if !ok {
+				t.Fatalf("no expectation for %s: classify it in this table", name)
+			}
+			b, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pane := string(b)
+			got, gotOK := AgentModeFromPane("agy", pane)
+			if got != w.mode || gotOK != (w.mode != unknown) {
+				t.Errorf("AgentModeFromPane = %q, %v; want %q", got, gotOK, w.mode)
+			}
+			if ready := ComposerReadyForMode("agy", pane); ready != w.ready {
+				t.Errorf("ComposerReadyForMode = %v; want %v", ready, w.ready)
+			}
+		})
+	}
+	for name := range want {
+		if !seen[name] {
+			t.Errorf("expectation for %s names no fixture", name)
+		}
+	}
+}
+
+// TestAgyAgentModeNeedsTheComposerRuleAboveTheBar: the status bar alone is not
+// enough — agy paints the same bar under every form and picker, where the mode
+// segment still renders, so a bar under anything but the composer's rule must
+// stay unknown. The alias must reach the same parser.
+func TestAgyAgentModeNeedsTheComposerRuleAboveTheBar(t *testing.T) {
+	bar := "? for shortcuts                                  plan · Gemini 3.6 Flash · low"
+	if got, ok := AgentModeFromPane("antigravity", agyComposer); !ok || got != AgentModeDefault {
+		t.Errorf("alias read = %q, %v; want default", got, ok)
+	}
+	if got, ok := AgyAgentMode("  ↑/↓ Navigate · enter Select\n" + bar + "\n"); ok {
+		t.Errorf("a bar under a key hint read as %q", got)
+	}
+	if got, ok := AgyAgentMode("────────────────────────────────────────\n" + bar + "\n\n"); !ok || got != AgentModePlan {
+		t.Errorf("bar under the rule = %q, %v; want plan", got, ok)
+	}
+	if _, ok := AgyAgentMode(""); ok {
+		t.Error("an empty capture reported a mode")
 	}
 }
 

--- a/internal/domain/agy.go
+++ b/internal/domain/agy.go
@@ -81,20 +81,33 @@ var (
 // Callers only ever test the LAST non-empty line with this: the shapes are
 // distinctive at the bottom of the screen and nowhere else.
 func agyStatusBarLine(line string) bool {
+	_, ok := agyStatusBar(line)
+	return ok
+}
+
+// agyStatusBar is agyStatusBarLine that also returns the bar's right-aligned
+// model segment, "" when the bar carries none (no model loaded).
+func agyStatusBar(line string) (segment string, ok bool) {
 	trimmed := strings.TrimSpace(line)
 	if trimmed == "" {
-		return false
+		return "", false
 	}
 	for _, left := range []string{"? for shortcuts", "esc to cancel"} {
-		if rest, ok := strings.CutPrefix(trimmed, left); ok {
+		if rest, found := strings.CutPrefix(trimmed, left); found {
 			rest = strings.TrimSpace(rest)
-			return rest == "" || agyModelSegmentRE.MatchString(rest)
+			if rest == "" {
+				return "", true
+			}
+			return rest, agyModelSegmentRE.MatchString(rest)
 		}
 	}
 	// No left token: only the right-aligned model segment, which starts after a
 	// terminal-width padding run.
 	loc := agyStatusPadRE.FindStringIndex(strings.TrimRight(line, " \t"))
-	return loc != nil && loc[0] == 0 && agyModelSegmentRE.MatchString(trimmed)
+	if loc != nil && loc[0] == 0 && agyModelSegmentRE.MatchString(trimmed) {
+		return trimmed, true
+	}
+	return "", false
 }
 
 // agyBody returns the capture's lines with trailing blank lines and agy's

--- a/internal/fakeherdr/fakeherdr.go
+++ b/internal/fakeherdr/fakeherdr.go
@@ -259,8 +259,9 @@ func (s *Server) AddPane(paneID, workspaceID string) {
 }
 
 // AddAgentPane registers a pane that already hosts a detected agent — what
-// real herdr reports for a pane running claude or codex: pane.list carries
-// its label, so a subscriber watches its status from the first subscribe.
+// real herdr reports for a pane running claude, codex or agy: pane.list
+// carries its label (any string, verbatim), so a subscriber watches its status
+// from the first subscribe.
 func (s *Server) AddAgentPane(paneID, workspaceID, agentLabel string) {
 	s.mu.Lock()
 	s.agents[paneID] = agentLabel

--- a/internal/frontend/agentmode.go
+++ b/internal/frontend/agentmode.go
@@ -275,7 +275,7 @@ func (a *App) SetAgentMode(ctx context.Context, target, modeName string, opts Mo
 	want, ok := domain.ParseAgentMode(agent.AgentType, modeName)
 	if !ok {
 		if modes := domain.AgentModesFor(agent.AgentType); modes != nil {
-			return ModeChange{}, fmt.Errorf("%q is not a mode for a %s agent (want one of %s)",
+			return ModeChange{}, fmt.Errorf("%q is not a mode %s offers (want one of %s)",
 				modeName, agent.AgentType, joinModes(modes))
 		}
 		return ModeChange{}, fmt.Errorf("%w: %q", ErrModeUnsupported, agent.AgentType)

--- a/internal/frontend/agentmode_test.go
+++ b/internal/frontend/agentmode_test.go
@@ -134,6 +134,117 @@ func renderCodex(m domain.AgentMode) string {
 	return "› Summarize recent commits\n\n" + footer + "\n"
 }
 
+// agyRule is the full-width rule agy draws around its composer.
+var agyRule = strings.Repeat("─", 60)
+
+// renderAgy paints agy's composer and status bar the way agy 1.2.1 does: the
+// mode placeholder on the empty caret line, and the mode prefix on the bar's
+// right-aligned segment — none for default.
+func renderAgy(m domain.AgentMode) string {
+	caret, prefix := ">", ""
+	switch m {
+	case domain.AgentModeAcceptEdits:
+		caret, prefix = "> Accept-edits mode: file edits auto-approved (shift+tab to cycle)", "accept-edits · "
+	case domain.AgentModePlan:
+		caret, prefix = "> Plan mode: research & plan only (shift+tab to cycle)", "plan · "
+	}
+	return "● PONG\n\n" + agyRule + "\n" + caret + "\n" + agyRule + "\n" +
+		"? for shortcuts" + strings.Repeat(" ", 40) + prefix + "Gemini 3.6 Flash · low\n"
+}
+
+func agyApp(t *testing.T, start domain.AgentMode) (*frontend.App, *modeHerdr) {
+	t.Helper()
+	app, st := testApp(t)
+	fake := &modeHerdr{
+		agents: []domain.AgentTransition{{AgentID: "w1:p4", PaneID: "w1:p4", AgentType: "agy", Status: "idle"}},
+		cycle:  []domain.AgentMode{domain.AgentModeDefault, domain.AgentModeAcceptEdits, domain.AgentModePlan},
+		render: renderAgy,
+	}
+	for i, m := range fake.cycle {
+		if m == start {
+			fake.at = i
+		}
+	}
+	app.Herdr = fake
+	seedRoster(t, st, fake.agents...)
+	return app, fake
+}
+
+// TestSetAgentModeRotatesAgy: agy's three-mode cycle, reached by agy's own
+// spelling of the middle mode, and the press count proving the loop stopped on
+// the pane's report.
+func TestSetAgentModeRotatesAgy(t *testing.T) {
+	tests := []struct {
+		from    domain.AgentMode
+		target  string
+		want    domain.AgentMode
+		presses int
+	}{
+		{domain.AgentModeDefault, "accept-edits", domain.AgentModeAcceptEdits, 1},
+		{domain.AgentModeDefault, "plan", domain.AgentModePlan, 2},
+		{domain.AgentModePlan, "default", domain.AgentModeDefault, 1},
+		{domain.AgentModeAcceptEdits, "default", domain.AgentModeDefault, 2},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.from)+"->"+tt.target, func(t *testing.T) {
+			app, fake := agyApp(t, tt.from)
+			change, err := app.SetAgentMode(context.Background(), "w1:p4", tt.target, fastModes)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if change.From != tt.from || change.Mode != tt.want || change.Presses != tt.presses {
+				t.Errorf("change = %s -> %s in %d presses; want %s -> %s in %d",
+					change.From, change.Mode, change.Presses, tt.from, tt.want, tt.presses)
+			}
+			if chords, _ := fake.counts(); chords != tt.presses {
+				t.Errorf("sent %d chords; want %d", chords, tt.presses)
+			}
+		})
+	}
+}
+
+// TestSetAgentModeRefusesAgyAtAFormOrADraft: herdr reports agy idle under
+// every modal, so the press gate is agy's empty-composer proof. An approval
+// covers the bar (unreadable, nothing sent); a draft still shows the mode,
+// but pressing into it is refused.
+func TestSetAgentModeRefusesAgyAtAFormOrADraft(t *testing.T) {
+	approval := "Run this command?\n> 1. Yes, run command\n  2. No, cancel\n\n" +
+		"  ↑/↓ Navigate · tab Amend · ctrl+g edit/expand command\n" +
+		"esc to cancel" + strings.Repeat(" ", 40) + "Gemini 3.6 Flash · low\n"
+	draft := agyRule + "\n> half a thought\n" + agyRule + "\n" +
+		strings.Repeat(" ", 60) + "Gemini 3.6 Flash · low\n"
+	for name, tc := range map[string]struct {
+		pane string
+		err  error
+	}{
+		"approval": {approval, frontend.ErrModeUnreadable},
+		"draft":    {draft, frontend.ErrModeUnsafe},
+	} {
+		t.Run(name, func(t *testing.T) {
+			app, fake := agyApp(t, domain.AgentModeDefault)
+			fake.render = func(domain.AgentMode) string { return tc.pane }
+			_, err := app.SetAgentMode(context.Background(), "w1:p4", "plan", fastModes)
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("err = %v; want %v", err, tc.err)
+			}
+			if chords, _ := fake.counts(); chords != 0 {
+				t.Errorf("sent %d chords into a %s", chords, name)
+			}
+		})
+	}
+}
+
+// TestFillAgentModesReadsAgy: the `hap agents` MODE column and the TUI detail
+// both come from FillAgentModes, which skips every type with no toggle.
+func TestFillAgentModesReadsAgy(t *testing.T) {
+	app, fake := agyApp(t, domain.AgentModePlan)
+	st := frontend.Status{MonitoredAgents: fake.agents}
+	app.FillAgentModes(context.Background(), &st)
+	if got := st.AgentMode("w1:p4"); got != domain.AgentModePlan {
+		t.Errorf("AgentMode(w1:p4) = %q; want plan", got)
+	}
+}
+
 // fastModes keeps the settle wait short so tests do not sleep for real. The
 // values still exercise the poll loop (several polls per press).
 var fastModes = frontend.ModeOptions{SettleTimeout: 300 * time.Millisecond, PollInterval: time.Millisecond}

--- a/internal/llm/sessionid.go
+++ b/internal/llm/sessionid.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -19,7 +20,9 @@ const SessionIDPlaceholder = "{session_id}"
 // flag name, because a wrong one is a hard argv error that fails every consult.
 //
 // codex is deliberately NOT here. It has no such flag — it MINTS a session id
-// and prints it, so hap reads it back with ExtractSessionID instead.
+// and prints it, so hap reads it back with ExtractSessionID instead. Neither is
+// agy: its --conversation takes the id of an EXISTING conversation to resume
+// and cannot name a new one, so it mints its own too.
 var sessionIDFlag = map[string]string{
 	"claude": "--session-id",
 }
@@ -69,14 +72,53 @@ func InjectSessionID(argv []string, sessionID string) []string {
 var codexSessionLine = regexp.MustCompile(
 	`(?im)^\s*session[ _-]?id\s*:\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b`)
 
+// agyEnvelope is the one field hap reads from agy's print-mode JSON envelope:
+//
+//	{"conversation_id":"bf5cacf9-…","status":"SUCCESS","response":"PONG\n",…}
+//
+// agy prints it only under --output-format json (one envelope) or stream-json
+// (one per line); plain text output carries no id at all (verified live, agy
+// 1.2.1, 2026-09-11).
+type agyEnvelope struct {
+	ConversationID string `json:"conversation_id"`
+}
+
+// agyConversationID matches the UUID shape of an agy conversation id, which
+// also names its store file.
+var agyConversationID = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// agySessionID returns the conversation id from the first output line that
+// DECODES as agy's JSON envelope. Decoding the whole line, rather than
+// searching for the key, is what keeps an id merely QUOTED in the response out:
+// inside the envelope the response is an escaped JSON string, so its text can
+// never be a top-level key.
+func agySessionID(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var env agyEnvelope
+		if json.Unmarshal([]byte(line), &env) != nil {
+			continue
+		}
+		if id := strings.ToLower(env.ConversationID); agyConversationID.MatchString(id) {
+			return id
+		}
+	}
+	return ""
+}
+
 // ExtractSessionID reads the session id a CLI reported in its own output, for
 // the CLIs that mint one rather than accept one.
 //
 // WHERE THE TRANSCRIPT LANDS DIFFERS PER CLI, and anything that later goes
-// looking for one must not assume claude's layout (verified live 2026-08-03):
+// looking for one must not assume claude's layout (verified live 2026-08-03,
+// agy 2026-09-11):
 //
 //	claude  <CLAUDE_CONFIG_DIR>/projects/<slugified-cwd>/<session-id>.jsonl
 //	codex   <CODEX_HOME>/sessions/<YYYY>/<MM>/<DD>/rollout-<ISO-ts>-<session-id>.jsonl
+//	agy     ~/.gemini/antigravity-cli/conversations/<session-id>.db
 //
 // So codex needs a suffix glob, not an exact filename. Its store is also the
 // larger of the two in practice (120 MB vs 24 MB on one live machine).
@@ -90,7 +132,11 @@ var codexSessionLine = regexp.MustCompile(
 // printing). An empty result means "unknown", never an error: the session id is
 // bookkeeping, and failing a consult over it would be absurd.
 func ExtractSessionID(argv0, output string) string {
-	if filepath.Base(argv0) != "codex" {
+	switch filepath.Base(argv0) {
+	case "codex":
+	case "agy":
+		return agySessionID(output)
+	default:
 		return ""
 	}
 	m := codexSessionLine.FindStringSubmatch(output)

--- a/internal/llm/sessionid_test.go
+++ b/internal/llm/sessionid_test.go
@@ -162,11 +162,11 @@ func TestExtractSessionIDReadsAgyEnvelope(t *testing.T) {
 // envelope at all, so neither may be read as the conversation's id.
 func TestExtractSessionIDIgnoresAnAgyIDThatIsNotTheEnvelopes(t *testing.T) {
 	for name, out := range map[string]string{
-		"text mode prose": `the conversation_id is "bf5cacf9-ff49-41f5-86c1-334922f5a62d"`,
+		"text mode prose":        `the conversation_id is "bf5cacf9-ff49-41f5-86c1-334922f5a62d"`,
 		"quoted in the response": `{"status":"SUCCESS","response":"{\"conversation_id\":\"bf5cacf9-ff49-41f5-86c1-334922f5a62d\"}"}`,
-		"not a uuid":  `{"conversation_id":"not-a-uuid"}`,
-		"broken json": `{"conversation_id":"bf5cacf9-ff49-41f5-86c1-334922f5a62d"`,
-		"empty":       "",
+		"not a uuid":             `{"conversation_id":"not-a-uuid"}`,
+		"broken json":            `{"conversation_id":"bf5cacf9-ff49-41f5-86c1-334922f5a62d"`,
+		"empty":                  "",
 	} {
 		t.Run(name, func(t *testing.T) {
 			if got := ExtractSessionID("agy", out); got != "" {

--- a/internal/llm/sessionid_test.go
+++ b/internal/llm/sessionid_test.go
@@ -134,6 +134,48 @@ func TestExtractSessionIDOnlyForCodex(t *testing.T) {
 	}
 }
 
+// agyJSONOutput is agy's print-mode envelope, verbatim from a live
+// `agy -p … --output-format json` run (agy 1.2.1, 2026-09-11).
+const agyJSONOutput = `{"conversation_id":"bf5cacf9-ff49-41f5-86c1-334922f5a62d","status":"SUCCESS","response":"PONG\n","duration_seconds":2.629765096,"num_turns":1,"usage":{"input_tokens":6316,"output_tokens":21,"thinking_tokens":19,"cache_read_tokens":8133,"total_tokens":6337}}
+`
+
+// TestExtractSessionIDReadsAgyEnvelope: agy mints a conversation id and
+// reports it in its JSON envelope, and only there.
+func TestExtractSessionIDReadsAgyEnvelope(t *testing.T) {
+	const want = "bf5cacf9-ff49-41f5-86c1-334922f5a62d"
+	if got := ExtractSessionID("/root/.local/bin/agy", agyJSONOutput); got != want {
+		t.Errorf("json envelope: got %q, want %q", got, want)
+	}
+	// stream-json: one envelope per line, after unrelated output.
+	stream := "warming up\n" + `{"type":"init","conversation_id":"` + want + `"}` + "\n"
+	if got := ExtractSessionID("agy", stream); got != want {
+		t.Errorf("stream-json: got %q, want %q", got, want)
+	}
+	// The same output under another CLI's name is not scanned.
+	if got := ExtractSessionID("codex", agyJSONOutput); got != "" {
+		t.Errorf("codex must not read agy's envelope, got %q", got)
+	}
+}
+
+// TestExtractSessionIDIgnoresAnAgyIDThatIsNotTheEnvelopes: an id QUOTED in the
+// response is escaped inside the envelope, and plain-text output has no
+// envelope at all, so neither may be read as the conversation's id.
+func TestExtractSessionIDIgnoresAnAgyIDThatIsNotTheEnvelopes(t *testing.T) {
+	for name, out := range map[string]string{
+		"text mode prose": `the conversation_id is "bf5cacf9-ff49-41f5-86c1-334922f5a62d"`,
+		"quoted in the response": `{"status":"SUCCESS","response":"{\"conversation_id\":\"bf5cacf9-ff49-41f5-86c1-334922f5a62d\"}"}`,
+		"not a uuid":  `{"conversation_id":"not-a-uuid"}`,
+		"broken json": `{"conversation_id":"bf5cacf9-ff49-41f5-86c1-334922f5a62d"`,
+		"empty":       "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := ExtractSessionID("agy", out); got != "" {
+				t.Errorf("must not extract from %q, got %q", out, got)
+			}
+		})
+	}
+}
+
 // TestExtractSessionIDIgnoresQuotedIDs is the reason the pattern is anchored to
 // the line start: the model's own prose routinely quotes ids back.
 func TestExtractSessionIDIgnoresQuotedIDs(t *testing.T) {

--- a/internal/tui/skillinstall_test.go
+++ b/internal/tui/skillinstall_test.go
@@ -39,8 +39,11 @@ func TestConfigSkillShortcutInstallsCheckedTargets(t *testing.T) {
 	if m.prompt == nil || !m.prompt.multi {
 		t.Fatalf("enter on the shortcut should open the multi-select, got %+v", m.prompt)
 	}
-	if len(m.prompt.options) != 3 {
-		t.Fatalf("expected the three install targets, got %v", m.prompt.options)
+	if len(m.prompt.options) != 4 {
+		t.Fatalf("expected the four install targets, got %v", m.prompt.options)
+	}
+	if !strings.Contains(strings.Join(m.prompt.options, "\n"), "~/.gemini/antigravity-cli/skills/hap") {
+		t.Fatalf("agy's global skills directory is not offered: %v", m.prompt.options)
 	}
 	if view := m.View(); !strings.Contains(view, "space: toggle") {
 		t.Fatalf("help line should advertise the toggle key:\n%s", view)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2119,7 +2119,7 @@ func buildRuleItems(cfg config.Config) []ruleItem {
 	items = append(items, ruleItem{
 		kind:  "shortcut",
 		key:   "install-skill",
-		label: "Install hap agent skill for coding agents (Claude / Codex / others)",
+		label: "Install hap agent skill for coding agents (Claude / Codex / agy / others)",
 	})
 	return items
 }

--- a/skilldoc.go
+++ b/skilldoc.go
@@ -36,6 +36,11 @@ func Targets() []Target {
 	return []Target{
 		{Name: "claude", Label: "Claude", Dir: ".claude/skills"},
 		{Name: "codex", Label: "Codex", Dir: ".codex/skills"},
+		// agy's global skills directory, as its own `/skills` lists it
+		// (verified live, agy 1.2.1): "~/.gemini/config/skills" appears in
+		// agy's bundled migration guide but is NOT loaded, and ~/.agents is
+		// read only per workspace (<workspace>/.agents/skills).
+		{Name: "agy", Label: "Antigravity (agy)", Dir: ".gemini/antigravity-cli/skills"},
 		{Name: "agents", Label: "Others", Dir: ".agents/skills"},
 	}
 }

--- a/skilldoc_test.go
+++ b/skilldoc_test.go
@@ -21,13 +21,14 @@ func TestHapSkillIsEmbedded(t *testing.T) {
 
 func TestInstallToWritesEverySelectedTarget(t *testing.T) {
 	home := t.TempDir()
-	written, err := InstallTo(home, []string{"claude", "codex", "agents"})
+	written, err := InstallTo(home, []string{"claude", "codex", "agy", "agents"})
 	if err != nil {
 		t.Fatalf("InstallTo: %v", err)
 	}
 	want := []string{
 		filepath.Join(home, ".claude", "skills", "hap", "SKILL.md"),
 		filepath.Join(home, ".codex", "skills", "hap", "SKILL.md"),
+		filepath.Join(home, ".gemini", "antigravity-cli", "skills", "hap", "SKILL.md"),
 		filepath.Join(home, ".agents", "skills", "hap", "SKILL.md"),
 	}
 	if len(written) != len(want) {
@@ -77,7 +78,7 @@ func TestInstallToRefusesAnUnknownTargetBeforeWriting(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), `unknown install target "cursor"`) {
 		t.Fatalf("expected an unknown-target error naming the valid set, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "claude, codex, agents") {
+	if !strings.Contains(err.Error(), "claude, codex, agy, agents") {
 		t.Errorf("error should list the valid targets, got %v", err)
 	}
 	if _, statErr := os.Stat(filepath.Join(home, ".claude")); !os.IsNotExist(statErr) {


### PR DESCRIPTION
## Summary

Phase 4 of agy (Antigravity CLI) support covers the rest of the per-type surface: permission modes, session ids, skill install, display and docs. Design: `docs/designer/agy-support.md` §11.

- **`hap mode` and the `hap agents` MODE column cover agy.** The cycle is `default → acceptEdits → plan`, and agy's own `accept-edits` spelling parses too. The press cap is 6, and every per-type switch folds agy's aliases.
  - **Read** (`domain.AgyAgentMode`): the `accept-edits · ` / `plan · ` prefix on the status bar's model segment; no prefix means `default`. The bar counts only as the last line directly under the composer's bottom rule, because agy paints the same bar, prefix included, under every form, picker and popup.
  - A bar with no model segment (agy offline) is **unknown**, never `default`.
  - The read is not gated on an empty composer. A working agy, or one holding a draft, still reports its mode.
  - **Press gate**: `ComposerReadyForMode` uses phase 3's `AgyComposerReady` (an empty composer, no survey), because herdr reports agy idle under every modal. `SetAgentMode`'s rotation detection and restore apply unchanged.
- **`--dangerously-skip-permissions`** paints no indicator. Verified live that the cycle's prefixes still render under it, so reads and sets stay honest, and such an agent reads `default` at launch. `hap help mode`, the README and the skill say so, and note that agy's `default` is its *most* restrictive mode where codex's is its least.
- **Session id.** herdr reports no `agent_session` for agy, and a live pane shows none. For the LLM path, `agy -p … --output-format json` prints `{"conversation_id":"<uuid>",…}`. `llm.ExtractSessionID` reads it from the first line that **decodes** as the envelope, so an id quoted inside the escaped `response` is never taken. Text output carries no id. Nothing is injected, because `--conversation` resumes an existing id and cannot name a new one. The README does not recommend JSON output for agy templates: taskgen, rerank and learn-from-user read stdout.
- **`hap skill install agy`** writes `~/.gemini/antigravity-cli/skills/hap/`, the global directory agy's own `/skills` loads (verified live with a probe skill). `~/.gemini/config/skills`, which agy's bundled migration guide names, is **not** loaded.
- **Display and fakeherdr.** `hap agents` and the TUI agent detail read modes through `FillAgentModes`, so they needed no agy code. The TUI skill shortcut names agy. fakeherdr already carries any label verbatim; only its comment changed.
- **Docs:** CLAUDE.md, README, the hap skill, `hap help mode` / `hap help skill`, and the design doc.

## Test plan

- [x] `domain`: `TestAgyAgentModeOverEveryRecordedScreen` gives every one of the 31 agy fixtures an explicit mode and press-gate expectation. That includes offline, all forms, pickers and popups (unknown), working (`plan`), and a draft (`default`, not pressable). Also covered: the rule-above-the-bar rule, aliases, parse and press-cap tables.
- [x] `frontend`: agy rotation press counts, including `accept-edits`; refusal at an approval (unreadable) and at a draft (unsafe) with zero chords; `FillAgentModes` for agy.
- [x] `llm`: the verbatim agy envelope and stream-json; a quoted id, text-mode prose, a non-uuid and broken JSON are all refused.
- [x] `skilldoc` and the TUI shortcut: the agy target.
- [x] Full unit suite green, in memory-safe groups. gofmt clean.
- [x] golangci-lint (go1.26.2): 0 issues.
- [x] Real-herdr integration suite, with `HAP_ITEST_CLAUDE=1` and then `HAP_ITEST_CODEX=1` run one after the other. Results are **identical to the #452 baseline**: 16 pass, 2 fail, 2 skip. Neither failure comes from this PR:
  - `TestRealShiftTabKeyNameIsStillBroken` is a tripwire. It fails because herdr 0.8.2's `shift+tab` now works.
  - `TestRealClaudeModeCycle` hits the front end's roster gate: `modeApp` has no daemon. It fails on main too, and the phase-5 PR fixes the helper.
  - `TestRealCodexModeToggle` skips because codex reports `agent_not_ready` at startup. `TestRealClaudeConsult` skips because claude raised no approval menu.
- [x] **Live**, on scratch agy agents (agy 1.2.1, herdr 0.8.2), hap disabled on them. `hap mode` is front-end only, so no daemon swap was needed and the herd stayed on the release throughout. The scratch workspace and temp dirs were removed afterwards.

  ```
  read: default
  set accept-edits: wR:p1: default -> acceptEdits (1 shift+tab)
  set plan: wR:p1: acceptEdits -> plan (1 shift+tab)
  set default: wR:p1: plan -> default (1 shift+tab)
  auto: error: "auto" is not a mode … (want one of default, acceptEdits, plan)
  draft read: default
  draft set: error: wR:p1 is not at its composer, so shift+tab would answer … — refusing to send it
  hap agents: quick-lemur  w1:p8E  agy  idle  disabled  default   (read-only)
  ```
