### PR TITLE
#0 refactor: remove unreferenced helpers and consolidate signature/cli formatting

### DIFF
--- a/changelog.d/chore-codebase-cleanup.md
+++ b/changelog.d/chore-codebase-cleanup.md
@@ -1,0 +1,3 @@
+- Removed unreferenced internal helpers (`NodeWatching`, `SeedRuleDisabled`, `TaskFilePath`, `GetTask`) across domain and frontend layers.
+- Consolidated duplicate signature truncation logic across the CLI and TUI into `domain.ShortSignature`.
+- Consolidated duplicate CLI row formatting helpers.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -856,10 +856,7 @@ func graduationN(app *frontend.App) int {
 
 // shortSignature abbreviates a signature for one-line listings.
 func shortSignature(sig string) string {
-	if len(sig) <= 16 {
-		return sig
-	}
-	return sig[:16] + "…"
+	return domain.ShortSignature(sig)
 }
 
 func orDash(s string) string {
@@ -1225,7 +1222,7 @@ func agents(ctx context.Context, app *frontend.App, out io.Writer) error {
 			status += " (stale)"
 		}
 		fmt.Fprintf(out, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			orDashCLI(r.Name), r.AgentID, r.AgentType, status, automation, orDashCLI(r.Cwd), "-", r.NodeLabel)
+			orDash(r.Name), r.AgentID, r.AgentType, status, automation, orDash(r.Cwd), "-", r.NodeLabel)
 	}
 	// The first column is the handle every other command takes, so the footer
 	// spells the follow-ups with <agent> in that position.
@@ -1474,7 +1471,7 @@ func audit(ctx context.Context, app *frontend.App, out io.Writer, args []string)
 		fmt.Fprintf(out, "#%d\t%s\t%s\t%s\t%s\tconf=%s\tllm=%s\trule=%s\t%s\tagent=%s\tby=%s\tnode=%s\n",
 			r.ID, r.CreatedAt.Format("01-02 15:04:05"), frontend.AuditStatusLabel(r), r.SituationType,
 			r.Action, frontend.ConfidenceLabel(r.Confidence), llmConfCLI(r.LLMConfidence), rule, r.Rationale,
-			st.RecordAgent(r), orDashCLI(r.Actor), st.NodeLabel(r.NodeID))
+			st.RecordAgent(r), orDash(r.Actor), st.NodeLabel(r.NodeID))
 	}
 	return nil
 }
@@ -3495,13 +3492,4 @@ func reloadNote(reloaded bool) string {
 		return " (daemon reloaded)"
 	}
 	return " (saved — no daemon running; it takes effect when the daemon starts)"
-}
-
-// orDashCLI renders an optional value as "-" so tab-separated rows keep their
-// field count.
-func orDashCLI(v string) string {
-	if v == "" {
-		return "-"
-	}
-	return v
 }

--- a/internal/domain/node.go
+++ b/internal/domain/node.go
@@ -60,11 +60,6 @@ func NodeStale(n NodeInfo, now time.Time) bool {
 	return n.LastSeen.IsZero() || now.Sub(n.LastSeen) > nodeStaleAfter
 }
 
-// NodeWatching reports whether a TUI on that node is watching the fleet.
-func NodeWatching(n NodeInfo, now time.Time) bool {
-	return !n.WatchingUntil.IsZero() && now.Before(n.WatchingUntil)
-}
-
 // NodeLabelOrID is the display label, falling back to the id's first eight
 // characters — the same shape a git short hash has, for the same reason.
 func NodeLabelOrID(n NodeInfo) string {

--- a/internal/domain/signature.go
+++ b/internal/domain/signature.go
@@ -541,3 +541,11 @@ func VarianceGuardTripped(history []DecisionRecord, minimumAgreement, confirmWei
 	conf := Confidence(history, confirmWeight)
 	return conf.Score < minimumAgreement
 }
+
+// ShortSignature abbreviates a signature hash for one-line rows and listings.
+func ShortSignature(sig string) string {
+	if len(sig) <= 16 {
+		return sig
+	}
+	return sig[:16] + "…"
+}

--- a/internal/domain/signature_test.go
+++ b/internal/domain/signature_test.go
@@ -471,3 +471,20 @@ func TestStructuredSalient(t *testing.T) {
 		}
 	}
 }
+
+func TestShortSignature(t *testing.T) {
+	cases := []struct {
+		sig  string
+		want string
+	}{
+		{"", ""},
+		{"short", "short"},
+		{"exact-16-chars--", "exact-16-chars--"},
+		{"longer-than-sixteen-characters", "longer-than-sixt…"},
+	}
+	for _, tc := range cases {
+		if got := ShortSignature(tc.sig); got != tc.want {
+			t.Errorf("ShortSignature(%q) = %q, want %q", tc.sig, got, tc.want)
+		}
+	}
+}

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -3634,21 +3634,6 @@ func (a *App) RemoveNeverAutoPattern(ctx context.Context, index int, expected st
 	})
 }
 
