### PR TITLE
#1 chore: bump plugin version to 0.9.39 [skip release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ section in `CLAUDE.md`.
 automation folds those into a new section here under the version it actually
 assigns. Do not add a heading or an entry by hand.
 
+## 0.9.39
+
+- Added the real agy file-edit approval screen to the classifier corpus, so the idle-verdict suppression is proved against the recorded pane that caused the stall rather than a synthetic stand-in.
+
 ## 0.9.38
 
 - Fixed hap reporting an agy agent as idle while a prompt it does not recognise is on screen: agy must now show its composer to earn the idle verdict, so an unreadable modal escalates instead of being offered the next task. Previously such an agent could sit untouched behind a standing prompt while hap treated it as free — and a pane scored idle is exactly the one a hand-out gets typed into.

--- a/changelog.d/test-agy-edit-approval-fixture.md
+++ b/changelog.d/test-agy-edit-approval-fixture.md
@@ -1,1 +1,0 @@
-- Added the real agy file-edit approval screen to the classifier corpus, so the idle-verdict suppression is proved against the recorded pane that caused the stall rather than a synthetic stand-in.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 # Herd Auto Prompter — Herdr plugin manifest (IR-004)
 id = "herd-auto-prompter"
 name = "Herd Auto Prompter"
-version = "0.9.38"
+version = "0.9.39"
 description = "Monitors every agent in the herd, auto-supplies the next prompt or response when confident, and escalates to you when not — learned from your own past decisions."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Automated bump: v0.9.39 is being released from this commit by the Auto Release workflow.