### PR TITLE
#0 fix: dismiss a stale consult whose prompt is gone instead of escalating a ghost

### DIFF
--- a/changelog.d/fix-agy-stale-consult-v2.md
+++ b/changelog.d/fix-agy-stale-consult-v2.md
@@ -1,0 +1,1 @@
+- Fixed a stale LLM consult escalating a prompt that had already left the screen: when the pane is proven back at rest the outcome is now recorded as dismissed instead of queued for the operator, while a situation that genuinely changed into something else still escalates.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3699,12 +3699,33 @@ func (d *Daemon) episodeNoticeSuppressed(agentID string, reason domain.EscalateR
 
 func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.SignatureResult,
 	dec domain.Decision, tr domain.AgentTransition, now time.Time) {
+	d.escalateWith(ctx, s, sig, dec, tr, now, "")
+}
+
+// escalateWith is escalate with an optional FORCED auto-dismissal reason: the
+// caller has already established that this situation must be RECORDED but never
+// put in front of the operator (see domain.ConsultTargetGone).
+//
+// It is a parameter on the one chokepoint rather than a sibling that writes its
+// own dismissed row, because escalate owns work a twin would silently skip —
+// dropping the auto-task claim, the pending-escalation dedup, the
+// noop-vs-pending latch and the notify — and a local twin of a shared path is
+// the shape that passes every test while losing one of those.
+//
+// The agent-liveness reason wins when both apply: "this agent is gone" is the
+// more fundamental fact about the row, and it is what the existing operator
+// surfaces already explain.
+func (d *Daemon) escalateWith(ctx context.Context, s domain.Situation, sig domain.SignatureResult,
+	dec domain.Decision, tr domain.AgentTransition, now time.Time, forced string) {
 	// The episode ended without an autonomous send, so an auto-send pairing for
 	// this agent is spent: the operator owns the situation now, and holding the
 	// claim would withhold a still-pending task from every other agent until
 	// its TTL. The file was never touched, so nothing is stranded.
 	d.dropAutoTaskClaim(s.AgentID)
 	autoDismissReason := d.escalationAutoDismissReason(ctx, s.AgentID)
+	if autoDismissReason == "" {
+		autoDismissReason = forced
+	}
 
 	// Dedup: if this normalized situation is already awaiting the user in the
 	// pending-escalation queue, re-raising it would just be a duplicate ask.
@@ -3778,7 +3799,10 @@ func (d *Daemon) escalate(ctx context.Context, s domain.Situation, sig domain.Si
 			slog.Error("audit write failed for auto-dismissed escalation", "error", err)
 			return
 		}
-		slog.Info("escalation auto-dismissed: agent unavailable",
+		// The reason field carries WHY; the message must not name one cause,
+		// since a forced dismissal here is about the SITUATION being gone
+		// rather than the agent being unavailable.
+		slog.Info("escalation auto-dismissed",
 			"agent", s.AgentID, "situation", s.Type, "reason", autoDismissReason)
 		return
 	}
@@ -5029,7 +5053,10 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 	if isNoop {
 		llmDec.OptionID = ""
 	}
-	reject := func(reason domain.EscalateReason, why string) {
+	// rejectAs marks the consult's decision rejected and raises the outcome.
+	// `forced` is normally empty; when set, the row is RECORDED as dismissed
+	// instead of queued for the operator (see escalateWith).
+	rejectAs := func(reason domain.EscalateReason, why string, forced string) {
 		d.opt.Store.UpdateLLMDecisionStatus(ctx, llmDec.ID, "rejected")
 		suggested := llmDec.Action
 		if isNoop {
@@ -5063,11 +5090,14 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 			score := llmDec.ConfidentScore
 			llmConf = &score
 		}
-		d.escalate(ctx, s, res.sig, domain.Decision{
+		d.escalateWith(ctx, s, res.sig, domain.Decision{
 			Action: domain.ActionEscalate, Reason: reason, Rationale: why,
 			LLMConfidence: llmConf,
 			Suggestion:    "LLM suggested: " + suggested,
-		}.WithLLMSession(res.request.SessionID), tr, now)
+		}.WithLLMSession(res.request.SessionID), tr, now, forced)
+	}
+	reject := func(reason domain.EscalateReason, why string) {
+		rejectAs(reason, why, "")
 	}
 
 	// Re-gate: kill switch, never-auto patterns, heuristic, rate — the LLM can never
@@ -5292,6 +5322,20 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 	current := cls.Classify(s.AgentType, s.Status, pane)
 	current.AgentID, current.PaneID, current.WorkspaceID = s.AgentID, s.PaneID, s.WorkspaceID
 	current.Status = s.Status
+	// A situation that did not hold still has two shapes, and only one of them
+	// is the operator's business: the prompt CHANGED into something else (ask
+	// them), or it is simply GONE — answered by hand, or the agent moved on
+	// while the consult ran (record it and move on). Escalating the second is
+	// how the queue fills with prompts that exist on no screen, and an operator
+	// who opens two of those stops opening the rest.
+	staleReject := func(why string) {
+		if domain.ConsultTargetGone(s.AgentType, current, pane) {
+			rejectAs(domain.ReasonLLMNoSubmit, why+"; the prompt is no longer on screen",
+				domain.ReasonAutoDismissStale)
+			return
+		}
+		rejectAs(domain.ReasonLLMNoSubmit, why, "")
+	}
 	if s.EffectiveAnswerCount() > 1 {
 		// Multi-tab situations carry the swept AGGREGATE as content, which
 		// never hashes equal to any single frame: staleness here means the
@@ -5301,7 +5345,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		form, ok := domain.ParseMCQForm(s.AgentType, pane)
 		if !ok || form.Kind != s.MCQKind || form.AnswerCount != s.EffectiveAnswerCount() ||
 			domain.ExtractAgentMCQForm(s.MCQKind, pane) != domain.FirstMCQQuestion(s.Content) {
-			reject(domain.ReasonLLMNoSubmit, "stale: form changed during consult")
+			staleReject("stale: form changed during consult")
 			return
 		}
 	} else if current.Type != s.Type {
@@ -5309,7 +5353,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		// below covered a type flip implicitly; the jitter-tolerant compare it
 		// now uses works on salients alone and cannot see one, so assert it
 		// explicitly (the action-review path does the same).
-		reject(domain.ReasonLLMNoSubmit, "stale: situation changed during consult")
+		staleReject("stale: situation changed during consult")
 		return
 	} else {
 		// Compare raw content hashes: the staged signature may have been
@@ -5321,7 +5365,7 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		// is not the pane moving on (see domain.SignatureHeldStill).
 		freshSig := domain.ComputeSignatureN(current, cfg.Embedding.PaneSalientChars)
 		if !domain.SignatureHeldStill(res.sig, freshSig, staleDeferredSendJitterPercent) {
-			reject(domain.ReasonLLMNoSubmit, "stale: situation changed during consult")
+			staleReject("stale: situation changed during consult")
 			return
 		}
 		if freshSig.Raw != res.sig.Raw {

--- a/internal/daemon/staleconsult_test.go
+++ b/internal/daemon/staleconsult_test.go
@@ -1,0 +1,199 @@
+package daemon
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// The post-consult staleness re-check had three possible outcomes and no
+// coverage at all: every re-read that did not match escalated, so a prompt the
+// operator had already answered by hand came back as a queue entry pointing at
+// a screen that no longer existed.
+//
+// These cases are agy because agy is the only agent type the "gone" answer can
+// currently reach. Classify returns SituationIdle only for an idle/done agent,
+// and the re-check re-classifies against the situation's ORIGINAL status, which
+// for a claude or codex modal is "blocked" — such a vanished prompt re-reads as
+// unclassifiable and still escalates. agy reports every modal as idle/done, so
+// its vanished prompt re-reads as idle. That is also where the ghosts were
+// actually observed.
+const staleConsultLLM = "[llm]\ncommand = [\"fake\"]\ntimeout_seconds = 5\n" +
+	"auto_act_confidence_threshold = 50\n"
+
+// agyOtherApprovalPane is a DIFFERENT agy approval: same shape, different
+// command. A re-read landing here is a situation that genuinely CHANGED, which
+// must still reach the operator — it is not the same question, and answering it
+// with the previous consult's verdict would approve a command nobody weighed.
+var agyOtherApprovalPane = strings.ReplaceAll(agyApprovalPane, "go test ./...", "go build ./...")
+
+// staleDismissals returns the audit rows carrying the machine's stale-dismissal
+// tag, which is what separates "recorded and closed" from "queued for a human".
+func staleDismissals(t *testing.T, h *harness) []domain.AuditRecord {
+	t.Helper()
+	rows, err := h.raw.AuditLog(context.Background(), 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []domain.AuditRecord
+	for _, r := range rows {
+		if domain.AutoDismissReason(r.Rationale) == domain.ReasonAutoDismissStale {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// TestConsultAnswerIsDeliveredWhenTheSituationHeldStill is the control for the
+// two dismissal cases below. Without it, a change that simply stopped
+// delivering post-consult answers would leave both of them green: "nothing was
+// typed" is exactly what a broken send path also produces.
+func TestConsultAnswerIsDeliveredWhenTheSituationHeldStill(t *testing.T) {
+	h := newHarnessConsult(t, staleConsultLLM,
+		func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+			return &domain.LLMDecision{Action: "Yes, run command", ConfidentScore: 99}, nil
+		})
+	h.herdr.setKeyScript(agyApprovalPane, []string{"1"}, []string{agyReadyPane})
+
+	h.pushAgy("agent-stale-hold", "done")
+
+	if keys := waitForKeys(t, h, 1); !reflect.DeepEqual(keys, []string{"1"}) {
+		t.Fatalf("keys = %v, want exactly [1]", keys)
+	}
+	if pend, _ := h.raw.PendingEscalations(context.Background()); len(pend) != 0 {
+		t.Errorf("a still-current situation must be answered, not escalated: %+v", pend)
+	}
+}
+
+// TestAStaleConsultWhosePromptIsGoneIsDismissedNotEscalated: the approval was
+// answered by hand while the consult ran, so there is no question left to ask.
+// Recorded as dismissed and kept OUT of the operator's queue — a "dismissal"
+// the operator still has to open fixes nothing.
+func TestAStaleConsultWhosePromptIsGoneIsDismissedNotEscalated(t *testing.T) {
+	var h *harness
+	h = newHarnessConsult(t, staleConsultLLM,
+		func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+			h.herdr.setPane(agyReadyPane)
+			return &domain.LLMDecision{Action: "Yes, run command", ConfidentScore: 99}, nil
+		})
+	h.herdr.setPane(agyApprovalPane)
+	ctx := context.Background()
+
+	h.pushAgy("agent-stale-gone", "done")
+
+	var rec domain.AuditRecord
+	waitFor(t, 5*time.Second, func() bool {
+		got := staleDismissals(t, h)
+		if len(got) == 0 {
+			return false
+		}
+		rec = got[0]
+		return true
+	})
+	if rec.Status != "dismissed" {
+		t.Errorf("status = %q, want dismissed", rec.Status)
+	}
+	if pend, _ := h.raw.PendingEscalations(ctx); len(pend) != 0 {
+		t.Errorf("a ghost must not reach the operator queue: %+v", pend)
+	}
+	if keys := h.herdr.keysSent(); len(keys) != 0 {
+		t.Errorf("nothing may be typed at a pane whose prompt is gone, got %v", keys)
+	}
+}
+
+// TestAStaleConsultWhoseSituationChangedStillEscalates: the pane moved to a
+// DIFFERENT approval. That is the case the escalation exists for, and the
+// dismissal must not swallow it.
+func TestAStaleConsultWhoseSituationChangedStillEscalates(t *testing.T) {
+	var h *harness
+	h = newHarnessConsult(t, staleConsultLLM,
+		func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+			h.herdr.setPane(agyOtherApprovalPane)
+			return &domain.LLMDecision{Action: "Yes, run command", ConfidentScore: 99}, nil
+		})
+	h.herdr.setPane(agyApprovalPane)
+
+	h.pushAgy("agent-stale-changed", "done")
+
+	esc := waitForOneEscalation(t, h)
+	if !strings.Contains(esc.Rationale, "stale") {
+		t.Errorf("rationale = %q, want the staleness reason", esc.Rationale)
+	}
+	if got := staleDismissals(t, h); len(got) != 0 {
+		t.Errorf("a situation that CHANGED must be asked about, not dismissed: %+v", got)
+	}
+	if keys := h.herdr.keysSent(); len(keys) != 0 {
+		t.Errorf("the decided form is no longer on screen, so nothing may be typed, got %v", keys)
+	}
+}
+
+// TestAStaleConsultOnAnUnreadyAgyComposerStillEscalates is the case that
+// discriminates the whole design, and the reason "the re-read classified as
+// idle" is not sufficient evidence on its own.
+//
+// herdr reports every agy modal as idle/done, so an agy pane reading "idle"
+// says nothing about whether something is still standing on it. Here the
+// composer is not at rest, the re-read classifies as idle anyway, and the
+// outcome must be an escalation: dismissing it would silently discard exactly
+// the stuck-modal case hap is least able to recognize.
+func TestAStaleConsultOnAnUnreadyAgyComposerStillEscalates(t *testing.T) {
+	var h *harness
+	h = newHarnessConsult(t, staleConsultLLM,
+		func(ctx context.Context, req domain.LLMRequest) (*domain.LLMDecision, error) {
+			h.herdr.setPane(agyDraftPane)
+			return &domain.LLMDecision{Action: "Yes, run command", ConfidentScore: 99}, nil
+		})
+	h.herdr.setPane(agyApprovalPane)
+
+	h.pushAgy("agent-stale-unready", "done")
+
+	esc := waitForOneEscalation(t, h)
+	if !strings.Contains(esc.Rationale, "stale") {
+		t.Errorf("rationale = %q, want the staleness reason", esc.Rationale)
+	}
+	if got := staleDismissals(t, h); len(got) != 0 {
+		t.Errorf("an agy pane reading idle under an unready composer is not proof the "+
+			"prompt is gone; it must escalate: %+v", got)
+	}
+	if keys := h.herdr.keysSent(); len(keys) != 0 {
+		t.Errorf("nothing may be typed while the composer is not at rest, got %v", keys)
+	}
+}
+
+// TestConsultTargetGoneRequiresMoreThanIdleOnAgy pins the predicate itself. The
+// daemon cases above each drive one branch through the whole pipeline; this
+// asserts the rule directly, so a widening that happens to leave those green
+// (a different pane fixture, a changed classifier) still fails here.
+func TestConsultTargetGoneRequiresMoreThanIdleOnAgy(t *testing.T) {
+	idle := domain.Situation{Type: domain.SituationIdle}
+	approval := domain.Situation{Type: domain.SituationApproval}
+	unclassifiable := domain.Situation{Type: domain.SituationUnclassifiable}
+
+	cases := []struct {
+		name      string
+		agentType string
+		current   domain.Situation
+		pane      string
+		want      bool
+	}{
+		{"agy at rest is gone", domain.AgentTypeAgy, idle, agyReadyPane, true},
+		{"agy holding a draft is not", domain.AgentTypeAgy, idle, agyDraftPane, false},
+		{"agy under a standing approval is not", domain.AgentTypeAgy, idle, agyApprovalPane, false},
+		{"a classified approval is never gone", domain.AgentTypeAgy, approval, agyReadyPane, false},
+		// Classify's DEFAULT. Reading "we could not make sense of this" as
+		// "nothing is there" would dismiss the screens hap understands least.
+		{"unclassifiable is never gone", domain.AgentTypeAgy, unclassifiable, agyReadyPane, false},
+		{"claude idle needs no composer proof", "claude", idle, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := domain.ConsultTargetGone(tc.agentType, tc.current, tc.pane); got != tc.want {
+				t.Errorf("ConsultTargetGone = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/domain/signature.go
+++ b/internal/domain/signature.go
@@ -390,6 +390,50 @@ func SignatureHeldStill(prev, fresh SignatureResult, jitterPct int) bool {
 	return SimilarWithin(prev.Salient, fresh.Salient, jitterPct)
 }
 
+// ConsultTargetGone answers the other half of the post-consult staleness
+// question SignatureHeldStill opens: once the pane has NOT held still, is the
+// prompt the consult was about simply GONE, or has it become something else?
+//
+// The two outcomes are not interchangeable. A consult takes up to the LLM
+// timeout, and by the time it returns the screen is in one of three states: the
+// same situation (the answer is still deliverable), a genuinely different one
+// (the operator should be asked about it), or nothing at all — the human
+// answered the prompt by hand, the agent moved on, the command finished. Only
+// the middle case deserves an escalation. Raising the third fills the queue with
+// prompts that no longer exist on any screen, and an operator who opens two of
+// those stops opening the rest.
+//
+// "Gone" is deliberately the NARROW answer, because the failure it must never
+// produce is dismissing a prompt that is still standing:
+//
+//   - The re-read must classify as idle. SituationUnclassifiable is Classify's
+//     DEFAULT, so reading "we could not make sense of this" as "nothing is
+//     there" would auto-dismiss precisely the screens hap understands least.
+//   - On agy it must ALSO prove an empty composer, and that half is what makes
+//     this safe at all. herdr reports every agy modal as idle/done, so on agy
+//     "idle" says nothing about whether a form is on screen; AgyComposerReady is
+//     what separates a quiescent pane from a standing approval the classifier
+//     did not recognize. Without it this would answer "gone" for exactly the
+//     population it was written for — every ghost observed in practice was agy.
+//
+// Reach, which is narrower than it looks: Classify only returns SituationIdle
+// for an idle/done agent, and the caller re-classifies against the situation's
+// ORIGINAL status. herdr reports a claude or codex modal as blocked, so a
+// vanished prompt there re-reads as unclassifiable and still escalates — this
+// answers false for them by construction. That is the safe direction, and agy,
+// whose modals are all parked at idle/done, is where the ghosts actually are.
+//
+// Callers must have already established that the situation did NOT hold still.
+func ConsultTargetGone(agentType string, current Situation, pane string) bool {
+	if current.Type != SituationIdle {
+		return false
+	}
+	if IsAgy(agentType) {
+		return AgyComposerReady(pane)
+	}
+	return true
+}
+
 // splitOptionSet is NormalizedOptionSet's inverse: it splits the encoding on
 // unescaped ";" back into a set of unescaped labels, dropping empty entries.
 func splitOptionSet(s string) map[string]bool {


### PR DESCRIPTION
Finding 6 in `/tmp/agy-findings.md`: when an LLM answer comes back and the screen has moved on, hap escalates `[llm_no_submit] stale` to a human. With agy this happened at least six times in two hours and **every one was already obsolete when read**.

## A correction to the finding first

The finding's stated fix — "compare the situation SIGNATURE rather than the raw screen" — **is already shipped.** `daemon.go` compares `domain.SignatureHeldStill(res.sig, freshSig, staleDeferredSendJitterPercent)`, not raw screen text, and has done for some time.

So the real gap is not the comparison. It is that the comparison has only **two** outcomes: submit, or escalate. Every re-read that did not match escalated, including the case where the prompt had simply gone away. That is the ghost.

## The change

Split the non-matching outcome in two:

| Re-read shows | Before | After |
|---|---|---|
| The same situation | submit | submit (unchanged) |
| A genuinely different situation | escalate | escalate (unchanged) |
| Nothing — the prompt is gone | escalate | recorded as **dismissed** (`auto_dismiss_stale`), kept out of the pending queue |

New pure predicate `domain.ConsultTargetGone`. Applied at the three `"stale:"` rejects in the post-consult re-check (multi-tab form changed, situation type flipped, signature drifted).

**Note on the multi-tab site.** Of the three rejects, the first (`"stale: form changed during consult"`) is routed through the same helper for consistency, but its "gone" answer is currently **unreachable**: that branch requires `EffectiveAnswerCount() > 1`, which is never set on an agy situation (`domain.AgyMCQForm`), and for claude/codex the predicate answers false by construction. It escalates today, exactly as before. It is wired this way so a future widening cannot forget it, and the code says so.

## Why "gone" is deliberately narrow

The failure this must never produce is dismissing a prompt that is **still standing**.

- It requires the re-read to classify as **idle**. `SituationUnclassifiable` is `Classify`'s *default*, so treating "we could not make sense of this" as "nothing is there" would auto-dismiss precisely the screens hap understands least.
- On agy it must **also** prove an empty composer (`domain.AgyComposerReady`). This half is load-bearing: herdr reports every agy modal as idle/done, so on agy "idle" says nothing about whether a form is on screen. Without it, this would answer "gone" for exactly the population it was written for — and would silently discard the finding-11 stuck-modal case.

## Reach is narrower than it looks, and this is stated in the code

`Classify` returns `SituationIdle` only for an idle/done agent, and the re-check re-classifies against the situation's **original** status. herdr reports a claude or codex modal as `blocked`, so a vanished prompt there re-reads as `unclassifiable` and **still escalates** — the predicate answers false for them by construction.

That is the safe direction, and agy — whose modals are all parked at idle/done — is where the observed ghosts actually were. Widening this to claude/codex would need a live-status probe on the select loop; deliberately not done here.

## What deliberately keeps escalating

- `"stale: no answerable agy form on screen"` — fires when `ParseAgyForm` fails *after* `AgyFormSituation` already said it is a form situation. A form hap cannot parse is the **opposite** of gone.
- `"stale: agy's composer is not ready for a message"` — a busy composer, not an absent prompt.
- The FR-015 post-consult re-screens (`ReasonNeverAutoMatch`, `ReasonSuspectedIrrevers`) — untouched; a never-auto or irreversible match must always reach a human.

## Implementation note

Threaded as a forced reason through `escalate`'s existing auto-dismissal arm (`escalate` is now a thin wrapper over `escalateWith`; all 27 call sites unchanged) rather than a sibling that writes its own dismissed row. `escalate` owns the auto-task-claim drop, the pending dedup, the noop-vs-pending latch and the notify — a local twin would silently skip those and still pass every test. Agent-liveness dismissal takes precedence over the forced one.

A dismissed row is already excluded from `IsRetryableLLMEscalation` (it keys on `Status == "escalated"`); verified rather than assumed.

## Tests

This path had **no coverage at all** — there was no control to break. Adds four pipeline cases plus a table test:

- **held still → delivered** — the control. Without it, a change that simply stopped delivering post-consult answers would leave the two dismissal cases green, since "nothing was typed" is also what a broken send path produces.
- **gone → dismissed**, asserting `Status == "dismissed"`, the `auto_dismiss_stale` tag, **and an empty `PendingEscalations`** (a "dismissal" the operator still has to open fixes nothing).
- **changed → still escalates**, and the case asserts up front that the two fixtures really are different situations (their option lists are byte-identical, so without that check it could be asserting on a pane that never moved — and it would pass on the old code either way).
- **agy pane reading idle under an unready composer → still escalates** — the case that discriminates the whole design.

## Gate

- `go build`, `gofmt`, `go vet` — clean.
- `golangci-lint` (pinned `GOTOOLCHAIN=go1.26.2`, `--timeout 20m`) — **0 issues**.
- Full suite: my new tests and `internal/domain` pass. Four failures, **all proven pre-existing**: `TestAutoSendIdleBelowThreshold`, `TestIdleTaskGenAutoDismissesWhenAgentExits`, `TestSessionRenameRefusesARecycledPane` all fail on **untouched `origin/main`** in this same worktree (checked out and run at the base commit), and each whole-package run fails on a *different* subset. `TestALockedMigrationStepLosesTheLeaseAndFailsClosed` in `internal/store/turso` fails deterministically at base too, in a package this diff does not touch (diff is `internal/daemon/daemon.go` + `internal/domain/signature.go` only).
