### PR TITLE
#0 test: real-agy integration cases, and fixes they found

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,13 +58,14 @@ golangci-lint run --build-tags "vectors,cpu"
 ## Local integration suite (real herdr + claude)
 
 `test/integration/` drives an **actual running herdr** (and, with `HAP_ITEST_CLAUDE=1` /
-`HAP_ITEST_CODEX=1`, a real agent CLI), gated by the `integration` build tag so
+`HAP_ITEST_CODEX=1` / `HAP_ITEST_AGY=1`, a real agent CLI), gated by the `integration` build tag so
 `go test ./...` and CI never run them. Each case **skips** (never fails) when its
 dependency is absent.
 
 ```sh
 go test -tags integration ./test/integration/ -v                    # from inside herdr, or set HERDR_BIN_PATH
 HAP_ITEST_CLAUDE=1 go test -tags integration ./test/integration/ -v -timeout 20m  # spends tokens
+HAP_ITEST_AGY=1 go test -tags integration ./test/integration/ -run TestRealAgy -v  # Gemini tokens
 go test -tags "integration vectors cpu" ./test/integration/ -v      # + the real-model semantic case
 ```
 
@@ -89,6 +90,13 @@ Three traps, each of which already cost a shipped regression:
   command to the shell, and the startup reconcile classifies an unpainted pane as empty,
   whose escalation then stops the injected transition re-capturing. A 1s sleep held in
   isolation and lost under full-suite load.
