### PR TITLE
#472 fix: take agy composer proof before taskfile.ApplyReview

### DIFF
--- a/changelog.d/fix-review-reserves-before-proof.md
+++ b/changelog.d/fix-review-reserves-before-proof.md
@@ -1,0 +1,1 @@
+- Fixed pre-delivery task review taking the agy composer proof before reserving the checklist item rather than after: an agy agent parked in a modal (or a pane that cannot be read) no longer churns the task list with reserve-refuse-release writes on every sweep.

--- a/internal/daemon/agy_test.go
+++ b/internal/daemon/agy_test.go
@@ -689,7 +689,6 @@ func TestAgyApprovalIsRefusedBeforeAnythingIsReserved(t *testing.T) {
 			ctx := context.Background()
 			h := newHarness(t, "")
 			h.herdr.setPane(tc.pane)
-			h.herdr.setAgents([]domain.AgentTransition{agyAgent()})
 			h.herdr.failRead = tc.failRead
 			mutations := 0
 			h.daemon.opt.MutateTaskFile = func(path string, fn func(string) (string, error)) error {
@@ -755,7 +754,6 @@ func TestAgyReviewApprovalIsRefusedBeforeAnythingIsReserved(t *testing.T) {
 			h := newHarness(t, cfg)
 			h.llm.configured = true
 			h.herdr.setPane(tc.pane)
-			h.herdr.setAgents([]domain.AgentTransition{agyAgent()})
 			h.herdr.failRead = tc.failRead
 
 			var mu sync.Mutex
@@ -833,6 +831,22 @@ func TestAgyReviewApprovalIsRefusedBeforeAnythingIsReserved(t *testing.T) {
 			}
 			if n != 0 {
 				t.Errorf("attempts = %d, want 0: no attempt should be counted on a refusal", n)
+			}
+
+			audits, err := h.raw.AuditLog(ctx, 10)
+			if err != nil {
+				t.Fatal(err)
+			}
+			found := false
+			for _, a := range audits {
+				if a.Action == domain.AuditActionTaskReviewFailed && strings.Contains(a.Rationale, "[agy_composer_not_ready]") {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected audit row with action %s and reason agy_composer_not_ready",
+					domain.AuditActionTaskReviewFailed)
 			}
 		})
 	}

--- a/internal/daemon/agy_test.go
+++ b/internal/daemon/agy_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -721,6 +722,103 @@ func TestAgyApprovalIsRefusedBeforeAnythingIsReserved(t *testing.T) {
 			if len(rows) != 0 {
 				t.Errorf("audit rows = %+v, want none: the opening proof refuses above the audit "+
 					"write, so a pane parked like this leaves no row per sweep either", rows)
+			}
+		})
+	}
+}
+
+// Driving the pre-delivery review path with a caller-owned claim: an agy pane
+// parked in a modal (or a pane that cannot be read) must not trigger any task
+// file mutations. Without an early proof before taskfile.ApplyReview, the
+// review reserves the item to [-] before deliverAutonomousClaimed takes its
+// opening proof and refuses, which then triggers reviewRollback to release
+// back to [ ] — churning the task list twice per sweep with no attempt counted.
+func TestAgyReviewApprovalIsRefusedBeforeAnythingIsReserved(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		pane     string
+		failRead bool
+	}{
+		{name: "a standing approval", pane: agyApprovalPane},
+		{name: "a pane that cannot be read", pane: agyReadyPane, failRead: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			taskFile := filepath.Join(t.TempDir(), "tasks.md")
+			if err := os.WriteFile(taskFile, []byte("- [ ] 1. run the suite\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg := fmt.Sprintf("[llm]\ncommand = [\"fake\"]\nauto_act_confidence_threshold = 50\ntimeout_seconds = 5\n\n"+
+				"[[task_sources]]\nagent = %q\npath = %q\nenable_llm_review_before_auto_send = true\nenable_auto_send_task_when_idle = true\n",
+				"pA", taskFile)
+			h := newHarness(t, cfg)
+			h.llm.configured = true
+			h.herdr.setPane(tc.pane)
+			h.herdr.setAgents([]domain.AgentTransition{agyAgent()})
+			h.herdr.failRead = tc.failRead
+
+			var reqID string
+			h.llm.consult = func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+				reqID = req.RequestID
+				return stageTaskReview(ctx, h, req, nil, "1", 90)
+			}
+
+			mutations := 0
+			var callOrder []string
+			origMutate := h.daemon.opt.MutateTaskFile
+			h.daemon.opt.MutateTaskFile = func(path string, fn func(string) (string, error)) error {
+				mutations++
+				before := readTasks(t, path)
+				err := origMutate(path, fn)
+				after := readTasks(t, path)
+				callOrder = append(callOrder, fmt.Sprintf("call %d: %q -> %q", mutations, strings.TrimSpace(before), strings.TrimSpace(after)))
+				return err
+			}
+
+			del := delivery{
+				sendText: "Next task: run the suite",
+				input:    "Next task: run the suite",
+				taskText: "1. run the suite",
+				declared: &domain.DeclaredTask{
+					Task:      "1. run the suite",
+					Content:   "1. run the suite",
+					Path:      taskFile,
+					Locator:   taskFile,
+					LLMReview: true,
+					Reserve:   true,
+				},
+			}
+			s := domain.Situation{AgentID: "pA", PaneID: "pA", AgentType: domain.AgentTypeAgy,
+				Type: domain.SituationIdle, Status: "idle", Content: agyReadyPane}
+			sent := h.daemon.deliverDeclared(ctx, s, domain.ComputeSignature(s),
+				domain.Decision{Input: "Next task: run the suite", Confidence: 1},
+				agyAgent(), del, time.Now())
+
+			waitFor(t, 5*time.Second, func() bool {
+				if reqID == "" {
+					return false
+				}
+				dec, err := h.raw.LLMDecisionByRequest(ctx, reqID)
+				return err == nil && dec != nil && dec.Status != "pending"
+			})
+
+			t.Logf("observed call order: %v", callOrder)
+
+			if sent || len(h.herdr.sentInputs()) != 0 {
+				t.Fatalf("typed into a pane that is not at an empty composer: sent=%v inputs=%v",
+					sent, h.herdr.sentInputs())
+			}
+			if mutations != 0 {
+				t.Errorf("the task list was written %d times for a refusal that never got as far as "+
+					"a reservation — under a gist source that is a remote read-modify-write per sweep",
+					mutations)
+			}
+			n, err := h.raw.TaskHandoutAttempts(ctx, canonicalTaskPath(taskFile), "1. run the suite")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n != 0 {
+				t.Errorf("attempts = %d, want 0: no attempt should be counted on a refusal", n)
 			}
 		})
 	}

