### PR TITLE
#0 test: stop shared test waits failing on a loaded machine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ permissions:
 
 env:
   GO_BUILD_TAGS: vectors cpu
+  # Multiplies every shared test wait deadline (internal/testutil.Scale). The
+  # deadlines are sized for an unloaded machine — measured idle, the slowest
+  # single wait already consumes 62% of its 3s budget — so a contended runner
+  # crosses them and fails a job for timing rather than behaviour. Scaling only
+  # ever lengthens a wait, so a genuinely stuck condition still fails, just a
+  # few seconds later.
+  HAP_TEST_TIMEOUT_SCALE: "4"
 
 jobs:
   # gofmt is pure text: it neither builds nor typechecks, so it needs no

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ permissions:
 
 env:
   GO_BUILD_TAGS: vectors cpu
+  # Same reason as ci.yml: the gate below runs the full suite on a shared
+  # runner, and the shared test waits are sized for an unloaded machine.
+  HAP_TEST_TIMEOUT_SCALE: "4"
   MODEL_URL: https://huggingface.co/sudomoniker/all-MiniLM-L6-v2-Q8_0-GGUF/resolve/main/all-minilm-l6-v2-q8_0.gguf
   MODEL_FILE: all-minilm-l6-v2-q8_0.gguf
   MODEL_SHA256: 606364fbf83de64c258ea9e011b74691d509d66292be0da612307488a46dfba5

--- a/changelog.d/fix-racy-test-waits.md
+++ b/changelog.d/fix-racy-test-waits.md
@@ -1,1 +1,1 @@
-- Fixed two daemon tests that read state the daemon writes a moment later, so a loaded machine no longer fails the fleet-sync recovery and SQLite hand-out cases for reasons unrelated to what they cover
+- Fixed daemon tests failing on a loaded machine for timing rather than behaviour: two of them read state the daemon writes a moment later, and every shared test wait can now be stretched by one multiplier that CI sets, instead of each deadline being tuned by hand

--- a/changelog.d/fix-racy-test-waits.md
+++ b/changelog.d/fix-racy-test-waits.md
@@ -1,0 +1,1 @@
+- Fixed two daemon tests that read state the daemon writes a moment later, so a loaded machine no longer fails the fleet-sync recovery and SQLite hand-out cases for reasons unrelated to what they cover

--- a/internal/cli/stream_idle_test.go
+++ b/internal/cli/stream_idle_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/cli"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/streamlog"
+	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
 )
 
 // queryCountingLog counts the two statements an idle stream can issue per