+
+- **On a working machine the OPERATOR's daemon watches the scratch panes too.** It answers agy forms
+  (under full self-prompting within seconds), so the agy cases `hap disable` their pane
+  (`quietOperatorDaemon`) — and it reads `--source recent`, the same consuming delta, which is why
+  the agy hand-out case goes through the operator path (visible reads only) rather than the idle poll.
+  A front end also needs a PUBLISHED roster to resolve any target (#386): `modeApp` publishes herdr's
+  listing (`publishLiveRoster`), which is what `TestRealClaudeModeCycle` lacked while it failed.
 
 Cases worth knowing beyond their names: `TestRealShiftTabKeyNameIsStillBroken` is a
 **tripwire** — it FAILS if herdr's `shift+tab` key name starts working, the signal to delete

--- a/changelog.d/test-agy-integration.md
+++ b/changelog.d/test-agy-integration.md
@@ -1,0 +1,2 @@
+- Added real-agy integration cases, gated on `HAP_ITEST_AGY=1` (detection, a shell approval and a question answered through `hap confirm --send`, a task hand-out refused over a draft and delivered at an empty composer, and the permission-mode cycle), so agy's live screens and keys are checked the way claude's and codex's are
+- Fixed the real-agent mode integration cases, which were refused by the front end's roster check because their test app had no daemon behind it

--- a/docs/designer/agy-support.md
+++ b/docs/designer/agy-support.md
@@ -779,3 +779,40 @@ What shipped, and where it deliberately departs from §4:
   agy-specific code. The TUI's skill shortcut label names agy.
 - **fakeherdr.** It already carries any agent label verbatim (`AddAgentPane(pane, ws, "agy")`),
   so only its comment changed.
+
+## 12. Phase 5 as built (real-agy integration cases)
+
+`test/integration/agy_test.go`, gated on `HAP_ITEST_AGY=1`. It uses the cheapest model,
+overridable with `HAP_ITEST_AGY_MODEL`. Each case starts agy in a scratch workspace of its own,
+clears the trust prompt through the production parser, and begins only at a proven empty
+composer.
+
+| Case | Proves | Tokens |
+|---|---|---|
+| `TestRealAgyDetection` | herdr labels the pane agy; a fresh screen classifies idle; `AgyComposerReady`; the mode reads | none |
+| `TestRealAgyApprovalConfirm` | a live `touch` approval, confirmed through a daemon of its own (`hap confirm --send`), runs the command: the digit alone landed | one turn |
+| `TestRealAgyChoiceConfirm` | a live question form commits `Banana` and closes | one turn |
+| `TestRealAgyTaskHandout` | the operator hand-out (`hap task send`) is refused over a draft with the list untouched, then delivered at an empty composer and answered | one turn |
+| `TestRealAgyModeToggle` | the cycle is exactly `default → acceptEdits → plan`, every mode is reached by `SetAgentMode`, and a draft refuses the set with the mode unchanged | none |
+
+All five pass live (agy 1.2.1, herdr 0.8.2). Found and fixed on the way:
+
+- **The suite opened its agents beside the operator.** `newScratchPane` ran `tab create` with
+  no `--workspace`, which lands in whatever workspace the UI has focused. It now creates a
+  workspace per case and closes it afterwards. This applies to the claude and codex cases too.
+- **The operator hand-out lost an id-keyed source's template.**
+  `frontend.taskSourceRenderFor` matched `[[task_sources]] agent` against the agent's name
+  only, while the config documents "agent id or name". An id-keyed source's hand-out went out
+  under the default template, and agy then asked to run the `hap task` command that template
+  carries. It now matches both.
+- **The mode cases could never pass.** `modeApp` gave the front end a store no daemon writes,
+  so the roster gate (#386) refused every target. It now publishes herdr's listing, which is
+  also what `TestRealClaudeModeCycle` had been failing on.
+
+Two constraints of a working machine shape these cases:
+
+- **The operator's own daemon watches the scratch panes.** From 0.9.19 on it answers agy forms,
+  so each case `hap disable`s its pane (`quietOperatorDaemon`).
+- **That daemon also reads `--source recent`.** That source is a delta every reader consumes,
+  so the hand-out case uses the operator path, which reads `--source visible` only, rather than
+  the idle poll. The poll's agy gate stays covered by the daemon unit suite.

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -4473,7 +4473,7 @@ func (a *App) SendTaskForOperator(ctx context.Context, p domain.SendTaskPayload,
 	// an item that came from a different list would pair one source's text with
 	// another's template — the hazard the TUI used to guard with its own
 	// "task sources changed" snapshot check.
-	template, sourceIndex, err := a.taskSourceRenderFor(agentName, p.Locator)
+	template, sourceIndex, err := a.taskSourceRenderFor(agentID, agentName, p.Locator)
 	if err != nil {
 		return err
 	}
@@ -4577,14 +4577,19 @@ func (a *App) terminalIDFor(ctx context.Context, nodeID, target string) (string,
 // printed {task_source_index} differs. An agent whose sources do not include
 // the locator (a --path hand-out, say) gets the default template and no index,
 // and the prompt then addresses the list by the agent's name.
-func (a *App) taskSourceRenderFor(agentName, locator string) (template, sourceIndex string, err error) {
+//
+// A source names its agent by id OR name (config.TaskSource.Agent), so both
+// are matched: comparing the name alone dropped the template and index of
+// every source keyed by pane id, and the hand-out went out under the default
+// template instead (found by TestRealAgyTaskHandout).
+func (a *App) taskSourceRenderFor(agentID, agentName, locator string) (template, sourceIndex string, err error) {
 	cfg, err := a.Config()
 	if err != nil {
 		return "", "", err
 	}
 	want := tasklocator.Canonical(locator)
 	for i, src := range cfg.TaskSources {
-		if src.Agent != agentName {
+		if src.Agent == "" || (src.Agent != agentName && src.Agent != agentID) {
 			continue
 		}
 		if a.sourceLocatorMatches(cfg, src, agentName, want) {

--- a/internal/frontend/frontend_test.go
+++ b/internal/frontend/frontend_test.go
@@ -1710,6 +1710,33 @@ func TestConfirmGeneratedTaskUsesSourceTemplate(t *testing.T) {
 	}
 }
 
+// TestSendTaskUsesTheTemplateOfASourceKeyedByPaneID: a task source may name its
+// agent by pane id as well as by name, and the operator hand-out must find its
+// template either way. It matched the name alone, so an id-keyed source's
+// hand-out went out under the DEFAULT template — found live by
+// TestRealAgyTaskHandout, where agy then asked to run the `hap task` command
+// that template carries.
+func TestSendTaskUsesTheTemplateOfASourceKeyedByPaneID(t *testing.T) {
+	app, st := localFSApp(t)
+	fake := &fakeHerdr{}
+	app.Herdr = fake
+	ctx := context.Background()
+	name, _ := st.EnsureAgentName(ctx, "w1:p1")
+	path := filepath.Join(t.TempDir(), "tasks.md")
+	if err := os.WriteFile(path, []byte("- [ ] Ship it\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.AddTaskSource(ctx, "w1:p1", "", path, "DO {next_task_content}"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sendTask(app, ctx, "w1:p1", "claude", name, path, 1, "Ship it"); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.inputs) != 1 || fake.inputs[0] != "DO Ship it" {
+		t.Errorf("delivered %v, want the id-keyed source's template %q", fake.inputs, "DO Ship it")
+	}
+}
+
 func TestConfirmGeneratedTaskAppendCreatesMissingDeclaredFile(t *testing.T) {
 	// A declared source whose file does not exist yet still receives the
 	// tasks at ITS path — never a second bootstrap source.

--- a/test/integration/agentmode_test.go
+++ b/test/integration/agentmode_test.go
@@ -384,6 +384,8 @@ func driveMode(t *testing.T, app *frontend.App, target string, want domain.Agent
 
 // modeApp builds a real frontend.App over a throwaway store and the real herdr
 // CLI, so the integration cases exercise the same code path `hap mode` does.
+// Call it AFTER the agent under test has started: it publishes the live listing
+// once, and the roster stays fresh for domain.RosterStaleAfter.
 func modeApp(t *testing.T) *frontend.App {
 	t.Helper()
 	st, err := store.Open(filepath.Join(t.TempDir(), "mode.db"))
@@ -391,5 +393,33 @@ func modeApp(t *testing.T) *frontend.App {
 		t.Fatalf("opening a scratch store: %v", err)
 	}
 	t.Cleanup(func() { st.Close() })
-	return &frontend.App{Store: st, Herdr: herdr.NewCLI(), Author: "itest"}
+	cli := herdr.NewCLI()
+	publishLiveRoster(t, st, cli)
+	return &frontend.App{Store: st, Herdr: cli, Author: "itest"}
+}
+
+// publishLiveRoster stands in for the daemon's roster publish. A front end
+// resolves every target against the PUBLISHED roster and fails closed when
+// there is none (#386), so a front end over a store no daemon writes refuses
+// every agent — "no hap daemon has reported the running agents yet", which is
+// how TestRealClaudeModeCycle failed for as long as this helper published
+// nothing. It publishes herdr's own listing, as daemon.publishRoster does.
+func publishLiveRoster(t *testing.T, st *store.Store, cli *herdr.CLI) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	agents, err := cli.ListAgents(ctx)
+	if err != nil {
+		t.Fatalf("listing herdr's agents: %v", err)
+	}
+	now := time.Now()
+	rows := make([]domain.RosterAgent, 0, len(agents))
+	for _, tr := range agents {
+		if !domain.IsPlaceholderAgent(tr.AgentType, tr.Status) {
+			rows = append(rows, domain.RosterAgentFrom(tr, now))
+		}
+	}
+	if err := st.PublishRoster(ctx, rows, now); err != nil {
+		t.Fatalf("publishing the roster: %v", err)
+	}
 }

--- a/test/integration/agy_test.go
+++ b/test/integration/agy_test.go
@@ -1,0 +1,421 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/classify"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/frontend"
+	"github.com/0xGosu/herdr-auto-pilot/internal/herdr"
+)
+
+// Real-agy coverage, gated on HAP_ITEST_AGY=1 because every case but the
+// detection and mode ones spends Gemini tokens (one short turn each, on the
+// cheapest model). The unit suite pins agy's screens against recorded
+// fixtures; only these prove the live render still matches, that the keys hap
+// sends are the keys agy commits on, and that the empty-composer proof holds
+// against a real agy.
+//
+// One hazard is specific to running these on a working machine. The
+// operator's own hap daemon watches every pane on this herdr, and since phase 3
+// it answers agy's prompts — under full self-prompting within seconds. Left
+// enabled it would answer the very form a case is about to confirm, and the
+// case would fail on a form that is already gone. quietOperatorDaemon disables
+// its automation for the scratch pane (a pane id herdr never reuses).
+
+// requireAgy skips unless the real-agy cases were asked for and agy is here.
+func requireAgy(t *testing.T) {
+	t.Helper()
+	if os.Getenv("HAP_ITEST_AGY") != "1" {
+		t.Skip("set HAP_ITEST_AGY=1 to drive a real agy (spends Gemini tokens)")
+	}
+	requireHerdr(t)
+	if _, err := exec.LookPath("agy"); err != nil {
+		t.Skipf("agy CLI not found: %v", err)
+	}
+}
+
+// agyModel is the model the real-agy cases run with: the cheapest, since no
+// case depends on the answer's quality. Override with HAP_ITEST_AGY_MODEL.
+func agyModel() string {
+	if m := os.Getenv("HAP_ITEST_AGY_MODEL"); m != "" {
+		return m
+	}
+	return "gemini-3.6-flash-low"
+}
+
+// quietOperatorDaemon turns off the operator's hap automation for pane, if a
+// hap is installed. Best effort and logged: on a machine with no hap daemon
+// there is nothing to race.
+func quietOperatorDaemon(t *testing.T, pane string) {
+	t.Helper()
+	if _, err := exec.LookPath("hap"); err != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if out, err := exec.CommandContext(ctx, "hap", "disable", pane).CombinedOutput(); err != nil {
+		t.Logf("could not disable the operator's hap automation for %s (%v: %s); "+
+			"it may answer this case's form first", pane, err, strings.TrimSpace(string(out)))
+	}
+}
+
+// startAgyAgent launches an interactive agy in a fresh scratch pane and returns
+// its pane id once agy shows an EMPTY composer — the production proof
+// (domain.AgyComposerReady), so a case never starts against a modal.
+//
+// agy asks to trust every new folder, and every case gets a fresh
+// t.TempDir(); "Yes, I trust this folder" is pre-selected, so Enter clears it.
+func startAgyAgent(t *testing.T, cli *herdr.CLI, cwd string) string {
+	t.Helper()
+	name := sanitizeAgentName(t.Name())
+	pane := newScratchPane(t, cwd, name)
+	startAgentInPane(t, pane, name, "agy", "--", "--model", agyModel())
+	quietOperatorDaemon(t, pane)
+
+	var last string
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		content, _ := cli.ReadPaneVisible(context.Background(), pane, 60)
+		last = content
+		if f, ok := domain.ParseAgyForm(content); ok && f.Kind == domain.AgyFormTrust {
+			tryHerdr("pane", "send-keys", pane, "enter")
+			time.Sleep(3 * time.Second)
+			continue
+		}
+		if domain.AgyComposerReady(content) {
+			time.Sleep(2 * time.Second)
+			return pane
+		}
+		time.Sleep(time.Second)
+	}
+	t.Skipf("agy's composer did not become ready within 60s (slow start, signed out, or a "+
+		"first-run screen this helper does not clear). Last capture:\n%s", lastLines(last, 12))
+	return pane
+}
+
+// waitForAgyForm polls the visible screen until the production parser sees an
+// agy form of the given kind, and returns that capture.
+func waitForAgyForm(t *testing.T, cli *herdr.CLI, pane string, kind domain.AgyFormKind, within time.Duration) (string, domain.AgyForm, bool) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if content, err := cli.ReadPaneVisible(context.Background(), pane, 60); err == nil {
+			if f, ok := domain.ParseAgyForm(content); ok && f.Kind == kind {
+				return content, f, true
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return "", domain.AgyForm{}, false
+}
+
+// promptAgy submits a one-line prompt at agy's empty composer.
+func promptAgy(t *testing.T, cli *herdr.CLI, pane, prompt string) {
+	t.Helper()
+	if err := cli.Send(context.Background(), pane, prompt); err != nil {
+		t.Fatalf("send prompt to agy: %v", err)
+	}
+}
+
+// TestRealAgyDetection is the ground everything else stands on: herdr reports
+// the pane as an agy agent, hap reads its fresh screen as idle (not one of the
+// parked forms), proves its composer empty, and reads its permission mode.
+// Spends no tokens.
+func TestRealAgyDetection(t *testing.T) {
+	requireAgy(t)
+	cli := herdr.NewCLI()
+	pane := startAgyAgent(t, cli, t.TempDir())
+
+	agents, err := cli.ListAgents(context.Background())
+	if err != nil {
+		t.Fatalf("listing agents: %v", err)
+	}
+	var found *domain.AgentTransition
+	for i := range agents {
+		if agents[i].PaneID == pane || agents[i].AgentID == pane {
+			found = &agents[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("herdr's agent listing does not include %s", pane)
+	}
+	if !domain.IsAgy(found.AgentType) {
+		t.Fatalf("herdr reports %s as %q; want an agy label", pane, found.AgentType)
+	}
+	if domain.AgentBusy(found.Status) {
+		t.Errorf("a fresh agy reports %q; want a parked status", found.Status)
+	}
+
+	content, err := cli.ReadPaneVisible(context.Background(), pane, 60)
+	if err != nil {
+		t.Fatalf("reading pane: %v", err)
+	}
+	if s := classify.New(nil).Classify(found.AgentType, found.Status, content); s.Type != domain.SituationIdle {
+		t.Errorf("a fresh agy classifies as %s; want idle.\npane:\n%s", s.Type, lastLines(content, 12))
+	}
+	if !domain.AgyComposerReady(content) {
+		t.Errorf("AgyComposerReady rejected a fresh agy's composer.\npane:\n%s", lastLines(content, 8))
+	}
+	if mode, ok := domain.AgentModeFromPane(found.AgentType, content); !ok {
+		t.Errorf("could not read a fresh agy's mode.\npane:\n%s", lastLines(content, 4))
+	} else {
+		t.Logf("agy detected as %q, status %s, mode %s", found.AgentType, found.Status, mode)
+	}
+}
+
+// TestRealAgyApprovalConfirm raises a real agy shell approval and confirms it
+// through the plugin, as an operator's `hap confirm --send` would. agy commits
+// on the digit ALONE: a trailing Enter would answer whatever agy draws next, so
+// the proof is the command actually running. Delivery goes through a daemon of
+// its own over a scratch store, for the reason TestRealConfirmDeliversMenuDigit
+// gives.
+func TestRealAgyApprovalConfirm(t *testing.T) {
+	requireAgy(t)
+	cli := herdr.NewCLI()
+	work := t.TempDir()
+	marker := filepath.Join(work, "hap-agy-itest-marker")
+	pane := startAgyAgent(t, cli, work)
+
+	var form string
+	var f domain.AgyForm
+	var ok bool
+	for attempt := 0; attempt < 2 && !ok; attempt++ {
+		promptAgy(t, cli, pane, "Use your shell tool to run exactly this one command and nothing else: touch "+marker)
+		form, f, ok = waitForAgyForm(t, cli, pane, domain.AgyFormApproval, 60*time.Second)
+	}
+	if !ok {
+		t.Skip("agy did not raise a shell approval (auto-approved or slow); nothing to assert")
+	}
+	if len(f.Options) == 0 {
+		t.Fatalf("the approval parsed with no options.\npane:\n%s", lastLines(form, 12))
+	}
+	t.Logf("agy approval is up; options=%v", f.Options)
+
+	h := newTestDaemon(t, cli, "")
+	dctx, cancel := context.WithCancel(context.Background())
+	runDaemon(t, dctx, cancel, h.Daemon)
+	ctx := context.Background()
+	id, err := h.Store.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: pane, AgentType: domain.AgentTypeAgy, SituationType: domain.SituationApproval,
+		Trigger: "t", Action: "escalated", Status: "escalated",
+		Suggestion: "LLM suggested: " + f.Options[0].Label, PaneExcerpt: form, CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.App().Confirm(ctx, id, true); err != nil {
+		t.Fatalf("confirm: %v", err)
+	}
+
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(marker); err == nil {
+			return // agy ran the command — the digit landed
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	after, _ := cli.ReadPaneVisible(ctx, pane, 40)
+	t.Fatalf("agy did not run the command after the confirm.\npane:\n%s", lastLines(after, 16))
+}
+
+// TestRealAgyChoiceConfirm does the same for agy's question form: the option's
+// digit alone commits the answer, and the form closes on it.
+func TestRealAgyChoiceConfirm(t *testing.T) {
+	requireAgy(t)
+	cli := herdr.NewCLI()
+	pane := startAgyAgent(t, cli, t.TempDir())
+
+	var form string
+	var f domain.AgyForm
+	var ok bool
+	for attempt := 0; attempt < 2 && !ok; attempt++ {
+		if attempt > 0 {
+			// Never type a prompt into a standing form: its characters are
+			// answer keys there.
+			if content, err := cli.ReadPaneVisible(context.Background(), pane, 60); err == nil {
+				if _, standing := domain.ParseAgyForm(content); standing {
+					t.Skip("agy raised a form this case did not ask for; nothing to assert")
+				}
+			}
+		}
+		promptAgy(t, cli, pane, "Use your ask-question tool right now and nothing else: ask me exactly ONE "+
+			"multiple-choice question, 'Which fruit do you prefer?', with the options Apple, Banana and Cherry.")
+		form, f, ok = waitForAgyForm(t, cli, pane, domain.AgyFormQuestion, 60*time.Second)
+	}
+	if !ok {
+		t.Skip("agy did not ask the question; nothing to assert")
+	}
+	t.Logf("agy question is up; options=%v", f.Options)
+	var banana bool
+	for _, o := range f.Options {
+		banana = banana || strings.EqualFold(o.Label, "Banana")
+	}
+	if !banana {
+		t.Skipf("agy offered %v, not the options asked for; nothing to assert", f.Options)
+	}
+
+	h := newTestDaemon(t, cli, "")
+	dctx, cancel := context.WithCancel(context.Background())
+	runDaemon(t, dctx, cancel, h.Daemon)
+	ctx := context.Background()
+	id, err := h.Store.AppendAudit(ctx, domain.AuditRecord{
+		AgentID: pane, AgentType: domain.AgentTypeAgy, SituationType: domain.SituationChoice,
+		Trigger: "t", Action: "escalated", Status: "escalated",
+		Suggestion: "LLM suggested: Banana", PaneExcerpt: form, CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.App().Confirm(ctx, id, true); err != nil {
+		t.Fatalf("confirm: %v", err)
+	}
+
+	var last string
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		content, err := cli.ReadPaneVisible(ctx, pane, 60)
+		if err == nil {
+			last = content
+			// agy renders the committed answer as "You selected Banana".
+			if _, standing := domain.ParseAgyForm(content); !standing && strings.Contains(content, "selected Banana") {
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("the question did not commit Banana after the confirm.\npane:\n%s", lastLines(last, 16))
+}
+
+// TestRealAgyTaskHandout hands a checklist item to a real agy through the
+// operator's `hap task send` path. The executor's idle check must refuse while
+// agy's composer holds a draft — herdr reports agy idle regardless, so only the
+// empty-composer proof keeps a task from landing in someone's half-typed text
+// — and deliver once the composer is empty.
+//
+// Why the OPERATOR path and not the daemon's own idle poll: the poll classifies
+// from `pane read --source recent`, a delta every reader of the pane CONSUMES,
+// and on a working machine the operator's daemon is reading this pane too. The
+// operator path decides from --source visible reads only, so it is
+// deterministic here; the poll's agy gate is pinned by the daemon unit suite.
+func TestRealAgyTaskHandout(t *testing.T) {
+	requireAgy(t)
+	cli := herdr.NewCLI()
+	pane := startAgyAgent(t, cli, t.TempDir())
+
+	const task = "What is the capital of France? Answer with the city name only."
+	taskFile := filepath.Join(t.TempDir(), "tasks.md")
+	if err := os.WriteFile(taskFile, []byte("- [ ] "+task+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgTOML := fmt.Sprintf("[[task_sources]]\nagent = %q\npath = %q\nnext_task_template = \"{next_task_content}\"\n",
+		pane, taskFile)
+	h := newTestDaemon(t, cli, cfgTOML)
+	dctx, cancel := context.WithCancel(context.Background())
+	runDaemon(t, dctx, cancel, h.Daemon)
+	publishLiveRoster(t, h.Store, cli)
+	ctx := context.Background()
+	name, err := h.Store.EnsureAgentName(ctx, pane)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := h.App()
+
+	// A draft in the composer: refused, and the item is left untouched.
+	runHerdr(t, "pane", "send-text", pane, "draft")
+	time.Sleep(time.Second)
+	err = app.SendTaskToAgentOn(ctx, "", name, taskFile, 1, task)
+	if err == nil || !strings.Contains(err.Error(), "empty composer") {
+		t.Fatalf("a hand-out over a draft returned %v; want the empty-composer refusal", err)
+	}
+	if b, _ := os.ReadFile(taskFile); !strings.Contains(string(b), "- [ ] ") {
+		t.Fatalf("a refused hand-out changed the list:\n%s", b)
+	}
+	for range len("draft") {
+		tryHerdr("pane", "send-keys", pane, "backspace")
+	}
+	time.Sleep(time.Second)
+	if content, _ := cli.ReadPaneVisible(ctx, pane, 60); !domain.AgyComposerReady(content) {
+		t.Fatalf("could not clear the draft.\npane:\n%s", lastLines(content, 6))
+	}
+
+	if err := app.SendTaskToAgentOn(ctx, "", name, taskFile, 1, task); err != nil {
+		t.Fatalf("hand-out at an empty composer: %v", err)
+	}
+	var last string
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		if content, err := cli.ReadPaneVisible(ctx, pane, 60); err == nil {
+			last = content
+			if strings.Contains(content, "Paris") {
+				if b, _ := os.ReadFile(taskFile); !strings.Contains(string(b), "- [-] ") {
+					t.Errorf("agy answered but the item was not reserved:\n%s", b)
+				}
+				return
+			}
+		}
+		time.Sleep(time.Second)
+	}
+	t.Fatalf("agy never answered the handed-out task.\npane:\n%s", lastLines(last, 16))
+}
+
+// TestRealAgyModeToggle drives agy's three-mode cycle for real: the chord
+// rotates it, the status bar reports each mode, the production loop reaches
+// every one, and a draft in the composer refuses the set without a keystroke.
+// Spends no tokens.
+func TestRealAgyModeToggle(t *testing.T) {
+	requireAgy(t)
+	cli := herdr.NewCLI()
+	pane := startAgyAgent(t, cli, t.TempDir())
+	app := modeApp(t)
+
+	start, ok := readMode(t, cli, pane, domain.AgentTypeAgy)
+	if !ok {
+		t.Fatal("could not read a fresh agy's mode — its status bar did not parse")
+	}
+	offered := discoverCycle(t, cli, pane, domain.AgentTypeAgy, start)
+	t.Logf("this session's cycle: %v", offered)
+	if len(offered) != 3 {
+		t.Fatalf("observed %v; agy should cycle through default, acceptEdits and plan", offered)
+	}
+	for _, want := range offered {
+		if got := driveMode(t, app, pane, want); got != want {
+			t.Fatalf("drove agy toward %s, pane reports %s", want, got)
+		}
+		t.Logf("agy reached %s", want)
+	}
+	if got := driveMode(t, app, pane, start); got != start {
+		t.Fatalf("could not restore the starting mode %s (pane reports %s)", start, got)
+	}
+
+	// The press gate is agy's EMPTY-composer proof: a draft still reports the
+	// mode, but pressing into it is refused, and nothing moves.
+	runHerdr(t, "pane", "send-text", pane, "draft")
+	time.Sleep(time.Second)
+	t.Cleanup(func() {
+		for range len("draft") {
+			tryHerdr("pane", "send-keys", pane, "backspace")
+		}
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	target := domain.AgentModePlan
+	if start == domain.AgentModePlan {
+		target = domain.AgentModeDefault
+	}
+	if _, err := app.SetAgentMode(ctx, pane, string(target), frontend.ModeOptions{}); err == nil {
+		t.Fatal("SetAgentMode pressed into a composer holding a draft")
+	}
+	if got, ok := readMode(t, cli, pane, domain.AgentTypeAgy); !ok || got != start {
+		t.Errorf("after a refused set the mode is %s (read ok=%v); want it unchanged at %s", got, ok, start)
+	}
+}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -86,31 +86,40 @@ func tryHerdr(args ...string) {
 	_ = exec.CommandContext(ctx, herdrBin(), args...).Run()
 }
 
-// newScratchPane opens a throwaway tab and returns its pane id, closing it when
-// the test ends.
+// newScratchPane opens a throwaway WORKSPACE and returns its root pane id,
+// closing the workspace when the test ends.
 //
 // herdr 0.7.5 reshaped `agent start` to `--kind KIND --pane ID`: it now starts a
 // KNOWN agent kind in an EXISTING pane, and can no longer launch an arbitrary
 // command as a named agent (the old `agent start <name> --cwd D -- <argv>` exits
 // 2). So a pane is created first, and what runs in it is a separate step.
+//
+// A workspace of its own, never a tab: `tab create` without `--workspace` lands
+// in whichever workspace the UI has focused, so the suite's agents used to open
+// beside whatever the operator (or the orchestrator) was looking at. Every
+// input here names its pane explicitly, but a scratch agent has no business
+// sitting in someone else's workspace.
 func newScratchPane(t *testing.T, cwd, label string) string {
 	t.Helper()
-	out := runHerdr(t, "tab", "create", "--cwd", cwd, "--label", label, "--no-focus")
+	out := runHerdr(t, "workspace", "create", "--cwd", cwd, "--label", "hap-itest-"+label, "--no-focus")
 	var resp struct {
 		Result struct {
+			Workspace struct {
+				WorkspaceID string `json:"workspace_id"`
+			} `json:"workspace"`
 			RootPane struct {
 				PaneID string `json:"pane_id"`
 			} `json:"root_pane"`
 		} `json:"result"`
 	}
 	if err := json.Unmarshal([]byte(out), &resp); err != nil {
-		t.Fatalf("parse tab create output: %v (%s)", err, out)
+		t.Fatalf("parse workspace create output: %v (%s)", err, out)
 	}
-	pane := resp.Result.RootPane.PaneID
-	if pane == "" {
-		t.Fatalf("no pane id in tab create output: %s", out)
+	ws, pane := resp.Result.Workspace.WorkspaceID, resp.Result.RootPane.PaneID
+	if ws == "" || pane == "" {
+		t.Fatalf("no workspace or pane id in workspace create output: %s", out)
 	}
-	t.Cleanup(func() { tryHerdr("pane", "close", pane) })
+	t.Cleanup(func() { tryHerdr("workspace", "close", ws) })
 	return pane
 }
 

--- a/test/integration/task_summary_test.go
+++ b/test/integration/task_summary_test.go
@@ -138,6 +138,11 @@ func newTestDaemon(t *testing.T, cli *herdr.CLI, cfgTOML string) *testDaemon {
 	events := newManualEvents()
 	llm := &capturingLLM{}
 	ctlPath := filepath.Join(testutil.SocketDir(t), "ctl.sock")
+	// The operator's task hand-out seam, wired the way cmd/hap wires it: the
+	// daemon executes a queued send_task through the FRONT END's checklist and
+	// render logic, handing it the pane access (ports.TaskSendHost). Without it
+	// every hand-out is refused as unsupported by this build.
+	fe := &frontend.App{Store: st, Author: "itest", ConfigPath: cfgPath, ControlPath: ctlPath}
 	d, err := daemon.New(daemon.Options{
 		ConfigPath:        cfgPath,
 		ControlSocketPath: ctlPath,
@@ -146,6 +151,7 @@ func newTestDaemon(t *testing.T, cli *herdr.CLI, cfgTOML string) *testDaemon {
 		Events:            events,
 		LLM:               llm,
 		StateDir:          dir,
+		SendTask:          fe.SendTaskForOperator,
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

Phase 5 of agy support adds real-agy integration cases, gated on `HAP_ITEST_AGY=1`, that mirror the claude and codex ones. It also fixes three problems the cases found. Design: `docs/designer/agy-support.md` §12.

- **`test/integration/agy_test.go`** runs on the cheapest model (`HAP_ITEST_AGY_MODEL` overrides it). Each case starts agy in a scratch workspace of its own, clears the trust prompt through the production parser, and begins only at a proven empty composer.
  - `TestRealAgyDetection`: herdr labels the pane agy; a fresh screen classifies idle; `AgyComposerReady` holds; the mode reads.
  - `TestRealAgyApprovalConfirm`: a live `touch` approval, confirmed through a daemon of its own (`hap confirm --send`), runs the command. That proves the digit alone landed.
  - `TestRealAgyChoiceConfirm`: a live question form commits `Banana` and closes.
  - `TestRealAgyTaskHandout`: the operator hand-out (`hap task send`) is refused over a draft with the list untouched, then delivered at an empty composer and answered.
  - `TestRealAgyModeToggle`: the cycle is exactly `default → acceptEdits → plan`, `SetAgentMode` reaches every mode, and a draft refuses the set with the mode unchanged.
- **Fixed: the suite opened agents beside the operator.** `newScratchPane` ran `tab create` without `--workspace`, so it landed in whatever workspace the UI had focused. That was the orchestrator's, as the orchestrator reported. It now creates, and afterwards closes, a workspace per case. This covers the claude and codex cases too.
- **Fixed: the operator hand-out ignored an id-keyed source's template.** `frontend.taskSourceRenderFor` compared `[[task_sources]] agent` with the agent's name only, although the config documents "agent id or name". The hand-out then went out under the default template, and agy asked to run the `hap task` command that template carries. It now matches both. A unit test fails without the fix.
- **Fixed: the real mode cases could never pass.** `modeApp` gave the front end a store no daemon writes, so the roster gate (#386) refused every target. That is why `TestRealClaudeModeCycle` failed on main. It now publishes herdr's listing.
- **The operator's daemon is quieted for each agy scratch pane** (`hap disable`). From 0.9.19 on it answers agy forms, and it would otherwise answer the form under test first. The hand-out case uses the operator path, which reads `--source visible`. The idle poll reads `--source recent`, a delta that the operator's daemon, also watching the pane, would consume.

## Test plan

- [x] `HAP_ITEST_AGY=1`: **5/5 pass** live (agy 1.2.1, herdr 0.8.2). The first run failed the hand-out case on the template bug above; the rerun with the fix passes.
- [x] `internal/frontend` unit suite green, including the new id-keyed template test, mutation-checked.
- [x] `HAP_ITEST_CLAUDE=1`, then `HAP_ITEST_CODEX=1`, run one after the other, with every case now in a workspace of its own. The result is **better than the #452/#456 baseline**: 17 pass (previously 16), 1 fail, and the rest skip.
  - `TestRealClaudeModeCycle` now **passes**, because of the `modeApp` roster fix.
  - The one failure is the `TestRealShiftTabKeyNameIsStillBroken` tripwire, unchanged from main. herdr 0.8.2's `shift+tab` key name now works, and removing the workaround is a separate follow-up.
  - Skips, all as on main: `TestRealCodexModeToggle` (codex `agent_not_ready` at startup) and `TestRealClaudeConsult` (claude raised no approval menu). The agy cases skip in these runs because they are gated.
