### PR TITLE
#0 feat: say when an agy agent is working outside the directory it was started in

### DIFF
--- a/.claude/skills/hap/SKILL.md
+++ b/.claude/skills/hap/SKILL.md
@@ -171,6 +171,16 @@ hap capture backend-dev           # re-run the capture pipeline for one agent no
 `cwd` and `mode` are `-` when unreadable. New columns are appended, so existing
 field positions never move.
 
+**Start an agy agent in the directory it will work in.** agy scopes its
+permissions to the directory it was STARTED in and asks approval for every file
+outside it (`Reason: outside workspace`), so an agy agent started in one
+checkout and told to work in another pays an approval round trip per file it
+reads. hap answers those prompts itself once the rule graduates — the path is
+masked out of the signature, so every one of them shares a single rule — but
+the only way to stop them being raised at all is to start the agent in the right
+directory. `hap status` says so when it sees the mismatch. This is agy-specific:
+claude and codex scope permissions differently.
+
 A disabled agent stays in the list marked `DISABLED`: autonomous actions are
 audited as `denied` with `[agent_disabled]`, and escalations are audited
 straight to `dismissed` and never enter the pending queue.

--- a/changelog.d/feat-agy-workspace-mismatch.md
+++ b/changelog.d/feat-agy-workspace-mismatch.md
@@ -1,0 +1,2 @@
+- `hap status` now says when an agy agent is working outside the directory it was started in, and names the directory to relaunch it in — agy asks approval for every file outside its start directory, so a misplaced agent turns each file read into a round trip.
+- Added the shipped skill note that an agy agent must be started in the directory it will work in.

