### PR TITLE
#0 test: prove the stale-consult "changed" fixture is really a different situation

### DIFF
--- a/changelog.d/test-stale-consult-fixture-guard.md
+++ b/changelog.d/test-stale-consult-fixture-guard.md
@@ -1,0 +1,1 @@
+- Strengthened the stale-consult tests so the dismiss-versus-escalate split cannot regress unnoticed: the "situation changed" case now proves its two panes really are different situations before asserting on the outcome.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -5345,6 +5345,12 @@ func (d *Daemon) handleLLMOutcome(ctx context.Context, res llmOutcome) {
 		form, ok := domain.ParseMCQForm(s.AgentType, pane)
 		if !ok || form.Kind != s.MCQKind || form.AnswerCount != s.EffectiveAnswerCount() ||
 			domain.ExtractAgentMCQForm(s.MCQKind, pane) != domain.FirstMCQQuestion(s.Content) {
+			// Routed through staleReject so all three staleness exits behave
+			// alike, but the "gone" answer is currently unreachable HERE: this
+			// branch needs EffectiveAnswerCount() > 1, which is never set on an
+			// agy situation (see domain.AgyMCQForm), and for claude/codex
+			// ConsultTargetGone answers false by construction. It escalates
+			// today; it is wired this way so a future widening cannot forget it.
 			staleReject("stale: form changed during consult")
 			return
 		}

--- a/internal/daemon/staleconsult_test.go
+++ b/internal/daemon/staleconsult_test.go
@@ -117,6 +117,18 @@ func TestAStaleConsultWhoseSituationChangedStillEscalates(t *testing.T) {
 		})
 	h.herdr.setPane(agyApprovalPane)
 
+	// The fixture must genuinely be a DIFFERENT situation. This case would pass
+	// on the old code too, which escalated unconditionally, so without this the
+	// whole test could be asserting on a pane that never actually moved — the
+	// two approvals differ only in the command, and their option lists are
+	// byte-identical.
+	cl := classifierForTest()
+	before := domain.ComputeSignature(cl.Classify(domain.AgentTypeAgy, "done", agyApprovalPane))
+	after := domain.ComputeSignature(cl.Classify(domain.AgentTypeAgy, "done", agyOtherApprovalPane))
+	if before.Raw == after.Raw {
+		t.Fatalf("fixture is not a different situation: both panes hash to %s", before.Raw)
+	}
+
 	h.pushAgy("agent-stale-changed", "done")
 
 	esc := waitForOneEscalation(t, h)


### PR DESCRIPTION
Follow-up to #483, from a review of that PR that arrived after it had already been merged. **No behaviour change** — one test assertion and one code comment.

## The test could not fail

`TestAStaleConsultWhoseSituationChangedStillEscalates` asserts that a consult whose pane moved to a *different* approval still escalates. But that case would have passed on the old code too, which escalated unconditionally — so the assertion only has value if the fixture genuinely is a different situation, and nothing proved that.

It is not obvious that it is. `agyOtherApprovalPane` is `agyApprovalPane` with the command swapped (`go test ./...` → `go build ./...`), and the two panes' **option lists are byte-identical** — the widening rows both say `commands that start with 'go'`. Had the salient folded the command away, the test would have been asserting on a pane that never moved, and would still have passed.

Now it compares both signatures up front and fails loudly if they collide.

## The multi-tab site is currently unreachable

Recorded in a comment at the `"stale: form changed during consult"` reject. Its "gone" answer cannot fire today: the branch requires `EffectiveAnswerCount() > 1`, which is never set on an agy situation (`domain.AgyMCQForm`), and for claude/codex `ConsultTargetGone` answers false by construction because the re-check re-classifies against the situation's original `blocked` status.

It escalates today, exactly as before. The routing through the shared helper is kept so a future widening cannot forget the site — but the code now says it is inert rather than implying three live paths.

## Gate

`go build`, `gofmt`, `go vet` clean; `golangci-lint` (pinned `GOTOOLCHAIN=go1.26.2`, `--timeout 20m`) **0 issues**; the four stale-consult cases and the predicate table test pass.
