### PR TITLE
#1 chore: bump plugin version to 0.9.29 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.29
+
+- Fixed daemon tests failing on a loaded machine for timing rather than behaviour: two of them read state the daemon writes a moment later, and every shared test wait can now be stretched by one multiplier that CI sets, instead of each deadline being tuned by hand
+
 ## 0.9.28
 
 - Standardized and tightened doc comments on exported symbols across `domain`, `frontend`, and `store` to follow Go conventions and maintain precision.

--- a/changelog.d/fix-racy-test-waits.md
+++ b/changelog.d/fix-racy-test-waits.md
@@ -1,1 +1,0 @@
-- Fixed daemon tests failing on a loaded machine for timing rather than behaviour: two of them read state the daemon writes a moment later, and every shared test wait can now be stretched by one multiplier that CI sets, instead of each deadline being tuned by hand

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.28"
+version = "0.9.29"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.29 is being released from this commit by the Auto Release workflow.