### PR TITLE
#0 test: pin the idle suppression against the recorded agy edit approval

### DIFF
--- a/changelog.d/test-agy-edit-approval-fixture.md
+++ b/changelog.d/test-agy-edit-approval-fixture.md
@@ -1,0 +1,1 @@
+- Added the real agy file-edit approval screen to the classifier corpus, so the idle-verdict suppression is proved against the recorded pane that caused the stall rather than a synthetic stand-in.

--- a/internal/classify/agy_test.go
+++ b/internal/classify/agy_test.go
@@ -83,6 +83,15 @@ var agyFixtures = map[string]agyCase{
 	"idle_agy_fresh.txt":             {typ: domain.SituationIdle},
 	"idle_agy_mode_accept_edits.txt": {typ: domain.SituationIdle},
 	"idle_agy_mode_plan.txt":         {typ: domain.SituationIdle},
+	// The screen from the reported stall: agy's file-edit approval, which no
+	// parser recognises. Recorded from the live run (signature
+	// idle:6c4846ec20090256ca937aa0, audit #224376287763128320 — the
+	// [noop_vs_pending_tasks] escalation raised while this modal stood).
+	//
+	// It earns unclassifiable STRUCTURALLY, because the composer is not on
+	// screen, and NOT through AgyHeldForm, which does not know this modal
+	// either — which is exactly why it is the case worth pinning.
+	"idle_agy_edit_approval.txt":     {typ: domain.SituationUnclassifiable},
 	"idle_agy_effort_picker.txt":     {typ: domain.SituationUnclassifiable, held: domain.AgyHeldPanel},
 	"idle_agy_model_picker.txt":      {typ: domain.SituationUnclassifiable, held: domain.AgyHeldPanel},
 	"idle_agy_shortcuts_overlay.txt": {typ: domain.SituationUnclassifiable, held: domain.AgyHeldPanel},

--- a/internal/classify/agyidlesuppression_test.go
+++ b/internal/classify/agyidlesuppression_test.go
@@ -53,6 +53,31 @@ func TestAgyUnknownModalSuppressesTheIdleVerdict(t *testing.T) {
 	}
 }
 
+// The recorded screen this rule exists for, and the reason the synthetic pane
+// above is no longer the only evidence. This is the pane hap read as idle while
+// the agent sat behind it for ten minutes; the audit row it produced was
+// [noop_vs_pending_tasks], i.e. hap offering the next task to a blocked agent.
+//
+// Asserting the two composer predicates alongside the verdict is the point: the
+// suppression must come from the composer being absent, and AgyComposerReady
+// must stay false so no send path can ever type into this screen.
+func TestAgyRecordedEditApprovalSuppressesTheIdleVerdict(t *testing.T) {
+	c := New(nil)
+	pane := readAgyFixture(t, "idle_agy_edit_approval.txt")
+	for _, status := range []string{"idle", "done"} {
+		if s := c.Classify(domain.AgentTypeAgy, status, pane); s.Type != domain.SituationUnclassifiable {
+			t.Errorf("@%s: type = %s, want unclassifiable — this is the recorded screen "+
+				"hap reported as a parked agent free to take the next task", status, s.Type)
+		}
+	}
+	if domain.AgyComposerVisible(pane) {
+		t.Error("the composer is covered by the modal; it must not read as visible")
+	}
+	if domain.AgyComposerReady(pane) {
+		t.Error("a standing approval must never read as a ready composer")
+	}
+}
+
 // The control, and the reason this is not simply "agy is never idle": a parked
 // composer must still earn the idle verdict, or the suppression kills every agy
 // hand-out instead of fixing a stall.

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -50,6 +50,7 @@ func TestGoldenTranscripts(t *testing.T) {
 		"idle_agy_background_task.txt":     "done",
 		"idle_agy_composer_draft.txt":      "done",
 		"idle_agy_declined.txt":            "done",
+		"idle_agy_edit_approval.txt":       "done",
 		"idle_agy_effort_picker.txt":       "idle",
 		"idle_agy_fresh.txt":               "idle",
 		"idle_agy_mode_accept_edits.txt":   "idle",

--- a/internal/classify/testdata/classifications.golden
+++ b/internal/classify/testdata/classifications.golden
@@ -42,6 +42,7 @@ idle_agy_after_turn.txt status=done type=idle verb= options=0
 idle_agy_background_task.txt status=done type=idle verb= options=0
 idle_agy_composer_draft.txt status=done type=idle verb= options=0
 idle_agy_declined.txt status=done type=idle verb= options=0
+idle_agy_edit_approval.txt status=done type=unclassifiable verb= options=0
 idle_agy_effort_picker.txt status=idle type=unclassifiable verb= options=0
 idle_agy_fresh.txt status=idle type=idle verb= options=0
 idle_agy_mode_accept_edits.txt status=idle type=idle verb= options=0

--- a/internal/classify/testdata/transcripts/idle_agy_edit_approval.txt
+++ b/internal/classify/testdata/transcripts/idle_agy_edit_approval.txt
@@ -1,0 +1,50 @@
+
+▸ Thought for 5s, 1.1k tokens
+  Evaluating Signature Function Location
+
+● Read(/workspaces/worktree-agent-no23/internal/taskfile/taskfile.go) (ctrl+o to expand)
+
+▸ Thought for 7s, 2.3k tokens
+  Examining checklist item management
+
+● Search(Confirm zero callers of NodeWatching)
+● Search(Confirm zero callers of SeedRuleDisabled)
+● Search(Confirm zero callers of TaskFilePath)
+● Search(Confirm zero callers of GetTask)
+● Search(Check calls to orDashCLI)
+● Search(Check calls to shortSig in tui)
+● Search(Check calls to shortSignature in cli) (ctrl+o to expand)
+
+▸ Thought for 3s, 491 tokens
+  Tracing Signature Abbreviation Logic
+
+● Bash(ls -la changelog.d)
+● Read(/workspaces/worktree-agent-no23/changelog.d/README.md) (ctrl+o to expand)
+
+▸ Thought for 4s, 1.4k tokens
+  Verifying test gate requirements
+
+● Read(/workspaces/worktree-agent-no23/internal/domain/node.go)
+● Edit(/workspaces/worktree-agent-no23/internal/domain/node.go) (ctrl+o to expand)
+
+Pending edit
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+/workspaces/worktree-agent-no23/internal/domain/node.go  -5
+   2        return n.LastSeen.IsZero() || now.Sub(n.LastSeen) > nodeStaleAfter
+   3    }
+   4
+   5 -  // NodeWatching reports whether a TUI on that node is watching the fleet.
+   5 -  func NodeWatching(n NodeInfo, now time.Time) bool {
+   5 -      return !n.WatchingUntil.IsZero() && now.Before(n.WatchingUntil)
+   5 -  }
+   5 -
+   5    // NodeLabelOrID is the display label, falling back to the id's first eight
+
+  shift+tab to auto-approve file edits
+Accept this file edit?
+> 1. Yes, accept this change
+  2. No, reject this change
+
+  ↑/↓ Navigate · tab Amend · f full diff · ctrl+r Review
+esc to cancel                                                                                                                                                        Gemini 3.8 Flash · high