@@ -186,7 +187,7 @@ func TestStreamIdleBackoffStillDeliversEvents(t *testing.T) {
 
 func waitFor(t *testing.T, ok func() bool) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(testutil.Scale(5 * time.Second))
 	for !ok() {
 		if time.Now().After(deadline) {
 			t.Fatal("condition never held")

--- a/internal/daemon/autosendidle_test.go
+++ b/internal/daemon/autosendidle_test.go
@@ -1912,10 +1912,15 @@ func TestAutoSendIdleHandsOutFromASQLiteProviderList(t *testing.T) {
 	}
 	// The reservation ledger keys on the locator, so the reclaim sweep can
 	// find the row again through the same database backend.
-	res, err := h.raw.OpenTaskReservations(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	//
+	// WAITED for, never asserted outright: deliverAutonomousClaimed records the
+	// row AFTER the send ("Recorded AFTER the send, so the failed-send path …
+	// never leaves a row behind"), while both signals this test already waited
+	// on — the sent input and the "[-]" mark — land BEFORE it. Reading the
+	// ledger immediately therefore races that write and fails with an empty
+	// list under load, which is a property of the test, not of the hand-out.
+	waitFor(t, 3*time.Second, func() bool { return len(openHandouts(t, h)) == 1 })
+	res := openHandouts(t, h)
 	if len(res) != 1 || res[0].SourcePath != locator {
 		t.Errorf("reservations = %+v, want one keyed on %s", res, locator)
 	}

--- a/internal/daemon/autosendidle_test.go
+++ b/internal/daemon/autosendidle_test.go
@@ -1836,7 +1836,17 @@ func TestAutoSendIdleUnattendedSourceSendsWithNoLearnedRule(t *testing.T) {
 	})
 	// And it went out silently — an unattended hand-out that escalates has not
 	// done its job, whatever else it did.
-	noEscalations(t, h)
+	//
+	// task_source_exhausted is EXCLUDED, and is not a weakening: this list holds
+	// exactly one item, so the moment the hand-out marks it "[-]" a later idle
+	// episode legitimately finds nothing pending and says so. That episode is
+	// reachable inside this assertion because the reservation row — the thing
+	// that withholds an agent with an unconfirmed hand-out from the poll — is
+	// recorded AFTER the send, so a sweep landing in that gap sees an eligible
+	// agent and an empty list. Observed on a loaded CI runner, never locally.
+	// Every other reason still fails the test, which is what it is really
+	// asserting: the hand-out itself went out without asking anyone.
+	noEscalationsExcept(t, h, domain.ReasonTaskSourceExhausted)
 }
 
 func TestAutoSendIdleAttendedSourceStillEscalatesWithNoLearnedRule(t *testing.T) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1050,16 +1050,25 @@ func newHarnessCore(t *testing.T, cfgTOML string, wrap func(*fakeHerdr) ports.He
 	}
 }
 
+// waitFor polls cond until it holds or the (scaled) deadline passes.
+//
+// Every caller's timeout goes through testutil.Scale, so a loaded runner gets
+// proportionally longer to satisfy the SAME condition — see the rationale and
+// the measurements there. The failure names the deadline actually in force,
+// because "condition not met within timeout" alone cannot distinguish a genuine
+// hang from a machine that needed one more poll.
 func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
+	scaled := testutil.Scale(timeout)
+	deadline := time.Now().Add(scaled)
 	for time.Now().Before(deadline) {
 		if cond() {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatal("condition not met within timeout")
+	t.Fatalf("condition not met within %s (base %s, scale %.3gx)",
+		scaled, timeout, testutil.TimeoutScale())
 }
 
 // tinyCaptureDelay keeps tests near-synchronous; appended LAST to every

--- a/internal/daemon/fleetsync_test.go
+++ b/internal/daemon/fleetsync_test.go
@@ -205,9 +205,17 @@ func TestFleetSyncHealthReportsErrorsAndRecovery(t *testing.T) {
 	sync.mu.Lock()
 	sync.pullErr = nil
 	sync.mu.Unlock()
+	// The wait must cover EVERY field the assertion below reads, revision
+	// included. A successful pull publishes the recovery in two steps —
+	// fleetPull sets lastPull and clears the error, and only then does
+	// fleetRefreshStats store the revision — so a wait on lastPull/LastError
+	// alone can return in the window where Revision is still empty, and the
+	// assertion then fails on a half-updated snapshot rather than on anything
+	// the test is about. Cheap under load, invisible when the machine is idle.
 	waitFor(t, 2*time.Second, func() bool {
 		fh := h.daemon.fleetHealth()
-		return fh != nil && fh.LastError == "" && !fh.LastPullAt.IsZero()
+		return fh != nil && fh.LastError == "" && !fh.LastPullAt.IsZero() &&
+			fh.Revision == "r1"
 	})
 	fh = h.daemon.fleetHealth()
 	if fh.LastError != "" || fh.Revision != "r1" {

--- a/internal/daemon/sessionname_test.go
+++ b/internal/daemon/sessionname_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/control"
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
 )
 
 // readPaneNow returns what the fake pane currently shows, so a test can feed
@@ -47,7 +48,7 @@ func claudeTr(agentID, status string) domain.AgentTransition {
 // Path 2 runs off the main loop, so a test cannot read the result inline.
 func waitForSend(t *testing.T, h *harness, want string) bool {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(testutil.Scale(3 * time.Second))
 	for time.Now().Before(deadline) {
 		for _, in := range h.herdr.sentInputs() {
 			if strings.Contains(in, want) {

--- a/internal/daemon/tasklistreview_test.go
+++ b/internal/daemon/tasklistreview_test.go
@@ -83,12 +83,43 @@ func auditActions(t *testing.T, h *harness) []domain.AuditRecord {
 // poll forever, so a review that escalates switches unattended hand-out off.
 func noEscalations(t *testing.T, h *harness) {
 	t.Helper()
+	noEscalationsExcept(t, h)
+}
+
+// noEscalationsExcept is noEscalations with an allowance for reasons the caller
+// has a stated reason to tolerate.
+//
+// It reads ONCE and deliberately does not poll, so it asserts over an INSTANT
+// rather than a window. That makes it exact for "this code path must not
+// escalate", and unsafe for a scenario whose own success legitimately produces
+// a LATER escalation: on a slow machine that follow-up lands inside the read
+// and the test fails for something it never claimed to be about. Such a caller
+// names the reason here rather than hoping the timing holds — naming it keeps
+// the assertion strict about every OTHER reason, which "just poll for longer"
+// would not.
+func noEscalationsExcept(t *testing.T, h *harness, allowed ...domain.EscalateReason) {
+	t.Helper()
 	esc, err := h.raw.PendingEscalations(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(esc) != 0 {
-		t.Errorf("the review must never escalate, got %d escalation(s): %+v", len(esc), esc)
+	var unexpected []domain.AuditRecord
+	for _, e := range esc {
+		tolerated := false
+		for _, r := range allowed {
+			// escalate() writes the reason as a "[reason]" prefix on Rationale.
+			if strings.HasPrefix(e.Rationale, "["+string(r)+"]") {
+				tolerated = true
+				break
+			}
+		}
+		if !tolerated {
+			unexpected = append(unexpected, e)
+		}
+	}
+	if len(unexpected) != 0 {
+		t.Errorf("nothing may be awaiting the operator, got %d escalation(s): %+v",
+			len(unexpected), unexpected)
 	}
 }
 

--- a/internal/store/turso/schema_lease_test.go
+++ b/internal/store/turso/schema_lease_test.go
@@ -12,6 +12,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
 )
 
 // localSyncServer runs `tursodb --sync-server` for one test, or skips. (The
@@ -51,7 +53,7 @@ func localSyncServerKillable(t *testing.T) (string, func()) {
 		kill()
 		logf.Close()
 	})
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(testutil.Scale(10 * time.Second))
 	for time.Now().Before(deadline) {
 		if c, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond); err == nil {
 			c.Close()
@@ -161,7 +163,7 @@ func TestASlowMigrationKeepsTheLeasePastItsNominalTTL(t *testing.T) {
 	go func() { done <- PrepareSharedSchema(ctx, a, owner, time.Now) }()
 
 	// Wait until A holds the lease, then past the nominal TTL.
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(testutil.Scale(10 * time.Second))
 	for {
 		if _, err := b.Pull(); err != nil {
 			t.Fatal(err)
@@ -219,7 +221,7 @@ func TestALockedMigrationStepLosesTheLeaseAndFailsClosed(t *testing.T) {
 	go func() { done <- PrepareSharedSchema(ctx, a, owner, time.Now) }()
 
 	// B keeps trying; once A's lease has lapsed unrenewed, B gets it.
-	deadline := time.Now().Add(15 * time.Second)
+	deadline := time.Now().Add(testutil.Scale(15 * time.Second))
 	bHolds := false
 	for !bHolds && time.Now().Before(deadline) {
 		got, err := AcquireSchemaLease(ctx, b, "bbbbbbbbbbbbbbbb", time.Now)
@@ -301,7 +303,7 @@ func TestALeaseTakenDuringTheFinalStepIsNotPublished(t *testing.T) {
 
 	owner := &takeoverOwner{id: "aaaaaaaaaaaaaaaa", db: a}
 	owner.steal = func() error {
-		deadline := time.Now().Add(15 * time.Second)
+		deadline := time.Now().Add(testutil.Scale(15 * time.Second))
 		for time.Now().Before(deadline) {
 			got, err := AcquireSchemaLease(ctx, b, "bbbbbbbbbbbbbbbb", time.Now)
 			if err != nil {

--- a/internal/store/turso/spike_test.go
+++ b/internal/store/turso/spike_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
+
 	turso "turso.tech/database/tursogo"
 )
 
@@ -48,7 +50,7 @@ func startSyncServer(t *testing.T) string {
 			t.Logf("server log:\n%s", b)
 		}
 	})
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(testutil.Scale(10 * time.Second))
 	for time.Now().Before(deadline) {
 		c, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
 		if err == nil {

--- a/internal/store/turso/sync_test.go
+++ b/internal/store/turso/sync_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store"
 	"github.com/0xGosu/herdr-auto-pilot/internal/store/turso"
+	"github.com/0xGosu/herdr-auto-pilot/internal/testutil"
 )
 
 // startLocalSyncServer runs `tursodb --sync-server` for one test, or skips.
@@ -49,7 +50,7 @@ func startLocalSyncServer(t *testing.T) string {
 		_, _ = cmd.Process.Wait()
 		logf.Close()
 	})
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(testutil.Scale(10 * time.Second))
 	for time.Now().Before(deadline) {
 		if c, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond); err == nil {
 			c.Close()

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -3,8 +3,81 @@ package testutil
 
 import (
 	"os"
+	"runtime"
+	"strconv"
+	"sync"
 	"testing"
+	"time"
 )
+
+// TimeoutScaleEnv is the environment variable that multiplies every shared test
+// wait deadline. CI sets it (.github/workflows/ci.yml); locally it is unset.
+const TimeoutScaleEnv = "HAP_TEST_TIMEOUT_SCALE"
+
+var timeoutScale = sync.OnceValue(func() float64 {
+	return scaleFrom(os.Getenv(TimeoutScaleEnv), runtime.GOMAXPROCS(0))
+})
+
+// scaleFrom resolves the multiplier from its two inputs.
+//
+// Pure, and deliberately separate from the sync.OnceValue above so it can be
+// tested: the cached value is resolved once per PROCESS, so a test that set the
+// environment and then called Scale would assert against whatever the first
+// caller in that binary already resolved — passing or failing for reasons that
+// have nothing to do with the code under test.
+//
+// A malformed or below-1 value is IGNORED rather than reported: this runs
+// inside every test binary, so a typo in CI's environment must not fail a
+// suite. Falling back can only ever lengthen a wait, never shorten one.
+func scaleFrom(env string, procs int) float64 {
+	if env != "" {
+		if f, err := strconv.ParseFloat(env, 64); err == nil && f >= 1 {
+			return f
+		}
+	}
+	// Fallback heuristic for a small runner. It cannot see load imposed from
+	// OUTSIDE this process — a busy shared devbox reports every core — which is
+	// exactly why the env knob above exists and is what CI sets.
+	switch {
+	case procs < 4:
+		return 4
+	case procs < 8:
+		return 2
+	default:
+		return 1
+	}
+}
+
+// Scale stretches a test wait deadline by TimeoutScaleEnv.
+//
+// Why this exists, measured on an idle devbox over one full internal/daemon run
+// (1721 waits, no timeouts): the median wait is 10ms and p99 is 260ms, so the
+// deadlines look enormously generous — but the TAIL is what fails a job. The
+// slowest single wait was 1862ms against a 3s deadline (62% consumed) and the
+// next 1988ms against 4s, so the worst cases carry only ~1.6x headroom while
+// the machine is otherwise doing nothing. A CI runner needs very little
+// contention to cross that, and one crossing fails the whole job: in a single
+// night seven distinct tests failed this way with "condition not met within
+// timeout", every one of them passing on a quiet machine.
+//
+// So the deadlines are not wrong in shape — a hung condition still fails within
+// seconds — they are simply sized for an unloaded machine. Scaling them in ONE
+// place keeps that property while letting a loaded runner finish, and is
+// deliberately preferred over editing individual tests: the per-test deadline
+// still expresses "this should take well under N seconds", and the multiplier
+// expresses "this machine is X times slower than the one that number was
+// chosen on".
+//
+// It only ever LENGTHENS a wait (the factor is floored at 1), so it can never
+// make a test flakier than its author intended, and it never touches an
+// assertion — a condition that is genuinely never satisfied still fails.
+func Scale(d time.Duration) time.Duration {
+	return time.Duration(float64(d) * timeoutScale())
+}
+
+// TimeoutScale reports the multiplier Scale applies, for a failure message that
+// needs to say what deadline was actually in force.
+func TimeoutScale() float64 { return timeoutScale() }
 
 // SocketDir returns a directory with a short absolute path for unix-domain
 // sockets. macOS caps socket paths at 104 bytes, and t.TempDir() embeds the

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,52 @@
+package testutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestScaleFromPrefersTheEnvironmentOverTheHeuristic(t *testing.T) {
+	// The env knob is what CI sets, and it must win on a runner with plenty of
+	// cores — the whole point is that core count cannot see contention.
+	if got := scaleFrom("4", 16); got != 4 {
+		t.Errorf("scaleFrom(\"4\", 16) = %v, want 4", got)
+	}
+	if got := scaleFrom("2.5", 2); got != 2.5 {
+		t.Errorf("a fractional scale must be honoured, got %v", got)
+	}
+}
+
+func TestScaleFromIgnoresAnUnusableEnvironmentValue(t *testing.T) {
+	// A typo in CI's environment must not fail every suite, and a value below 1
+	// must never SHORTEN a wait — both fall back to the heuristic, which on this
+	// many cores is 1.
+	for _, env := range []string{"", "abc", "0", "0.5", "-3"} {
+		if got := scaleFrom(env, 16); got != 1 {
+			t.Errorf("scaleFrom(%q, 16) = %v, want the 1x fallback", env, got)
+		}
+	}
+}
+
+func TestScaleFromStretchesForASmallRunner(t *testing.T) {
+	for _, c := range []struct {
+		procs int
+		want  float64
+	}{{1, 4}, {2, 4}, {3, 4}, {4, 2}, {7, 2}, {8, 1}, {32, 1}} {
+		if got := scaleFrom("", c.procs); got != c.want {
+			t.Errorf("scaleFrom(\"\", %d) = %v, want %v", c.procs, got, c.want)
+		}
+	}
+}
+
+func TestScaleOnlyEverLengthens(t *testing.T) {
+	// Scale reads the process-wide cached factor, which is floored at 1 by
+	// scaleFrom, so the guarantee callers rely on is that a deadline never
+	// comes back shorter than the one they asked for.
+	base := 3 * time.Second
+	if got := Scale(base); got < base {
+		t.Errorf("Scale(%s) = %s, must never shorten a deadline", base, got)
+	}
+	if s := TimeoutScale(); s < 1 {
+		t.Errorf("TimeoutScale() = %v, must never be below 1", s)
+	}
+}


### PR DESCRIPTION
Seven distinct tests failed in one night with "condition not met within timeout", across CI and a shared devbox — every one of them passing on a quiet machine. This started as two individual fixes; the later commits address the shared cause instead.

**Tests and CI config only. No production behaviour changes.**

## Is the deadline actually too short? Measured, yes — in the tail

One full `internal/daemon` run on an **idle** machine: 1721 waits, 0 timeouts.

| p50 | p90 | p99 | max |
|---|---|---|---|
| 10ms | 21ms | 260ms | 2519ms |

The medians make the deadlines look enormously generous, but the tail is what fails a job: the slowest single wait consumed **1862ms of its 3000ms budget (62%)**, the next 1988ms of 4000ms. So the worst cases carry only ~1.6x headroom *while the machine is doing nothing else*. A contended runner needs very little to cross that, and one crossing fails the whole job.

The deadlines are therefore not wrong in shape — a genuinely hung condition still fails in seconds — they are sized for an unloaded machine.

## The central fix

`testutil.Scale` multiplies every shared wait in one place, read from `HAP_TEST_TIMEOUT_SCALE`, which `ci.yml` and `release.yml` now set to 4.

Applied only at deadline-construction sites: `internal/daemon`'s `waitFor` (479 call sites) and `waitForSend`, `internal/cli`'s `waitFor`, and the six hand-rolled deadlines in `internal/store/turso`. **No per-test timeout is edited** — each still says "this should take well under N seconds", while the multiplier says "this machine is X times slower than the one that number was chosen on".

- Floored at 1, so it can only ever *lengthen* a wait; a condition never satisfied still fails.
- A malformed value falls back to a core-count heuristic rather than failing every suite. That heuristic is deliberately weak — it cannot see load from outside the process, which is why the env knob exists.
- Resolution is factored into a pure `scaleFrom` so it is testable: the value is cached once per process, so a test setting the env afterwards would assert against whatever the first caller resolved.
- `waitFor`'s failure now names the deadline actually in force — the old message could not distinguish a hang from one more poll.

## The two original waits

1. `TestFleetSyncHealthReportsErrorsAndRecovery` asserts on `Revision`, but recovery publishes in two steps: `fleetPull` sets `lastPull` and clears the error (fleetsync.go:276), and only then does `fleetRefreshStats` store the revision (:291). The wait covered the first step alone. (The failure is on `Revision`, not `RecoveredAt`/`RecoveryLatched` — those are other `%+v` fields.) I did **not** take the "store both under one update" option: that changes production write ordering to suit a test.
2. `TestAutoSendIdleHandsOutFromASQLiteProviderList` asserts the reservation row exists, but `deliverAutonomousClaimed` records it **after** the send by its own comment. It now waits for the row.

## An assertion the scaling surfaced — narrowed, not weakened

Raising the scale to 4 kept the shared waits open ~4x longer, giving the idle sweep more turns inside the window, and `TestAutoSendIdleUnattendedSourceSendsWithNoLearnedRule` then caught:

```
[task_source_exhausted] No more pending tasks
```

This was always possible; the old deadline simply expired first. The escalation is **legitimate**: the list holds exactly one item, so once the hand-out marks it `[-]` a later idle episode correctly finds nothing pending. It lands inside the assertion because the reservation row — the thing that withholds an agent with an unconfirmed hand-out from the poll — is recorded *after* the send, so a sweep in that gap sees an eligible agent and an empty list.

The assertion was also broader than its own intent: it wanted no *hand-out* escalation but counted every escalation on that agent. `noEscalationsExcept` lets a caller name a reason it has a stated reason to tolerate; `noEscalations` delegates to it with none, so its ten existing callers are unchanged. Every other reason still fails this test.

Seeding a second pending item was the alternative and is worse: the same post-send sweep would then find that item pending and deliver a **second** hand-out, trading a visible failure for silent extra behaviour the test does not assert against.

**Overlap with work in flight:** the underlying exhausted-list behaviour is being addressed separately by calm-lemur, and this PR deliberately leaves that production code alone — the two changes meet at exactly this symptom. This PR only stops the test from failing on a timing window; it makes no claim about whether that escalation *should* be raised.

## One failure this does NOT fix, deliberately

`TestALockedMigrationStepLosesTheLeaseAndFailsClosed` (`internal/store/turso`) fails under load with:

```
schema_lease_test.go:239: A's migration = <nil>, want ErrSchemaLeaseLost
```

That is **not a deadline** — it is a behavioural assertion, failing at 7.7s against 10s/15s budgets. Under load, A's migration step completes before B manages to steal the lease, so A never observes the loss. Scaling does not and should not paper over it. It reproduces on untouched main (2/10, same assertion), so it is pre-existing and outside this PR. It does not affect CI, where these tests skip without `tursodb` on PATH.

## Verification

- Both originally-fixed tests: 10/10 locally; both pass under `-race`.
- The narrowed hand-out test: 20/20 with `HAP_TEST_TIMEOUT_SCALE=4`; all `TaskReview|AutoSendIdle` callers of the refactored helper pass.
- New `testutil` tests cover env precedence, malformed/below-1 values, the core-count fallback, and the never-shortens guarantee.
- Full suite: 41 packages ok (sole exception the turso test above). `-race` on `internal/daemon`: 0 data races. `GOTOOLCHAIN=go1.26.2 golangci-lint` — 0 issues.