--- a/internal/cli/agyworkspace_status_test.go
+++ b/internal/cli/agyworkspace_status_test.go
@@ -1,0 +1,70 @@
+package cli_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/buildinfo"
+	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
+)
+
+// The daemon-side test proves the mismatch is RECORDED. This proves it reaches
+// an operator, which is a separate failure: a health field that nothing renders
+// is exactly the "works but is undiscoverable" gap the shipped-reference tests
+// in internal/frontend exist to argue about.
+//
+// The PID match is load-bearing — the health record is only trusted when it
+// belongs to the lock holder, so a record written under a different pid is
+// ignored and this test would pass while asserting nothing.
+func TestStatusReportsAnAgyWorkspaceMismatch(t *testing.T) {
+	app, _ := testApp(t)
+	app.DaemonInfo = func() (bool, int, string) { return true, os.Getpid(), buildinfo.Version }
+	if err := daemonhealth.Write(app.StateDir, daemonhealth.Health{
+		PID: os.Getpid(), HeartbeatAt: time.Now(),
+		AgyWorkspace: []daemonhealth.AgyWorkspaceMismatch{{
+			AgentID: "pane-agy", Name: "quick-lemur",
+			Root: "/workspaces/main-checkout", Elsewhere: "/workspaces/worktree-agent-no23",
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The name, both directories, and — the point of the line — the remedy.
+	// An operator shown two paths would not know that RESTARTING the agent is
+	// what stops the prompts.
+	for _, want := range []string{
+		"agy workspace:", "quick-lemur",
+		"/workspaces/main-checkout", "/workspaces/worktree-agent-no23",
+		"restart it in",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("status must carry %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// The control: with nothing recorded the line must be absent. Without it, a
+// render that printed unconditionally would still pass the case above.
+func TestStatusOmitsTheAgyWorkspaceLineWhenThereIsNoMismatch(t *testing.T) {
+	app, _ := testApp(t)
+	app.DaemonInfo = func() (bool, int, string) { return true, os.Getpid(), buildinfo.Version }
+	if err := daemonhealth.Write(app.StateDir, daemonhealth.Health{
+		PID: os.Getpid(), HeartbeatAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, app, "status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "agy workspace:") {
+		t.Errorf("a herd with no mismatch must not show the line, got:\n%s", out)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1061,6 +1061,14 @@ func status(ctx context.Context, app *frontend.App, out io.Writer, args []string
 	if h.OrchestratorLine != "" {
 		fmt.Fprintf(out, "orchestrator:        %s\n", h.OrchestratorLine)
 	}
+	// agy asks approval per file outside its start directory, so an agent
+	// launched in the wrong one turns every file read into a round trip. The
+	// remedy is in the line because the observation alone is not actionable:
+	// an operator seeing two directory paths would not know that RESTARTING
+	// the agent is what stops the prompts.
+	for _, line := range h.AgyWorkspaceLines {
+		fmt.Fprintf(out, "  agy workspace: %s\n", line)
+	}
 	// The evidence behind the state: which budgets are in force, how many calls
 	// hit them, and the last error. Printed even when NOT degraded, so a run of
 	// timeouts is visible before the latch trips (the diag lines are empty

--- a/internal/daemon/agyworkspace.go
+++ b/internal/daemon/agyworkspace.go
@@ -1,0 +1,94 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/daemonhealth"
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// agyWorkspaceNote is one agy agent observed working outside the directory it
+// was started in.
+type agyWorkspaceNote struct {
+	// terminalID is what makes this safe to remember. herdr recycles pane ids
+	// and an agent id IS a pane id, so without it a new tenant of the same
+	// pane inherits the previous agent's warning and the operator is told to
+	// restart an agent that was launched correctly.
+	terminalID string
+	name       string
+	root       string
+	elsewhere  string
+	at         time.Time
+}
+
+// noteAgyWorkspace records that this agy agent is asking permission for files
+// outside its own workspace root.
+//
+// Called from the classify path with the capture already in hand, so it costs
+// no pane read: paneCwd is a cache that refreshes off the main loop and returns
+// "" while cold, which AgyWorkspaceMismatch reads as "unknown" rather than as a
+// mismatch. That is the important direction — a fresh agent must never be
+// reported as misconfigured because its cwd had not been read yet.
+//
+// Deliberately not gated on the situation TYPE beyond agy: the prompt is
+// recognized structurally from the pane, and an approval hap is about to answer
+// autonomously is exactly the one an operator would otherwise never see.
+func (d *Daemon) noteAgyWorkspace(ctx context.Context, s domain.Situation, agentName, pane string) {
+	if !domain.IsAgy(s.AgentType) {
+		return
+	}
+	path, ok := domain.AgyOutsideWorkspacePath(pane)
+	if !ok {
+		return
+	}
+	root := d.paneCwd(ctx, s.PaneID)
+	if !domain.AgyWorkspaceMismatch(root, path) {
+		return
+	}
+	note := agyWorkspaceNote{
+		terminalID: s.TerminalID,
+		name:       agentName,
+		root:       root,
+		elsewhere:  domain.AgyWorkspaceRootOf(path),
+		at:         d.opt.Clock.Now(),
+	}
+	d.mu.Lock()
+	prev, had := d.agyOutsideWorkspace[s.AgentID]
+	d.agyOutsideWorkspace[s.AgentID] = note
+	d.mu.Unlock()
+	// Say it once per (agent, terminal, directory). The prompt repeats per
+	// FILE — that is the whole complaint — so logging each one would reproduce
+	// the noise this exists to explain.
+	if had && prev.terminalID == note.terminalID && prev.elsewhere == note.elsewhere {
+		return
+	}
+	slog.Info("agy agent is working outside the directory it was started in",
+		"agent", s.AgentID, "started_in", note.root, "working_in", note.elsewhere)
+}
+
+// agyWorkspaceHealth reports the mismatches for the heartbeat, or nil when
+// there are none — the same "absent when there is nothing to say" contract the
+// other optional health sections keep, so an older reader and a healthy daemon
+// look identical.
+//
+// Sorted by agent id so the status page does not reorder between reads over a
+// map whose iteration order is random.
+func (d *Daemon) agyWorkspaceHealth() []daemonhealth.AgyWorkspaceMismatch {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if len(d.agyOutsideWorkspace) == 0 {
+		return nil
+	}
+	out := make([]daemonhealth.AgyWorkspaceMismatch, 0, len(d.agyOutsideWorkspace))
+	for agentID, n := range d.agyOutsideWorkspace {
+		out = append(out, daemonhealth.AgyWorkspaceMismatch{
+			AgentID: agentID, Name: n.name,
+			Root: n.root, Elsewhere: n.elsewhere, SeenAt: n.at,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].AgentID < out[j].AgentID })
+	return out
+}

--- a/internal/daemon/agyworkspace_test.go
+++ b/internal/daemon/agyworkspace_test.go
@@ -1,0 +1,135 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+	"github.com/0xGosu/herdr-auto-pilot/internal/ports"
+)
+
+// agyOutsidePane is an agy file approval for a path in a DIFFERENT checkout
+// from the one the agent was started in — the shape that cost an approval
+// round trip per file read in the run this came from.
+const agyOutsidePane = "● Read(/workspaces/other-checkout/internal/x.go) (ctrl+o to expand)\n\n" +
+	"File access\n────────────────\n\n" +
+	"Read: /workspaces/other-checkout/internal/x.go\n" +
+	"Reason: outside workspace\n\n" +
+	"Allow access to this file?\n" +
+	"> 1. Yes, allow access\n" +
+	"  2. Yes, and always allow non-workspace access\n" +
+	"  3. No, deny access\n\n" +
+	"  ↑/↓ Navigate\n" +
+	"esc to cancel                                              Gemini 3.6 Flash · low\n"
+
+// warmPaneCwdAndPush drives events until the mismatch is observed or the wait
+// expires. The first event on a cold pane CANNOT see it: paneCwd is a cache
+// that never shells out on the main loop, so it returns "" and refreshes in
+// the background — and "" is deliberately read as "unknown", not "mismatch".
+// One further event picks it up, which is why this pushes rather than asserts
+// after a single transition.
+func warmPaneCwdAndPush(t *testing.T, h *harness, agentID string, want int) []struct {
+	Root, Elsewhere string
+} {
+	t.Helper()
+	var got []struct{ Root, Elsewhere string }
+	waitFor(t, 5*time.Second, func() bool {
+		h.pushAgy(agentID, "done")
+		got = got[:0]
+		for _, m := range h.daemon.agyWorkspaceHealth() {
+			got = append(got, struct{ Root, Elsewhere string }{m.Root, m.Elsewhere})
+		}
+		return len(got) == want
+	})
+	return got
+}
+
+// TestAgyWorkspaceMismatchIsNoticedFromTheApproval: hap cannot ask an agent
+// where its work is — the agy process never leaves the directory it was
+// started in — so the "outside workspace" prompt is the only evidence, and it
+// must be read from the CLASSIFY path. Once the rule graduates hap answers
+// these itself and no escalation is ever raised, so noticing at escalate()
+// would go quiet exactly when the agent is busiest.
+func TestAgyWorkspaceMismatchIsNoticedFromTheApproval(t *testing.T) {
+	h := newHarness(t, "")
+	h.herdr.mu.Lock()
+	h.herdr.paneInfo = domain.PaneInfo{ForegroundCwd: "/workspaces/started-here"}
+	h.herdr.mu.Unlock()
+	h.herdr.setPane(agyOutsidePane)
+
+	got := warmPaneCwdAndPush(t, h, "agent-agy-ws", 1)
+	if len(got) != 1 {
+		t.Fatalf("mismatches = %+v, want exactly one", got)
+	}
+	if got[0].Root != "/workspaces/started-here" {
+		t.Errorf("root = %q, want where the agent was started", got[0].Root)
+	}
+	// The DIRECTORY, not the first file that happened to be read: the file
+	// changes every run and tells the operator nothing about where to relaunch.
+	if got[0].Elsewhere != "/workspaces/other-checkout" {
+		t.Errorf("elsewhere = %q, want the directory the work is in", got[0].Elsewhere)
+	}
+}
+
+// The control: the same pane on an agent working INSIDE its own root is not a
+// mismatch. Without this, a predicate that answered "yes" for everything would
+// pass the case above.
+func TestAgyWorkspaceInsideItsRootIsNotReported(t *testing.T) {
+	h := newHarness(t, "")
+	h.herdr.mu.Lock()
+	h.herdr.paneInfo = domain.PaneInfo{ForegroundCwd: "/workspaces/other-checkout"}
+	h.herdr.mu.Unlock()
+	h.herdr.setPane(agyOutsidePane)
+
+	// Wait for the cwd cache to WARM before concluding anything. paneCwd
+	// returns "" while cold, and an unknown root is not a mismatch by design —
+	// so without this the test would pass whether or not the root-containment
+	// logic works, and would be indistinguishable from the unknown-cwd case
+	// below. The containment rule is what stops /workspaces/repo-two reading
+	// as inside /workspaces/repo.
+	waitFor(t, 5*time.Second, func() bool {
+		h.pushAgy("agent-agy-inside", "done")
+		return h.daemon.paneCwd(context.Background(), "agent-agy-inside") != ""
+	})
+	if got := h.daemon.agyWorkspaceHealth(); len(got) != 0 {
+		t.Errorf("an agent working inside its own root is not a mismatch: %+v", got)
+	}
+}
+
+// An unread cwd must never render as a misconfiguration. paneCwd returns ""
+// for a pane it has not resolved (no inspector surface here), and reporting
+// that as "started somewhere else" would flag every agent on a herdr build
+// that cannot answer `pane get`.
+func TestAgyWorkspaceUnknownCwdIsNotAMismatch(t *testing.T) {
+	h := newHarnessWrapped(t, "", func(f *fakeHerdr) ports.HerdrPort {
+		return inspectorlessHerdr{f}
+	})
+	h.herdr.setPane(agyOutsidePane)
+
+	for i := 0; i < 3; i++ {
+		h.pushAgy("agent-agy-nocwd", "done")
+		time.Sleep(30 * time.Millisecond)
+	}
+	if got := h.daemon.agyWorkspaceHealth(); len(got) != 0 {
+		t.Errorf("an unread cwd is not evidence of a mismatch: %+v", got)
+	}
+}
+
+// A claude pane carrying the same words is not an agy workspace prompt: the
+// detection is agy-specific because the permission model is.
+func TestAgyWorkspaceIgnoresOtherAgentTypes(t *testing.T) {
+	h := newHarness(t, "")
+	h.herdr.mu.Lock()
+	h.herdr.paneInfo = domain.PaneInfo{ForegroundCwd: "/workspaces/started-here"}
+	h.herdr.mu.Unlock()
+	h.herdr.setPane(agyOutsidePane)
+
+	for i := 0; i < 3; i++ {
+		h.push("agent-claude-ws", "blocked")
+		time.Sleep(30 * time.Millisecond)
+	}
+	if got := h.daemon.agyWorkspaceHealth(); len(got) != 0 {
+		t.Errorf("only agy scopes permissions this way: %+v", got)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -664,6 +664,12 @@ type Daemon struct {
 	paneCwds          map[string]paneCwdEntry
 	paneCwdRefreshing map[string]bool
 
+	// agyOutsideWorkspace records agy agents seen asking permission for files
+	// outside the directory they were started in, keyed by agent id. In
+	// memory only: it is an advisory about how an agent was launched, so
+	// losing it on restart costs one re-observation and nothing else.
+	agyOutsideWorkspace map[string]agyWorkspaceNote
+
 	// Background lifecycle. bg tracks every goroutine and AfterFunc callback
 	// the daemon spawns via spawn/afterFunc; Run awaits it (shutdownBackground)
 	// before its deferred matcher/embedder Close — and before the caller closes
@@ -882,6 +888,7 @@ func New(opt Options) (*Daemon, error) {
 		snapshotSaved:             map[string]bool{},
 		paneCwds:                  map[string]paneCwdEntry{},
 		paneCwdRefreshing:         map[string]bool{},
+		agyOutsideWorkspace:       map[string]agyWorkspaceNote{},
 		embedder:                  opt.Embedder,
 		timers:                    map[*time.Timer]struct{}{},
 	}
@@ -1335,6 +1342,7 @@ func (d *Daemon) writeHealth(startedAt time.Time) {
 		BinaryReplaced: d.binaryReplaced.Load(),
 		FleetSync:      d.fleetHealth(),
 		Orchestrator:   d.orchestratorHealth(),
+		AgyWorkspace:   d.agyWorkspaceHealth(),
 	}
 	if err := daemonhealth.Write(d.opt.StateDir, h); err != nil {
 		slog.Debug("heartbeat write failed", "error", err)
@@ -2457,6 +2465,12 @@ func (d *Daemon) handleAttention(ctx context.Context, tr domain.AgentTransition)
 	if situation.AgentType == "" {
 		situation.AgentType = "unknown"
 	}
+
+	// Noted from the capture that is already in hand, and from the CLASSIFY
+	// path rather than escalate(): the prompt this reads is one hap answers by
+	// itself once the rule graduates, so by the time it matters most it never
+	// reaches an escalation at all.
+	d.noteAgyWorkspace(ctx, situation, agentName, pane)
 
 	// Multi-tab MCQ forms show one question at a time: sweep the remaining
 	// tabs (Right-arrow protocol) so the signature, the escalation, and the

--- a/internal/daemon/parkedstate_test.go
+++ b/internal/daemon/parkedstate_test.go
@@ -1,0 +1,83 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/0xGosu/herdr-auto-pilot/internal/domain"
+)
+
+// agy reports a parked agent as "done" where claude reports "idle", and the
+// original write-up claimed hap therefore misses a parked agy agent. Reading
+// the code says otherwise: every gate below already accepts both spellings.
+//
+// What was missing is a test that says so. Each of these predicates is a
+// separate hand-written switch, so "done" can be dropped from any ONE of them
+// without failing anything else — and the failure that produces is silent, an
+// agy agent that is simply never considered parked by that one path.
+//
+// These are driven DIRECTLY rather than through the pipeline on purpose:
+// end-to-end coverage of one path proves nothing about the other three.
+
+func TestParkedStatesAcceptDoneAsWellAsIdle(t *testing.T) {
+	// The auto-accept pass also treats a blocked agent as parked (a standing
+	// modal is exactly what it exists to answer); the other two do not.
+	cases := []struct {
+		status                            string
+		autoSend, sessionRename, autoAcpt bool
+	}{
+		{"idle", true, true, true},
+		{"done", true, true, true},
+		{"blocked", false, false, true},
+		{"working", false, false, false},
+		{"", false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run("status="+tc.status, func(t *testing.T) {
+			if got := autoSendParked(tc.status); got != tc.autoSend {
+				t.Errorf("autoSendParked(%q) = %v, want %v", tc.status, got, tc.autoSend)
+			}
+			if got := sessionRenameParked(tc.status); got != tc.sessionRename {
+				t.Errorf("sessionRenameParked(%q) = %v, want %v", tc.status, got, tc.sessionRename)
+			}
+			if got := autoAcceptParked(tc.status); got != tc.autoAcpt {
+				t.Errorf("autoAcceptParked(%q) = %v, want %v", tc.status, got, tc.autoAcpt)
+			}
+		})
+	}
+}
+
+// sessionRenameParked is the one that folds case and spacing, because it reads
+// a status that has been round-tripped through the roster rather than taken
+// straight off a transition.
+func TestSessionRenameParkedFoldsCaseAndSpace(t *testing.T) {
+	for _, s := range []string{"Done", " done ", "DONE", "Idle"} {
+		if !sessionRenameParked(s) {
+			t.Errorf("sessionRenameParked(%q) = false, want true", s)
+		}
+	}
+}
+
+// domain.AgentBusy is the inverse gate — every hand-out path asks it before
+// typing — so "done" must read as NOT busy for the same reason.
+func TestAgentBusyTreatsDoneAsParked(t *testing.T) {
+	cases := []struct {
+		status string
+		busy   bool
+	}{
+		{"idle", false},
+		{"done", false},
+		{"working", true},
+		{"blocked", true},
+		// An unreported status is not evidence of work; the roster records it
+		// for a pane herdr has not described yet.
+		{"", false},
+		// Guarded deliberately: "detected" is a real roster status and IS
+		// busy, which is what stops a hand-out landing in a starting agent.
+		{"detected", true},
+	}
+	for _, tc := range cases {
+		if got := domain.AgentBusy(tc.status); got != tc.busy {
+			t.Errorf("AgentBusy(%q) = %v, want %v", tc.status, got, tc.busy)
+		}
+	}
+}

--- a/internal/daemonhealth/health.go
+++ b/internal/daemonhealth/health.go
@@ -78,6 +78,47 @@ type Health struct {
 	// operator should answer. Absent when the feature is off or all is well
 	// (and on older daemons) — its failures otherwise live only in the log.
 	Orchestrator *OrchestratorHealth `json:"orchestrator,omitempty"`
+	// AgyWorkspace lists agy agents observed asking permission for files
+	// outside the directory they were started in. Absent when there are none
+	// (and on older daemons).
+	AgyWorkspace []AgyWorkspaceMismatch `json:"agy_workspace,omitempty"`
+}
+
+// AgyWorkspaceMismatch records one agy agent working outside its own
+// workspace root.
+//
+// agy scopes permissions to the directory it was STARTED in and raises an
+// approval per file outside it, so an agent started in one checkout and told
+// to work in another pays a round trip per file read. hap answers those
+// prompts once the rule graduates — the path is masked out of the salient, so
+// every such prompt shares one signature — but the approvals keep coming, and
+// nothing else tells the operator that restarting the agent in the right
+// directory would remove them altogether.
+type AgyWorkspaceMismatch struct {
+	AgentID string `json:"agent_id"`
+	// Name is the agent's short name when it has one, for a line an operator
+	// can act on without translating a pane id.
+	Name string `json:"name,omitempty"`
+	// Root is where the agent was started; Elsewhere is where its work
+	// actually is, reduced to a directory rather than the first file seen.
+	Root      string    `json:"root"`
+	Elsewhere string    `json:"elsewhere"`
+	SeenAt    time.Time `json:"seen_at,omitempty"`
+}
+
+// Line renders one mismatch as the status page's advisory: the consequence and
+// the remedy, not the observation. Empty for a zero value.
+func (m AgyWorkspaceMismatch) Line() string {
+	if m.Root == "" || m.Elsewhere == "" {
+		return ""
+	}
+	who := m.Name
+	if who == "" {
+		who = m.AgentID
+	}
+	return who + " was started in " + m.Root + " but is working in " + m.Elsewhere +
+		" — agy asks permission for every file outside its start directory;" +
+		" restart it in " + m.Elsewhere + " to stop the prompts"
 }
 
 // OrchestratorHealth is the heartbeat's copy of the orchestrator's state.

--- a/internal/domain/agyworkspace.go
+++ b/internal/domain/agyworkspace.go
@@ -1,0 +1,97 @@
+package domain
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// agyOutsideWorkspaceReason is the Reason text agy prints when a file lies
+// outside the directory it was started in. Matched case-insensitively on a
+// prefix: the reason line is agy's own wording and other reasons exist
+// ("outside workspace and not under /tmp" was seen), so an exact compare
+// would silently stop matching on a wording change.
+const agyOutsideWorkspaceReason = "outside workspace"
+
+// AgyOutsideWorkspacePath reports the file an agy approval is asking about
+// when the reason it is asking is that the file lies outside its workspace.
+//
+// agy scopes permissions to the directory it was STARTED in, so an agent
+// pointed at work elsewhere raises one of these per file it touches. The path
+// is the evidence of where the work actually is, which is the half hap cannot
+// otherwise know: the agent's own cwd never moves.
+//
+// Returns false for every other approval, including a file prompt with a
+// different reason — the caller must not read "some approval" as this one.
+func AgyOutsideWorkspacePath(pane string) (string, bool) {
+	form, ok := ParseAgyApproval(pane)
+	if !ok {
+		return "", false
+	}
+	if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(form.Reason)),
+		agyOutsideWorkspaceReason) {
+		return "", false
+	}
+	// Target is "<Op>: <path>" ("Read: /etc/hostname"); the create prompt
+	// shows a diff instead and carries none.
+	_, path, found := strings.Cut(form.Target, ":")
+	if !found {
+		return "", false
+	}
+	path = strings.TrimSpace(path)
+	if !strings.HasPrefix(path, "/") {
+		// Only an absolute path can be compared against a workspace root.
+		return "", false
+	}
+	return path, true
+}
+
+// AgyWorkspaceMismatch reports that path lies outside root, i.e. that this
+// agent is doing its work somewhere other than where it was started.
+//
+// Both blanks answer FALSE, and that is the whole safety of this: root is
+// read from a CACHE that is empty for a cold pane (daemon.paneCwd), so
+// "we have not read it yet" must never render as "this agent is misconfigured".
+// Unknown is not evidence.
+//
+// herdr renders a deleted directory as "/path (deleted)", so that suffix is
+// stripped before comparing — otherwise every agent whose directory was
+// removed would read as a mismatch against itself.
+func AgyWorkspaceMismatch(root, path string) bool {
+	root = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(root), "(deleted)"))
+	path = strings.TrimSpace(path)
+	if root == "" || path == "" || !strings.HasPrefix(root, "/") {
+		return false
+	}
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	if root == "/" {
+		// An agent started at the filesystem root contains everything; there
+		// is no mismatch to report and saying so would be noise on every file.
+		return false
+	}
+	if path == root {
+		return false
+	}
+	// Compare on a SEPARATOR boundary: a plain prefix test makes /work/one
+	// contain /work/one-other, which is a different directory entirely.
+	return !strings.HasPrefix(path, root+string(filepath.Separator))
+}
+
+// AgyWorkspaceRootOf reduces a mismatching path to the root worth REPORTING —
+// the first two segments ("/workspaces/worktree-agent-no23"), which is the
+// shape of the directory an operator would have started the agent in.
+//
+// Reporting the whole file path would name whichever file happened to be read
+// first, which changes on every run and tells the operator nothing about where
+// to restart the agent. A shorter path is returned as-is.
+func AgyWorkspaceRootOf(path string) string {
+	path = filepath.Clean(strings.TrimSpace(path))
+	if !strings.HasPrefix(path, "/") {
+		return path
+	}
+	parts := strings.Split(strings.TrimPrefix(path, "/"), string(filepath.Separator))
+	if len(parts) <= 2 {
+		return path
+	}
+	return "/" + filepath.Join(parts[0], parts[1])
+}

--- a/internal/domain/agyworkspace_test.go
+++ b/internal/domain/agyworkspace_test.go
@@ -1,0 +1,87 @@
+package domain
+
+import "testing"
+
+// The agy "outside workspace" approval is the only evidence hap has of where an
+// agent's work actually is: the agent's own cwd never moves off the directory
+// it was started in, so a mismatch is invisible without reading the prompt.
+
+func TestAgyOutsideWorkspacePath(t *testing.T) {
+	access := "File access\n────────────────\nRead: /workspaces/other/main.go\n" +
+		"Reason: outside workspace\n\nAllow access to this file?\n" +
+		"> 1. Yes, allow access\n  2. No, deny access\n\n  ↑/↓ Navigate\n"
+	// Same form, a reason that is NOT about the workspace.
+	otherReason := "File access\n────────────────\nRead: /workspaces/other/main.go\n" +
+		"Reason: protected path\n\nAllow access to this file?\n" +
+		"> 1. Yes, allow access\n  2. No, deny access\n\n  ↑/↓ Navigate\n"
+	// A shell approval carries no file target at all.
+	shell := "Run this command?\n> 1. Yes, run command\n  2. No, cancel\n\n  ↑/↓ Navigate\n"
+
+	cases := []struct {
+		name     string
+		pane     string
+		wantPath string
+		wantOK   bool
+	}{
+		{"an outside-workspace read", access, "/workspaces/other/main.go", true},
+		{"a different reason is not this signal", otherReason, "", false},
+		{"a shell approval has no path", shell, "", false},
+		{"an empty pane", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := AgyOutsideWorkspacePath(tc.pane)
+			if ok != tc.wantOK || got != tc.wantPath {
+				t.Errorf("AgyOutsideWorkspacePath = (%q, %v), want (%q, %v)",
+					got, ok, tc.wantPath, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestAgyWorkspaceMismatch(t *testing.T) {
+	cases := []struct {
+		name string
+		root string
+		path string
+		want bool
+	}{
+		{"work outside the root", "/workspaces/repo", "/workspaces/other/main.go", true},
+		{"work inside the root", "/workspaces/repo", "/workspaces/repo/internal/x.go", false},
+		{"the root itself", "/workspaces/repo", "/workspaces/repo", false},
+		// A plain prefix test would call this a match: /workspaces/repo-two is
+		// a different directory that merely starts with the same bytes.
+		{"a sibling sharing a prefix is outside", "/workspaces/repo", "/workspaces/repo-two/x.go", true},
+		// Unknown is never evidence: paneCwd returns "" for a cold pane, and
+		// rendering that as a misconfiguration would flag every fresh agent.
+		{"an unread root is not a mismatch", "", "/workspaces/other/x.go", false},
+		{"no path is not a mismatch", "/workspaces/repo", "", false},
+		// herdr renders a removed directory with this suffix; without
+		// stripping it, such an agent mismatches against itself.
+		{"a deleted root still compares", "/workspaces/repo (deleted)", "/workspaces/repo/x.go", false},
+		{"an agent started at / contains everything", "/", "/anywhere/x.go", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AgyWorkspaceMismatch(tc.root, tc.path); got != tc.want {
+				t.Errorf("AgyWorkspaceMismatch(%q, %q) = %v, want %v",
+					tc.root, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// The reported directory must be stable across runs: naming whichever file was
+// read first tells the operator nothing about where to restart the agent.
+func TestAgyWorkspaceRootOf(t *testing.T) {
+	cases := []struct{ path, want string }{
+		{"/workspaces/worktree-agent-no23/internal/daemon/x.go", "/workspaces/worktree-agent-no23"},
+		{"/workspaces/other", "/workspaces/other"},
+		{"/tmp/x.go", "/tmp/x.go"},
+	}
+	for _, tc := range cases {
+		if got := AgyWorkspaceRootOf(tc.path); got != tc.want {
+			t.Errorf("AgyWorkspaceRootOf(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}

--- a/internal/frontend/daemonhealth.go
+++ b/internal/frontend/daemonhealth.go
@@ -116,6 +116,14 @@ type DaemonHealth struct {
 	// page's full rendering (retry timing included).
 	OrchestratorError string
 	OrchestratorLine  string
+	// AgyWorkspaceLines names agy agents working outside the directory they
+	// were started in, one advisory line each. A WARNING at most: the herd is
+	// served correctly either way, and hap answers the resulting prompts
+	// itself once the rule graduates. What it buys the operator is knowing
+	// that RELAUNCHING the agent removes those prompts at the source — which
+	// neither this page nor `hap agents` says, though the cwd column has
+	// carried the raw fact all along.
+	AgyWorkspaceLines []string
 	// Reason explains a gave-up / auto-disabled latch.
 	Reason string
 	// StderrLog is the captured daemon stderr path (for hung/crashed post-mortem).
@@ -167,6 +175,11 @@ func (a *App) AssessDaemonHealth() DaemonHealth {
 				h.OrchestratorWaiting = o.Waiting
 				h.OrchestratorError = o.LastError
 				h.OrchestratorLine = o.Line(now)
+			}
+			for _, m := range rec.AgyWorkspace {
+				if line := m.Line(); line != "" {
+					h.AgyWorkspaceLines = append(h.AgyWorkspaceLines, line)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Findings 7 and 8 of the agy write-up. Both turned out to be narrower than written, and the corrections are the most useful part of this PR.

## Finding 7 was already wrong, and the doc says so

It claimed hap misses a parked agy agent because agy reports `done` where claude reports `idle`. `autoSendParked`, `sessionRenameParked`, `autoAcceptParked` and `domain.AgentBusy` **all already accept both**, re-verified against current main.

What was missing is a test. Each is a separate hand-written switch, so `done` can be dropped from any ONE of them without failing anything else, and the result is silent: an agy agent that one path simply never considers parked. Now driven directly — end-to-end coverage of one path proves nothing about the other three.

## Finding 8: the throughput claim does not survive reading the code

The finding calls the per-file `outside workspace` approvals "the single biggest drag on throughput". Before building anything I checked whether hap can already answer them, and **it can**:

```
permission:access file (Read: <path>; outside workspace) | options:no, deny access;yes, allow access;…
```

The path is masked to `<path>`, so classifying the fixture with two different paths yields the **identical signature** (`approval:96de7e86621d573be230eb63`). Every one of these prompts shares a single rule and graduates normally, after which hap answers them silently. There is no defect underneath the finding, and the round trips stop being operator-visible on their own.

What remains is real but smaller: nothing tells the operator that **relaunching the agent in the right directory removes the prompts at the source**.

## What this adds

hap is well placed to notice, because the agy process never leaves the directory it was started in — so the agent's own cwd *is* the workspace root, and the approval's target path is the only evidence of where the work actually is. Comparing the two is the whole detection.

Surfaced in `hap status`:

```
  agy workspace: quick-lemur was started in /workspaces/main-checkout but is working in
                 /workspaces/worktree-agent-no23 — agy asks permission for every file
                 outside its start directory; restart it in … to stop the prompts
```

Plus the shipped skill note, since starting the agent in the right place is the actual fix.

**Noticed from the CLASSIFY path, not `escalate()`** — that is the load-bearing choice. Because the rule graduates, these approvals are auto-answered and never reach an escalation, so a hook there would go quiet exactly when the agent is busiest.

**`hap status`, not a 9th `hap agents` column** — a choice, not a constraint (the skill says columns are appended). This is an advisory, and the `cwd` column has carried the raw fact all along; what was missing is the interpretation and the remedy.

## Bounds, including one honest limitation

- **An unread cwd is never a mismatch.** `paneCwd` is a cache that never shells out on the main loop and returns `""` while cold; `""` means *unknown*. A fresh agent must never be reported as misconfigured.
- **Keyed on the terminal id, not the agent alone** — herdr recycles pane ids, so otherwise a new tenant inherits the previous agent's warning.
- **Limitation:** `workspaceCacheTTL` is 5s, so a *lone* approval more than 5s after the last `pane get` is missed and picked up on a later one. The complaint is a *stream* of per-file approvals, so the cache warms on the first and the rest are caught — and missing is the safe direction.

## Tests

Domain table (containment, including `/workspaces/repo` vs `/workspaces/repo-two`, deleted-dir suffix, unknown inputs); daemon detection with three controls (inside-root, unknown-cwd, non-agy); the parked-state predicates; and a `hap status` render test with a negative control. The inside-root control **waits for the cwd cache to warm before concluding** — otherwise it would pass on an empty cwd and be indistinguishable from the unknown-cwd case.

## Gate

`go build`, `gofmt`, `go vet` clean. `golangci-lint` (pinned `GOTOOLCHAIN=go1.26.2`, `--timeout 20m`) **0 issues**. `internal/daemon` and `internal/cli` both pass in full. The known load-dependent daemon flake and the deterministic `internal/store/turso` schema-lease failure are pre-existing — both were reproduced on untouched `origin/main` earlier today, and this diff touches neither package.
