### PR TITLE
#0 docs: tighten exported symbol doc comments to start with symbol name

### DIFF
--- a/changelog.d/docs-concise-comments.md
+++ b/changelog.d/docs-concise-comments.md
@@ -1,0 +1,1 @@
+- Standardized and tightened doc comments on exported symbols across `domain`, `frontend`, and `store` to follow Go conventions and maintain precision.

--- a/internal/domain/agentmode.go
+++ b/internal/domain/agentmode.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 )
 
-// An agent's PERMISSION MODE — how much the agent asks before acting. Claude
-// Code, Codex and agy all expose it as a rotating toggle bound to Shift+Tab, and
-// none reports it over any API: herdr's `agent list` and `pane get` carry no
+// AgentMode represents an agent's permission mode — how much the agent asks
+// before acting. Claude Code, Codex and agy all expose it as a rotating toggle
+// bound to Shift+Tab, and none reports it over any API: herdr's `agent list` and `pane get` carry no
 // mode field (verified against herdr 0.7.5 and 0.8.2), so the ONLY source of
 // truth is the mode indicator the agent paints in its own composer footer.
 //

--- a/internal/domain/agentsession.go
+++ b/internal/domain/agentsession.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 )
 
-// A Claude CONVERSATION NAME — what `/rename` sets, and what Claude paints
-// right-aligned inside the rule above its composer:
+// ClaudeSession represents a Claude conversation name — what `/rename` sets,
+// and what Claude paints right-aligned inside the rule above its composer:
 //
 //	──────────────────────────────────────────── add-sweep-command-grid ─
 //	❯

--- a/internal/frontend/fleet.go
+++ b/internal/frontend/fleet.go
@@ -280,10 +280,10 @@ func (a *App) requireLiveDaemonFor(ctx context.Context, nodeID string) error {
 	return fmt.Errorf("%w: node %s is unknown to this store", ErrDaemonUnavailable, nodeID)
 }
 
-// RemoteActionTimeout bounds how long a confirm waits for ANOTHER node's daemon
+// DefaultRemoteActionTimeout bounds how long a confirm waits for ANOTHER node's daemon
 // to deliver: the request travels on this node's next push and that node's
 // next pull, and the verdict comes back the same way, so two sync intervals
-// plus slack. Zero means DefaultRemoteActionTimeout.
+// plus slack.
 const DefaultRemoteActionTimeout = 45 * time.Second
 
 // awaitTimeoutFor is how long to wait for a queued action's verdict.

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -3888,6 +3888,7 @@ func validateAgentSelector(agent string) error {
 	return nil
 }
 
+// SetTaskSourceAgent re-points a task source to a different agent selector.
 // An empty selector is legal and means "any agent" — the widest re-point there
 // is, which is why the caller says so rather than silently applying it.
 func (a *App) SetTaskSourceAgent(ctx context.Context, index int, expected config.TaskSource,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2131,7 +2131,6 @@ func (s *Store) GetAudit(ctx context.Context, id int64) (*domain.AuditRecord, er
 	return &audits[0], nil
 }
 
-// PendingEscalations returns unresolved escalations, newest first.
 // CountPendingEscalations reports how many escalations are pending without
 // fetching the rows (each can carry a multi-KB pane excerpt).
 func (s *Store) CountPendingEscalations(ctx context.Context) (int64, error) {
@@ -2166,6 +2165,7 @@ func (s *Store) HasOpenEscalation(ctx context.Context, agentID string) (bool, er
 	return err == nil, err
 }
 
+// PendingEscalations returns unresolved escalations, newest first.
 func (s *Store) PendingEscalations(ctx context.Context) ([]domain.AuditRecord, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT `+s.auditColumns(ctx)+` FROM audit_log WHERE status = 'escalated' ORDER BY id DESC LIMIT 200`)


### PR DESCRIPTION
## Summary
This PR standardizes and tightens code comments on exported symbols across `domain`, `frontend`, and `store` packages to follow Go doc comment conventions and keep doc comments precise and accurate:

- `internal/domain/agentsession.go`: Updated `ClaudeSession` doc comment to start with symbol name (`ClaudeSession represents...`).
- `internal/domain/agentmode.go`: Updated `AgentMode` doc comment to start with symbol name (`AgentMode represents...`).
- `internal/frontend/fleet.go`: Updated `DefaultRemoteActionTimeout` doc comment to start with symbol name.
- `internal/frontend/frontend.go`: Updated `SetTaskSourceAgent` doc comment to start with symbol name.
- `internal/store/store.go`: Fixed doc comment placement on `CountPendingEscalations` and `PendingEscalations` where `PendingEscalations`'s doc comment had been misplaced above `CountPendingEscalations`.
- `changelog.d/docs-concise-comments.md`: Added changelog fragment.

## Verification
- `bash scripts/check-submodule-gitlink.sh`: PASS
- `go build -tags "vectors cpu" ./...`: PASS
- `gofmt -l . | grep -v submodule`: PASS (clean)
- `go vet -tags "vectors cpu" ./...`: PASS (clean)
- `golangci-lint`: PASS (0 issues with Go 1.26 toolchain; no new findings)
- `go test -tags "vectors cpu" ./... -count=1 -p 2`: PASS (all 37 packages pass)
- `go test -tags integration ./test/integration/ -v`: PASS
- `TestRealAgyDetection` with `HAP_ITEST_AGY=1`: PASS