### PR TITLE
#0 fix: read an agy agent's mode and composer through its background-task strip

### DIFF
--- a/changelog.d/fix-agy-background-task-footer.md
+++ b/changelog.d/fix-agy-background-task-footer.md
@@ -1,0 +1,2 @@
+- Fixed `hap mode` failing to read or set an agy agent's permission mode while it had background work running: agy paints a task strip above its footer and adds a `N task(s)` suffix to the status bar, and neither was recognised — which put `acceptEdits` out of reach for exactly the agents that run background tasks.
+- The unreadable-mode error now says what was actually seen instead of asserting that an approval or form is up.

--- a/internal/classify/agy_test.go
+++ b/internal/classify/agy_test.go
@@ -67,14 +67,17 @@ var agyFixtures = map[string]agyCase{
 	"approval_agy_shell_wrapped.txt": {typ: domain.SituationApproval, verb: agyRunRM, options: agyRMOptions},
 	"approval_agy_trust_folder.txt": {typ: domain.SituationApproval, verb: domain.PermissionVerbAgyTrust,
 		options: []string{"Yes, I trust this folder", "No, exit"}},
-	"choice_agy_mcq.txt":             {typ: domain.SituationChoice, options: []string{"Apple", "Banana", "Cherry"}},
-	"choice_agy_mcq_two.txt":         {typ: domain.SituationChoice, options: []string{"Red", "Green", "Blue"}},
-	"choice_agy_mcq_two_recent.txt":  {typ: domain.SituationChoice, options: []string{"Red", "Green", "Blue"}},
-	"choice_agy_mcq_two_q2.txt":      {typ: domain.SituationChoice, options: []string{"Cat", "Dog"}},
-	"error_agy_interrupted.txt":      {typ: domain.SituationError, errSum: domain.AgyErrorInterrupted},
-	"error_agy_offline.txt":          {typ: domain.SituationError, errSum: domain.AgyErrorEligibilityCheck},
-	"error_agy_model_warning.txt":    {typ: domain.SituationIdle}, // a warning: the agent is usable
-	"idle_agy_after_turn.txt":        {typ: domain.SituationIdle},
+	"choice_agy_mcq.txt":            {typ: domain.SituationChoice, options: []string{"Apple", "Banana", "Cherry"}},
+	"choice_agy_mcq_two.txt":        {typ: domain.SituationChoice, options: []string{"Red", "Green", "Blue"}},
+	"choice_agy_mcq_two_recent.txt": {typ: domain.SituationChoice, options: []string{"Red", "Green", "Blue"}},
+	"choice_agy_mcq_two_q2.txt":     {typ: domain.SituationChoice, options: []string{"Cat", "Dog"}},
+	"error_agy_interrupted.txt":     {typ: domain.SituationError, errSum: domain.AgyErrorInterrupted},
+	"error_agy_offline.txt":         {typ: domain.SituationError, errSum: domain.AgyErrorEligibilityCheck},
+	"error_agy_model_warning.txt":   {typ: domain.SituationIdle}, // a warning: the agent is usable
+	"idle_agy_after_turn.txt":       {typ: domain.SituationIdle},
+	// Same parked composer, with agy's background-task strip between it and
+	// the status bar: still idle, because nothing is covering the composer.
+	"idle_agy_background_task.txt":   {typ: domain.SituationIdle},
 	"idle_agy_composer_draft.txt":    {typ: domain.SituationIdle},
 	"idle_agy_declined.txt":          {typ: domain.SituationIdle},
 	"idle_agy_fresh.txt":             {typ: domain.SituationIdle},

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -47,6 +47,7 @@ func TestGoldenTranscripts(t *testing.T) {
 		"error_agy_model_warning.txt":      "idle",
 		"error_agy_offline.txt":            "idle",
 		"idle_agy_after_turn.txt":          "done",
+		"idle_agy_background_task.txt":     "done",
 		"idle_agy_composer_draft.txt":      "done",
 		"idle_agy_declined.txt":            "done",
 		"idle_agy_effort_picker.txt":       "idle",

--- a/internal/classify/testdata/classifications.golden
+++ b/internal/classify/testdata/classifications.golden
@@ -39,6 +39,7 @@ error_codex_interrupted.txt status=blocked type=error verb= options=0
 error_codex_rate_limit.txt status=idle type=error verb= options=3
 error_codex_usage_limit.txt status=idle type=error verb= options=0
 idle_agy_after_turn.txt status=done type=idle verb= options=0
+idle_agy_background_task.txt status=done type=idle verb= options=0
 idle_agy_composer_draft.txt status=done type=idle verb= options=0
 idle_agy_declined.txt status=done type=idle verb= options=0
 idle_agy_effort_picker.txt status=idle type=unclassifiable verb= options=0

--- a/internal/classify/testdata/transcripts/idle_agy_background_task.txt
+++ b/internal/classify/testdata/transcripts/idle_agy_background_task.txt
@@ -1,0 +1,17 @@
+     ▀▀▀▀▀▀       operator@example.com (Google AI Pro)
+    ▀▀▀▀▀▀▀▀      Gemini 3.6 Flash (Low)
+   ▄▀▀    ▀▀▄     /tmp/agyscratch.H2CE
+  ▄▀▀      ▀▀▄
+
+────────────────────────────────────────────────────────────
+> Use your shell tool to run exactly this command: ls -la /tmp/agyscratch.H2CE . Then reply with one line.
+
+● Bash(ls -la /tmp/agyscratch.H2CE) (ctrl+o to expand)
+
+  The directory /tmp/agyscratch.H2CE is empty, containing only the standard . and .. directory references.
+
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+>
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  ● [03:57:33] go build -tags "vectors cpu" ./... running
+? for shortcuts                                                                                                                               Gemini 3.8 Flash · high · 1 task(s) · /tasks

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -290,8 +290,13 @@ func modeReadError(r frontend.ModeReport, target string, err error) error {
 		return fmt.Errorf("%s is a %q agent, which has no shift+tab mode toggle (claude, codex and agy do)",
 			r.Label(target), r.AgentType)
 	case errors.Is(err, frontend.ErrModeUnreadable):
-		return fmt.Errorf("could not read %s's mode: its pane is not showing the composer footer "+
-			"(an approval or form is probably up — answer it, then retry)", r.Label(target))
+		// Say what was SEEN, not what is presumed. This message used to assert
+		// that an approval or form was up; it was reported firing on a pane
+		// plainly showing its composer, which sends the operator looking for a
+		// modal that is not there.
+		return fmt.Errorf("could not read %s's mode: no composer footer this build recognises at the "+
+			"bottom of its pane — a form or approval may be covering it, or the footer may carry "+
+			"something new (run `hap capture %s` to see the pane)", r.Label(target), target)
 	case errors.Is(err, frontend.ErrModeUnsafe):
 		return fmt.Errorf("%s is not at its composer, so shift+tab would answer whatever is on screen "+
 			"instead of changing the mode — refusing to send it", r.Label(target))

--- a/internal/domain/agentmode.go
+++ b/internal/domain/agentmode.go
@@ -350,7 +350,8 @@ func codexFooterLine(pane string) (string, bool) {
 // as whatever its cycle shows — "default" at launch. Callers MUST gate this on
 // the agent type being agy.
 func AgyAgentMode(pane string) (AgentMode, bool) {
-	lines := trimTrailingBlank(strings.Split(strings.ReplaceAll(pane, "\r", ""), "\n"))
+	lines := agyDropBackgroundStrip(
+		trimTrailingBlank(strings.Split(strings.ReplaceAll(pane, "\r", ""), "\n")))
 	n := len(lines)
 	if n < 2 || !agyRuleLineRE.MatchString(strings.TrimSpace(lines[n-2])) {
 		return AgentModeUnknown, false

--- a/internal/domain/agentmode_test.go
+++ b/internal/domain/agentmode_test.go
@@ -379,8 +379,12 @@ func TestAgyAgentModeOverEveryRecordedScreen(t *testing.T) {
 		mode  AgentMode
 		ready bool
 	}{
-		"idle_agy_fresh":             {AgentModeDefault, true},
-		"idle_agy_after_turn":        {AgentModeDefault, true},
+		"idle_agy_fresh":      {AgentModeDefault, true},
+		"idle_agy_after_turn": {AgentModeDefault, true},
+		// The same parked composer with a background task running. Both must
+		// hold THROUGH the task strip agy paints above the footer: the mode is
+		// readable, and the composer is safe to press into.
+		"idle_agy_background_task":   {AgentModeDefault, true},
 		"idle_agy_declined":          {AgentModeDefault, true},
 		"idle_agy_mode_accept_edits": {AgentModeAcceptEdits, true},
 		"idle_agy_mode_plan":         {AgentModePlan, true},

--- a/internal/domain/agy.go
+++ b/internal/domain/agy.go
@@ -62,12 +62,31 @@ var (
 	// agyRuleLineRE matches the full-width rules agy draws around its composer
 	// and between turns.
 	agyRuleLineRE = regexp.MustCompile(`^[─━]{8,}$`)
+
+	// agyBackgroundTaskRE matches one row of agy's background-task strip, which
+	// it paints BETWEEN the composer and the status bar while work is running:
+	//
+	//	  ● [03:57:33] go build -tags "vectors cpu" ./... running
+	//
+	// Anchored on the bullet AND a clock-shaped timestamp on purpose. agy also
+	// prints "● Bash(…)" rows in the ordinary transcript, and the composer
+	// checks below decide whether hap may TYPE into the pane — so a loose
+	// "skip a line above the footer" rule would let a modal's last row be
+	// skipped and turn a standing prompt into a ready composer.
+	agyBackgroundTaskRE = regexp.MustCompile(`^\s*●\s+\[\d{1,2}:\d{2}:\d{2}\]\s`)
 	// agyModelSegmentRE matches the right-aligned half of agy's status bar:
 	// "[accept-edits · |plan · ]<model>[ · <effort>]", e.g.
 	// "plan · Gemini 3.6 Flash · low" or "Claude Sonnet 4.6 (Thinking)".
 	// It must END on a word character or ")", never on the period a sentence
 	// ends with: a right-indented "Done." as the last line is prose.
-	agyModelSegmentRE = regexp.MustCompile(`^(?:(?:accept-edits|plan) · )?[A-Za-z](?:[\w.() -]*[\w)])?(?: · (?:low|medium|high))?$`)
+	// The trailing "· N task(s) · /tasks" is agy's BACKGROUND-TASK suffix: it
+	// appears in the status bar whenever the agent has work running, which for
+	// an agent worth automating is most of the time. Without it the whole
+	// footer fails to parse, so the mode reads UNKNOWN and `hap mode` refuses
+	// -- putting acceptEdits out of reach for exactly those agents. The count
+	// and the "/tasks" hint are matched separately because only the count was
+	// observed varying.
+	agyModelSegmentRE = regexp.MustCompile(`^(?:(?:accept-edits|plan) · )?[A-Za-z](?:[\w.() -]*[\w)])?(?: · (?:low|medium|high))?(?: · \d+ task\(s\))?(?: · /tasks)?$`)
 	// agyStatusPadRE is the terminal-width padding run that separates the status
 	// bar's left token from its right-aligned model segment.
 	agyStatusPadRE = regexp.MustCompile(`\s{10,}`)
@@ -113,6 +132,51 @@ func agyStatusBar(line string) (segment string, ok bool) {
 // agyBody returns the capture's lines with trailing blank lines and agy's
 // status bar removed — what is left ends with the live form's key-hint line
 // when a form stands.
+// agyDropBackgroundStrip removes agy's background-task rows from directly above
+// the status bar, so the composer sits where the footer-anchored checks expect
+// it again.
+//
+// Everything that reads agy's footer counts lines UP from the bottom (status
+// bar, rule, caret, rule). A running background task inserts a row into that
+// run, so the mode reads UNKNOWN and the composer never proves ready — which
+// is how `hap mode` came to refuse on a pane plainly showing its composer, and
+// left acceptEdits unreachable for any agent doing background work.
+//
+// Deliberately narrow: it requires the bottom line to already BE a recognised
+// status bar, and removes only rows matching agyBackgroundTaskRE from the
+// window just above it. Anything it cannot positively identify is kept.
+//
+// It filters the WINDOW rather than walking the unbroken run directly above the
+// footer, because the strip's position relative to the composer's lower rule is
+// not settled: the report that produced this shows the caret, the strip and the
+// status bar with the rules elided, so the strip may sit either side of that
+// rule, and a run-walk anchored on the footer handles only one of the two. A
+// count above one is expected too — the status bar itself says "N task(s)".
+//
+// Dropping a row can only ever bring a genuine rule/caret/rule sandwich into
+// alignment: a modal's rows are not strip-shaped, so no prompt can be collapsed
+// into a "ready" composer this way.
+func agyDropBackgroundStrip(lines []string) []string {
+	n := len(lines)
+	if n < 2 || !agyStatusBarLine(lines[n-1]) {
+		return lines
+	}
+	// The composer sandwich is three rows; the window leaves room for it plus
+	// several task rows, and bounds how far a match can reach into the
+	// transcript body.
+	const window = 8
+	start := max(0, n-1-window)
+	out := make([]string, 0, n)
+	out = append(out, lines[:start]...)
+	for _, line := range lines[start : n-1] {
+		if agyBackgroundTaskRE.MatchString(line) {
+			continue
+		}
+		out = append(out, line)
+	}
+	return append(out, lines[n-1])
+}
+
 func agyBody(pane string) []string {
 	lines := strings.Split(strings.ReplaceAll(pane, "\r", ""), "\n")
 	lines = trimTrailingBlank(lines)

--- a/internal/domain/agyanswer.go
+++ b/internal/domain/agyanswer.go
@@ -174,7 +174,8 @@ var agyModePlaceholderRE = regexp.MustCompile(`^>\s*(?:Plan|Accept-edits) mode: 
 //
 // Absence of any piece is "not ready", never "unknown so go ahead".
 func AgyComposerReady(pane string) bool {
-	lines := trimTrailingBlank(strings.Split(strings.ReplaceAll(pane, "\r", ""), "\n"))
+	lines := agyDropBackgroundStrip(
+		trimTrailingBlank(strings.Split(strings.ReplaceAll(pane, "\r", ""), "\n")))
 	n := len(lines)
 	if n < 4 {
 		return false

--- a/internal/domain/agybackgroundtask_test.go
+++ b/internal/domain/agybackgroundtask_test.go
@@ -1,0 +1,174 @@
+package domain
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// agy paints a background-task strip between the composer and the status bar
+// whenever it has work running — which, for an agent worth automating, is most
+// of the time. Everything that reads agy's footer counts lines UP from the
+// bottom, so that one row made the mode unreadable and the composer unprovable:
+// `hap mode` refused on a pane plainly showing its composer, and blamed a modal
+// that was not there. acceptEdits — the documented cure for agy's edit-approval
+// stalls — was therefore unreachable for exactly the agents that need it.
+//
+// Two independent causes, fixed together and tested apart below: the status
+// bar's own "· N task(s) · /tasks" suffix failed to parse, AND the strip broke
+// the line offsets.
+
+func agyFixture(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("..", "classify", "testdata", "transcripts", name+".txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// Cause 1: the model segment carries agy's background-task suffix.
+func TestAgyStatusBarAcceptsTheBackgroundTaskSuffix(t *testing.T) {
+	cases := []struct {
+		line string
+		want bool
+	}{
+		{"? for shortcuts                    Gemini 3.6 Flash · low", true},
+		{"? for shortcuts                    Gemini 3.8 Flash · high · 1 task(s) · /tasks", true},
+		{"? for shortcuts                    Gemini 3.8 Flash · 2 task(s)", true},
+		{"? for shortcuts                    accept-edits · Gemini 3.8 Flash · high · 1 task(s) · /tasks", true},
+		// Still not a status bar: the right-hand side must look like agy's
+		// model segment, or any wrapped prose line at the bottom would pass.
+		{"? for shortcuts                    · · ·", false},
+		{"Accept this file edit?", false},
+	}
+	for _, tc := range cases {
+		if _, ok := agyStatusBar(tc.line); ok != tc.want {
+			t.Errorf("agyStatusBar(%q) = %v, want %v", tc.line, ok, tc.want)
+		}
+	}
+}
+
+// Cause 2: the strip displaces the footer-anchored rows.
+func TestAgyReadsModeAndComposerThroughTheBackgroundTaskStrip(t *testing.T) {
+	withStrip := agyFixture(t, "idle_agy_background_task")
+	plain := agyFixture(t, "idle_agy_after_turn")
+
+	// The control: the same screen WITHOUT the strip already worked, so a
+	// regression here would mean the fix broke the ordinary case.
+	if mode, ok := AgyAgentMode(plain); !ok || mode != AgentModeDefault {
+		t.Fatalf("control: AgyAgentMode = %v/%v, want default/true", mode, ok)
+	}
+	if !AgyComposerReady(plain) {
+		t.Fatal("control: a parked agy composer must read ready")
+	}
+
+	if mode, ok := AgyAgentMode(withStrip); !ok || mode != AgentModeDefault {
+		t.Errorf("AgyAgentMode through the strip = %v/%v, want default/true", mode, ok)
+	}
+	if !AgyComposerReady(withStrip) {
+		t.Error("a running background task does not stop the composer being ready")
+	}
+}
+
+// The widening must be positively identified, never "skip a line above the
+// footer". AgyComposerReady gates every send path, so a rule loose enough to
+// skip a modal's last row would let hap type into a standing prompt — the exact
+// failure the gate exists to prevent.
+func TestAgyBackgroundStripIsMatchedStrictlyNotLoosely(t *testing.T) {
+	footer := "? for shortcuts                    Gemini 3.8 Flash · high · 1 task(s) · /tasks"
+	cases := []struct {
+		name    string
+		above   string
+		dropped bool
+	}{
+		{"a real strip row", `  ● [03:57:33] go build ./... running`, true},
+		// agy prints these in the ordinary transcript; they carry no clock and
+		// must never be skipped.
+		{"an ordinary bullet row", `● Bash(ls -la /tmp) (ctrl+o to expand)`, false},
+		{"a modal's last option", `  2. No, reject this change`, false},
+		{"a bare bullet", `● something happened`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lines := []string{"body", tc.above, footer}
+			got := agyDropBackgroundStrip(lines)
+			if dropped := len(got) != len(lines); dropped != tc.dropped {
+				t.Errorf("agyDropBackgroundStrip kept %d of %d lines (dropped=%v), want dropped=%v",
+					len(got), len(lines), dropped, tc.dropped)
+			}
+			// The status bar must survive as the last line either way, or
+			// every footer-anchored check breaks in a new way.
+			if got[len(got)-1] != footer {
+				t.Errorf("last line = %q, want the status bar", got[len(got)-1])
+			}
+		})
+	}
+}
+
+// Without a recognisable status bar at the bottom there is nothing to anchor
+// on, so nothing is removed: the pane may be mid-repaint or covered.
+func TestAgyBackgroundStripNeedsAFooterToAnchorOn(t *testing.T) {
+	lines := []string{"body", `  ● [03:57:33] go build ./... running`}
+	if got := agyDropBackgroundStrip(lines); len(got) != len(lines) {
+		t.Errorf("with no status bar nothing may be dropped, got %d of %d", len(got), len(lines))
+	}
+}
+
+// Every standing agy prompt must still refuse the composer. This is the
+// regression that would matter: the fix removes rows from just above the
+// footer, and a form whose rows were removed would read as a ready composer.
+func TestAgyStandingPromptsStillRefuseTheComposer(t *testing.T) {
+	dir := filepath.Join("..", "classify", "testdata", "transcripts")
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range ents {
+		name := e.Name()
+		if !strings.HasPrefix(name, "approval_agy_") && !strings.HasPrefix(name, "choice_agy_") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if AgyComposerReady(string(b)) {
+			t.Errorf("%s: a standing prompt must never read as a ready composer", name)
+		}
+	}
+}
+
+// The report's quote shows the caret, then the strip, then the status bar --
+// with the composer's rules elided, so it does NOT settle whether the strip
+// sits above or below the lower rule. The recorded fixture is one guess; the
+// detector must not depend on which guess was right, and a run of rows must
+// work because the status bar itself reports "N task(s)".
+func TestAgyBackgroundStripInEitherPositionAndAnyCount(t *testing.T) {
+	rule := strings.Repeat("─", 60)
+	footer := "? for shortcuts                    Gemini 3.8 Flash · high · 2 task(s) · /tasks"
+	s1 := `  ● [03:57:33] go build -tags "vectors cpu" ./... running`
+	s2 := `  ● [03:57:40] go test ./... running`
+
+	cases := []struct {
+		name  string
+		lines []string
+	}{
+		{"one row below the lower rule", []string{"body", rule, ">", rule, s1, footer}},
+		{"one row above the lower rule", []string{"body", rule, ">", s1, rule, footer}},
+		{"two rows below the lower rule", []string{"body", rule, ">", rule, s1, s2, footer}},
+		{"two rows above the lower rule", []string{"body", rule, ">", s1, s2, rule, footer}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pane := strings.Join(tc.lines, "\n") + "\n"
+			if mode, ok := AgyAgentMode(pane); !ok || mode != AgentModeDefault {
+				t.Errorf("AgyAgentMode = %v/%v, want default/true", mode, ok)
+			}
+			if !AgyComposerReady(pane) {
+				t.Error("the composer is at rest behind the strip; it must read ready")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Finding 12 of the agy write-up, split out from the findings 9/11 classification work because it is a separate defect with no safety surface — and because it is a **prerequisite** for finding 11 (see the last section).

## The report

`hap mode` refused on a pane plainly showing its composer, and blamed a modal that was not there:

> error: could not read quick-lemur's mode: its pane is not showing the composer footer (an approval or form is probably up — answer it, then retry)

Nine edit modals were cleared by hand and the mode still could not be set. This matters beyond the error text: `acceptEdits` is the documented cure for agy's edit-approval stalls, so the cure was unreachable for any agy agent doing background work — which the write-up notes is the only kind worth automating.

## Two independent causes

My first hypothesis — that this was purely a line-offset problem — was **wrong**, and reading the regex falsified it:

1. **The status bar itself fails to parse.** agy appends `· N task(s) · /tasks` while work is running, and `agyModelSegmentRE`'s character class contains neither `·` nor `/`.
2. **The task strip displaces the footer-anchored rows.** Everything reading agy's footer counts lines up from the bottom (status bar, rule, caret, rule).

Either alone leaves the mode unreadable, so both are fixed. They're tested apart.

## Why a window filter, not a walk up from the footer

I first wrote `agyDropBackgroundStrip` to walk the unbroken run directly above the footer. **That handled only one of the two possible layouts.** The report shows the caret, the strip and the status bar with the composer's rules elided:

```
>
  ● [03:57:33] go build ... running
? for shortcuts    Gemini 3.8 Flash · high · 1 task(s) · /tasks
```

so the strip may sit either side of the lower rule. With the strip *above* the rule, the rule is still at `n-2` (so the mode read succeeded) but the caret at `n-3` is the strip — and `AgyComposerReady` still failed. That is the likelier reading of the report, so the first version would not have fixed the reported case. A test asserting both layouts now covers it, along with multiple rows, which `N task(s)` implies.

## Safety

`AgyComposerReady` gates every agy send path, so the widening is deliberately narrow: the bottom line must already BE a recognised status bar, and only rows matching a bullet **and** a clock-shaped timestamp are removed. Dropping such a row can only bring a genuine rule/caret/rule sandwich into alignment — a modal's rows are not strip-shaped — so no standing prompt can collapse into a "ready" composer.

Pinned by a sweep over every recorded agy screen: all ten standing prompts still refuse the composer, and the only reading that changed is the new fixture's. Negative cases cover an ordinary `● Bash(…)` row, a modal's last option, and a bare bullet — none is skipped.

The mode READ is loose and the press gate strict, per the existing split, so widening the read costs nothing; the composer proof is what needed the care.

## Fixture provenance — weaker than its neighbours

`idle_agy_background_task.txt` is **derived**: a real transcript (`idle_agy_after_turn`) plus the strip row and footer from the report. Every other fixture in that file is a verbatim live capture, and the file says so. The strip's exact position relative to the lower rule is unverified — which is why the detector handles both rather than committing to one. **This is the line to re-verify against a real agy**, and it would suit a `HAP_ITEST_AGY=1` case.

## Gate

`go build`, `go vet`, `gofmt` clean; `golangci-lint` (pinned `GOTOOLCHAIN=go1.26.2`) **0 issues**; `internal/domain`, `internal/classify`, `internal/cli` and `internal/daemon` all pass — daemon especially, since it exercises the send gate end to end. The only failure in the full suite is `TestALockedMigrationStepLosesTheLeaseAndFailsClosed` in `internal/store/turso`, which fails identically on untouched `origin/main` and is in a package this diff does not touch.

## This unblocks finding 11

Finding 11's structural fix is to make an unclassified modal suppress the idle verdict. The right predicate is the composer *sandwich* — and the background-task strip breaks that sandwich. Without this fix, the suppression rule would have misfired on every agy agent running background work, turning them all unclassifiable and killing agy hand-outs. That is why this lands first.