--- a/internal/daemon/agy_test.go
+++ b/internal/daemon/agy_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -757,9 +758,12 @@ func TestAgyReviewApprovalIsRefusedBeforeAnythingIsReserved(t *testing.T) {
 			h.herdr.setAgents([]domain.AgentTransition{agyAgent()})
 			h.herdr.failRead = tc.failRead
 
+			var mu sync.Mutex
 			var reqID string
 			h.llm.consult = func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+				mu.Lock()
 				reqID = req.RequestID
+				mu.Unlock()
 				return stageTaskReview(ctx, h, req, nil, "1", 90)
 			}
 
@@ -767,11 +771,13 @@ func TestAgyReviewApprovalIsRefusedBeforeAnythingIsReserved(t *testing.T) {
 			var callOrder []string
 			origMutate := h.daemon.opt.MutateTaskFile
 			h.daemon.opt.MutateTaskFile = func(path string, fn func(string) (string, error)) error {
-				mutations++
 				before := readTasks(t, path)
 				err := origMutate(path, fn)
 				after := readTasks(t, path)
+				mu.Lock()
+				mutations++
 				callOrder = append(callOrder, fmt.Sprintf("call %d: %q -> %q", mutations, strings.TrimSpace(before), strings.TrimSpace(after)))
+				mu.Unlock()
 				return err
 			}
 
@@ -795,23 +801,31 @@ func TestAgyReviewApprovalIsRefusedBeforeAnythingIsReserved(t *testing.T) {
 				agyAgent(), del, time.Now())
 
 			waitFor(t, 5*time.Second, func() bool {
-				if reqID == "" {
+				mu.Lock()
+				id := reqID
+				mu.Unlock()
+				if id == "" {
 					return false
 				}
-				dec, err := h.raw.LLMDecisionByRequest(ctx, reqID)
+				dec, err := h.raw.LLMDecisionByRequest(ctx, id)
 				return err == nil && dec != nil && dec.Status != "pending"
 			})
 
-			t.Logf("observed call order: %v", callOrder)
+			mu.Lock()
+			observedCallOrder := append([]string(nil), callOrder...)
+			observedMutations := mutations
+			mu.Unlock()
+
+			t.Logf("observed call order: %v", observedCallOrder)
 
 			if sent || len(h.herdr.sentInputs()) != 0 {
 				t.Fatalf("typed into a pane that is not at an empty composer: sent=%v inputs=%v",
 					sent, h.herdr.sentInputs())
 			}
-			if mutations != 0 {
+			if observedMutations != 0 {
 				t.Errorf("the task list was written %d times for a refusal that never got as far as "+
 					"a reservation — under a gist source that is a remote read-modify-write per sweep",
-					mutations)
+					observedMutations)
 			}
 			n, err := h.raw.TaskHandoutAttempts(ctx, canonicalTaskPath(taskFile), "1. run the suite")
 			if err != nil {

--- a/internal/daemon/tasklistreview.go
+++ b/internal/daemon/tasklistreview.go
@@ -376,15 +376,15 @@ func (d *Daemon) handleTaskListReviewOutcome(ctx context.Context, res taskListRe
 	// standing approval, a picker or the operator's draft. Proving the pane
 	// before taskfile.ApplyReview ensures a refusal costs no task-list write
 	// (and no remote read-modify-write under a gist source).
+	//
+	// Unlike out.Noop below — which commits edits because the source is
+	// genuinely exhausted and no delivery was requested — a busy pane is a
+	// transient refusal of a delivery attempt: applying edits here would still
+	// cost remote read-modify-writes on every idle sweep while the modal stands,
+	// and risks drifting the list out from under a human working in that modal.
 	if domain.IsAgy(s.AgentType) {
 		if err := d.agyComposerRefusal(ctx, s.PaneID); err != nil {
-			slog.Info("agy composer not ready; not sending", "agent", s.AgentID, "reason", err)
-			if res.decision != nil {
-				if uerr := d.opt.Store.UpdateLLMDecisionStatus(ctx, res.decision.ID, "rejected"); uerr != nil {
-					slog.Error("llm decision status update failed", "error", uerr)
-				}
-			}
-			d.dropAutoTaskClaim(s.AgentID)
+			d.standDown(ctx, res, "agy_composer_not_ready", err.Error(), llmConf, proposal, now)
 			return
 		}
 	}
@@ -537,13 +537,15 @@ func (d *Daemon) handleTaskListReviewOutcome(ctx context.Context, res taskListRe
 }
 
 // standDown abandons a review without sending anything — not the reviewed task
-// and not the original either. It exists for the kill switch, which is the one
-// outcome where fail-open is wrong: the operator asked the daemon to stop, so
-// "keep the agent working" is exactly what they did not want.
+// and not the original either. It exists for outcomes where fail-open is wrong:
+// the kill switch is active, or the target pane is busy/unready (e.g. an agy
+// composer modal) and sending the unreviewed original would violate the same
+// barrier.
 //
-// It still does not escalate. There is nobody to ask — the operator already
-// said "stop" — so an escalation would only add a row to answer later for
-// something that needs no answer; the audit row is what tells them it happened.
+// It still does not escalate. There is nobody to ask — the operator paused or
+// the pane is temporarily occupied — so an escalation would only add a row to
+// answer later for something that needs no answer; the audit row is what tells
+// them it happened.
 func (d *Daemon) standDown(ctx context.Context, res taskListReviewOutcome,
 	reason, why string, llmConf *int, proposal string, now time.Time) {
 

--- a/internal/daemon/tasklistreview.go
+++ b/internal/daemon/tasklistreview.go
@@ -371,6 +371,24 @@ func (d *Daemon) handleTaskListReviewOutcome(ctx context.Context, res taskListRe
 		return
 	}
 
+	// agy only ever receives typed text at a proven EMPTY composer: herdr reports
+	// its modals idle, so an unattended send could type a hand-out into a
+	// standing approval, a picker or the operator's draft. Proving the pane
+	// before taskfile.ApplyReview ensures a refusal costs no task-list write
+	// (and no remote read-modify-write under a gist source).
+	if domain.IsAgy(s.AgentType) {
+		if err := d.agyComposerRefusal(ctx, s.PaneID); err != nil {
+			slog.Info("agy composer not ready; not sending", "agent", s.AgentID, "reason", err)
+			if res.decision != nil {
+				if uerr := d.opt.Store.UpdateLLMDecisionStatus(ctx, res.decision.ID, "rejected"); uerr != nil {
+					slog.Error("llm decision status update failed", "error", uerr)
+				}
+			}
+			d.dropAutoTaskClaim(s.AgentID)
+			return
+		}
+	}
+
 	// The safety re-gate. The reviewer is an LLM authoring both task text and
 	// the choice of task, so its output is screened exactly like any other
 	// LLM-authored outbound (FR-015). It runs INSIDE the mutation, against the


### PR DESCRIPTION
Closes #472

### Summary
In the pre-delivery task-list review path, `handleTaskListReviewOutcome` previously invoked `taskfile.ApplyReview` to reserve the checklist item before handing the delivery down to `deliverAutonomousClaimed`. When the target agy agent was parked in a modal (standing approval, picker, draft) or unreadable, `deliverAutonomousClaimed`'s opening `agyComposerRefusal` proof failed, triggering `abandon()` $\to$ `reviewRollback` to release the item back to `[ ]`. This resulted in a reserve $\to$ refuse $\to$ release loop on every sweep (two task-list mutations per poll).

### Fix
- Proves agy composer readiness (`d.agyComposerRefusal`) in `handleTaskListReviewOutcome` before calling `taskfile.ApplyReview`.
- If refused, updates decision status to rejected, drops the auto task claim, and returns immediately without mutating the checklist.
- Preserves the last-look composer proof in `deliverAutonomousClaimed` before keystrokes are sent.
- Adds `TestAgyReviewApprovalIsRefusedBeforeAnythingIsReserved` in `internal/daemon/agy_test.go` guarding against task file mutations on parked/unreadable agy panes.