### PR TITLE
#0 fix: stop flooding the escalation queue with hand-out proposals

### DIFF
--- a/changelog.d/fix-agy-handout-flood.md
+++ b/changelog.d/fix-agy-handout-flood.md
@@ -1,0 +1,1 @@
+- Fixed the escalation queue filling with the same "send next declared task" proposal: a hand-out is no longer proposed while the list already has an item in progress, and a repeat within one parked spell is folded into the row the operator already has instead of adding another

--- a/internal/daemon/autosendidle.go
+++ b/internal/daemon/autosendidle.go
@@ -726,6 +726,8 @@ func (d *Daemon) noteIdleAgents(agents []domain.AgentTransition, now time.Time) 
 		live[a.AgentID] = struct{}{}
 		if !autoSendParked(a.Status) {
 			delete(d.idleSince, a.AgentID)
+			// The parked episode ended, so the next one may propose again.
+			delete(d.noopVsPendingRaised, a.AgentID)
 			delete(d.autoTaskClaim, a.AgentID)
 			// The agent is working (or gone): whatever its episodes were not
 			// resolving, they are resolving now. Start the next parked spell
@@ -747,11 +749,19 @@ func (d *Daemon) noteIdleAgents(agents []domain.AgentTransition, now time.Time) 
 		// A new parked episode (or a recycled pane) is a fresh start for the
 		// backoff too — the budget belongs to the spell, not to the agent id.
 		delete(d.pollRedrive, a.AgentID)
+		// Same reasoning for the hand-out proposal: the latch belongs to the
+		// spell, and a recycled pane is a different agent entirely.
+		delete(d.noopVsPendingRaised, a.AgentID)
 		d.idleSince[a.AgentID] = idleMark{paneID: a.PaneID, terminalID: a.TerminalID, at: now}
 	}
 	for id := range d.idleSince {
 		if _, ok := live[id]; !ok {
 			delete(d.idleSince, id)
+		}
+	}
+	for id := range d.noopVsPendingRaised {
+		if _, ok := live[id]; !ok {
+			delete(d.noopVsPendingRaised, id)
 		}
 	}
 	for id := range d.pollRedrive {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -345,6 +345,30 @@ type Daemon struct {
 	lastAutoSend map[string]time.Time
 	lastAutoNoop map[string]time.Time
 
+	// noopVsPendingRaised latches the noop-vs-pending proposal to ONE per
+	// parked episode, per agent. duplicatePendingEscalation keys on the pane
+	// excerpt, and an agy repaints between every background command, so a
+	// parked agy mints a new excerpt on every event and the same proposal is
+	// re-raised until the operator's queue is nothing else (finding 5).
+	//
+	// An episode latch rather than a cooldown duration: there is no interval to
+	// justify, and the happy path self-clears — confirming the escalation
+	// delivers the task, the agent goes working, and the latch is dropped with
+	// the episode. Accepted behavior change: after the operator DISMISSES the
+	// row, nothing re-raises it until the agent works again.
+	//
+	// Deliberately not hung on idleSince's idleMark, which would be
+	// episode-scoped for free: that mark is written only by the 60s sweep, so
+	// an attention-path proposal in the first minute of a park would have
+	// nothing to stamp and the next event would re-raise. Cleared wherever
+	// idleSince is, and pruned against the live listing in noteIdleAgents.
+	//
+	// Counts rather than latches so the suppression can name itself exactly
+	// ONCE per episode (notePending's rule): 0 = not raised, 1 = raised, n>1 =
+	// n-1 repeats ignored. A log line per suppressed event would move the very
+	// flood this fixes into the log.
+	noopVsPendingRaised map[string]int
+
 	// preDeliveryReviewInFlight tracks the one live pre-delivery review per
 	// agent; the token lets the outcome handler drop superseded results.
 	// Guarded by mu alongside preDeliveryReviewSeq.
@@ -813,6 +837,7 @@ func New(opt Options) (*Daemon, error) {
 		learnInFlight:             map[string]bool{},
 		lastAutoSend:              map[string]time.Time{},
 		lastAutoNoop:              map[string]time.Time{},
+		noopVsPendingRaised:       map[string]int{},
 		preDeliveryReviewInFlight: map[string]preDeliveryReviewFlight{},
 		rerankInFlight:            map[string]rerankFlight{},
 		rerankCache:               map[string][]domain.RerankResult{},
@@ -1863,7 +1888,10 @@ func (d *Daemon) handleTransition(ctx context.Context, tr domain.AgentTransition
 		d.mu.Lock()
 		delete(d.episodeHandled, tr.PaneID)
 		delete(d.idleSince, tr.AgentID)
+		delete(d.noopVsPendingRaised, tr.AgentID)
 		delete(d.autoTaskClaim, tr.AgentID)
+		// The parked episode is over, so the next one may propose its own
+		// hand-out: confirming the escalation is what set the agent working.
 		// A genuinely new episode: the session-name sync gets its full patience
 		// budget back, and its settle window starts again from the next park.
 		delete(d.sessionSyncDeferred, tr.AgentID)
@@ -2102,6 +2130,7 @@ func (d *Daemon) resetRecycledPaneState(ctx context.Context, a domain.AgentTrans
 	delete(d.lastAutoSend, a.AgentID)
 	delete(d.lastAutoNoop, a.AgentID)
 	delete(d.idleSince, a.AgentID)
+	delete(d.noopVsPendingRaised, a.AgentID)
 	delete(d.autoTaskClaim, a.AgentID)
 	d.forgetSessionRenamePushesLocked(a.AgentID)
 	d.mu.Unlock()
@@ -3538,6 +3567,40 @@ func (d *Daemon) deliverActionReviewNoop(ctx context.Context, res actionReviewOu
 }
 
 // escalate records and surfaces an escalation: no input is sent (FR-018).
+// noteNoopVsPendingRaised records that this agent's parked episode now carries
+// a hand-out proposal. Called only once the audit row exists — see the call
+// site in escalate.
+func (d *Daemon) noteNoopVsPendingRaised(agentID string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.noopVsPendingRaised[agentID] == 0 {
+		d.noopVsPendingRaised[agentID] = 1
+	}
+}
+
+// noopVsPendingSuppressed reports whether this parked episode already raised a
+// hand-out proposal, counting the repeat.
+//
+// It names itself exactly ONCE per episode. The screen this exists for repaints
+// several times a minute, so a line per suppressed event would reproduce the
+// flood in the log; silence is not the alternative (notePending's rule — the
+// unlogged auto-accept skips cost a five-round investigation).
+func (d *Daemon) noopVsPendingSuppressed(agentID string) bool {
+	d.mu.Lock()
+	n := d.noopVsPendingRaised[agentID]
+	if n == 0 {
+		d.mu.Unlock()
+		return false
+	}
+	d.noopVsPendingRaised[agentID] = n + 1
+	d.mu.Unlock()
+	if n == 1 {
+		slog.Info("hand-out already proposed for this parked episode; ignoring repeats until the agent works again",
+			"agent", agentID, "reason", domain.ReasonNoopVsPendingTasks)
+	}
+	return true
+}
+
 func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.SignatureResult,
 	dec domain.Decision, tr domain.AgentTransition, now time.Time) {
 	// The episode ended without an autonomous send, so an auto-send pairing for
@@ -3560,6 +3623,18 @@ func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.Si
 	// pending row turn that lifecycle decision into an opaque "duplicate".
 	if autoDismissReason == "" && d.duplicatePendingEscalation(ctx, s) {
 		d.ignoreDuplicate(ctx, s, tr, now)
+		return
+	}
+
+	// One hand-out proposal per parked episode. The dedup above keys on the
+	// pane excerpt, which an agy changes on every repaint, so this reason needs
+	// an identity that survives a moving screen (finding 5, noopVsPendingRaised).
+	// Scoped to this ONE reason: every other escalation on the same event still
+	// reaches the operator. Below the auto-dismiss guard for the same reason the
+	// dedup is — a lifecycle dismissal must stay visible in history — and no
+	// audit row is written per repeat, since audit_log is never swept.
+	if autoDismissReason == "" && dec.Reason == domain.ReasonNoopVsPendingTasks &&
+		d.noopVsPendingSuppressed(s.AgentID) {
 		return
 	}
 
@@ -3610,6 +3685,12 @@ func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.Si
 	auditID, auditErr := d.opt.Store.AppendAudit(ctx, rec)
 	if auditErr != nil {
 		slog.Error("audit write failed for escalation", "error", auditErr)
+	}
+	// Latch AFTER the row exists: a failed insert must leave the next event
+	// free to raise the proposal, or one store error silences it for the
+	// whole parked episode.
+	if auditErr == nil && dec.Reason == domain.ReasonNoopVsPendingTasks {
+		d.noteNoopVsPendingRaised(s.AgentID)
 	}
 
 	// Rate-limit escalations pause the agent until human check-in — EXCEPT an
@@ -5969,6 +6050,11 @@ func (d *Daemon) declaredTask(ctx context.Context, cfg config.Config, tr domain.
 		// is handed the very same "[ ]" line. Composes with LLMReview above:
 		// the review runs at delivery and reserves the task it actually chose.
 		Reserve: m.src.EnableAutoSendTaskWhenIdle,
+		// Gates the noop-vs-pending ESCALATION only (see the field's doc): a
+		// list already being worked does not need the operator asked to start
+		// another task. Read from the same content NextDeclaredTask parsed, so
+		// the two can never disagree about the list they describe.
+		InProgress: len(domain.InProgressDeclaredTasks(string(m.data))) > 0,
 	}
 }
 

--- a/internal/daemon/handoutflood_test.go
+++ b/internal/daemon/handoutflood_test.go
@@ -1,0 +1,118 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// idleSituation builds a parked idle situation carrying the given pane content.
+// The content varies per call on purpose: duplicatePendingEscalation keys on the
+// pane excerpt, and the flood this guards exists precisely because an agy
+// repaints between every background command, so no two events share one.
+func parkedAgySituation(agentID, content string) domain.Situation {
+	return domain.Situation{
+		AgentID: agentID, PaneID: agentID, AgentType: "agy",
+		Type: domain.SituationIdle, Status: "idle", Content: content,
+	}
+}
+
+func handoutProposal() domain.Decision {
+	return domain.Decision{
+		Action: domain.ActionEscalate, Reason: domain.ReasonNoopVsPendingTasks,
+		Suggestion: "send next declared task: build the parser",
+	}
+}
+
+// TestHandoutProposalIsRaisedOncePerParkedEpisode covers finding 5: hap filled
+// the operator's queue with the same hand-out proposal because every agy repaint
+// presented a new pane excerpt to the dedup.
+func TestHandoutProposalIsRaisedOncePerParkedEpisode(t *testing.T) {
+	h := newHarness(t, "")
+	ctx := context.Background()
+	// The agent must be live and enabled, or escalate() auto-dismisses instead
+	// and the test would pass without the latch ever being consulted.
+	h.herdr.setAgents(parked("pA", "idle"))
+
+	now := time.Now()
+	first := parkedAgySituation("pA", "Waiting for your next instruction.\nNothing left to run here.\n")
+	h.daemon.escalate(ctx, first, domain.ComputeSignature(first), handoutProposal(),
+		parked("pA", "idle")[0], now)
+
+	pending, err := h.raw.PendingEscalations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("first proposal should escalate, pending = %d", len(pending))
+	}
+
+	// A repaint: same parked episode, entirely different screen, so the excerpt
+	// dedup cannot collapse it. Only the episode latch can.
+	repaint := parkedAgySituation("pA", "$ git status\nOn branch main\nnothing to commit\nStill idle.\n")
+	h.daemon.escalate(ctx, repaint, domain.ComputeSignature(repaint), handoutProposal(),
+		parked("pA", "idle")[0], now.Add(time.Second))
+
+	pending, err = h.raw.PendingEscalations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("a repaint must not raise a second proposal, pending = %d", len(pending))
+	}
+	// Unlike the excerpt dedup, the latch writes NO audit row per repeat:
+	// audit_log is never swept, so one row per repaint would be permanent.
+	audits, err := h.raw.AuditLog(ctx, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(audits) != 1 {
+		t.Fatalf("a suppressed repeat must write no audit row, rows = %d", len(audits))
+	}
+
+	// The control: the latch belongs to the parked EPISODE. Once the agent works
+	// again the next park may propose afresh — without this half, a test asserting
+	// "exactly one row" would also pass if the escalation were disabled outright.
+	h.daemon.noteIdleAgents(parked("pA", "working"), now.Add(2*time.Second))
+
+	next := parkedAgySituation("pA", "Build finished. Awaiting instructions.\nAll green.\n")
+	h.daemon.escalate(ctx, next, domain.ComputeSignature(next), handoutProposal(),
+		parked("pA", "idle")[0], now.Add(3*time.Second))
+
+	pending, err = h.raw.PendingEscalations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("a new parked episode must be able to propose again, pending = %d", len(pending))
+	}
+}
+
+// TestHandoutLatchNeverSuppressesAnotherReason is the scoping control: the latch
+// is keyed to one reason, so every other escalation on the same parked agent
+// still reaches the operator while it is held.
+func TestHandoutLatchNeverSuppressesAnotherReason(t *testing.T) {
+	h := newHarness(t, "")
+	ctx := context.Background()
+	h.herdr.setAgents(parked("pB", "idle"))
+
+	now := time.Now()
+	first := parkedAgySituation("pB", "Idle. Nothing queued.\nWaiting.\n")
+	h.daemon.escalate(ctx, first, domain.ComputeSignature(first), handoutProposal(),
+		parked("pB", "idle")[0], now)
+
+	other := parkedAgySituation("pB", "error: the build could not find a toolchain\nexit status 1\n")
+	h.daemon.escalate(ctx, other, domain.ComputeSignature(other), domain.Decision{
+		Action: domain.ActionEscalate, Reason: domain.ReasonNoHistory,
+	}, parked("pB", "idle")[0], now.Add(time.Second))
+
+	pending, err := h.raw.PendingEscalations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("a different reason must still escalate while the latch is held, pending = %d", len(pending))
+	}
+}

--- a/internal/domain/decide.go
+++ b/internal/domain/decide.go
@@ -416,8 +416,14 @@ func resolveSituation(in DecideInput, conf ConfidenceResult) (candidate, suggest
 		// screens), so the conflict escalates for the operator, suggesting
 		// the next declared task; confirming delivers it and teaches
 		// @next_task:declared.
+		//
+		// An item already marked "[-]" is the one exception: the list IS being
+		// worked, so asking the operator to start another task is noise rather
+		// than a conflict. See DeclaredTask.InProgress — it gates this
+		// escalation alone, never the unattended hand-out above.
 		if conf.TopAction == ActionNoop &&
-			in.DeclaredTask != nil && in.DeclaredTask.Task != NoTaskContent {
+			in.DeclaredTask != nil && in.DeclaredTask.Task != NoTaskContent &&
+			!in.DeclaredTask.InProgress {
 			return "", "send next declared task: " + in.DeclaredTask.Prompt(), ReasonNoopVsPendingTasks
 		}
 		// With no pending work there is nothing to park, and a learned noop

--- a/internal/domain/noop_test.go
+++ b/internal/domain/noop_test.go
@@ -84,6 +84,51 @@ func TestDecideIdlePendingTasksEscalateOverNoopRule(t *testing.T) {
 	}
 }
 
+func TestDecideInProgressListSuppressesTheHandoutProposal(t *testing.T) {
+	// Finding 5: the proposal above is worth an operator's attention only while
+	// NOBODY is working the list. With an item already "[-]" it asks them to
+	// start a SECOND task, and since an agy repaints between every background
+	// command each repeat carries a fresh pane excerpt and slips past the
+	// escalation dedup — the queue fills with one proposal per repaint.
+	//
+	// Both halves are asserted: suppressing unconditionally would pass the
+	// first check alone while silently deleting the #175 guard.
+	base := func(inProgress bool) DecideInput {
+		in := baseInput(SituationIdle)
+		in.State = &SignatureState{Mode: ModeAutonomous, ConsecutiveConfirmations: 8}
+		in.History = sourcedHistory(SourceOperator, noopHistory()...)
+		in.DeclaredTask = &DeclaredTask{Task: "build the parser", InProgress: inProgress}
+		return in
+	}
+
+	if d := Decide(base(true)); d.Action == ActionEscalate && d.Reason == ReasonNoopVsPendingTasks {
+		t.Fatalf("a list already being worked must not propose another hand-out, got %+v", d)
+	}
+	// The control: the very same input with nothing in progress still escalates.
+	if d := Decide(base(false)); d.Action != ActionEscalate || d.Reason != ReasonNoopVsPendingTasks {
+		t.Fatalf("an unworked list must still escalate over a noop rule, got %+v", d)
+	}
+}
+
+func TestDecideInProgressNeverGatesTheUnattendedHandout(t *testing.T) {
+	// The suppression is scoped to the ESCALATION. The idle poll pairs distinct
+	// agents with distinct items, so a "[-]" is routinely another agent's
+	// reservation — gating the unattended send on it would stop the second
+	// agent ever being handed work.
+	in := baseInput(SituationIdle)
+	in.State = &SignatureState{Mode: ModeAutonomous, ConsecutiveConfirmations: 8}
+	in.History = sourcedHistory(SourceOperator, noopHistory()...)
+	in.DeclaredTask = &DeclaredTask{Task: "build the parser", Reserve: true, InProgress: true}
+
+	d := Decide(in)
+	if d.Action != ActionSend {
+		t.Fatalf("an unattended source must still send while another item is in progress, got %+v", d)
+	}
+	if !strings.Contains(d.Input, "build the parser") {
+		t.Errorf("delivered input lost the task: %q", d.Input)
+	}
+}
+
 func TestDecideIdleOperatorNoopStillQuietOnExhaustedSource(t *testing.T) {
 	// The noop-vs-pending escalation is about REAL pending work only: with
 	// the declared list fully checked off, an operator-backed noop keeps

--- a/internal/domain/tasklist.go
+++ b/internal/domain/tasklist.go
@@ -229,6 +229,21 @@ type DeclaredTask struct {
 	// must not grow a list past the size the daemon would refuse to refill.
 	// 0 means uncapped.
 	MaxTasks int
+	// InProgress reports that the source already holds at least one "[-]" item
+	// (InProgressDeclaredTasks). It suppresses the noop-vs-pending ESCALATION
+	// only: proposing a hand-out while a task is already being worked asks the
+	// operator to start a second one, and an agy repaints between every
+	// background command, so each repaint mints a fresh pane excerpt and slips
+	// past duplicatePendingEscalation — the queue fills with the same proposal.
+	//
+	// It deliberately does NOT gate the Reserve hand-out above it: the idle
+	// poll pairs DISTINCT agents with DISTINCT items, so a "[-]" there is
+	// another agent's reservation and suppressing on it would stop the second
+	// agent ever being handed work.
+	//
+	// Zero value is the permissive one (false = propose), so a caller that does
+	// not populate it keeps the historical behavior.
+	InProgress bool
 }
 
 // DefaultRemoteNextTaskTemplate is DefaultNextTaskTemplate for a task list that


### PR DESCRIPTION
Finding 5 from the agy field report: driving a real agy under 0.9.21, the operator's queue filled with the same `send next declared task` proposal over and over. Two independent causes, both fixed here.

## An in-progress list still proposed

The `noop_vs_pending_tasks` escalation fired whenever the source had a pending `[ ]` item — even with another item already `[-]`. `NextDeclaredTask` skips `[-]`, so a list being actively worked still resolves a next task and the conflict escalated, asking the operator to start a *second* task. `DeclaredTask.InProgress` now gates that one branch.

It deliberately does **not** gate the unattended hand-out above it: the idle poll pairs distinct agents with distinct items, so a `[-]` there is another agent's reservation, and suppressing on it would stop a second agent ever being handed work. There is a test for that.

## Repeats were never collapsed

`duplicatePendingEscalation` keys on the pane excerpt, and agy repaints between every background command — so each event presented a new excerpt and slipped straight past the dedup. This reason now latches to one proposal per parked episode (`noopVsPendingRaised`), cleared wherever `idleSince` is and pruned against the live listing.

An **episode latch rather than a cooldown**: no interval to justify, and the happy path self-clears — confirming the escalation delivers the task, the agent works, the latch goes with the episode.

Accepted behaviour change, stated in the doc comment: after the operator *dismisses* the row, nothing re-raises it until the agent works again.

Bounds, each load-bearing:
- Scoped to this one reason — every other escalation on the same parked agent still reaches the operator.
- Below the auto-dismiss guard, so a lifecycle dismissal stays visible in history rather than becoming an opaque suppression.
- Stamped only **after** the audit row exists — a failed insert must not silence the retry for the whole episode.
- No audit row per repeat (`audit_log` is never swept), unlike the excerpt dedup's `ignoreDuplicate`.
- Names itself **once per episode**, not once per event, or the flood just moves into the log.
- Not hung on `idleSince`'s `idleMark`, tempting though that is: the mark is written only by the 60s sweep, so an attention-path proposal in the first minute of a park would have nothing to stamp and the next event would re-raise.

## Deliberately not done

The task also suggested debouncing on parked duration. `idleSince` is *parked-since* and monotonic across a park, so `idleLongEnough` is an age check, not a rate limiter — it cannot debounce a sustained flood, and would delay the first legitimate proposal of every park by 1–2 minutes. The episode latch is what actually collapses repeats.

## Test plan

- `go build -tags "vectors cpu" ./...`, `gofmt`, `go vet` — clean
- Full suite `go test -tags "vectors cpu" ./... -count=1` — 41 packages ok, 0 failures
- `GOTOOLCHAIN=go1.26.2 golangci-lint run --build-tags "vectors,cpu"` — 0 issues
- New tests verified by mutation: reverting each half makes its test fail
  - `TestDecideInProgressListSuppressesTheHandoutProposal` — both halves (in-progress suppresses; the same input without it still escalates, so the #175 guard is not silently deleted)
  - `TestDecideInProgressNeverGatesTheUnattendedHandout`
  - `TestHandoutProposalIsRaisedOncePerParkedEpisode` — repaint suppressed, no audit row, and a proposal raised again after a working→park cycle
  - `TestHandoutLatchNeverSuppressesAnotherReason`