### PR TITLE
#1 chore: bump plugin version to 0.9.31 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.31
+
+- Fixed pre-delivery task review taking the agy composer proof before reserving the checklist item rather than after: an agy agent parked in a modal (or a pane that cannot be read) no longer churns the task list with reserve-refuse-release writes on every sweep.
+
 ## 0.9.30
 
 - Fixed an agent whose task list is finished filling the queue with `task_source_exhausted` escalations — one per sweep, forever. It is now raised at most once per parked episode, the way the hand-out proposal already was, and survives its own auto-dismissal under full self-prompting. Its text names the remedy (queue more work) instead of only restating that the list is empty, so silencing it no longer means reaching for `hap disable`

--- a/changelog.d/fix-review-reserves-before-proof.md
+++ b/changelog.d/fix-review-reserves-before-proof.md
@@ -1,1 +1,0 @@
-- Fixed pre-delivery task review taking the agy composer proof before reserving the checklist item rather than after: an agy agent parked in a modal (or a pane that cannot be read) no longer churns the task list with reserve-refuse-release writes on every sweep.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.30"
+version = "0.9.31"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.31 is being released from this commit by the Auto Release workflow.