### PR TITLE
#1 chore: bump plugin version to 0.9.35 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.35
+
+- `hap status` now says when an agy agent is working outside the directory it was started in, and names the directory to relaunch it in — agy asks approval for every file outside its start directory, so a misplaced agent turns each file read into a round trip.
+- Added the shipped skill note that an agy agent must be started in the directory it will work in.
+
 ## 0.9.34
 
 - Strengthened the stale-consult tests so the dismiss-versus-escalate split cannot regress unnoticed: the "situation changed" case now proves its two panes really are different situations before asserting on the outcome.

--- a/changelog.d/feat-agy-workspace-mismatch.md
+++ b/changelog.d/feat-agy-workspace-mismatch.md
@@ -1,2 +1,0 @@
-- `hap status` now says when an agy agent is working outside the directory it was started in, and names the directory to relaunch it in — agy asks approval for every file outside its start directory, so a misplaced agent turns each file read into a round trip.
-- Added the shipped skill note that an agy agent must be started in the directory it will work in.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.34"
+version = "0.9.35"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.35 is being released from this commit by the Auto Release workflow.