### PR TITLE
#1 chore: bump plugin version to 0.9.34 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.34
+
+- Strengthened the stale-consult tests so the dismiss-versus-escalate split cannot regress unnoticed: the "situation changed" case now proves its two panes really are different situations before asserting on the outcome.
+
 ## 0.9.33
 
 - Fixed the timed auto-accept and full self-prompting sending an answer the `--action` rules refuse: the unattended path, the one that types with nobody watching, was the only send that never screened what it chose. A refused answer now waits for you instead, without counting as a failed delivery.

--- a/changelog.d/test-stale-consult-fixture-guard.md
+++ b/changelog.d/test-stale-consult-fixture-guard.md
@@ -1,1 +1,0 @@
-- Strengthened the stale-consult tests so the dismiss-versus-escalate split cannot regress unnoticed: the "situation changed" case now proves its two panes really are different situations before asserting on the outcome.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.33"
+version = "0.9.34"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.34 is being released from this commit by the Auto Release workflow.