--- a/internal/domain/agentmode_test.go
+++ b/internal/domain/agentmode_test.go
@@ -410,13 +410,17 @@ func TestAgyAgentModeOverEveryRecordedScreen(t *testing.T) {
 		"choice_agy_mcq_two":           {unknown, false},
 		"choice_agy_mcq_two_q2":        {unknown, false},
 		"choice_agy_mcq_two_recent":    {unknown, false},
-		"idle_agy_effort_picker":       {unknown, false},
-		"idle_agy_model_picker":        {unknown, false},
-		"idle_agy_shortcuts_overlay":   {unknown, false},
-		"idle_agy_signin_method":       {unknown, false},
-		"idle_agy_signin_url":          {unknown, false},
-		"idle_agy_slash_popup":         {unknown, false},
-		"idle_agy_terms":               {unknown, false},
+		// The file-edit approval ends in a FORM's bar ("esc to cancel" beside
+		// the model segment), not the composer's rule, so there is no mode to
+		// read and nothing safe to press into.
+		"idle_agy_edit_approval":     {unknown, false},
+		"idle_agy_effort_picker":     {unknown, false},
+		"idle_agy_model_picker":      {unknown, false},
+		"idle_agy_shortcuts_overlay": {unknown, false},
+		"idle_agy_signin_method":     {unknown, false},
+		"idle_agy_signin_url":        {unknown, false},
+		"idle_agy_slash_popup":       {unknown, false},
+		"idle_agy_terms":             {unknown, false},
 	}
 	files, err := filepath.Glob(filepath.Join("..", "classify", "testdata", "transcripts", "*_agy_*.txt"))
 	if err != nil || len(files) == 0 {

--- a/internal/domain/agybackgroundtask_test.go
+++ b/internal/domain/agybackgroundtask_test.go
@@ -127,7 +127,14 @@ func TestAgyStandingPromptsStillRefuseTheComposer(t *testing.T) {
 	}
 	for _, e := range ents {
 		name := e.Name()
-		if !strings.HasPrefix(name, "approval_agy_") && !strings.HasPrefix(name, "choice_agy_") {
+		// idle_agy_edit_approval is named for the STATUS herdr reports, not
+		// for what is on screen: it is a standing approval and belongs in this
+		// sweep. Without naming it here the prefixes alone would skip the one
+		// recorded modal whose composer-readiness nothing else checks.
+		standing := strings.HasPrefix(name, "approval_agy_") ||
+			strings.HasPrefix(name, "choice_agy_") ||
+			name == "idle_agy_edit_approval.txt"
+		if !standing {
 			continue
 		}
 		b, err := os.ReadFile(filepath.Join(dir, name))

--- a/test/integration/agy_test.go
+++ b/test/integration/agy_test.go
@@ -419,3 +419,107 @@ func TestRealAgyModeToggle(t *testing.T) {
 		t.Errorf("after a refused set the mode is %s (read ok=%v); want it unchanged at %s", got, ok, start)
 	}
 }
+
+// TestRealAgyEditApprovalIsNotIdle is a DRIFT TRIPWIRE for the recorded
+// idle_agy_edit_approval fixture, not a source for it. The corpus screen was
+// captured from the run that produced the stall report; this case proves the
+// live agy still renders that modal the same way, so the suppression the unit
+// suite pins is still about a screen agy actually paints.
+//
+// It deliberately does NOT write into testdata. A test that refreshes its own
+// fixture cannot fail honestly — it would rewrite the evidence and go green on
+// whatever agy happens to render today. When agy's layout really does move,
+// this fails and LOGS the capture for a human to install.
+//
+// The assertion is the one that matters in production: herdr reports this pane
+// idle/done, and hap must NOT agree, or the agent is offered the next task
+// while a modal stands (the [noop_vs_pending_tasks] row in the report).
+func TestRealAgyEditApprovalIsNotIdle(t *testing.T) {
+	requireAgy(t)
+	cli := herdr.NewCLI()
+	work := t.TempDir()
+
+	// The target sits outside agy's start directory, matching the reported
+	// stall's shape (an agent started in the main checkout editing a sibling
+	// worktree). Be warned that this is NOT known to be sufficient.
+	//
+	// Measured live, agy 1.2.2 / Gemini 3.6 Flash Low, twice: an edit INSIDE the
+	// start directory and an edit outside it under /tmp were BOTH applied with
+	// no modal at all — Read, then Edit, then a success message. So whatever
+	// raises "Accept this file edit?" is not simply "outside the workspace";
+	// the remaining candidates (agy trusting /tmp, or the prompt depending on
+	// mode or on how the edit was reached) are untested guesses.
+	//
+	// The case therefore SKIPS with the pane logged rather than failing. The
+	// corpus fixture it guards was captured from the real stall, so the unit
+	// suite's coverage does not depend on reproducing the modal on demand.
+	outside := t.TempDir()
+	target := filepath.Join(outside, "hello.txt")
+	if err := os.WriteFile(target, []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pane := startAgyAgent(t, cli, work)
+
+	promptAgy(t, cli, pane, "Use your edit tool to change the single line in "+target+
+		" from 'one' to 'two'. Do not run any shell command.")
+
+	// The modal is not one ParseAgyForm knows, which is the whole point, so
+	// poll for its own anchor rather than for a parsed form.
+	// A skip must carry evidence. "agy did not raise the modal" has several
+	// causes that need different fixes — it auto-approved an in-workspace edit,
+	// it reached for a shell tool instead, or it was still thinking — and a bare
+	// skip cannot tell them apart, so the last screen goes into the log.
+	var capture, last string
+	deadline := time.Now().Add(150 * time.Second)
+	for time.Now().Before(deadline) {
+		content, err := cli.ReadPaneVisible(context.Background(), pane, 60)
+		if err == nil {
+			last = content
+			if strings.Contains(content, "Accept this file edit?") {
+				capture = content
+				break
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if capture == "" {
+		if _, standing := domain.ParseAgyForm(last); standing {
+			t.Skipf("agy raised a DIFFERENT form than the file-edit approval; nothing to assert.\npane:\n%s",
+				lastLines(last, 20))
+		}
+		t.Skipf("agy did not raise a file-edit approval (auto-approved, refused, or slow); "+
+			"nothing to assert.\npane:\n%s", lastLines(last, 20))
+	}
+
+	c := classify.New(nil)
+	for _, status := range []string{"idle", "done"} {
+		if s := c.Classify(domain.AgentTypeAgy, status, capture); s.Type != domain.SituationUnclassifiable {
+			t.Errorf("@%s: the live edit approval classified %s, want unclassifiable.\npane:\n%s",
+				status, s.Type, lastLines(capture, 16))
+		}
+	}
+	if domain.AgyComposerReady(capture) {
+		t.Errorf("the live edit approval read as a READY composer — a send path could type into it.\npane:\n%s",
+			lastLines(capture, 16))
+	}
+	if domain.AgyComposerVisible(capture) {
+		t.Errorf("the live edit approval read as a visible composer.\npane:\n%s", lastLines(capture, 16))
+	}
+
+	// Drift check against the recorded corpus screen. A changed footer does not
+	// fail the case on its own — the assertions above are what must hold — but
+	// it is the signal that the fixture needs re-capturing.
+	for _, anchor := range []string{
+		"shift+tab to auto-approve file edits",
+		"1. Yes, accept this change",
+		"2. No, reject this change",
+		"esc to cancel",
+	} {
+		if !strings.Contains(capture, anchor) {
+			t.Logf("DRIFT: the live modal no longer contains %q; refresh "+
+				"internal/classify/testdata/transcripts/idle_agy_edit_approval.txt from:\n%s",
+				anchor, lastLines(capture, 20))
+			break
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #494, which made agy earn the idle verdict by showing its composer but proved it only against a synthetic pane.

## The premise of this task is disproven, with evidence

The task says the edit-accept modal "is not reproduced verbatim because no capture of it exists". **A capture does exist — five of them**, byte-identical in the modal region, still in the operator's store from the incident window:

| signature | seen |
|---|---|
| `idle:6c4846ec20090256ca937aa0` | 03:49:01Z |
| `idle:af22bc6548e…`, `idle:d995378bf84…`, `idle:6ab0d32a43d…` | 03:54:15–03:54:37Z |
| `idle:80cdc31a472…` | 04:55:31Z |

They were found with `hap signatures search "Accept this file edit" --screen`, which matches the raw captured pane. The fixture is the first one, and its provenance is exact: its last audit is **#224376287763128320 — `[noop_vs_pending_tasks] learned noop rule, but the declared source has pending tasks`**, the very escalation the report cites, raised while that modal stood.

That is strictly better provenance than a fresh scratch capture, which would be a different diff at whatever width the scratch pane happened to be — and the corpus already treats width as significant (`approval_agy_shell_wide`, `_wrapped`).

The recorded wording also confirms the earlier correction: the screen says **`Accept this file edit?`**, not the design doc's guessed `Allow edit of this file?`.

## What landed

The fixture is registered in all three tables that gate a new agy transcript (`agyFixtures`, `statusFor`, the `agentmode` want map) and the golden regenerated to `status=done type=unclassifiable` — not the `status=blocked` default that caught the last agy fixture.

Two things it forced, neither cosmetic:

- **A safety guard would have silently skipped it.** `TestAgyStandingPromptsStillRefuseTheComposer` sweeps only `approval_agy_*` and `choice_agy_*`. This screen is a standing approval named for the status herdr reports (`idle_agy_*`), so it would have escaped the one test proving such a screen never reads as a ready composer — a live hole with no coverage. The sweep now names it.
- **`AgyAgentMode` reads UNKNOWN here**, derived rather than predicted: the screen ends in a *form's* bar (`esc to cancel` beside the model segment), not the composer's rule.

**No parser for the modal, deliberately.** Teaching `ParseAgyForm` this screen would classify it `SituationApproval` and delete the suppression coverage this PR exists to add. It belongs in its own `feat:` change.

## The live case is a tripwire, and it currently skips

It never writes into `testdata` — a test that refreshes its own fixture cannot fail honestly. It skips with the pane logged, and the skip is informative rather than silent.

It does **not** reproduce the modal. Measured twice (agy 1.2.2, Gemini 3.6 Flash Low): an edit *inside* the start directory and one *outside* it under `/tmp` were **both applied with no modal at all** — `Read`, `Edit`, success message. So what raises "Accept this file edit?" is not simply "outside the workspace"; the remaining candidates (agy trusting `/tmp`, or the prompt depending on mode or on how the edit was reached) are untested guesses. The unit coverage does not depend on reproducing it.

## A gap in #494 this work exposed

An operator classifier rule with `Situation: "idle"` matching this screen **defeats the suppression** (`type=idle`), because #494's gate sits on the idle fall-through rather than ahead of operator rules. Genuine "held" screens (terms, pickers) are ignored ahead of every rule, the operator's included, on the grounds that a rule matching them can only be wrong about them — an unreadable modal is arguably the same category. `AgyHeldForm` returns `""` here, so this fixture is legitimately not a held screen. Out of scope for a test-only PR; flagged for a follow-up.

## Notes

- **NFR-005a does not apply.** That gate is the irreversible-command corpus (`internal/domain/testdata/corpus`, `safety_test.go`), not the classifier corpus, so an agy screen needs no registration there.
- Gate: full suite **42 ok** (`-count=1`), `golangci-lint` **0 issues** (`GOTOOLCHAIN=go1.26.2`), gofmt/vet clean including the `integration` tag, plus the `HAP_ITEST_AGY=1` run.

Leaving the merge to you, as asked.