### PR TITLE
#1 chore: bump plugin version to 0.9.28 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.28
+
+- Standardized and tightened doc comments on exported symbols across `domain`, `frontend`, and `store` to follow Go conventions and maintain precision.
+
 ## 0.9.27
 
 - Fixed hap answering an agy approval with a scope-widening option. The LLM was choosing "Yes, and always allow in this conversation for commands that start with X" at confidence 98-99 on nearly every approval, which pre-authorises a whole command prefix — every later command matching it then runs with no prompt, so it never reaches the classifier, the never-auto screen or the operator. hap now substitutes the narrowest option that still grants the request, and the audit rationale says when it did.

--- a/changelog.d/docs-concise-comments.md
+++ b/changelog.d/docs-concise-comments.md
@@ -1,1 +1,0 @@
-- Standardized and tightened doc comments on exported symbols across `domain`, `frontend`, and `store` to follow Go conventions and maintain precision.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.27"
+version = "0.9.28"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.28 is being released from this commit by the Auto Release workflow.