-// SeedRuleDisabled reports whether a shipped seed pattern has been disabled
-// individually via safety.disabled_seed_patterns, for list rendering.
-func (a *App) SeedRuleDisabled(pattern string) bool {
-	cfg, err := a.Config()
-	if err != nil {
-		return false
-	}
-	for _, p := range cfg.Safety.DisabledSeedPatterns {
-		if p == pattern {
-			return true
-		}
-	}
-	return false
-}
-
 // DisableSeedRule silences one shipped seed never-auto rule (strict or
 // heuristic) permanently, keeping every other seed rule active. The rule is
 // named by its exact pattern (resolved from a durable domain.SeedRuleID by the
@@ -4885,15 +4870,7 @@ func (a *App) ListTasks(agent, path string) ([]domain.ChecklistItem, error) {
 	return a.readList(context.Background(), cfg, locator)
 }
 
-// TaskFilePath resolves the checklist file a task target names, without
-// reading it: an explicit --path (made absolute) wins, otherwise the agent's
-// configured source. Exported for the CLI, which prints the resolved path in
-// the task-management hints under `hap task … list`.
-func (a *App) TaskFilePath(agent, path string) (string, error) {
-	return a.taskFilePath(agent, path)
-}
-
-// TaskListFor is TaskFilePath plus the resolved source's config position —
+// TaskListFor resolves the checklist file plus the resolved source's config position —
 // what the CLI's hints render as the provider-independent fallback selector.
 // sourceIndex is "" for a --path target (no config entry to point back at).
 func (a *App) TaskListFor(agent, path string) (locator, sourceIndex string, err error) {
@@ -4922,23 +4899,6 @@ func (a *App) ResolveTaskRef(agent, path, ref string) (domain.ChecklistItem, err
 		return domain.ChecklistItem{}, err
 	}
 	return items[index-1], nil
-}
-
-// GetTask returns the single item addressed by its 1-based number.
-func (a *App) GetTask(agent, path string, index int) (domain.ChecklistItem, error) {
-	items, err := a.ListTasks(agent, path)
-	if err != nil {
-		return domain.ChecklistItem{}, err
-	}
-	for _, it := range items {
-		if it.Index == index {
-			return it, nil
-		}
-	}
-	if len(items) == 0 {
-		return domain.ChecklistItem{}, fmt.Errorf("no task #%d: the checklist has no items", index)
-	}
-	return domain.ChecklistItem{}, fmt.Errorf("no task #%d: valid task numbers are 1..%d", index, len(items))
 }
 
 // taskSourceLimit returns the max_tasks cap of the [[task_sources]] entry that

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -6156,10 +6156,7 @@ func (m Model) signatureDetailLines(row frontend.SignatureRow, history []domain.
 
 // shortSig abbreviates a signature hash for one-line rows.
 func shortSig(sig string) string {
-	if len(sig) <= 16 {
-		return sig
-	}
-	return sig[:16] + "…"
+	return domain.ShortSignature(sig)
 }
 
 // auditIDColWidth is the width of the ID column in the Escalations, Audit and


### PR DESCRIPTION
## Summary
This PR applies the safe subset identified during codebase cleanup analysis:

### 1. Dead Code Removal
- Removed unreferenced `NodeWatching` in `internal/domain/node.go`.
- Removed unreferenced `SeedRuleDisabled` in `internal/frontend/frontend.go`.
- Removed unreferenced `TaskFilePath` in `internal/frontend/frontend.go` (leftover after CLI migrated to `TaskListFor`).
- Removed unreferenced `GetTask` in `internal/frontend/frontend.go` (superseded by `ResolveTaskRef`).

### 2. Duplication Consolidation
- Extracted shared 16-character signature truncation logic into `domain.ShortSignature` in `internal/domain/signature.go` (with unit test `TestShortSignature`).
- Delegated CLI `shortSignature` and TUI `shortSig` to `domain.ShortSignature`.
- Eliminated redundant `orDashCLI` in `internal/cli/cli.go` in favor of existing `orDash`.

### 3. Changelog
- Added changelog fragment `changelog.d/chore-codebase-cleanup.md`.

### Verification Gate
- `bash scripts/check-submodule-gitlink.sh`: PASS
- `go build -tags "vectors cpu" ./...`: PASS
- `go test -tags "vectors cpu" ./... -count=1 -p 2`: PASS (all suites pass, flake-prone turso/daemon tests re-verified in isolation)
- `gofmt -l . | grep -v submodule`: PASS (clean)
- `go vet -tags "vectors cpu" ./...`: PASS (0 diagnostics)
- `golangci-lint`: PASS (no new issues; 0 issues under Go 1.26 toolchain)
- `go test -tags integration ./test/integration/ -v`: PASS
- `TestRealAgyDetection` with `HAP_ITEST_AGY=1`: PASS