### PR TITLE
#1 chore: bump plugin version to 0.9.21 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.21
+
+- Added real-agy integration cases, gated on `HAP_ITEST_AGY=1` (detection, a shell approval and a question answered through `hap confirm --send`, a task hand-out refused over a draft and delivered at an empty composer, and the permission-mode cycle), so agy's live screens and keys are checked the way claude's and codex's are
+- Fixed the real-agent mode integration cases, which were refused by the front end's roster check because their test app had no daemon behind it
+
 ## 0.9.20
 
 - `hap mode` and the `hap agents` MODE column now cover agy: its `default → acceptEdits → plan` cycle is read from agy's status bar and set with shift+tab (agy's own `accept-edits` spelling works too); hap presses into agy only at an empty composer, and a status bar with no model shows `-` rather than a guessed `default`

--- a/changelog.d/test-agy-integration.md
+++ b/changelog.d/test-agy-integration.md
@@ -1,2 +1,0 @@
-- Added real-agy integration cases, gated on `HAP_ITEST_AGY=1` (detection, a shell approval and a question answered through `hap confirm --send`, a task hand-out refused over a draft and delivered at an empty composer, and the permission-mode cycle), so agy's live screens and keys are checked the way claude's and codex's are
-- Fixed the real-agent mode integration cases, which were refused by the front end's roster check because their test app had no daemon behind it

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.20"
+version = "0.9.21"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.21 is being released from this commit by the Auto Release workflow.