### PR TITLE
#1 chore: bump plugin version to 0.9.22 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.22
+
+- Removed unreferenced internal helpers (`NodeWatching`, `SeedRuleDisabled`, `TaskFilePath`, `GetTask`) across domain and frontend layers.
+- Consolidated duplicate signature truncation logic across the CLI and TUI into `domain.ShortSignature`.
+- Consolidated duplicate CLI row formatting helpers.
+
 ## 0.9.21
 
 - Added real-agy integration cases, gated on `HAP_ITEST_AGY=1` (detection, a shell approval and a question answered through `hap confirm --send`, a task hand-out refused over a draft and delivered at an empty composer, and the permission-mode cycle), so agy's live screens and keys are checked the way claude's and codex's are

--- a/changelog.d/chore-codebase-cleanup.md
+++ b/changelog.d/chore-codebase-cleanup.md
@@ -1,3 +1,0 @@
-- Removed unreferenced internal helpers (`NodeWatching`, `SeedRuleDisabled`, `TaskFilePath`, `GetTask`) across domain and frontend layers.
-- Consolidated duplicate signature truncation logic across the CLI and TUI into `domain.ShortSignature`.
-- Consolidated duplicate CLI row formatting helpers.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.21"
+version = "0.9.22"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.22 is being released from this commit by the Auto Release workflow.